### PR TITLE
feat: map resize, character sprites, and WASD movement

### DIFF
--- a/editor/src/components/MenuBar.tsx
+++ b/editor/src/components/MenuBar.tsx
@@ -9,7 +9,13 @@ export function MenuBar() {
 
   const handleNew = useCallback(() => {
     if (!confirm("Create a new map? Unsaved changes will be lost.")) return;
-    store.newMap(64, 40);
+    const widthStr = prompt("Map width (16–256 tiles):", "64");
+    if (widthStr === null) return;
+    const heightStr = prompt("Map height (16–256 tiles):", "40");
+    if (heightStr === null) return;
+    const w = Math.max(16, Math.min(256, Math.round(Number(widthStr) || 64)));
+    const h = Math.max(16, Math.min(256, Math.round(Number(heightStr) || 40)));
+    store.newMap(w, h);
   }, [store]);
 
   const handleSave = useCallback(() => {
@@ -71,7 +77,7 @@ export function MenuBar() {
         Village Editor
       </span>
       <div className="w-px h-4 bg-gray-700" />
-      <Tooltip text="New Map" desc="Create a blank 64x40 map. Unsaved changes will be lost." side="bottom">
+      <Tooltip text="New Map" desc="Create a new map with custom dimensions. Unsaved changes will be lost." side="bottom">
         <button onClick={handleNew} className="px-2 py-0.5 hover:bg-gray-700 rounded text-gray-300">
           New
         </button>


### PR DESCRIPTION
## Summary
- **Map resize**: Editor "New" button now prompts for custom width/height (16–256 tiles) instead of hardcoding 64×40
- **Character sprite assignment**: Spawn points with a `sprite_sheet` property (e.g. `Character_010_2`) dynamically load character sheet PNGs and create frame-based animations, falling back to atlas sprites when unset
- **WASD/arrow key movement**: User avatar moves tile-by-tile with collision checking, continuous movement on key hold, and smooth camera follow

## Test plan
- [ ] Editor → New → verify prompted for width/height, map created at specified size
- [ ] Editor → place agent_spawn with `sprite_sheet: Character_010_2` → save → frontend uses that character sheet
- [ ] Frontend → no `sprite_sheet` on spawn points → atlas-based sprites still work (backward compat)
- [ ] Frontend → WASD/arrow keys move user avatar tile-by-tile, collisions respected
- [ ] Frontend → camera smoothly follows user avatar
- [ ] `npx tsc --noEmit` passes in both `editor/` and `frontend/`
- [ ] `npx vitest run` passes in `frontend/` (56/56 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)