### PR TITLE
feat: add proactive intelligence and frontend feedback (Phase 3.4)

### DIFF
--- a/backend/src/agent/strategist.py
+++ b/backend/src/agent/strategist.py
@@ -1,0 +1,126 @@
+"""Strategist agent — periodic strategic reasoning with restricted tool set."""
+
+import json
+import logging
+from dataclasses import dataclass
+
+from smolagents import LiteLLMModel, ToolCallingAgent
+
+from config.settings import settings
+from src.tools.soul_tool import view_soul
+from src.tools.goal_tools import get_goals, get_goal_progress
+
+logger = logging.getLogger(__name__)
+
+STRATEGIST_INSTRUCTIONS = """\
+You are Seraph's strategic reasoning module. You periodically review the user's context \
+and decide whether a proactive intervention is warranted.
+
+Proactivity level: {proactivity_level}/5 (1=minimal, 5=very proactive).
+
+## Current Context
+{context_block}
+
+## Your Task
+Analyze the context and decide:
+1. Is there something the user should know right now?
+2. Would a nudge, advisory, or alert help them?
+3. Or is everything fine and no intervention is needed?
+
+Use the available tools to check the soul file and goals if you need more context.
+
+## Response Format
+Return ONLY a JSON object (no markdown fences):
+{{
+  "should_intervene": true/false,
+  "content": "The message to send to the user (if intervening)",
+  "intervention_type": "nudge" | "advisory" | "alert",
+  "urgency": 1-5,
+  "reasoning": "Why you made this decision"
+}}
+
+Guidelines:
+- "nudge" = subtle reminder shown as speech bubble (5s). Use for gentle prods.
+- "advisory" = opens chat panel. Use for useful information or suggestions.
+- "alert" = opens chat panel + high urgency. Use only for time-sensitive items.
+- At proactivity_level 1-2, only intervene for urgent/time-sensitive items.
+- At proactivity_level 3, intervene for helpful suggestions too.
+- At proactivity_level 4-5, be more liberal with nudges and check-ins.
+- If the user is in deep_work or a meeting, prefer NOT intervening unless urgent.
+- Keep messages concise and RPG-themed (you are a guardian Seraph).
+"""
+
+
+@dataclass
+class StrategistDecision:
+    should_intervene: bool
+    content: str
+    intervention_type: str  # nudge | advisory | alert
+    urgency: int
+    reasoning: str
+
+
+def create_strategist_agent(context_block: str) -> ToolCallingAgent:
+    """Create a restricted agent for strategic reasoning."""
+    model = LiteLLMModel(
+        model_id=settings.default_model,
+        api_key=settings.openrouter_api_key,
+        api_base="https://openrouter.ai/api/v1",
+        temperature=0.4,
+        max_tokens=settings.model_max_tokens,
+    )
+
+    instructions = STRATEGIST_INSTRUCTIONS.format(
+        proactivity_level=settings.proactivity_level,
+        context_block=context_block,
+    )
+
+    return ToolCallingAgent(
+        tools=[view_soul, get_goals, get_goal_progress],
+        model=model,
+        max_steps=5,
+        instructions=instructions,
+    )
+
+
+def parse_strategist_response(raw: str) -> StrategistDecision:
+    """Parse the strategist agent's JSON response into a decision.
+
+    Falls back to should_intervene=False on any parse failure.
+    """
+    if not raw or not raw.strip():
+        return StrategistDecision(
+            should_intervene=False,
+            content="",
+            intervention_type="nudge",
+            urgency=0,
+            reasoning="Empty response from strategist",
+        )
+
+    text = raw.strip()
+
+    # Strip markdown fences if present
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1] if "\n" in text else text[3:]
+        if text.endswith("```"):
+            text = text[:-3]
+        text = text.strip()
+
+    try:
+        data = json.loads(text)
+        return StrategistDecision(
+            should_intervene=bool(data.get("should_intervene", False)),
+            content=str(data.get("content", "")),
+            intervention_type=str(data.get("intervention_type", "nudge")),
+            urgency=int(data.get("urgency", 3)),
+            reasoning=str(data.get("reasoning", "")),
+        )
+    except (json.JSONDecodeError, ValueError, TypeError) as e:
+        logger.warning("Failed to parse strategist response: %s", e)
+        return StrategistDecision(
+            should_intervene=False,
+            content="",
+            intervention_type="nudge",
+            urgency=0,
+            reasoning=f"Parse failure: {e}",
+        )

--- a/backend/src/observer/sources/screen_source.py
+++ b/backend/src/observer/sources/screen_source.py
@@ -1,12 +1,52 @@
-"""Screen context source — stub for Phase 3.4 native daemon integration.
+"""Screen context source — native daemon integration for screen awareness.
 
