### PR TITLE
docs: update phase status, roadmap, and sidebar for Phase 3.5

### DIFF
--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Testing Guide
 
-Seraph has 207 automated tests (152 backend, 55 frontend) with CI running on every push and PR.
+Seraph has 336 automated tests (281 backend, 55 frontend) with CI running on every push and PR.
 
 ## Running Tests
 
@@ -63,7 +63,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_delivery.py` | 9 | Delivery coordinator — deliver/queue/drop routing, budget decrement, bundle formatting |
 | `test_insight_queue.py` | 9 | Insight queue — enqueue, drain, peek, ordering, expiry |
 | `test_observer_manager.py` | 5 | ContextManager — refresh, state transitions, budget reset |
-| `test_user_state.py` | 9 | User state machine — derive_state, should_deliver, budget management |
+| `test_user_state.py` | 13 | User state machine — derive_state (incl. IDE deep work detection), should_deliver, budget management |
 | `test_strategist.py` | 12 | Strategist agent — JSON parsing (valid, fenced, invalid, empty, partial), agent creation |
 | `test_daily_briefing.py` | 5 | Daily briefing — happy path, context/LLM failure, empty data, events in prompt |
 | `test_evening_review.py` | 8 | Evening review — happy path, no goals/messages, DB/LLM failure, date filtering |

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -90,8 +90,8 @@ See [Testing Guide](./development/testing) for full details.
 
 ## Current Status
 
-- **Phase 0** (Foundation): Complete
+- **Phase 0** (Foundation): Complete — chat, WebSocket streaming, Phaser village, day/night cycle
 - **Phase 1** (Persistent Identity): Complete — DB, soul/memory, goals, onboarding, quest UI, two-pane chat sidebar, session auto-naming, sprite tooltips, chat maximize/close controls, HUD panel buttons, session persistence (localStorage)
-- **Phase 2** (Capable Executor): Complete — shell, browser, calendar, email, plugin system
-- **Phase 3** (The Observer): Planned — scheduler, context awareness, proactive reasoning
+- **Phase 2** (Capable Executor): Complete — shell, browser, calendar, email, plugin system, MCP integrations (Things3)
+- **Phase 3** (The Observer): Complete (3.1–3.5) — background scheduler, context awareness, user state machine, proactive strategist, daily briefing, evening review, attention guardian, insight queue, ambient/nudge frontend, native macOS screen daemon
 - **Phase 4** (The Network): Planned — SKILL.md ecosystem, multi-channel messaging, workflows, multi-agent, voice, canvas, remote access

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -8,11 +8,11 @@ sidebar_position: 2
 
 ---
 
-## Phase 0 — Foundation (Current State)
+## Phase 0 — Foundation
 
 **Status**: Complete
 
-What exists today:
+What was built:
 - Chat interface with WebSocket streaming
 - 4 tools (web search, file read/write, template fill)
 - Animated RPG avatar in Phaser 3 village scene
@@ -105,7 +105,7 @@ Seraph can search the web, run code, manage your calendar, handle email, take no
 
 **Theme**: Seraph watches (with consent) and understands what the human is doing.
 
-**Status**: Core infrastructure implemented (Phases 3.1–3.4). Background scheduler, context awareness, user state machine, strategist agent, daily briefing, evening review, and frontend ambient/nudge feedback are operational. Screen capture daemon, pattern detection, state inference, and avatar state reflection remain planned.
+**Status**: Complete (Phases 3.1–3.5). Background scheduler, context awareness, user state machine, strategist agent, daily briefing, evening review, frontend ambient/nudge feedback, and native macOS screen daemon are all operational. Pattern detection, behavioral state inference, and avatar state reflection remain planned for future iterations.
 
 ### 3.1 Context Awareness Layer ✅
 - **Active application detection** — What app/site is the user on? *(API contract documented, daemon deferred)*

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -15,6 +15,8 @@ const sidebars: SidebarsConfig = {
         'development/phase-1-persistent-identity',
         'development/phase-2-capable-executor',
         'development/phase-3-the-observer',
+        'development/phase-4-the-network',
+        'development/screen-daemon-research',
       ],
     },
     {


### PR DESCRIPTION
## Summary
- Update `intro.md` — Phase 3 status from "Planned" to "Complete (3.1-3.5)", fix Phase 0/2 descriptions
- Update `roadmap.md` — Phase 0 no longer "Current State", Phase 3 status reflects 3.5 completion
- Rewrite `phase-3-the-observer.md` daemon section (was "Deferred", now "Implemented" with full details), update verification checklist and implementation order
- Add Phase 4 and Screen Daemon Research to sidebar navigation
- Update `testing.md` test count: 336 total (281 backend + 55 frontend)

## Test plan
- [x] Docs build locally
- [ ] Verify sidebar shows Phase 4 and Screen Daemon Research links
- [ ] Verify phase status is accurate across all docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)