### PR TITLE
fix: set intro doc as root page to fix broken links

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /intro
+slug: /
 ---
 
 # Getting Started

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -75,7 +75,7 @@ const config: Config = {
           items: [
             {
               label: 'Getting Started',
-              to: '/intro',
+              to: '/',
             },
             {
               label: 'Vision',


### PR DESCRIPTION
## Summary
- Set `intro.md` slug from `/intro` to `/` so it serves as the docs homepage
- Update footer "Getting Started" link to `/`

Fixes the broken link build error from #28 where every page linked to `/` via the navbar logo but no doc was mapped to that route.

## Test plan
- [ ] `npm run build` in `docs/` passes without broken link errors
- [ ] `docs.seraph.quest` root page shows the Getting Started doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)