-The native daemon will POST screen context to:
+The Seraph native daemon (a lightweight macOS/Linux process running outside Docker)
+captures screen context and posts it to the backend. This module documents the
+API contract for that integration.
+
+## Daemon API Contract
+
+### Endpoint
     POST /api/observer/context
-    Body: {
-        "active_window": "VS Code — seraph/backend/src/observer/manager.py",
-        "screen_context": "User is editing Python code in observer module"
+
+### Request Body
+    {
+        "active_window": str,       # Window title + app name
+                                    # e.g. "VS Code — seraph/backend/src/agent/strategist.py"
+        "screen_context": str,      # Brief description of what the user appears to be doing
+                                    # e.g. "User is writing Python code in the strategist module"
     }
 
-The ContextManager stores this data via update_screen_context() and
-includes it in the next context snapshot.
+### Field Details
+
+- **active_window** (required): The currently focused application and window title.
+  Format: "{App Name} — {window/document title}". The backend uses this to derive
+  user state (e.g., detecting IDE = deep_work, calendar app = scheduling).
+
+- **screen_context** (optional): A human-readable summary of what's on screen.
+  The daemon may use local OCR or window metadata to generate this. Should be
+  1-2 sentences max. Used by the strategist for richer context.
+
+### Frequency
+The daemon should POST every 30-60 seconds while the user is active.
+If the active window hasn't changed, the daemon may skip the POST to reduce
+noise. The backend does NOT poll — it relies on the daemon to push updates.
+
+### Privacy
+- Screen context stays local (backend runs on localhost or user's Docker).
+- The daemon should NEVER capture screenshots or send pixel data.
+- Only window titles and inferred activity descriptions are transmitted.
+- The user can disable screen context in settings (daemon should respect this).
+
+### Backend Handler
+The POST endpoint is handled in `src/api/router.py` and calls:
+    context_manager.update_screen_context(active_window, screen_context)
+
+The data is then included in the next context refresh and available to the
+strategist agent and delivery gate for state derivation.
+
+## Implementation Status
+The daemon is deferred to a future phase. The backend endpoint and
+ContextManager.update_screen_context() method are already implemented and
+ready to receive data when the daemon is built.
 """

--- a/backend/src/scheduler/jobs/daily_briefing.py
+++ b/backend/src/scheduler/jobs/daily_briefing.py
@@ -1,11 +1,105 @@
+"""Daily briefing — generates and delivers a morning briefing."""
+
+import asyncio
 import logging
+
+from config.settings import settings
+from src.models.schemas import WSResponse
 
 logger = logging.getLogger(__name__)
 
+_BRIEFING_PROMPT = """\
+You are Seraph, a guardian intelligence. Generate a concise morning briefing for your human.
+
+Keep the RPG framing light. Be warm but efficient. Use bullet points for clarity.
+
+## User Identity
+{soul}
+
+## Today's Context
+{context}
+
+## Upcoming Events
+{events}
+
+## Active Goals
+{goals}
+
+## Relevant Memories
+{memories}
+
+Write a short morning briefing (3-6 sentences) covering:
+1. A warm greeting appropriate to the time/day
+2. Key events or deadlines today
+3. Goal check-in — what should they focus on?
+4. Any relevant memories or patterns worth noting
+
+Be concise. No preamble. Just the briefing text."""
+
 
 async def run_daily_briefing() -> None:
-    """Generate and send the morning briefing to connected clients.
+    """Generate and send the morning briefing to connected clients."""
+    try:
+        from src.observer.manager import context_manager
 
-    Stub — will be implemented in Phase 3.4.
-    """
-    logger.info("daily_briefing ran")
+        ctx = await context_manager.refresh()
+
+        # Gather context data
+        from src.memory.soul import read_soul
+        soul = read_soul()
+
+        events_text = "No events scheduled."
+        if ctx.upcoming_events:
+            lines = []
+            for e in ctx.upcoming_events:
+                lines.append(f"- {e.get('summary', '?')} at {e.get('start', '?')}")
+            events_text = "\n".join(lines)
+
+        goals_text = ctx.active_goals_summary or "No active goals."
+
+        from src.memory.vector_store import search_formatted
+        memories = await asyncio.to_thread(
+            search_formatted,
+            "daily priorities and routines",
+            top_k=3,
+        )
+        memories_text = memories or "No relevant memories yet."
+
+        context_text = ctx.to_prompt_block()
+
+        prompt = _BRIEFING_PROMPT.format(
+            soul=soul,
+            context=context_text,
+            events=events_text,
+            goals=goals_text,
+            memories=memories_text,
+        )
+
+        import litellm
+
+        response = await asyncio.to_thread(
+            litellm.completion,
+            model=settings.default_model,
+            messages=[{"role": "user", "content": prompt}],
+            api_key=settings.openrouter_api_key,
+            api_base="https://openrouter.ai/api/v1",
+            temperature=0.6,
+            max_tokens=512,
+        )
+
+        briefing_text = response.choices[0].message.content.strip()
+
+        from src.observer.delivery import deliver_or_queue
+
+        message = WSResponse(
+            type="proactive",
+            content=briefing_text,
+            intervention_type="advisory",
+            urgency=3,
+            reasoning="Scheduled morning briefing",
+        )
+        await deliver_or_queue(message, is_scheduled=True)
+        logger.info("daily_briefing: delivered morning briefing")
+
+    except Exception:
+        logger.exception("daily_briefing failed")

--- a/backend/src/scheduler/jobs/evening_review.py
+++ b/backend/src/scheduler/jobs/evening_review.py
@@ -1,11 +1,128 @@
+"""Evening review — generates and delivers an end-of-day reflection."""
+
+import asyncio
 import logging
+from datetime import date
+
+from config.settings import settings
+from src.models.schemas import WSResponse
 
 logger = logging.getLogger(__name__)
 
+_REVIEW_PROMPT = """\
+You are Seraph, a guardian intelligence. Generate a concise evening review for your human.
+
+Keep the RPG framing light. Be reflective and encouraging.
+
+## User Identity
+{soul}
+
+## Today's Summary
+- Messages exchanged today: {message_count}
+- Goals completed today: {completed_goals}
+- Git activity: {git_activity}
+
+## Active Goals
+{active_goals}
+
+Write a short evening review (3-6 sentences) covering:
+1. Acknowledge what was accomplished today
+2. Note any goals that were completed or progressed
+3. Gentle observation about patterns (if any)
+4. A brief look-ahead at tomorrow
+
+Be concise. No preamble. Just the review text."""
+
+
+async def _count_messages_today() -> int:
+    """Count messages created today."""
+    try:
+        from src.db.engine import get_session as get_db_session
+        from src.db.models import Message
+        from sqlmodel import select, func
+
+        async with get_db_session() as db:
+            today = date.today()
+            result = await db.execute(
+                select(func.count(Message.id)).where(
+                    func.date(Message.created_at) == today
+                )
+            )
+            return result.scalar_one_or_none() or 0
+    except Exception:
+        logger.exception("Failed to count today's messages")
+        return 0
+
+
+async def _get_completed_goals_today() -> list[str]:
+    """Get titles of goals completed today."""
+    try:
+        from src.goals.repository import goal_repository
+
+        goals = await goal_repository.list_goals(status="completed")
+        today = date.today()
+        return [
+            g.title for g in goals
+            if g.updated_at and g.updated_at.date() == today
+        ]
+    except Exception:
+        logger.exception("Failed to get completed goals")
+        return []
+
 
 async def run_evening_review() -> None:
-    """Generate and send the evening review/summary to connected clients.
+    """Generate and send the evening review to connected clients."""
+    try:
+        from src.observer.manager import context_manager
 
-    Stub — will be implemented in Phase 3.4.
-    """
-    logger.info("evening_review ran")
+        ctx = await context_manager.refresh()
+
+        from src.memory.soul import read_soul
+        soul = read_soul()
+
+        # Gather today's data
+        message_count, completed_titles = await asyncio.gather(
+            _count_messages_today(),
+            _get_completed_goals_today(),
+        )
+
+        completed_text = ", ".join(completed_titles) if completed_titles else "None today"
+        git_text = f"{len(ctx.recent_git_activity)} commits" if ctx.recent_git_activity else "No git activity"
+        goals_text = ctx.active_goals_summary or "No active goals."
+
+        prompt = _REVIEW_PROMPT.format(
+            soul=soul,
+            message_count=message_count,
+            completed_goals=completed_text,
+            git_activity=git_text,
+            active_goals=goals_text,
+        )
+
+        import litellm
+
+        response = await asyncio.to_thread(
+            litellm.completion,
+            model=settings.default_model,
+            messages=[{"role": "user", "content": prompt}],
+            api_key=settings.openrouter_api_key,
+            api_base="https://openrouter.ai/api/v1",
+            temperature=0.6,
+            max_tokens=512,
+        )
+
+        review_text = response.choices[0].message.content.strip()
+
+        from src.observer.delivery import deliver_or_queue
+
+        message = WSResponse(
+            type="proactive",
+            content=review_text,
+            intervention_type="advisory",
+            urgency=2,
+            reasoning="Scheduled evening review",
+        )
+        await deliver_or_queue(message, is_scheduled=True)
+        logger.info("evening_review: delivered evening review")
+
+    except Exception:
+        logger.exception("evening_review failed")

--- a/backend/src/scheduler/jobs/strategist_tick.py
+++ b/backend/src/scheduler/jobs/strategist_tick.py
@@ -1,11 +1,50 @@
+"""Strategist tick — periodic strategic reasoning via restricted agent."""
+
+import asyncio
 import logging
+
+from src.agent.strategist import create_strategist_agent, parse_strategist_response
+from src.models.schemas import WSResponse
 
 logger = logging.getLogger(__name__)
 
 
 async def run_strategist_tick() -> None:
-    """Periodic strategic reasoning — review context and decide if proactive action needed.
+    """Review context and decide if proactive intervention is warranted."""
+    try:
+        from src.observer.manager import context_manager
 
-    Stub — will be implemented in Phase 3.3.
-    """
-    logger.info("strategist_tick ran")
+        ctx = await context_manager.refresh()
+        context_block = ctx.to_prompt_block()
+
+        agent = create_strategist_agent(context_block)
+        raw = await asyncio.to_thread(
+            agent.run,
+            "Analyze the current context and decide whether to intervene.",
+        )
+
+        decision = parse_strategist_response(str(raw))
+
+        if not decision.should_intervene:
+            logger.info("strategist_tick: no intervention needed — %s", decision.reasoning)
+            return
+
+        from src.observer.delivery import deliver_or_queue
+
+        message = WSResponse(
+            type="proactive",
+            content=decision.content,
+            intervention_type=decision.intervention_type,
+            urgency=decision.urgency,
+            reasoning=decision.reasoning,
+        )
+        result = await deliver_or_queue(message)
+        logger.info(
+            "strategist_tick: intervention sent (type=%s, urgency=%d, delivery=%s)",
+            decision.intervention_type,
+            decision.urgency,
+            result.value,
+        )
+
+    except Exception:
+        logger.exception("strategist_tick failed")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -23,6 +23,7 @@ _PATCH_TARGETS = [
     "src.api.settings.get_db",  # aliased: `import get_session as get_db`
     "src.scheduler.jobs.memory_consolidation.get_session",
     "src.observer.insight_queue.get_session",
+    "src.scheduler.jobs.evening_review.get_db_session",
 ]
 
 

--- a/backend/tests/test_daily_briefing.py
+++ b/backend/tests/test_daily_briefing.py
@@ -1,0 +1,147 @@
+"""Tests for daily briefing job."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.observer.context import CurrentContext
+from src.scheduler.jobs.daily_briefing import run_daily_briefing
+
+
+def _make_context(**overrides) -> CurrentContext:
+    defaults = dict(
+        time_of_day="morning",
+        day_of_week="Monday",
+        is_working_hours=True,
+        active_goals_summary="3 active goals",
+    )
+    defaults.update(overrides)
+    return CurrentContext(**defaults)
+
+
+def _mock_litellm_response(text: str):
+    """Create a mock litellm completion response."""
+    mock_choice = MagicMock()
+    mock_choice.message.content = text
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    return mock_response
+
+
+@pytest.mark.asyncio
+async def test_daily_briefing_happy_path():
+    ctx = _make_context()
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=ctx)
+
+    mock_deliver = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.memory.soul.read_soul", return_value="# Soul\nName: Hero"),
+        patch("src.memory.vector_store.search_formatted", return_value="- [fact] User likes mornings"),
+        patch("litellm.completion", return_value=_mock_litellm_response("Good morning, Hero! Here's your briefing...")),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        await run_daily_briefing()
+
+        mock_deliver.assert_called_once()
+        call_args = mock_deliver.call_args
+        msg = call_args[0][0]
+        assert msg.type == "proactive"
+        assert msg.intervention_type == "advisory"
+        assert "Good morning" in msg.content
+        # is_scheduled=True
+        assert call_args[1]["is_scheduled"] is True
+
+
+@pytest.mark.asyncio
+async def test_daily_briefing_context_refresh_failure():
+    """Context refresh failure → early return (exception caught)."""
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(side_effect=Exception("DB down"))
+
+    mock_deliver = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        # Should not raise — exception is caught internally
+        await run_daily_briefing()
+        mock_deliver.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_daily_briefing_llm_failure():
+    """LLM failure → early return (exception caught)."""
+    ctx = _make_context()
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=ctx)
+
+    mock_deliver = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.memory.soul.read_soul", return_value="# Soul"),
+        patch("src.memory.vector_store.search_formatted", return_value=""),
+        patch("litellm.completion", side_effect=Exception("LLM API error")),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        await run_daily_briefing()
+        mock_deliver.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_daily_briefing_empty_calendar_goals():
+    """Empty calendar/goals → still generates briefing."""
+    ctx = _make_context(upcoming_events=[], active_goals_summary="")
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=ctx)
+
+    mock_deliver = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.memory.soul.read_soul", return_value="# Soul"),
+        patch("src.memory.vector_store.search_formatted", return_value=""),
+        patch("litellm.completion", return_value=_mock_litellm_response("A quiet morning ahead.")),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        await run_daily_briefing()
+        mock_deliver.assert_called_once()
+        msg = mock_deliver.call_args[0][0]
+        assert "quiet morning" in msg.content
+
+
+@pytest.mark.asyncio
+async def test_daily_briefing_with_events():
+    """Calendar events are included in the prompt."""
+    ctx = _make_context(upcoming_events=[
+        {"summary": "Team standup", "start": "09:00"},
+        {"summary": "1:1 with manager", "start": "14:00"},
+    ])
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=ctx)
+
+    captured_prompt = {}
+
+    def mock_completion(**kwargs):
+        captured_prompt["messages"] = kwargs.get("messages", [])
+        return _mock_litellm_response("Briefing with events...")
+
+    mock_deliver = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.memory.soul.read_soul", return_value="# Soul"),
+        patch("src.memory.vector_store.search_formatted", return_value=""),
+        patch("litellm.completion", side_effect=mock_completion),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        await run_daily_briefing()
+
+        # Check that events were included in the prompt
+        prompt_text = captured_prompt["messages"][0]["content"]
+        assert "Team standup" in prompt_text
+        assert "1:1 with manager" in prompt_text

