### PR TITLE
fix: remove broken conftest patch target causing 104 test errors

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -23,7 +23,6 @@ _PATCH_TARGETS = [
     "src.api.settings.get_db",  # aliased: `import get_session as get_db`
     "src.scheduler.jobs.memory_consolidation.get_session",
     "src.observer.insight_queue.get_session",
-    "src.scheduler.jobs.evening_review.get_db_session",
 ]
 
 


### PR DESCRIPTION
## Summary
- Remove invalid patch target `src.scheduler.jobs.evening_review.get_db_session` from `tests/conftest.py`
- `evening_review.py` imports `get_session` locally inside `_count_messages_today()`, so it's never a module-level attribute — the patch always failed with `AttributeError`
- The import is already covered by the existing `src.db.engine.get_session` patch target

## Test plan
- [x] `uv run pytest -v` — 281 passed, 0 errors (was 177 passed, 104 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)