### PR TITLE
docs: add Phase 5 to sidebar

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -17,6 +17,7 @@ const sidebars: SidebarsConfig = {
         'development/phase-2-capable-executor',
         'development/phase-3-the-observer',
         'development/phase-4-the-network',
+        'development/phase-5-security',
         'development/screen-daemon-research',
       ],
     },


### PR DESCRIPTION
## Summary
- Add Phase 5 (Security) to the Docusaurus sidebar navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)