### PR TITLE
fix: use Vite publicDir for editor asset serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ docker-data
 .claude/settings.local.json
 backend/data/mcp-servers.json
 seraph-quest.github.io/
+.vite/

--- a/editor/vite.config.ts
+++ b/editor/vite.config.ts
@@ -1,37 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
-import fs from "fs";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const frontendPublic = path.resolve(__dirname, "../frontend/public");
 
 export default defineConfig({
-  plugins: [
-    react(),
-    {
-      name: "serve-frontend-assets",
-      configureServer(server) {
-        // Serve /assets/* from ../frontend/public/assets/
-        server.middlewares.use("/assets", (req, res, next) => {
-          const filePath = path.join(frontendPublic, "assets", req.url ?? "");
-          if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
-            const ext = path.extname(filePath).toLowerCase();
-            const mimeTypes: Record<string, string> = {
-              ".png": "image/png",
-              ".jpg": "image/jpeg",
-              ".json": "application/json",
-            };
-            res.setHeader("Content-Type", mimeTypes[ext] ?? "application/octet-stream");
-            fs.createReadStream(filePath).pipe(res);
-          } else {
-            next();
-          }
-        });
-      },
-    },
-  ],
+  plugins: [react()],
+  publicDir: frontendPublic,
   server: {
     port: 3001,
     fs: { allow: ["..", frontendPublic] },


### PR DESCRIPTION
## Summary
- Replace custom Connect middleware with Vite's built-in `publicDir` to serve frontend assets in the editor dev server
- Gitignore `.vite/` cache directories

The custom middleware was silently failing, causing Vite's SPA fallback to serve `index.html` instead of PNG tilesets.

## Test plan
- [ ] Start editor dev server (`npm run dev` in `editor/`)
- [ ] Tilesets load successfully (no "Failed to load" errors)
- [ ] Map canvas renders tiles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)