### PR TITLE
fix: align settings divider with chat input box

### DIFF
--- a/frontend/src/components/chat/ChatSidebar.tsx
+++ b/frontend/src/components/chat/ChatSidebar.tsx
@@ -15,10 +15,10 @@ export function ChatSidebar() {
           <div className="flex-1 min-h-0 overflow-y-auto retro-scrollbar">
             <SessionList />
           </div>
-          <div className="border-t border-retro-border/20">
+          <div className="border-t border-retro-border/20 mt-2">
             <button
               onClick={() => setSettingsOpen(true)}
-              className="w-full text-[8px] text-retro-text/40 hover:text-retro-highlight text-left px-2 py-1.5 uppercase tracking-wider"
+              className="w-full text-[8px] text-retro-text/40 hover:text-retro-highlight text-left px-2 py-3 uppercase tracking-wider"
             >
               Settings
             </button>


### PR DESCRIPTION
## Summary
- Align the sidebar divider line with the top border of the chat input area
- Increase settings button padding for better visual balance

## Test plan
- [ ] Divider line above "Settings" aligns horizontally with the top of the "Type your message..." input box

🤖 Generated with [Claude Code](https://claude.com/claude-code)