--- a/backend/tests/test_evening_review.py
+++ b/backend/tests/test_evening_review.py
@@ -1,0 +1,203 @@
+"""Tests for evening review job."""
+
+from datetime import datetime, date, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.observer.context import CurrentContext
+from src.scheduler.jobs.evening_review import (
+    run_evening_review,
+    _count_messages_today,
+    _get_completed_goals_today,
+)
+
+
+def _make_context(**overrides) -> CurrentContext:
+    defaults = dict(
+        time_of_day="evening",
+        day_of_week="Monday",
+        is_working_hours=False,
+        active_goals_summary="2 active goals",
+    )
+    defaults.update(overrides)
+    return CurrentContext(**defaults)
+
+
+def _mock_litellm_response(text: str):
+    mock_choice = MagicMock()
+    mock_choice.message.content = text
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    return mock_response
+
+
+@pytest.mark.asyncio
+async def test_evening_review_happy_path():
+    ctx = _make_context(recent_git_activity=[{"msg": "fix bug"}])
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=ctx)
+
+    mock_deliver = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.memory.soul.read_soul", return_value="# Soul\nName: Hero"),
+        patch("src.scheduler.jobs.evening_review._count_messages_today", AsyncMock(return_value=15)),
+        patch("src.scheduler.jobs.evening_review._get_completed_goals_today", AsyncMock(return_value=["Exercise"])),
+        patch("litellm.completion", return_value=_mock_litellm_response("Great day, Hero! You completed Exercise.")),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        await run_evening_review()
+
+        mock_deliver.assert_called_once()
+        call_args = mock_deliver.call_args
+        msg = call_args[0][0]
+        assert msg.type == "proactive"
+        assert msg.intervention_type == "advisory"
+        assert msg.urgency == 2
+        assert "Great day" in msg.content
+        assert call_args[1]["is_scheduled"] is True
+
+
+@pytest.mark.asyncio
+async def test_evening_review_no_completed_goals():
+    ctx = _make_context()
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=ctx)
+
+    captured_prompt = {}
+
+    def mock_completion(**kwargs):
+        captured_prompt["messages"] = kwargs.get("messages", [])
+        return _mock_litellm_response("Rest well tonight.")
+
+    mock_deliver = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.memory.soul.read_soul", return_value="# Soul"),
+        patch("src.scheduler.jobs.evening_review._count_messages_today", AsyncMock(return_value=5)),
+        patch("src.scheduler.jobs.evening_review._get_completed_goals_today", AsyncMock(return_value=[])),
+        patch("litellm.completion", side_effect=mock_completion),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        await run_evening_review()
+
+        mock_deliver.assert_called_once()
+        prompt_text = captured_prompt["messages"][0]["content"]
+        assert "None today" in prompt_text
+
+
+@pytest.mark.asyncio
+async def test_evening_review_no_messages_today():
+    ctx = _make_context()
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=ctx)
+
+    captured_prompt = {}
+
+    def mock_completion(**kwargs):
+        captured_prompt["messages"] = kwargs.get("messages", [])
+        return _mock_litellm_response("Quiet day.")
+
+    mock_deliver = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.memory.soul.read_soul", return_value="# Soul"),
+        patch("src.scheduler.jobs.evening_review._count_messages_today", AsyncMock(return_value=0)),
+        patch("src.scheduler.jobs.evening_review._get_completed_goals_today", AsyncMock(return_value=[])),
+        patch("litellm.completion", side_effect=mock_completion),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        await run_evening_review()
+
+        mock_deliver.assert_called_once()
+        prompt_text = captured_prompt["messages"][0]["content"]
+        assert "0" in prompt_text
+
+
+@pytest.mark.asyncio
+async def test_evening_review_db_query_failure():
+    """DB failure in context refresh → graceful catch."""
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(side_effect=Exception("DB error"))
+
+    mock_deliver = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        await run_evening_review()
+        mock_deliver.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evening_review_llm_failure():
+    """LLM failure → graceful catch."""
+    ctx = _make_context()
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=ctx)
+
+    mock_deliver = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.memory.soul.read_soul", return_value="# Soul"),
+        patch("src.scheduler.jobs.evening_review._count_messages_today", AsyncMock(return_value=0)),
+        patch("src.scheduler.jobs.evening_review._get_completed_goals_today", AsyncMock(return_value=[])),
+        patch("litellm.completion", side_effect=Exception("LLM down")),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        await run_evening_review()
+        mock_deliver.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_count_messages_today_db_failure():
+    """_count_messages_today returns 0 on DB failure."""
+    with patch(
+        "src.db.engine.get_session",
+        side_effect=Exception("DB error"),
+    ):
+        count = await _count_messages_today()
+        assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_get_completed_goals_today_db_failure():
+    """_get_completed_goals_today returns [] on failure."""
+    with patch(
+        "src.goals.repository.goal_repository",
+        MagicMock(list_goals=AsyncMock(side_effect=Exception("DB error"))),
+    ):
+        result = await _get_completed_goals_today()
+        assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_completed_goals_today_filters_by_date():
+    """Only returns goals completed today."""
+    today = date.today()
+    yesterday = date(today.year, today.month, today.day - 1) if today.day > 1 else today
+
+    goal_today = MagicMock()
+    goal_today.title = "Today goal"
+    goal_today.updated_at = datetime(today.year, today.month, today.day, 15, 0, tzinfo=timezone.utc)
+
+    goal_yesterday = MagicMock()
+    goal_yesterday.title = "Yesterday goal"
+    goal_yesterday.updated_at = datetime(yesterday.year, yesterday.month, yesterday.day, 10, 0, tzinfo=timezone.utc)
+
+    with patch(
+        "src.goals.repository.goal_repository",
+        MagicMock(list_goals=AsyncMock(return_value=[goal_today, goal_yesterday])),
+    ):
+        result = await _get_completed_goals_today()
+
+        assert "Today goal" in result
+        # Yesterday's goal should only be excluded if it's actually a different date
+        if yesterday != today:
+            assert "Yesterday goal" not in result

