### PR TITLE
feat: daemon OCR — Apple Vision + OpenRouter providers

### DIFF
--- a/backend/src/observer/context.py
+++ b/backend/src/observer/context.py
@@ -72,6 +72,10 @@ class CurrentContext:
         if self.active_window:
             lines.append(f"User is in: {self.active_window}")
 
+        if self.screen_context:
+            sc = self.screen_context[:500] + "..." if len(self.screen_context) > 500 else self.screen_context
+            lines.append(f"Screen content: {sc}")
+
         if self.last_interaction:
             delta = datetime.now(timezone.utc) - self.last_interaction
             minutes_ago = int(delta.total_seconds() / 60)

--- a/backend/src/observer/manager.py
+++ b/backend/src/observer/manager.py
@@ -157,9 +157,15 @@ class ContextManager:
         self._context.last_interaction = datetime.now(timezone.utc)
 
     def update_screen_context(self, active_window: str | None, screen_context: str | None) -> None:
-        """Update screen context from native daemon POST."""
-        self._context.active_window = active_window
-        self._context.screen_context = screen_context
+        """Update screen context from native daemon POST.
+
+        Supports partial updates — only overwrites fields that are non-None,
+        so the window loop and OCR loop don't clobber each other's data.
+        """
+        if active_window is not None:
+            self._context.active_window = active_window
+        if screen_context is not None:
+            self._context.screen_context = screen_context
 
     def decrement_attention_budget(self) -> None:
         """Reduce attention budget by 1 (minimum 0)."""

--- a/backend/tests/test_observer_api.py
+++ b/backend/tests/test_observer_api.py
@@ -34,7 +34,8 @@ class TestObserverAPI:
         assert mgr.get_context().screen_context == "Running tests"
 
     @pytest.mark.asyncio
-    async def test_post_screen_context_null(self, client):
+    async def test_post_screen_context_null_preserves(self, client):
+        """Posting None fields should not overwrite existing values (partial update)."""
         mgr = ContextManager()
         mgr.update_screen_context("VS Code", "Editing")
         with patch("src.api.observer.context_manager", mgr):
@@ -44,7 +45,9 @@ class TestObserverAPI:
             })
 
         assert resp.status_code == 200
-        assert mgr.get_context().active_window is None
+        # None means "don't overwrite" — previous values preserved
+        assert mgr.get_context().active_window == "VS Code"
+        assert mgr.get_context().screen_context == "Editing"
 
     @pytest.mark.asyncio
     async def test_post_refresh(self, client):

--- a/backend/tests/test_observer_manager.py
+++ b/backend/tests/test_observer_manager.py
@@ -105,13 +105,30 @@ class TestContextManagerUpdates:
         assert ctx.active_window == "Safari"
         assert ctx.screen_context == "Reading docs"
 
-    def test_update_screen_context_none(self):
+    def test_update_screen_context_partial_preserves_fields(self):
+        """None means 'don't touch' — partial updates don't clobber each other."""
         mgr = ContextManager()
         mgr.update_screen_context("Safari", "Reading docs")
         mgr.update_screen_context(None, None)
         ctx = mgr.get_context()
-        assert ctx.active_window is None
-        assert ctx.screen_context is None
+        assert ctx.active_window == "Safari"
+        assert ctx.screen_context == "Reading docs"
+
+    def test_update_screen_context_partial_window_only(self):
+        mgr = ContextManager()
+        mgr.update_screen_context("Safari", "Reading docs")
+        mgr.update_screen_context("VS Code", None)
+        ctx = mgr.get_context()
+        assert ctx.active_window == "VS Code"
+        assert ctx.screen_context == "Reading docs"
+
+    def test_update_screen_context_partial_screen_only(self):
+        mgr = ContextManager()
+        mgr.update_screen_context("Safari", "Reading docs")
+        mgr.update_screen_context(None, "New OCR text")
+        ctx = mgr.get_context()
+        assert ctx.active_window == "Safari"
+        assert ctx.screen_context == "New OCR text"
 
 
 class TestCurrentContextSerialization:

