### PR TITLE
fix: track frontend/src/lib/toolParser.ts (gitignore lib/ rule)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,8 +157,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/frontend/src/lib/toolParser.ts
+++ b/frontend/src/lib/toolParser.ts
@@ -1,0 +1,31 @@
+import { TOOL_NAMES } from "../config/constants";
+
+const TOOL_PATTERNS = [
+  /ToolCall\(\s*name\s*=\s*['"](\w+)['"]/i,
+  /tool_name\s*[:=]\s*['"](\w+)['"]/i,
+  /Calling tool:\s*['"]?(\w+)['"]?/i,
+  /Using tool:\s*['"]?(\w+)['"]?/i,
+  /"tool"\s*:\s*"(\w+)"/i,
+];
+
+const KNOWN_TOOLS: Set<string> = new Set(Object.values(TOOL_NAMES));
+
+export function detectToolFromStep(stepContent: string): string | null {
+  for (const pattern of TOOL_PATTERNS) {
+    const match = stepContent.match(pattern);
+    if (match && match[1]) {
+      const toolName = match[1].toLowerCase();
+      if (KNOWN_TOOLS.has(toolName)) {
+        return toolName;
+      }
+    }
+  }
+
+  for (const tool of KNOWN_TOOLS) {
+    if (stepContent.toLowerCase().includes(tool)) {
+      return tool;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- The `.gitignore` had a broad `lib/` pattern (Python convention) that also matched `frontend/src/lib/`, causing `toolParser.ts` to be untracked while its test file was tracked
- Changed `lib/` → `/lib/` so it only matches the repo root directory
- Added the missing `toolParser.ts` to git — fixes the failing `toolParser.test.ts` suite in CI

## Test plan
- [ ] CI passes: `toolParser.test.ts` can now resolve `./toolParser` import
- [ ] No other files inadvertently un-ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)