### PR TITLE
Fix snekbox sandbox on Apple Silicon

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -31,7 +31,9 @@ services:
 
   sandbox-dev:
     container_name: sandbox-dev
+    platform: linux/amd64
     image: ghcr.io/python-discord/snekbox:latest
+    privileged: true
     ipc: none
     networks:
       - seraph-network-dev


### PR DESCRIPTION
## Summary
- Add `platform: linux/amd64` to sandbox-dev service (snekbox lacks ARM64 build)
- Add `privileged: true` to grant cgroup access needed by NsJail sandboxing

## Test plan
- [ ] `./manage.sh -e dev up -d` starts all 3 containers successfully on Apple Silicon
- [ ] `docker ps` shows sandbox-dev running (not exited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)