--- a/backend/tests/test_strategist.py
+++ b/backend/tests/test_strategist.py
@@ -1,0 +1,120 @@
+"""Tests for strategist agent — parse_strategist_response and create_strategist_agent."""
+
+from unittest.mock import patch, MagicMock
+
+from src.agent.strategist import (
+    StrategistDecision,
+    create_strategist_agent,
+    parse_strategist_response,
+)
+
+
+# ── parse_strategist_response tests ──────────────────────
+
+
+def test_parse_valid_json():
+    raw = '{"should_intervene": true, "content": "Time to stretch!", "intervention_type": "nudge", "urgency": 2, "reasoning": "User idle 30m"}'
+    result = parse_strategist_response(raw)
+
+    assert isinstance(result, StrategistDecision)
+    assert result.should_intervene is True
+    assert result.content == "Time to stretch!"
+    assert result.intervention_type == "nudge"
+    assert result.urgency == 2
+    assert result.reasoning == "User idle 30m"
+
+
+def test_parse_json_no_intervene():
+    raw = '{"should_intervene": false, "content": "", "intervention_type": "nudge", "urgency": 0, "reasoning": "All good"}'
+    result = parse_strategist_response(raw)
+
+    assert result.should_intervene is False
+    assert result.content == ""
+
+
+def test_parse_markdown_fenced_json():
+    raw = """```json
+{"should_intervene": true, "content": "Goal behind!", "intervention_type": "advisory", "urgency": 3, "reasoning": "Weekly goal overdue"}
+```"""
+    result = parse_strategist_response(raw)
+
+    assert result.should_intervene is True
+    assert result.content == "Goal behind!"
+    assert result.intervention_type == "advisory"
+
+
+def test_parse_invalid_json():
+    raw = "This is not JSON at all"
+    result = parse_strategist_response(raw)
+
+    assert result.should_intervene is False
+    assert "Parse failure" in result.reasoning
+
+
+def test_parse_empty_string():
+    result = parse_strategist_response("")
+
+    assert result.should_intervene is False
+    assert "Empty response" in result.reasoning
+
+
+def test_parse_none_like_string():
+    result = parse_strategist_response("   ")
+
+    assert result.should_intervene is False
+
+
+def test_parse_partial_json():
+    raw = '{"should_intervene": true}'
+    result = parse_strategist_response(raw)
+
+    assert result.should_intervene is True
+    assert result.content == ""
+    assert result.intervention_type == "nudge"
+    assert result.urgency == 3
+
+
+def test_parse_json_with_extra_fields():
+    raw = '{"should_intervene": false, "content": "", "intervention_type": "nudge", "urgency": 0, "reasoning": "OK", "extra": "ignored"}'
+    result = parse_strategist_response(raw)
+
+    assert result.should_intervene is False
+
+
+def test_parse_markdown_fenced_no_language():
+    raw = """```
+{"should_intervene": true, "content": "Check goals", "intervention_type": "nudge", "urgency": 2, "reasoning": "overdue"}
+```"""
+    result = parse_strategist_response(raw)
+
+    assert result.should_intervene is True
+    assert result.content == "Check goals"
+
+
+# ── create_strategist_agent tests ────────────────────────
+
+
+@patch("src.agent.strategist.LiteLLMModel")
+def test_create_strategist_agent_returns_agent(mock_model_cls):
+    mock_model_cls.return_value = MagicMock()
+    agent = create_strategist_agent("Time: morning\nGoals: 3 active")
+
+    assert agent is not None
+    assert len(agent.tools) == 4  # view_soul, get_goals, get_goal_progress + final_answer (built-in)
+
+
+@patch("src.agent.strategist.LiteLLMModel")
+def test_create_strategist_agent_model_temperature(mock_model_cls):
+    mock_model_cls.return_value = MagicMock()
+    create_strategist_agent("context")
+
+    call_kwargs = mock_model_cls.call_args[1]
+    assert call_kwargs["temperature"] == 0.4
+
+
+@patch("src.agent.strategist.LiteLLMModel")
+def test_create_strategist_agent_max_steps(mock_model_cls):
+    mock_model_cls.return_value = MagicMock()
+    agent = create_strategist_agent("context")
+
+    assert agent.max_steps == 5