--- a/daemon/ocr/__init__.py
+++ b/daemon/ocr/__init__.py
@@ -1,0 +1,33 @@
+"""OCR provider package — factory for creating providers."""
+
+from ocr.base import OCRProvider
+
+
+def create_provider(
+    name: str,
+    api_key: str | None = None,
+    model: str | None = None,
+) -> OCRProvider:
+    """Create an OCR provider by name.
+
+    Args:
+        name: "apple-vision" or "openrouter"
+        api_key: Required for openrouter provider
+        model: Model name for openrouter (has default)
+
+    Raises:
+        ValueError: Unknown provider or missing api_key for openrouter
+    """
+    if name == "apple-vision":
+        from ocr.apple_vision import AppleVisionProvider
+
+        return AppleVisionProvider()
+
+    if name == "openrouter":
+        if not api_key:
+            raise ValueError("OpenRouter provider requires --openrouter-api-key or OPENROUTER_API_KEY env var")
+        from ocr.openrouter import OpenRouterProvider
+
+        return OpenRouterProvider(api_key=api_key, model=model)
+
+    raise ValueError(f"Unknown OCR provider: {name!r} (choose 'apple-vision' or 'openrouter')")

--- a/daemon/ocr/apple_vision.py
+++ b/daemon/ocr/apple_vision.py
@@ -1,0 +1,98 @@
+"""Apple Vision framework OCR provider — local, offline text extraction."""
+
+import asyncio
+import logging
+import time
+
+from ocr.base import OCRProvider, OCRResult
+
+logger = logging.getLogger("seraph_daemon")
+
+
+class AppleVisionProvider(OCRProvider):
+    """OCR using macOS Vision framework (VNRecognizeTextRequest).
+
+    Runs entirely on-device. ~200ms per full-screen capture on Apple Silicon.
+    """
+
+    @property
+    def name(self) -> str:
+        return "apple-vision"
+
+    def is_available(self) -> bool:
+        try:
+            import Vision  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    async def extract_text(self, png_bytes: bytes) -> OCRResult:
+        """Extract text from PNG bytes using Vision framework.
+
+        Wraps the synchronous Vision call in asyncio.to_thread to avoid
+        blocking the event loop.
+        """
+        return await asyncio.to_thread(self._extract_sync, png_bytes)
+
+    def _extract_sync(self, png_bytes: bytes) -> OCRResult:
+        start = time.monotonic()
+        try:
+            import Vision
+            from AppKit import NSImage
+
+            # Load PNG into NSImage → CGImage
+            ns_image = NSImage.alloc().initWithData_(png_bytes)
+            if ns_image is None:
+                return OCRResult(
+                    text="", provider=self.name, duration_ms=0,
+                    success=False, error="Failed to load PNG into NSImage",
+                )
+
+            # Get CGImage from NSImage
+            cg_image = ns_image.CGImageForProposedRect_context_hints_(None, None, None)
+            if cg_image is None:
+                return OCRResult(
+                    text="", provider=self.name, duration_ms=0,
+                    success=False, error="Failed to get CGImage from NSImage",
+                )
+
+            # Create and configure text recognition request
+            request = Vision.VNRecognizeTextRequest.alloc().init()
+            request.setRecognitionLevel_(Vision.VNRequestTextRecognitionLevelAccurate)
+            request.setUsesLanguageCorrection_(True)
+
+            # Run the request
+            handler = Vision.VNImageRequestHandler.alloc().initWithCGImage_options_(
+                cg_image, None,
+            )
+            success, error = handler.performRequests_error_([request], None)
+
+            if not success:
+                duration_ms = int((time.monotonic() - start) * 1000)
+                return OCRResult(
+                    text="", provider=self.name, duration_ms=duration_ms,
+                    success=False, error=str(error) if error else "VNImageRequestHandler failed",
+                )
+
+            # Extract text from observations
+            results = request.results()
+            lines = []
+            for observation in results or []:
+                candidates = observation.topCandidates_(1)
+                if candidates and len(candidates) > 0:
+                    lines.append(candidates[0].string())
+
+            text = "\n".join(lines)
+            duration_ms = int((time.monotonic() - start) * 1000)
+
+            return OCRResult(
+                text=text, provider=self.name, duration_ms=duration_ms, success=True,
+            )
+
+        except Exception as exc:
+            duration_ms = int((time.monotonic() - start) * 1000)
+            return OCRResult(
+                text="", provider=self.name, duration_ms=duration_ms,
+                success=False, error=str(exc),
+            )

