### PR TITLE
feat: add ambient state bubble above user avatar

### DIFF
--- a/frontend/src/game/scenes/StudyScene.ts
+++ b/frontend/src/game/scenes/StudyScene.ts
@@ -356,9 +356,8 @@ export class StudyScene extends Phaser.Scene {
       });
     };
 
-    this.handleAmbientState = () => {
-      // No-op in Phaser scene — visual indicator is in React HudButtons layer.
-      // Registered for future Phaser-level effects (e.g., glow, particles).
+    this.handleAmbientState = (payload: { state: string; tooltip: string }) => {
+      this.userAvatar.setAmbientState(payload.state, payload.tooltip);
     };
 
     EventBus.on("agent-think", this.handleThink);
@@ -383,6 +382,7 @@ export class StudyScene extends Phaser.Scene {
 
   update() {
     this.speechBubble.updatePosition();
+    this.userAvatar.updateStatusPosition();
   }
 
   shutdown() {


### PR DESCRIPTION
## Summary
- Add a color-coded status bubble above the user's avatar in the Phaser village scene that reflects the current ambient state
- States: **Behind!** (red), **On Track** (green), **Insight** (yellow), **Waiting...** (blue) — hidden when idle
- Attention-drawing states (goal_behind, has_insight, waiting) pulse gently via scale tween
- Bubble tracks the sprite during bob and movement animations via `update()` loop
- Wires the previously no-op `agent-ambient-state` EventBus handler to `UserSprite.setAmbientState()`

## Test plan
- [x] All 55 frontend tests pass
- [ ] Verify bubble appears above user avatar when ambient state changes
- [ ] Verify bubble hides when state returns to idle
- [ ] Verify bubble follows avatar during bob animation
- [ ] Verify pulse animation on goal_behind/has_insight/waiting states

🤖 Generated with [Claude Code](https://claude.com/claude-code)