### PR TITLE
chore: adopt trunk-based development, retire develop branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 concurrency:
   group: tests-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Remove `develop` from CI workflow trigger branches
- Default branch already changed to `main` via GitHub API
- After merge, `develop` branch will be deleted

Going forward: feature branches (`feat/`, `fix/`, `docs/`, `chore/`) → PR → `main`. CalVer tags (`vYYYY.M.D`) for releases.

## Test plan
- [ ] CI triggers on pushes to `main` and PRs to `main` only
- [ ] `develop` branch can be safely deleted after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)