--- a/daemon/ocr/base.py
+++ b/daemon/ocr/base.py
@@ -1,0 +1,31 @@
+"""OCR provider interface and result dataclass."""
+
+import abc
+from dataclasses import dataclass
+
+
+@dataclass
+class OCRResult:
+    text: str
+    provider: str
+    duration_ms: int
+    success: bool
+    error: str | None = None
+
+
+class OCRProvider(abc.ABC):
+    """Abstract base for OCR providers."""
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str: ...
+
+    @abc.abstractmethod
+    async def extract_text(self, png_bytes: bytes) -> OCRResult:
+        """Extract text from a PNG screenshot."""
+        ...
+
+    @abc.abstractmethod
+    def is_available(self) -> bool:
+        """Check if this provider can run (dependencies / keys present)."""
+        ...

--- a/daemon/ocr/openrouter.py
+++ b/daemon/ocr/openrouter.py
@@ -1,0 +1,102 @@
+"""OpenRouter cloud OCR provider — uses vision models via OpenRouter API."""
+
+import base64
+import logging
+import time
+
+import httpx
+
+from ocr.base import OCRProvider, OCRResult
+
+logger = logging.getLogger("seraph_daemon")
+
+_DEFAULT_MODEL = "google/gemini-2.0-flash-lite-001"
+
+_SYSTEM_PROMPT = (
+    "You are a screen reader. Describe the visible text on screen concisely. "
+    "Focus on: file names, code, error messages, document titles, URLs, and UI labels. "
+    "Output plain text only, no markdown."
+)
+
+
+class OpenRouterProvider(OCRProvider):
+    """OCR using a cloud vision model via OpenRouter."""
+
+    def __init__(self, api_key: str, model: str | None = None) -> None:
+        self._api_key = api_key
+        self._model = model or _DEFAULT_MODEL
+        self._client: httpx.AsyncClient | None = None
+
+    @property
+    def name(self) -> str:
+        return "openrouter"
+
+    def is_available(self) -> bool:
+        return bool(self._api_key)
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=30.0)
+        return self._client
+
+    async def extract_text(self, png_bytes: bytes) -> OCRResult:
+        """Send screenshot to OpenRouter vision model for text extraction."""
+        start = time.monotonic()
+        try:
+            b64 = base64.b64encode(png_bytes).decode("ascii")
+            client = self._get_client()
+
+            response = await client.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": self._model,
+                    "messages": [
+                        {"role": "system", "content": _SYSTEM_PROMPT},
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": f"data:image/png;base64,{b64}",
+                                        "detail": "low",
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                    "max_tokens": 500,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            text = data["choices"][0]["message"]["content"].strip()
+            duration_ms = int((time.monotonic() - start) * 1000)
+
+            return OCRResult(
+                text=text, provider=self.name, duration_ms=duration_ms, success=True,
+            )
+
+        except httpx.HTTPStatusError as exc:
+            duration_ms = int((time.monotonic() - start) * 1000)
+            return OCRResult(
+                text="", provider=self.name, duration_ms=duration_ms,
+                success=False, error=f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
+            )
+        except Exception as exc:
+            duration_ms = int((time.monotonic() - start) * 1000)
+            return OCRResult(
+                text="", provider=self.name, duration_ms=duration_ms,
+                success=False, error=str(exc),
+            )
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None

--- a/daemon/ocr/screenshot.py
+++ b/daemon/ocr/screenshot.py
@@ -1,0 +1,74 @@
+"""Screenshot capture via macOS Quartz APIs.
+
+Captures the full screen as in-memory PNG bytes. Never writes to disk.
+Requires Screen Recording permission (System Settings > Privacy & Security > Screen Recording).
+"""
+
+import logging
+
+logger = logging.getLogger("seraph_daemon")
+
+# Track whether we've already warned about missing permission
+_warned_no_permission = False
+
+
+def capture_screen_png() -> bytes | None:
+    """Capture the full screen and return PNG bytes, or None on failure.
+
+    Returns None if Screen Recording permission is not granted (logs warning once).
+    """
+    global _warned_no_permission
+
+    try:
+        import Quartz
+        from AppKit import NSBitmapImageRep, NSPNGFileType
+
+        # Capture the full screen
+        image = Quartz.CGWindowListCreateImage(
+            Quartz.CGRectInfinite,
+            Quartz.kCGWindowListOptionOnScreenOnly,
+            Quartz.kCGNullWindowID,
+            Quartz.kCGWindowImageDefault,
+        )
+
+        if image is None:
+            if not _warned_no_permission:
+                logger.warning(
+                    "Screen capture returned None — Screen Recording permission likely not granted. "
+                    "Grant permission in System Settings > Privacy & Security > Screen Recording."
+                )
+                _warned_no_permission = True
+            return None
+
+        # Check if the image has meaningful content (permission denied returns a tiny image)
+        width = Quartz.CGImageGetWidth(image)
+        height = Quartz.CGImageGetHeight(image)
+        if width < 100 or height < 100:
+            if not _warned_no_permission:
+                logger.warning(
+                    "Screen capture returned a %dx%d image — Screen Recording permission likely not granted.",
+                    width,
+                    height,
+                )
+                _warned_no_permission = True
+            return None
+
+        # Reset warning flag on success
+        _warned_no_permission = False
+
+        # Convert CGImage → PNG bytes via NSBitmapImageRep
+        bitmap = NSBitmapImageRep.alloc().initWithCGImage_(image)
+        png_data = bitmap.representationUsingType_properties_(NSPNGFileType, {})
+
+        if png_data is None:
+            logger.warning("Failed to convert screenshot to PNG")
+            return None
+
+        return bytes(png_data)
+
+    except ImportError:
+        logger.error("Quartz/AppKit not available — are you running on macOS with PyObjC?")
+        return None
+    except Exception:
+        logger.exception("Unexpected error capturing screenshot")
+        return None

--- a/daemon/requirements.txt
+++ b/daemon/requirements.txt
@@ -1,3 +1,4 @@
 pyobjc-framework-Cocoa>=11.0
 pyobjc-framework-Quartz>=11.0
+pyobjc-framework-Vision>=11.0
 httpx>=0.27.0

--- a/daemon/run.sh
+++ b/daemon/run.sh
@@ -9,15 +9,24 @@
 # Runs natively on macOS — outside Docker.
 #
 # Usage:
-#   ./daemon/run.sh                  # Default: poll every 5s, backend at :8004
-#   ./daemon/run.sh --verbose        # Log every context POST
-#   ./daemon/run.sh --interval 3     # Poll every 3 seconds
-#   ./daemon/run.sh --help           # Show all options
+#   ./daemon/run.sh                     # Default: window polling every 5s
+#   ./daemon/run.sh --verbose           # Log every context POST
+#   ./daemon/run.sh --interval 3        # Poll every 3 seconds
+#
+# OCR (opt-in, requires Screen Recording permission):
+#   ./daemon/run.sh --ocr --verbose                        # Local Apple Vision (free, offline, ~200ms)
+#   ./daemon/run.sh --ocr --ocr-interval 15 --verbose      # Local OCR every 15s instead of 30s
+#   ./daemon/run.sh --ocr --ocr-provider openrouter        # Cloud via Gemini Flash 1.5 8B (~$0.09/mo)
+#   ./daemon/run.sh --ocr --ocr-provider openrouter \
+#     --ocr-model google/gemini-2.0-flash-lite-001 --verbose     # Cloud with explicit model
+#
+#   ./daemon/run.sh --help              # Show all options
 #
 # Prerequisites:
 #   - macOS 13+ with Python 3.12+
 #   - Accessibility permission for your terminal app
 #     (System Settings > Privacy & Security > Accessibility)
+#   - Screen Recording permission (only if using --ocr)
 #
 # ==============================================================================
 
@@ -35,6 +44,9 @@ fi
 # Sync dependencies
 echo "Syncing dependencies..."
 uv pip install -q -r "$SCRIPT_DIR/requirements.txt" -p "$VENV_DIR/bin/python"
+
+# Forward OPENROUTER_API_KEY if set (used by --ocr-provider openrouter)
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY:-}"
 
 # Run the daemon, passing through all arguments
 exec "$VENV_DIR/bin/python" "$SCRIPT_DIR/seraph_daemon.py" "$@"

