### PR TITLE
feat: add tile stacking (multiple tiles per cell per layer)

### DIFF
--- a/editor/src/components/BuildingPanel.tsx
+++ b/editor/src/components/BuildingPanel.tsx
@@ -8,7 +8,9 @@ const TILE_LAYER_COUNT = 5;
 function createEmptyFloor(name: string, w: number, h: number): BuildingFloor {
   return {
     name,
-    layers: Array.from({ length: TILE_LAYER_COUNT }, () => new Array(w * h).fill(0)),
+    layers: Array.from({ length: TILE_LAYER_COUNT }, () =>
+      Array.from({ length: w * h }, () => [] as number[])
+    ),
     portals: [],
   };
 }

--- a/editor/src/components/ObjectPanel.tsx
+++ b/editor/src/components/ObjectPanel.tsx
@@ -116,9 +116,11 @@ export function ObjectPanel() {
                     </button>
                   </Tooltip>
                 )}
-                <span className="text-gray-600 flex-shrink-0">
-                  {Math.round(obj.x)},{Math.round(obj.y)}
-                </span>
+                {obj.type !== "spawn_point" && (
+                  <span className="text-gray-600 flex-shrink-0">
+                    {Math.round(obj.x)},{Math.round(obj.y)}
+                  </span>
+                )}
                 <button
                   onClick={() => { removeObject(i); if (spritePicker === i) setSpritePicker(null); }}
                   className="text-red-400 hover:text-red-300 ml-1 flex-shrink-0"

