### PR TITLE
fix: batch 2 — WS protocol, observer & daemon polish

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -42,6 +42,7 @@ class Settings(BaseSettings):
     working_hours_start: int = 9
     working_hours_end: int = 17
     observer_git_repo_path: str = ""
+    deep_work_apps: str = ""  # comma-separated extra app keywords for deep work detection
 
     model_config = {"env_file": ".env.dev", "env_file_encoding": "utf-8"}
 

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -29,6 +29,7 @@ class WSResponse(BaseModel):
     content: str = ""
     session_id: str = ""
     step: int | None = None
+    seq: int | None = None
     # Phase 3 — Proactive messages
     urgency: int | None = None
     intervention_type: str | None = None

--- a/backend/src/observer/context.py
+++ b/backend/src/observer/context.py
@@ -38,6 +38,9 @@ class CurrentContext:
     previous_user_state: str = "available"
     attention_budget_last_reset: Optional[datetime] = None
 
+    # Data quality — "good" if all sources succeeded, "degraded" if some failed, "stale" if all failed
+    data_quality: str = "good"
+
     def to_dict(self) -> dict:
         """Serialize for API responses."""
         data = asdict(self)

--- a/backend/src/observer/manager.py
+++ b/backend/src/observer/manager.py
@@ -18,6 +18,7 @@ class ContextManager:
     def __init__(self) -> None:
         self._context = CurrentContext()
         self._lock = asyncio.Lock()
+        self._transition_epoch = 0  # guards against duplicate bundle deliveries
 
     def get_context(self) -> CurrentContext:
         """Return current snapshot (sync, non-blocking)."""
@@ -33,11 +34,16 @@ class ContextManager:
         async with self._lock:
             old = self._context
 
+            # Track source success for data quality
+            sources_ok = 0
+            sources_total = 4
+
             # Time source (sync, pure computation)
             time_data: dict = {}
             try:
                 from src.observer.sources.time_source import gather_time
                 time_data = gather_time()
+                sources_ok += 1
             except Exception:
                 logger.exception("Time source failed")
 
@@ -46,6 +52,7 @@ class ContextManager:
             try:
                 from src.observer.sources.calendar_source import gather_calendar
                 calendar_data = await gather_calendar()
+                sources_ok += 1
             except Exception:
                 logger.exception("Calendar source failed during refresh")
 
@@ -56,6 +63,7 @@ class ContextManager:
                 result = gather_git()
                 if result:
                     git_data = result
+                sources_ok += 1
             except Exception:
                 logger.exception("Git source failed")
 
@@ -64,8 +72,17 @@ class ContextManager:
             try:
                 from src.observer.sources.goal_source import gather_goals
                 goal_data = await gather_goals()
+                sources_ok += 1
             except Exception:
                 logger.exception("Goal source failed")
+
+            # Derive data quality
+            if sources_ok == sources_total:
+                data_quality = "good"
+            elif sources_ok == 0:
+                data_quality = "stale"
+            else:
+                data_quality = "degraded"
 
             # Derive user state from gathered sources
             new_user_state = user_state_machine.derive_state(
@@ -102,20 +119,29 @@ class ContextManager:
                 # Phase 3.3 tracking
                 previous_user_state=old.user_state,
                 attention_budget_last_reset=last_reset,
+                data_quality=data_quality,
             )
 
             # Detect blocked → unblocked transition and deliver queued bundle
             if old.user_state in _BLOCKED_STATES and new_user_state in _UNBLOCKED_STATES:
+                self._transition_epoch += 1
+                epoch = self._transition_epoch
                 logger.info(
-                    "State transition %s → %s — delivering queued bundle",
-                    old.user_state, new_user_state,
+                    "State transition %s → %s (epoch=%d) — delivering queued bundle",
+                    old.user_state, new_user_state, epoch,
                 )
-                asyncio.create_task(self._deliver_bundle())
+                asyncio.create_task(self._deliver_bundle(epoch))
 
             return self._context
 
-    async def _deliver_bundle(self) -> None:
-        """Background task to deliver queued bundle after state transition."""
+    async def _deliver_bundle(self, epoch: int) -> None:
+        """Background task to deliver queued bundle after state transition.
+
+        Uses epoch to skip delivery if another transition happened in the meantime.
+        """
+        if epoch != self._transition_epoch:
+            logger.info("Skipping bundle delivery — epoch %d superseded by %d", epoch, self._transition_epoch)
+            return
         try:
             from src.observer.delivery import deliver_queued_bundle
             await deliver_queued_bundle()
@@ -128,25 +154,29 @@ class ContextManager:
         current_budget: int,
         last_reset: datetime | None,
     ) -> tuple[int, datetime | None]:
-        """Reset attention budget at morning_briefing_hour if not yet reset today."""
+        """Reset attention budget at morning_briefing_hour if not yet reset today.
+
+        Uses date-based comparison to be immune to NTP clock skew.
+        """
         from config.settings import settings
 
         now = datetime.now(timezone.utc)
         reset_hour = settings.morning_briefing_hour
 
         if last_reset is None:
-            # First time — set budget to default and record reset
             default = user_state_machine.get_default_budget(mode)
             return default, now
 
-        # Check if we've passed the reset hour today and haven't reset yet
-        today_reset = last_reset.replace(hour=reset_hour, minute=0, second=0, microsecond=0)
-        if last_reset < today_reset <= now:
+        last_date = last_reset.date()
+        today = now.date()
+
+        # New day and past the reset hour
+        if today > last_date and now.hour >= reset_hour:
             default = user_state_machine.get_default_budget(mode)
             return default, now
 
-        # Check next-day rollover
-        if now.date() > last_reset.date() and now.hour >= reset_hour:
+        # Same day but crossed the reset hour since last reset
+        if today == last_date and last_reset.hour < reset_hour <= now.hour:
             default = user_state_machine.get_default_budget(mode)
             return default, now
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -22,6 +22,7 @@ export interface WSResponse {
   content: string;
   session_id: string;
   step: number | null;
+  seq: number | null;
   urgency?: number;
   intervention_type?: string;
   reasoning?: string;


### PR DESCRIPTION
## Summary
Closes #50

**WebSocket Protocol (3 items)**
- **Message sequence IDs**: all WS messages now include a `seq` counter for proper client-side ordering
- **Session load race**: `switchSession()` now waits for `loadSessions()` to complete on reconnect
- **Reconnection backoff**: exponential backoff 3s → 30s max, resets on successful connect

**Observer & Scheduler (4 items)**
- **Timezone validation**: invalid `USER_TIMEZONE` logs a warning with help text and falls back to UTC
- **Budget date-based reset**: uses date comparison instead of timestamp math (immune to NTP clock skew)
- **Context staleness indicator**: new `data_quality` field (good/degraded/stale) based on source success count
- **Transition lock**: epoch counter prevents duplicate bundle deliveries on rapid context refreshes

**Daemon (2 items)**
- **Customizable deep work apps**: new `DEEP_WORK_APPS` env var (comma-separated keywords) extends the built-in list
- **Daemon heartbeat**: logs "alive" every 5 minutes for liveness monitoring

## Test plan
- [x] `uv run pytest -v` — all 283 tests pass
- [x] `npx tsc --noEmit` — clean TypeScript compilation
- [ ] Rebuild: `./manage.sh -e dev up -d --build`
- [ ] WS messages include `seq` field in browser DevTools
- [ ] Set invalid `USER_TIMEZONE=Foo` → logs warning, scheduler uses UTC
- [ ] Set `DEEP_WORK_APPS=figma,notion` → those apps trigger deep_work state
- [ ] Daemon logs "heartbeat" every 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)