### PR TITLE
fix: daemon run.sh venv creation and suppress httpx debug logs

### DIFF
--- a/daemon/run.sh
+++ b/daemon/run.sh
@@ -24,10 +24,17 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$SCRIPT_DIR/.venv"
 
-# Sync dependencies via uv
+# Create venv if it doesn't exist
+if [ ! -d "$VENV_DIR" ]; then
+    echo "Creating virtual environment..."
+    uv venv "$VENV_DIR"
+fi
+
+# Sync dependencies
 echo "Syncing dependencies..."
-uv pip install -q -r "$SCRIPT_DIR/requirements.txt" --directory "$SCRIPT_DIR"
+uv pip install -q -r "$SCRIPT_DIR/requirements.txt" -p "$VENV_DIR/bin/python"
 
 # Run the daemon, passing through all arguments
-exec uv run --directory "$SCRIPT_DIR" python "$SCRIPT_DIR/seraph_daemon.py" "$@"
+exec "$VENV_DIR/bin/python" "$SCRIPT_DIR/seraph_daemon.py" "$@"

--- a/daemon/seraph_daemon.py
+++ b/daemon/seraph_daemon.py
@@ -184,12 +184,16 @@ async def main() -> None:
     )
     args = parser.parse_args()
 
-    level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(
-        level=level,
+        level=logging.INFO,
         format="%(message)s",
         stream=sys.stdout,
     )
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+    # Suppress noisy httpx/httpcore debug logs
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
 
     # Clean shutdown on signals
     loop = asyncio.get_running_loop()


### PR DESCRIPTION
## Summary
- Fix `run.sh` to create a uv venv before installing deps (was failing with "No virtual environment found")
- Suppress httpx/httpcore debug logs that cluttered `--verbose` output — only the daemon's own logger is set to DEBUG now

## Test plan
- [x] `./daemon/run.sh --verbose` creates venv, installs deps, starts daemon
- [x] Verbose output shows clean `[HH:MM:SS] → App — Title` lines without httpx internals

🤖 Generated with [Claude Code](https://claude.com/claude-code)