--- a/docs/docs/development/screen-daemon-research.md
+++ b/docs/docs/development/screen-daemon-research.md
@@ -37,14 +37,14 @@ Monthly cost estimates for an 8-hour workday (22 working days/month), assuming ~
 
 | Model | Cost/Image | 1/min ($$/mo) | 1/5min ($$/mo) | 1/30min ($$/mo) |
 |-------|-----------|---------------:|----------------:|----------------:|
-| Gemini Flash-Lite | $0.000042 | $0.44 | $0.09 | $0.01 |
+| Gemini 2.0 Flash Lite | $0.000042 | $0.44 | $0.09 | $0.01 |
 | GPT-4o (low detail) | $0.000213 | $2.25 | $0.45 | $0.08 |
 | Claude 3.5 Haiku | $0.001488 | $15.63 | $3.13 | $0.52 |
 | Claude 3.5 Sonnet | $0.004800 | $50.69 | $10.14 | $1.69 |
 
 **Calculation basis:** 8 hours x 60 min = 480 calls/day at 1/min. 22 days/month.
 
-**Takeaway:** Gemini Flash-Lite is essentially free even at 1/min. GPT-4o low is ~$2/mo. Cloud VLMs are viable for infrequent polling (1/5min or less).
+**Takeaway:** Gemini 2.0 Flash Lite (`google/gemini-2.0-flash-lite-001`) is essentially free even at 1/min. GPT-4o low is ~$2/mo. Cloud VLMs are viable for infrequent polling (1/5min or less).
 
 ## OCR-Only Approach
 