--- a/frontend/src/components/HudButtons.tsx
+++ b/frontend/src/components/HudButtons.tsx
@@ -1,5 +1,12 @@
 import { useChatStore } from "../stores/chatStore";
 
+const AMBIENT_DOT_COLORS: Record<string, string> = {
+  goal_behind: "bg-red-500 animate-pulse",
+  on_track: "bg-green-500",
+  has_insight: "bg-yellow-400 animate-pulse",
+  waiting: "bg-blue-400 animate-pulse",
+};
+
 export function HudButtons() {
   const chatPanelOpen = useChatStore((s) => s.chatPanelOpen);
   const questPanelOpen = useChatStore((s) => s.questPanelOpen);
@@ -7,9 +14,13 @@ export function HudButtons() {
   const setChatPanelOpen = useChatStore((s) => s.setChatPanelOpen);
   const setQuestPanelOpen = useChatStore((s) => s.setQuestPanelOpen);
   const setSettingsPanelOpen = useChatStore((s) => s.setSettingsPanelOpen);
+  const ambientState = useChatStore((s) => s.ambientState);
+  const ambientTooltip = useChatStore((s) => s.ambientTooltip);
+
+  const dotClass = AMBIENT_DOT_COLORS[ambientState];
 
   return (
-    <div className="fixed bottom-4 left-4 z-50 flex gap-2">
+    <div className="fixed bottom-4 left-4 z-50 flex gap-2 items-center">
       {!chatPanelOpen && (
         <button
           onClick={() => setChatPanelOpen(true)}
@@ -36,6 +47,14 @@ export function HudButtons() {
         >
           Settings
         </button>
+      )}
+      {dotClass && (
+        <div
+          className={`rpg-frame w-5 h-5 flex items-center justify-center`}
+          title={ambientTooltip || ambientState}
+        >
+          <span className={`block w-2 h-2 rounded-full ${dotClass}`} />
+        </div>
       )}
     </div>
   );

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -142,6 +142,7 @@ export function useWebSocket() {
           // Phase 3: Ambient state change
           if (data.state) {
             setAmbientState(data.state as "idle" | "has_insight" | "goal_behind" | "on_track" | "waiting");
+            useChatStore.getState().setAmbientTooltip(data.tooltip ?? "");
             EventBus.emit("agent-ambient-state", {
               state: data.state,
               tooltip: data.tooltip ?? "",

--- a/frontend/src/stores/chatStore.ts
+++ b/frontend/src/stores/chatStore.ts
@@ -16,6 +16,7 @@ interface ChatStore {
   isAgentBusy: boolean;
   agentVisual: AgentVisualState;
   ambientState: AmbientState;
+  ambientTooltip: string;
   chatPanelOpen: boolean;
   chatMaximized: boolean;
   questPanelOpen: boolean;
@@ -31,6 +32,7 @@ interface ChatStore {
   setAgentVisual: (visual: Partial<AgentVisualState>) => void;
   resetAgentVisual: () => void;
   setAmbientState: (state: AmbientState) => void;
+  setAmbientTooltip: (tooltip: string) => void;
   setChatPanelOpen: (open: boolean) => void;
   toggleChatMaximized: () => void;
   setQuestPanelOpen: (open: boolean) => void;
@@ -64,6 +66,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   isAgentBusy: false,
   agentVisual: { ...defaultVisual },
   ambientState: "idle",
+  ambientTooltip: "",
   chatPanelOpen: true,
   chatMaximized: false,
   questPanelOpen: false,
@@ -94,6 +97,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   resetAgentVisual: () => set({ agentVisual: { ...defaultVisual } }),
 
   setAmbientState: (state) => set({ ambientState: state }),
+
+  setAmbientTooltip: (tooltip) => set({ ambientTooltip: tooltip }),
 
   setChatPanelOpen: (open) =>
     set({ chatPanelOpen: open, questPanelOpen: open ? false : get().questPanelOpen }),


### PR DESCRIPTION
## Summary
- **Strategist agent**: Restricted smolagents agent (`view_soul`, `get_goals`, `get_goal_progress`, temp=0.4, max_steps=5) that periodically analyzes context and decides whether to nudge, advise, or alert the user — routed through the Phase 3.3 attention guardian
- **Daily briefing & evening review**: LiteLLM-based scheduler jobs that gather soul/calendar/goals/memories/git context and generate narrative briefings, delivered with `is_scheduled=True` to bypass the delivery gate
- **Frontend ambient indicator**: Color-coded pulsing dot in HudButtons (red=goal_behind, green=on_track, yellow=has_insight, blue=waiting) with tooltip from ambient WS messages
- **Phaser nudge handler**: Speech bubble appears on agent sprite for 5s on nudge events, with proper timer cleanup

## Files changed
### New (4 + 3 tests)
- `backend/src/agent/strategist.py` — `StrategistDecision` dataclass, agent factory, JSON response parser
- `backend/tests/test_strategist.py` — 12 tests (parsing + agent creation)
- `backend/tests/test_daily_briefing.py` — 5 tests (happy path, failures, edge cases)
- `backend/tests/test_evening_review.py` — 8 tests (happy path, failures, date filtering)

### Modified (9)
- `backend/src/scheduler/jobs/strategist_tick.py` — replaced stub with full implementation
- `backend/src/scheduler/jobs/daily_briefing.py` — replaced stub with LiteLLM briefing generator
- `backend/src/scheduler/jobs/evening_review.py` — replaced stub with LiteLLM review generator
- `backend/src/observer/sources/screen_source.py` — comprehensive daemon API contract docstring
- `backend/tests/conftest.py` — added `evening_review.get_db_session` patch target
- `frontend/src/stores/chatStore.ts` — added `ambientTooltip` field + action
- `frontend/src/hooks/useWebSocket.ts` — stores tooltip on ambient messages
- `frontend/src/components/HudButtons.tsx` — ambient state indicator dot
- `frontend/src/game/scenes/StudyScene.ts` — nudge + ambient EventBus listeners with cleanup

## Test plan
- [x] All 25 new tests pass
- [x] All 173 passing tests still pass (0 regressions)
- [ ] Verify strategist_tick logs decisions in Docker dev environment
- [ ] Verify daily_briefing generates and delivers with `is_scheduled=True`
- [ ] Verify evening_review generates and delivers with `is_scheduled=True`
- [ ] Verify ambient `goal_behind` → red pulsing dot in HudButtons
- [ ] Verify nudge → speech bubble on agent sprite for 5s then hides
- [ ] Verify alert/advisory → chat panel opens (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)