### PR TITLE
fix: OCR compatibility on macOS Tahoe + scheduler event loop crash

### DIFF
--- a/daemon/ocr/screenshot.py
+++ b/daemon/ocr/screenshot.py
@@ -1,10 +1,13 @@
-"""Screenshot capture via macOS Quartz APIs.
+"""Screenshot capture via macOS APIs.
 
-Captures the full screen as in-memory PNG bytes. Never writes to disk.
+Captures the full screen as in-memory PNG bytes.
 Requires Screen Recording permission (System Settings > Privacy & Security > Screen Recording).
 """
 
 import logging
+import subprocess
+import tempfile
+from pathlib import Path
 
 logger = logging.getLogger("seraph_daemon")
 
@@ -15,21 +18,86 @@ _warned_no_permission = False
 def capture_screen_png() -> bytes | None:
     """Capture the full screen and return PNG bytes, or None on failure.
 
+    Uses macOS `screencapture` CLI for maximum compatibility with Sequoia+
+    and Tahoe permission models. Falls back to Quartz API if screencapture
+    is unavailable. Screenshot file is deleted immediately after reading.
+
     Returns None if Screen Recording permission is not granted (logs warning once).
     """
+    global _warned_no_permission
+
+    png_bytes = _capture_via_screencapture()
+    if png_bytes is None:
+        png_bytes = _capture_via_quartz()
+
+    if png_bytes is None:
+        return None
+
+    # Sanity check: a valid full-screen PNG should be at least a few KB.
+    if len(png_bytes) < 5000:
+        if not _warned_no_permission:
+            logger.warning(
+                "Screenshot PNG suspiciously small (%d bytes) — "
+                "Screen Recording permission may not be fully active.",
+                len(png_bytes),
+            )
+            _warned_no_permission = True
+        return None
+
+    _warned_no_permission = False
+    return png_bytes
+
+
+def _capture_via_screencapture() -> bytes | None:
+    """Capture using macOS screencapture CLI — most reliable on newer macOS."""
+    global _warned_no_permission
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        # -x: no sound, -C: capture cursor, -t png: format
+        result = subprocess.run(
+            ["screencapture", "-x", "-C", "-t", "png", str(tmp_path)],
+            capture_output=True,
+            timeout=5,
+        )
+
+        if result.returncode != 0:
+            logger.debug("screencapture exited with code %d", result.returncode)
+            tmp_path.unlink(missing_ok=True)
+            return None
+
+        if not tmp_path.exists() or tmp_path.stat().st_size == 0:
+            tmp_path.unlink(missing_ok=True)
+            return None
+
+        png_bytes = tmp_path.read_bytes()
+        tmp_path.unlink(missing_ok=True)
+        return png_bytes
+
+    except FileNotFoundError:
+        logger.debug("screencapture command not found")
+        return None
+    except subprocess.TimeoutExpired:
+        logger.warning("screencapture timed out")
+        tmp_path.unlink(missing_ok=True)
+        return None
+    except Exception:
+        logger.debug("screencapture failed", exc_info=True)
+        return None
+
+
+def _capture_via_quartz() -> bytes | None:
+    """Fallback capture using Quartz CGDisplayCreateImage."""
     global _warned_no_permission
 
     try:
         import Quartz
         from AppKit import NSBitmapImageRep, NSPNGFileType
 
-        # Capture the full screen
-        image = Quartz.CGWindowListCreateImage(
-            Quartz.CGRectInfinite,
-            Quartz.kCGWindowListOptionOnScreenOnly,
-            Quartz.kCGNullWindowID,
-            Quartz.kCGWindowImageDefault,
-        )
+        main_display = Quartz.CGMainDisplayID()
+        image = Quartz.CGDisplayCreateImage(main_display)
 
         if image is None:
             if not _warned_no_permission:
@@ -40,23 +108,19 @@ def capture_screen_png() -> bytes | None:
                 _warned_no_permission = True
             return None
 
-        # Check if the image has meaningful content (permission denied returns a tiny image)
         width = Quartz.CGImageGetWidth(image)
         height = Quartz.CGImageGetHeight(image)
         if width < 100 or height < 100:
             if not _warned_no_permission:
                 logger.warning(
-                    "Screen capture returned a %dx%d image — Screen Recording permission likely not granted.",
+                    "Screen capture returned a %dx%d image — Screen Recording permission "
+                    "likely not granted.",
                     width,
                     height,
                 )
                 _warned_no_permission = True
             return None
 
-        # Reset warning flag on success
-        _warned_no_permission = False
-
-        # Convert CGImage → PNG bytes via NSBitmapImageRep
         bitmap = NSBitmapImageRep.alloc().initWithCGImage_(image)
         png_data = bitmap.representationUsingType_properties_(NSPNGFileType, {})
 
@@ -70,5 +134,5 @@ def capture_screen_png() -> bytes | None:
         logger.error("Quartz/AppKit not available — are you running on macOS with PyObjC?")
         return None
     except Exception:
-        logger.exception("Unexpected error capturing screenshot")
+        logger.exception("Unexpected error in Quartz capture")
         return None


### PR DESCRIPTION
## Summary
- **OCR**: NSImage → CGImage roundtrip produces empty pixel buffers on macOS 15+/Tahoe. Switches to `screencapture` CLI (with Quartz fallback) and feeds raw PNG bytes directly to Vision via `initWithData:options:` — bypasses the broken conversion path.
- **Scheduler**: All 6 background jobs (strategist, memory consolidation, calendar scan, goal check, daily briefing, evening review) crashed with `RuntimeError: no current event loop in thread` because APScheduler 3.x runs jobs in a ThreadPoolExecutor. Captures the running loop at init time and uses `asyncio.run_coroutine_threadsafe()`.

## Test plan
- [ ] `./daemon/run.sh --ocr --verbose` — OCR captures screen text successfully
- [ ] `./manage.sh -e dev logs -f backend-dev` — no more "no current event loop" errors from scheduler jobs
- [ ] Scheduler jobs (strategist_tick, memory_consolidation, calendar_scan) run on schedule without exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)