@@ -115,8 +115,8 @@ macOS 15+ shows a monthly system notification: _"[App] has been recording your s
 
 | Level | Capability | Permission | Daemon Changes |
 |-------|-----------|------------|----------------|
-| **0 (current)** | App name + window title | Accessibility | `seraph_daemon.py` as shipped |
-| **1** | + OCR text extraction | + Screen Recording | Add `VNRecognizeTextRequest` capture, POST `screen_context` with extracted text |
+| **0** | App name + window title | Accessibility | `seraph_daemon.py` (default, no `--ocr` flag) |
+| **1 (implemented)** | + OCR text extraction | + Screen Recording | `--ocr` flag, pluggable providers: `apple-vision` (local) or `openrouter` (cloud) |
 | **2** | + Local VLM descriptions | + Screen Recording | Add FastVLM/Moondream inference, structured activity summary |
 | **3** | + Cloud VLM (on-demand) | + Screen Recording | Add cloud API call for complex scenes, hybrid with local VLM |
 


### PR DESCRIPTION
## Summary
- Add opt-in OCR screen text extraction to the native macOS daemon (`--ocr` flag)
- Pluggable provider system: **Apple Vision** (local, free, ~200ms) and **OpenRouter** (cloud, Gemini 2.0 Flash Lite, ~$0.09/mo)
- Dual-loop architecture: window polling stays at 5s, OCR runs on a separate slower loop (default 30s)
- Fix backend `update_screen_context()` for partial updates so the two loops don't clobber each other
- Add extracted screen text to the strategist's prompt block

## New files
- `daemon/ocr/base.py` — `OCRResult` dataclass + `OCRProvider` ABC
- `daemon/ocr/__init__.py` — factory function `create_provider()`
- `daemon/ocr/screenshot.py` — Quartz screenshot capture (in-memory only)
- `daemon/ocr/apple_vision.py` — local `VNRecognizeTextRequest` provider
- `daemon/ocr/openrouter.py` — cloud vision model provider

## Modified files
- `daemon/seraph_daemon.py` — OCR loop + CLI args
- `daemon/requirements.txt` — add `pyobjc-framework-Vision`
- `daemon/run.sh` — expanded examples, forward `OPENROUTER_API_KEY`
- `backend/src/observer/manager.py` — partial update fix
- `backend/src/observer/context.py` — screen_context in prompt block
- Tests, README, research doc, CLAUDE.md

## Test plan
- [ ] `./daemon/run.sh --ocr --verbose` — verify Apple Vision OCR posts appear
- [ ] `OPENROUTER_API_KEY=... ./daemon/run.sh --ocr --ocr-provider openrouter --verbose` — verify cloud OCR
- [ ] Revoke Screen Recording permission → daemon logs warning, continues window-only
- [ ] `curl localhost:8004/api/observer/state` → verify `screen_context` populated
- [ ] Verify window loop and OCR loop don't overwrite each other's fields
- [ ] `cd backend && uv run pytest tests/ -v` — 283 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)