### PR TITLE
feat: native macOS screen daemon + IDE deep work detection (Phase 3.5)

### DIFF
--- a/backend/src/observer/sources/screen_source.py
+++ b/backend/src/observer/sources/screen_source.py
@@ -46,7 +46,13 @@ The data is then included in the next context refresh and available to the
 strategist agent and delivery gate for state derivation.
 
 ## Implementation Status
-The daemon is deferred to a future phase. The backend endpoint and
-ContextManager.update_screen_context() method are already implemented and
-ready to receive data when the daemon is built.
+The native macOS daemon is implemented in ``daemon/seraph_daemon.py``.
+It captures app name + window title (Level 0) and posts to the backend
+endpoint.  See ``daemon/README.md`` for setup, permissions, and usage.
+
+The backend endpoint and ContextManager.update_screen_context() method are
+implemented in ``src/api/observer.py`` and ``src/observer/manager.py``.
+
+For research on future upgrades (OCR, VLMs, cloud APIs), see
+``docs/docs/development/screen-daemon-research.md``.
 """

--- a/backend/src/observer/user_state.py
+++ b/backend/src/observer/user_state.py
@@ -7,6 +7,15 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# Apps that indicate focused/deep work when in the foreground
+_DEEP_WORK_APPS = (
+    "vs code", "visual studio code", "code",
+    "xcode", "intellij", "pycharm", "webstorm", "goland", "rider",
+    "neovim", "vim", "emacs",
+    "terminal", "iterm", "warp", "alacritty",
+    "cursor",
+)
+
 
 # ─── Enums ────────────────────────────────────────────────
 
@@ -69,6 +78,12 @@ class UserStateMachine:
         # 2. In meeting
         if current_event:
             return UserState.in_meeting
+
+        # 2.5 Active window — IDE/terminal detected → deep work (if no calendar event)
+        if active_window and not current_event:
+            app_lower = active_window.lower()
+            if any(ide in app_lower for ide in _DEEP_WORK_APPS):
+                return UserState.deep_work
 
         # 3. Transition detection — previous state was blocked, now cleared
         if previous_state in {s.value for s in _BLOCKED_STATES} and not current_event:

--- a/backend/tests/test_user_state.py
+++ b/backend/tests/test_user_state.py
@@ -156,6 +156,50 @@ class TestDeriveState:
         )
         assert state == UserState.available
 
+    def test_ide_window_triggers_deep_work(self, sm):
+        state = sm.derive_state(
+            current_event=None,
+            previous_state="available",
+            time_of_day="morning",
+            is_working_hours=True,
+            last_interaction=datetime.now(timezone.utc),
+            active_window="VS Code — main.py",
+        )
+        assert state == UserState.deep_work
+
+    def test_terminal_triggers_deep_work(self, sm):
+        state = sm.derive_state(
+            current_event=None,
+            previous_state="available",
+            time_of_day="morning",
+            is_working_hours=True,
+            last_interaction=datetime.now(timezone.utc),
+            active_window="iTerm2 — ~/projects",
+        )
+        assert state == UserState.deep_work
+
+    def test_calendar_overrides_ide(self, sm):
+        state = sm.derive_state(
+            current_event="Standup",
+            previous_state="available",
+            time_of_day="morning",
+            is_working_hours=True,
+            last_interaction=datetime.now(timezone.utc),
+            active_window="VS Code — main.py",
+        )
+        assert state == UserState.in_meeting
+
+    def test_non_ide_window_stays_available(self, sm):
+        state = sm.derive_state(
+            current_event=None,
+            previous_state="available",
+            time_of_day="morning",
+            is_working_hours=True,
+            last_interaction=datetime.now(timezone.utc),
+            active_window="Chrome — YouTube",
+        )
+        assert state == UserState.available
+
     def test_focus_keyword_case_insensitive(self, sm):
         state = sm.derive_state(
             current_event="DEEP WORK session",

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -1,0 +1,126 @@
+# Seraph Native macOS Daemon
+
+Lightweight polling daemon that captures the active window (app name + window title) and posts it to the Seraph backend. Runs natively on macOS — outside Docker.
+
+## Prerequisites
+
+- macOS 13+ (Ventura or later)
+- Python 3.12+
+
+## Install
+
+```bash
+cd daemon
+pip install -r requirements.txt
+```
+
+## Run
+
+```bash
+python seraph_daemon.py
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--url` | `http://localhost:8004` | Backend base URL |
+| `--interval` | `5` | Poll interval in seconds |
+| `--idle-timeout` | `300` | Seconds of inactivity before skipping POSTs |
+| `--verbose` | off | Log every context POST |
+
+Example with all options:
+
+```bash
+python seraph_daemon.py --url http://localhost:8004 --interval 3 --idle-timeout 600 --verbose
+```
+
+## Permissions
+
+### Accessibility (required for window titles)
+
+The daemon uses AppleScript to read the frontmost window title, which requires the Accessibility permission.
+
+**To grant:**
+1. Open **System Settings > Privacy & Security > Accessibility**
+2. Click the **+** button
+3. Add your terminal app (Terminal.app, iTerm2, Warp, etc.)
+4. Toggle it **on**
+
+This is a one-time grant — macOS will not nag you about it again.
+
+### What is NOT needed
+
+- **Screen Recording** — not needed. The daemon never captures screenshots or pixel data.
+- **Full Disk Access** — not needed.
+- **Input Monitoring** — not needed. Idle detection uses `CGEventSourceSecondsSinceLastEventType` which only returns a duration, not individual keystrokes.
+
+## What Data is Captured
+
+| Captured | Example | How |
+|----------|---------|-----|
+| App name | `VS Code` | `NSWorkspace` (no permission) |
+| Window title | `main.py — seraph` | AppleScript (Accessibility) |
+| Idle duration | `312.5` seconds | `CGEventSource` (no permission) |
+
+**Not captured:** screenshots, keystrokes, screen content, clipboard, file contents.
+
+The daemon posts to `POST /api/observer/context`:
+```json
+{
+  "active_window": "VS Code — main.py",
+  "screen_context": null
+}
+```
+
+## How It Works
+
+1. Every `--interval` seconds, checks if the user is idle (no input for `--idle-timeout` seconds)
+2. If idle, skips the POST and logs once
+3. If active, reads the frontmost app name and window title
+4. If the value has changed since the last POST, sends it to the backend
+5. If the backend is unreachable, logs a warning and continues polling
+
+## Running as a launchd Service (Optional)
+
+To run the daemon automatically on login, create `~/Library/LaunchAgents/ai.seraph.daemon.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.seraph.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/python3</string>
+    <string>/path/to/seraph/daemon/seraph_daemon.py</string>
+    <string>--verbose</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/seraph-daemon.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/seraph-daemon.log</string>
+</dict>
+</plist>
+```
+
+Then load it:
+```bash
+launchctl load ~/Library/LaunchAgents/ai.seraph.daemon.plist
+```
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| "No window title" / title is always None | Accessibility permission not granted | Grant permission in System Settings (see above) |
+| "Backend not reachable" warnings | Backend not running or wrong URL | Start backend with `./manage.sh -e dev up -d` |
+| Daemon exits immediately | Python missing PyObjC | Run `pip install -r requirements.txt` |
+| High CPU usage | Interval too low | Increase `--interval` (default 5s is fine) |

--- a/daemon/requirements.txt
+++ b/daemon/requirements.txt
@@ -1,0 +1,3 @@
+pyobjc-framework-Cocoa>=11.0
+pyobjc-framework-Quartz>=11.0
+httpx>=0.27.0

--- a/daemon/seraph_daemon.py
+++ b/daemon/seraph_daemon.py
@@ -1,0 +1,227 @@
+"""Seraph native macOS daemon — captures active window context and posts to backend.
+
+Polls the frontmost application name and window title, posting changes to the
+Seraph backend's /api/observer/context endpoint.  Runs natively on macOS
+(outside Docker) and requires only the Accessibility permission for window titles.
+
+Usage:
+    python seraph_daemon.py [--url URL] [--interval SECS] [--idle-timeout SECS] [--verbose]
+"""
+
+import argparse
+import asyncio
+import logging
+import signal
+import subprocess
+import sys
+import time
+
+import httpx
+
+logger = logging.getLogger("seraph_daemon")
+
+# ─── macOS helpers ────────────────────────────────────────
+
+
+def get_frontmost_app_name() -> str | None:
+    """Return the localized name of the frontmost application via NSWorkspace.
+
+    Requires no special permissions.
+    """
+    try:
+        from AppKit import NSWorkspace
+
+        app = NSWorkspace.sharedWorkspace().frontmostApplication()
+        return app.localizedName() if app else None
+    except Exception:
+        logger.debug("NSWorkspace call failed", exc_info=True)
+        return None
+
+
+def get_window_title() -> str | None:
+    """Return the title of the frontmost window via AppleScript.
+
+    Requires the Accessibility permission (System Settings > Privacy & Security
+    > Accessibility).  Returns None if permission is not granted or no window
+    is open.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "osascript",
+                "-e",
+                'tell application "System Events" to get name of first window '
+                "of (first application process whose frontmost is true)",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        title = result.stdout.strip()
+        return title if title else None
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    except Exception:
+        logger.debug("osascript call failed", exc_info=True)
+        return None
+
+
+def get_idle_seconds() -> float:
+    """Return seconds since last user input event (mouse/keyboard).
+
+    Uses Quartz Event Services — no special permission required.
+    """
+    try:
+        import Quartz
+
+        return Quartz.CGEventSourceSecondsSinceLastEventType(
+            Quartz.kCGEventSourceStateCombinedSessionState,
+            Quartz.kCGAnyInputEventType,
+        )
+    except Exception:
+        logger.debug("Quartz idle check failed", exc_info=True)
+        return 0.0
+
+
+def format_active_window(app_name: str | None, window_title: str | None) -> str | None:
+    """Format the active window string for the backend."""
+    if not app_name:
+        return None
+    if window_title:
+        return f"{app_name} \u2014 {window_title}"
+    return app_name
+
+
+# ─── Main loop ────────────────────────────────────────────
+
+
+async def poll_loop(
+    url: str,
+    interval: float,
+    idle_timeout: float,
+    verbose: bool,
+) -> None:
+    """Core polling loop — detect window changes, post to backend."""
+    last_posted: str | None = None
+    was_idle = False
+
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        while True:
+            try:
+                # Check idle state
+                idle_secs = get_idle_seconds()
+                is_idle = idle_secs > idle_timeout
+
+                if is_idle:
+                    if not was_idle:
+                        idle_min = int(idle_timeout / 60)
+                        logger.info("idle (%dm)", idle_min)
+                        was_idle = True
+                    await asyncio.sleep(interval)
+                    continue
+
+                if was_idle:
+                    logger.info("active again")
+                    was_idle = False
+
+                # Get current window
+                app_name = get_frontmost_app_name()
+                window_title = get_window_title()
+                active_window = format_active_window(app_name, window_title)
+
+                # Skip if unchanged
+                if active_window == last_posted:
+                    await asyncio.sleep(interval)
+                    continue
+
+                # Post to backend
+                try:
+                    await client.post(
+                        f"{url}/api/observer/context",
+                        json={
+                            "active_window": active_window,
+                            "screen_context": None,
+                        },
+                    )
+                    if verbose:
+                        ts = time.strftime("%H:%M:%S")
+                        logger.info("[%s] \u2192 %s", ts, active_window)
+                    last_posted = active_window
+                except httpx.ConnectError:
+                    logger.warning("Backend not reachable at %s — will retry", url)
+                except httpx.HTTPError as exc:
+                    logger.warning("HTTP error posting context: %s", exc)
+
+            except Exception:
+                logger.exception("Unexpected error in poll loop")
+
+            await asyncio.sleep(interval)
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Seraph macOS screen daemon")
+    parser.add_argument(
+        "--url",
+        default="http://localhost:8004",
+        help="Backend base URL (default: http://localhost:8004)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=5,
+        help="Poll interval in seconds (default: 5)",
+    )
+    parser.add_argument(
+        "--idle-timeout",
+        type=float,
+        default=300,
+        help="Seconds of inactivity before marking idle (default: 300)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Log every context POST",
+    )
+    args = parser.parse_args()
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(message)s",
+        stream=sys.stdout,
+    )
+
+    # Clean shutdown on signals
+    loop = asyncio.get_running_loop()
+    stop_event = asyncio.Event()
+
+    def _shutdown(sig: int) -> None:
+        logger.info("Received %s — shutting down", signal.Signals(sig).name)
+        stop_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, _shutdown, sig)
+
+    logger.info(
+        "Seraph daemon started — polling every %gs, idle timeout %gs, backend %s",
+        args.interval,
+        args.idle_timeout,
+        args.url,
+    )
+
+    poll_task = asyncio.create_task(
+        poll_loop(args.url, args.interval, args.idle_timeout, args.verbose)
+    )
+
+    await stop_event.wait()
+    poll_task.cancel()
+    try:
+        await poll_task
+    except asyncio.CancelledError:
+        pass
+
+    logger.info("Daemon stopped")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/docs/development/screen-daemon-research.md
+++ b/docs/docs/development/screen-daemon-research.md
@@ -1,0 +1,123 @@
+---
+sidebar_position: 6
+---
+
+# Screen Daemon Research
+
+Research notes for upgrading the Seraph native macOS daemon beyond app name + window title.
+
+## macOS APIs for Screen Context
+
+| API | Permission Required | Data Available | Notes |
+|-----|-------------------|----------------|-------|
+| `NSWorkspace.sharedWorkspace()` | None | App name, bundle ID, launch date | No prompt, works immediately |
+| Accessibility API (AX) | Accessibility (one-time grant) | Window title, UI element tree, focused element | Single prompt, user grants once |
+| `CGWindowListCopyWindowInfo` | Screen Recording | Window bounds, on-screen list, owner PID | Prompted per-app |
+| `ScreenCaptureKit` | Screen Recording | Full screenshot, window capture, audio | Sequoia: monthly re-confirmation nag |
+| AppleScript via `osascript` | Accessibility | Window title, app properties | Uses AX under the hood |
+
+**Current implementation (Level 0):** NSWorkspace (no permission) + AppleScript window title (Accessibility permission). This gives us app name + window title with minimal friction.
+
+## Local Vision Models
+
+For future screenshot understanding (Level 2):
+
+| Model | Params | RAM (Apple Silicon) | Speed (M1 Pro) | Notes |
+|-------|--------|--------------------:|-----------------|-------|
+| FastVLM 0.5B | 500M | ~1-2 GB | ~0.5s/frame | Apple's own model, MLX-native, optimized for Apple Silicon |
+| Moondream 0.5B | 500M | ~1-2 GB | ~1s/frame | Strong on UI understanding, good at describing screen content |
+| SmolVLM2 500M | 500M | <1 GB | ~0.8s/frame | HuggingFace, smallest footprint |
+| Qwen2-VL 2B | 2B | ~3-4 GB | ~2s/frame | More capable but heavier |
+
+**Recommendation:** FastVLM 0.5B or Moondream 0.5B. Both fit comfortably in memory alongside other apps and process a frame in under 1 second on Apple Silicon.
+
+## Cloud Vision API Costs
+
+Monthly cost estimates for an 8-hour workday (22 working days/month), assuming ~500 tokens per image description:
+
+| Model | Cost/Image | 1/min ($$/mo) | 1/5min ($$/mo) | 1/30min ($$/mo) |
+|-------|-----------|---------------:|----------------:|----------------:|
+| Gemini Flash-Lite | $0.000042 | $0.44 | $0.09 | $0.01 |
+| GPT-4o (low detail) | $0.000213 | $2.25 | $0.45 | $0.08 |
+| Claude 3.5 Haiku | $0.001488 | $15.63 | $3.13 | $0.52 |
+| Claude 3.5 Sonnet | $0.004800 | $50.69 | $10.14 | $1.69 |
+
+**Calculation basis:** 8 hours x 60 min = 480 calls/day at 1/min. 22 days/month.
+
+**Takeaway:** Gemini Flash-Lite is essentially free even at 1/min. GPT-4o low is ~$2/mo. Cloud VLMs are viable for infrequent polling (1/5min or less).
+
+## OCR-Only Approach
+
+Apple's Vision framework provides `VNRecognizeTextRequest`:
+
+- **Speed:** ~200ms per full-screen capture on Apple Silicon
+- **Accuracy:** Near-perfect for rendered text (UI elements, code, documents)
+- **Permission:** Requires Screen Recording (screenshot capture)
+- **Output:** Structured text with bounding boxes and confidence scores
+
+### Advantages
+- No GPU memory pressure (CPU-based)
+- Output is plain text — cheap to send as LLM context tokens
+- Deterministic, no hallucination risk
+- Works offline
+
+### Limitations
+- Loses visual layout context (can't distinguish sidebar from main content)
+- Can't interpret images, charts, or non-text UI
+- Noisy output for complex UIs (captures every label, button, menu item)
+
+### Alternative: Tesseract
+- Cross-platform but significantly slower (~1-2s per frame)
+- Lower accuracy on macOS UI text compared to Apple Vision
+- Not recommended when running on macOS
+
+## Hybrid Recommendation
+
+The best approach combines OCR and VLM at different frequencies:
+
+```
+OCR every 10-30s:
+  → Extract visible text (file paths, function names, error messages)
+  → Cheap, fast, deterministic
+  → Feed as context tokens to strategist
+
+VLM every 1-5min (on change):
+  → Capture what the user is doing at a high level
+  → "User is debugging a test failure in the terminal"
+  → Richer context but more expensive
+```
+
+This gives the strategist both precise text context (from OCR) and high-level activity understanding (from VLM) without excessive cost or battery drain.
+
+## Language Comparison for Daemon
+
+| Language | Pros | Cons |
+|----------|------|------|
+| **Python + PyObjC** (chosen) | Same ecosystem as backend, easy to prototype, PyObjC is mature | Slightly higher memory footprint (~30-50MB), not a native binary |
+| Swift | First-class macOS APIs, smallest binary, best permission UX | Separate build toolchain, harder to iterate, different language from backend |
+| Rust + objc2 | Cross-platform potential, small binary | Overkill for this use case, immature macOS bindings, long compile times |
+
+**Decision:** Python + PyObjC. The daemon is simple enough that Python's overhead is negligible, and sharing the language with the backend reduces maintenance burden. If performance becomes an issue (e.g., running VLM inference), we can move to Swift for the capture loop and keep Python for the HTTP client.
+
+## Permission UX (macOS TCC)
+
+macOS uses Transparency, Consent, and Control (TCC) for privacy permissions:
+
+- **Accessibility:** One-time prompt. Once granted, persists until the app is removed or user revokes manually. Needed for window titles.
+- **Screen Recording:** Per-app prompt. Starting with macOS Sequoia (15.0), the system nags users monthly to re-confirm. This is the main UX friction point for screenshot-based approaches.
+
+### Sequoia Monthly Nag
+macOS 15+ shows a monthly system notification: _"[App] has been recording your screen. Do you want to continue allowing this?"_ This cannot be suppressed programmatically. Users who find this annoying may revoke permission.
+
+**Implication:** For Level 0 (app + title), we only need Accessibility — no monthly nag. Moving to Level 1+ (OCR/screenshots) will trigger the nag. This should be clearly communicated to users.
+
+## Recommended Upgrade Path
+
+| Level | Capability | Permission | Daemon Changes |
+|-------|-----------|------------|----------------|
+| **0 (current)** | App name + window title | Accessibility | `seraph_daemon.py` as shipped |
+| **1** | + OCR text extraction | + Screen Recording | Add `VNRecognizeTextRequest` capture, POST `screen_context` with extracted text |
+| **2** | + Local VLM descriptions | + Screen Recording | Add FastVLM/Moondream inference, structured activity summary |
+| **3** | + Cloud VLM (on-demand) | + Screen Recording | Add cloud API call for complex scenes, hybrid with local VLM |
+
+Each level is additive. The daemon's `--level` flag (future) would control which capture pipeline runs. The backend API already accepts both `active_window` and `screen_context` fields, so no backend changes are needed for any level.


### PR DESCRIPTION
## Summary
- Add lightweight macOS polling daemon (`daemon/`) that captures active window context (app name + window title via NSWorkspace/AppleScript) and POSTs to the backend — runs natively outside Docker, requires only Accessibility permission
- Enhance `UserStateMachine.derive_state()` to detect IDE/terminal apps as a deep work signal (priority between calendar events and transition detection)
- Add comprehensive research doc covering future upgrade path: OCR, local VLMs, cloud vision APIs, permission UX

## Test plan
- [x] All 43 user state tests pass (including 4 new: IDE→deep_work, terminal→deep_work, calendar overrides IDE, non-IDE→available)
- [ ] `cd daemon && python seraph_daemon.py --verbose` starts without errors on macOS
- [ ] Daemon logs window switches: `[HH:MM:SS] → VS Code — main.py`
- [ ] Daemon skips POSTs when window unchanged
- [ ] Daemon logs idle transition after `--idle-timeout` seconds
- [ ] Daemon handles backend-down gracefully (warning, continues polling)
- [ ] With backend running: `curl localhost:8004/api/observer/state` shows `active_window` after daemon POST

🤖 Generated with [Claude Code](https://claude.com/claude-code)