### PR TITLE
docs: update CLAUDE.md and docs for Phase 3.4

### DIFF
--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Testing Guide
 
-Seraph has 182 automated tests (127 backend, 55 frontend) with CI running on every push and PR.
+Seraph has 207 automated tests (152 backend, 55 frontend) with CI running on every push and PR.
 
 ## Running Tests
 
@@ -60,6 +60,13 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_tool_registry.py` | 4 | Tool metadata registry — lookup, required fields, copy safety |
 | `test_tools.py` | 9 | Filesystem tools, template tool, web search |
 | `test_websocket.py` | 3 | WebSocket — ping/pong, invalid JSON, skip onboarding |
+| `test_delivery.py` | 9 | Delivery coordinator — deliver/queue/drop routing, budget decrement, bundle formatting |
+| `test_insight_queue.py` | 9 | Insight queue — enqueue, drain, peek, ordering, expiry |
+| `test_observer_manager.py` | 5 | ContextManager — refresh, state transitions, budget reset |
+| `test_user_state.py` | 9 | User state machine — derive_state, should_deliver, budget management |
+| `test_strategist.py` | 12 | Strategist agent — JSON parsing (valid, fenced, invalid, empty, partial), agent creation |
+| `test_daily_briefing.py` | 5 | Daily briefing — happy path, context/LLM failure, empty data, events in prompt |
+| `test_evening_review.py` | 8 | Evening review — happy path, no goals/messages, DB/LLM failure, date filtering |
 
 ### Frontend (`frontend/src/`)
 

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -105,11 +105,13 @@ Seraph can search the web, run code, manage your calendar, handle email, take no
 
 **Theme**: Seraph watches (with consent) and understands what the human is doing.
 
-### 3.1 Context Awareness Layer
-- **Active application detection** — What app/site is the user on?
+**Status**: Core infrastructure implemented (Phases 3.1–3.4). Background scheduler, context awareness, user state machine, strategist agent, daily briefing, evening review, and frontend ambient/nudge feedback are operational. Screen capture daemon, pattern detection, state inference, and avatar state reflection remain planned.
+
+### 3.1 Context Awareness Layer ✅
+- **Active application detection** — What app/site is the user on? *(API contract documented, daemon deferred)*
 - **Calendar awareness** — What's coming up? What just ended?
 - **Git activity monitoring** — Commits, branches, build status
-- **Idle/active detection** — Is the user at their machine?
+- **Idle/active detection** — Is the user at their machine? *(basic: last interaction tracking)*
 - All observation is opt-in, configurable per source, locally processed
 
 ### 3.2 Screen Context (Optional, Opt-In)
@@ -118,11 +120,15 @@ Seraph can search the web, run code, manage your calendar, handle email, take no
 - Never stores raw screenshots — only extracted semantic context
 - User controls frequency (never / every 5 min / every minute)
 
+*Status: Planned. Backend endpoint and `ContextManager.update_screen_context()` are ready. Native daemon deferred.*
+
 ### 3.3 Working Memory System
 - Real-time context buffer: what the user is doing *right now*
 - Combines: active task, recent messages, calendar, observations
 - Pruned aggressively — only the relevant survives
 - Fed to Strategist as "current situation" context
+
+*Status: Partially implemented via `CurrentContext.to_prompt_block()` — aggregates time, calendar, git, goals, screen context, and user state into a text block for agent injection.*
 
 ### 3.4 Pattern Detection Engine
 - Tracks over time: work hours, break patterns, productivity cycles
@@ -130,10 +136,14 @@ Seraph can search the web, run code, manage your calendar, handle email, take no
 - Identifies: recurring behaviors, habit formation/decay, stress signals
 - Stores patterns in long-term memory, not raw data
 
+*Status: Planned.*
+
 ### 3.5 State Inference
 - Estimates current human state: focused / distracted / stressed / energized / idle
 - Uses: typing speed, app switching frequency, time of day, calendar density
 - Feeds into Advisor's interruption intelligence
+
+*Status: Partially implemented. User state machine derives state from calendar + time + activity, but not from behavioral signals like typing speed or app switching.*
 
 ### 3.6 Avatar Reflects Human State
 - Avatar's idle behavior changes based on inferred state:
@@ -142,6 +152,8 @@ Seraph can search the web, run code, manage your calendar, handle email, take no
   - **Energized**: Avatar practices sword forms, bright scene
   - **Idle/resting**: Avatar sleeps, fireflies in scene
   - **Distracted**: Avatar looks around nervously
+
+*Status: Planned. Frontend ambient indicator dot and nudge speech bubble are implemented (Phase 3.4), but Phaser-level avatar animation changes are not yet wired.*
 
 ### Milestone
 Seraph sees what you're doing, understands your patterns, and its avatar mirrors your state.


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Added strategist agent, scheduler jobs, observer layer (context, user state, delivery, insight queue, sources), ambient tooltip in chatStore, ambient indicator in HudButtons
- **phase-3-the-observer.md**: Marked Phases 3.1–3.4 as implemented, updated strategist section to reflect actual implementation, updated implementation order and verification checklist
- **roadmap.md**: Added status annotations to Phase 3 subsections while preserving planned feature details for screen context, pattern detection, state inference, and avatar reflection
- **testing.md**: Added 7 new test files (delivery, insight queue, observer, user state, strategist, daily briefing, evening review), updated total count to 207

## Test plan
- [ ] Verify docs site builds correctly
- [ ] Review CLAUDE.md accuracy against codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)