### PR TITLE
feat: update docs theme to violet/purple color palette

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -6,25 +6,25 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
+  --ifm-color-primary: #7c5cbf;
+  --ifm-color-primary-dark: #6c4ab3;
+  --ifm-color-primary-darker: #6444aa;
+  --ifm-color-primary-darkest: #52378c;
+  --ifm-color-primary-light: #8c6ecb;
+  --ifm-color-primary-lighter: #9478cf;
+  --ifm-color-primary-lightest: #ac96db;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+  --ifm-color-primary: #9b7fd4;
+  --ifm-color-primary-dark: #8d6dcc;
+  --ifm-color-primary-darker: #8664c8;
+  --ifm-color-primary-darkest: #7050b5;
+  --ifm-color-primary-light: #a991dc;
+  --ifm-color-primary-lighter: #b09ae0;
+  --ifm-color-primary-lightest: #c5b5e8;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
## Summary
- Replace default Docusaurus green theme with violet/purple to match the landing page
- Light mode: `#7c5cbf`, Dark mode: `#9b7fd4`
- Unified color identity across `seraph.quest` and `docs.seraph.quest`

## Test plan
- [ ] Docs site renders with purple accent colors in both light and dark mode
- [ ] Links, buttons, and highlighted code lines use the new palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)