### PR TITLE
docs: update stale tool counts and route references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Seraph AI Agent
 
-A proactive AI guardian with a retro 16-bit RPG village UI. An animated pixel-art avatar walks between tool stations in a Phaser 3 village while you chat via an RPG-style dialog box. Persistent identity (soul file), long-term memory (vector embeddings), hierarchical goal/quest system, and 16 tools across web search, file I/O, shell execution, browser automation, calendar, and email.
+A proactive AI guardian with a retro 16-bit RPG village UI. An animated pixel-art avatar walks between tool stations in a Phaser 3 village while you chat via an RPG-style dialog box. Persistent identity (soul file), long-term memory (vector embeddings), hierarchical goal/quest system, and 16 native tools + MCP integrations across web search, file I/O, shell execution, browser automation, calendar, email, and task management (Things3).
 
 ## Quick Start
 
@@ -26,7 +26,7 @@ A proactive AI guardian with a retro 16-bit RPG village UI. An animated pixel-ar
 - **Frontend**: React 19, Vite 6, TypeScript, Tailwind CSS, Zustand, Phaser 3.90
 - **Backend**: Python 3.12, FastAPI, uvicorn, smolagents, LiteLLM (OpenRouter)
 - **Database**: SQLModel + SQLite (aiosqlite), LanceDB (vector memory)
-- **Tools**: 16 auto-discovered tools — web search, file I/O, shell (snekbox sandbox), browser (Playwright), calendar (Google), email (Gmail), soul/memory, goals
+- **Tools**: 16 auto-discovered tools + MCP integrations (Things3) — web search, file I/O, shell (snekbox sandbox), browser (Playwright), calendar (Google), email (Gmail), soul/memory, goals, task management
 - **Infra**: Docker Compose (3 services: backend, frontend, snekbox sandbox), uv package manager
 
 ## Project Structure
@@ -50,7 +50,7 @@ backend/
 │   ├── models/schemas.py
 │   ├── api/             # REST + WebSocket endpoints (chat, sessions, goals, profile, tools)
 │   ├── agent/           # smolagents factory, onboarding agent, session manager
-│   ├── tools/           # 16 @tool implementations (auto-discovered)
+│   ├── tools/           # 16 @tool implementations (auto-discovered) + MCP tools
 │   ├── db/              # SQLModel engine + models (Session, Message, Goal, UserProfile, Memory)
 │   ├── memory/          # Soul file, LanceDB vector store, embedder, consolidator
 │   ├── goals/           # Hierarchical goal CRUD repository

--- a/docs/docs/architecture/feature-comparison.md
+++ b/docs/docs/architecture/feature-comparison.md
@@ -22,7 +22,7 @@ Different philosophies, but many of OpenClaw's features are worth adopting.
 
 - Real-time chat with AI agent (WebSocket streaming with step/final/error/proactive/ambient types)
 - Tool execution with visual feedback (animated RPG avatar walks to tool stations in village)
-- **16 auto-discovered tools**: web search, file I/O, template fill, soul view/update, goal CRUD, shell execute (snekbox sandbox), browser automation (Playwright), calendar (Google), email (Gmail)
+- **16 auto-discovered tools + MCP integrations**: web search, file I/O, template fill, soul view/update, goal CRUD, shell execute (snekbox sandbox), browser automation (Playwright), calendar (Google), email (Gmail), task management (Things3 via MCP)
 - **Persistent sessions** — SQLite-backed, survive restarts, session list UI with switch/delete
 - **Persistent memory** — Soul file (soul.md) + LanceDB vector store with sentence-transformer embeddings
 - **Memory consolidation** — Background extraction of facts/preferences/decisions after each conversation
@@ -97,7 +97,7 @@ These were gaps in the original analysis that have since been implemented:
 | **Sandboxed execution** | No sandboxing | snekbox Docker sidecar (Phase 2) |
 | **Browser automation** | DuckDuckGo text search only | Playwright with headless Chromium (Phase 2) |
 | **Shell command execution** | No shell tool | snekbox-based sandboxed execution (Phase 2) |
-| **Plugin/skill system** | 4 hardcoded tools | Auto-discovery from `src/tools/`, 16 tools (Phase 2) |
+| **Plugin/skill system** | 4 hardcoded tools | Auto-discovery from `src/tools/` (16 native tools) + MCP integrations (Phase 2) |
 
 ---
 

--- a/docs/docs/development/phase-2-capable-executor.md
+++ b/docs/docs/development/phase-2-capable-executor.md
@@ -162,7 +162,7 @@ RUN uv run playwright install chromium
 - Extended wandering waypoints
 
 **Modified**: `frontend/src/lib/animationStateMachine.ts`
-- Full `TOOL_TARGETS` mapping for all 16 tools to village positions and animations
+- Full `TOOL_TARGETS` mapping for all 16 native tools + Things3 MCP tools to village positions and animations
 
 ---
 
@@ -185,7 +185,7 @@ RUN uv run playwright install chromium
 - [x] Drop a new `.py` tool file in `src/tools/`, verify auto-discovered
 - [x] New tools trigger correct village building animations
 - [x] 16 tools auto-discovered by plugin loader
-- [x] 19 routes registered (including `GET /api/tools`)
+- [x] 18 routes registered (including `GET /api/tools`)
 - [x] TypeScript compiles clean
 - [x] Lock file updated
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -55,7 +55,7 @@ backend/
 │   ├── models/schemas.py
 │   ├── api/             # REST + WebSocket endpoints (chat, sessions, goals, profile, tools)
 │   ├── agent/           # smolagents factory, onboarding agent, session manager
-│   ├── tools/           # 16 @tool implementations (auto-discovered)
+│   ├── tools/           # 16 @tool implementations (auto-discovered) + MCP tools
 │   ├── db/              # SQLModel engine + models (Session, Message, Goal, UserProfile, Memory)
 │   ├── memory/          # Soul file, LanceDB vector store, embedder, consolidator
 │   ├── goals/           # Hierarchical goal CRUD repository


### PR DESCRIPTION
## Summary
- Update tool references across README, intro, feature comparison, and Phase 2 spec to mention MCP integrations (Things3) alongside the 16 native tools
- Fix route count in Phase 2 checklist (19 → 18)

## Files changed
- `README.md` — mention MCP/Things3 in description, architecture, project structure
- `docs/docs/intro.md` — project structure tree
- `docs/docs/architecture/feature-comparison.md` — "What Seraph Has" list + resolved gaps table
- `docs/docs/development/phase-2-capable-executor.md` — TOOL_TARGETS description, route count fix

## Test plan
- [ ] Verify docs site builds cleanly
- [ ] Spot-check that tool count references are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)