--- a/editor/src/hooks/useCanvasInteraction.ts
+++ b/editor/src/hooks/useCanvasInteraction.ts
@@ -123,10 +123,11 @@ export function useCanvasInteraction(canvasRef: React.RefObject<HTMLCanvasElemen
         if (gids.length !== 1) return;
         store.fillTiles(activeLayerIndex, col, row, gids[0]);
       } else if (activeTool === "walkability") {
-        // Toggle walkability for whatever tile is at this position
+        // Toggle walkability for the topmost tile at this position
         const { layers } = store;
         for (let li = layers.length - 1; li >= 0; li--) {
-          const gid = layers[li][row * store.mapWidth + col];
+          const stack = layers[li][row * store.mapWidth + col];
+          const gid = stack && stack.length > 0 ? stack[stack.length - 1] : 0;
           if (gid > 0) {
             const tilesets = tilesetStore.tilesets;
             for (let ti = tilesets.length - 1; ti >= 0; ti--) {

--- a/editor/src/lib/flood-fill.ts
+++ b/editor/src/lib/flood-fill.ts
@@ -1,16 +1,23 @@
-/** Flood fill algorithm for the map editor bucket tool */
+import type { CellStack } from "../types/editor";
+
+/** Get the topmost GID from a cell stack (0 if empty) */
+function topOf(stack: CellStack): number {
+  return stack.length > 0 ? stack[stack.length - 1] : 0;
+}
+
+/** Flood fill algorithm for the map editor bucket tool (operates on top-of-stack) */
 export function floodFill(
-  data: number[],
+  data: CellStack[],
   width: number,
   height: number,
   startX: number,
   startY: number,
   fillGid: number,
-): Array<{ x: number; y: number; oldValue: number }> {
-  const targetGid = data[startY * width + startX];
+): Array<{ x: number; y: number; oldValue: CellStack }> {
+  const targetGid = topOf(data[startY * width + startX]);
   if (targetGid === fillGid) return [];
 
-  const changes: Array<{ x: number; y: number; oldValue: number }> = [];
+  const changes: Array<{ x: number; y: number; oldValue: CellStack }> = [];
   const visited = new Set<number>();
   const queue: [number, number][] = [[startX, startY]];
 
@@ -20,11 +27,16 @@ export function floodFill(
 
     if (x < 0 || x >= width || y < 0 || y >= height) continue;
     if (visited.has(idx)) continue;
-    if (data[idx] !== targetGid) continue;
+    if (topOf(data[idx]) !== targetGid) continue;
 
     visited.add(idx);
-    changes.push({ x, y, oldValue: data[idx] });
-    data[idx] = fillGid;
+    changes.push({ x, y, oldValue: [...data[idx]] });
+    // Replace topmost GID with fillGid
+    if (data[idx].length > 0) {
+      data[idx] = [...data[idx].slice(0, -1), fillGid];
+    } else {
+      data[idx] = [fillGid];
+    }
 
     queue.push([x + 1, y], [x - 1, y], [x, y + 1], [x, y - 1]);
   }

--- a/editor/src/lib/undo.ts
+++ b/editor/src/lib/undo.ts
@@ -1,4 +1,4 @@
-import type { MapDelta } from "../types/editor";
+import type { MapDelta, CellStack } from "../types/editor";
 
 const MAX_UNDO = 100;
 
@@ -14,27 +14,9 @@ export class UndoManager {
     this.redoStack = [];
   }
 
-  undo(layers: number[][]): MapDelta | null {
+  undo(_layers: CellStack[][]): MapDelta | null {
     const delta = this.undoStack.pop();
     if (!delta) return null;
-
-    // Apply inverse
-    const layer = layers[delta.layerIndex];
-    const inverseDelta: MapDelta = {
-      layerIndex: delta.layerIndex,
-      changes: [],
-    };
-
-    for (const change of delta.changes) {
-      const idx = change.y * Math.sqrt(layer.length) | 0; // not clean but works
-      inverseDelta.changes.push({
-        x: change.x,
-        y: change.y,
-        oldValue: change.newValue,
-        newValue: change.oldValue,
-      });
-    }
-
     this.redoStack.push(delta);
     return delta;
   }

--- a/editor/src/types/editor.ts
+++ b/editor/src/types/editor.ts
@@ -1,5 +1,8 @@
 import type { TilesetCategory } from "../lib/tileset-loader";
 
+/** A cell can hold multiple stacked tile GIDs (bottom to top). Empty cell = []. */
+export type CellStack = number[];
+
 export type EditorTool = "brush" | "eraser" | "fill" | "stamp" | "object" | "walkability" | "hand";
 
 export interface TileSelection {
@@ -23,7 +26,7 @@ export interface Stamp {
 
 export interface MapDelta {
   layerIndex: number;
-  changes: Array<{ x: number; y: number; oldValue: number; newValue: number }>;
+  changes: Array<{ x: number; y: number; oldValue: CellStack; newValue: CellStack }>;
 }
 
 export interface SpawnPoint {
@@ -93,7 +96,7 @@ export interface BuildingFloor {
   /** Display name, e.g. "Ground Floor", "Upstairs" */
   name: string;
   /** Tile data layers for this floor interior (same dimensions as zone) */
-  layers: number[][]; // 5 layers, each zoneW * zoneH
+  layers: CellStack[][]; // 5 layers, each zoneW * zoneH
   /** Portals on this floor */
   portals: BuildingPortal[];
 }


### PR DESCRIPTION
## Summary
- Change cell storage from single `number` to `CellStack` (`number[]`) so overlapping tiles on the same layer composite correctly instead of replacing each other
- Paint pushes onto stack, erase pops top, flood-fill matches/replaces top-of-stack, undo/redo restores full stacks
- Serialization splits stacks into Tiled sublayers (`"terrain"`, `"terrain__2"`, etc.) and loading merges them back — backward compatible with old single-layer maps
- VillageScene handles sublayer names for depth, collision, and building enter/exit
- Hides confusing spawn point "256, 256" coordinates in ObjectPanel

## Test plan
- [x] `cd editor && npx tsc --noEmit` — editor compiles
- [x] `cd frontend && npx tsc --noEmit` — frontend compiles
- [x] `cd frontend && npx vitest run` — all 56 tests pass
- [ ] Manual: paint tree on terrain layer, paint overlapping tree on same layer → both visible
- [ ] Manual: erase from stacked cell → only top tile removed
- [ ] Manual: undo/redo on stacked cells → stacks restored correctly
- [ ] Manual: save/load map with stacks → stacks preserved
- [ ] Manual: export → load in Phaser frontend → sublayers render + collide correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)