### PR TITLE
fix: persist editor panel sizes across sessions

### DIFF
--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useCallback, useRef } from "react";
+import { useEditorStore } from "./stores/editorStore";
 import { useTilesetStore } from "./stores/tilesetStore";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { MenuBar } from "./components/MenuBar";
@@ -84,15 +85,19 @@ function HDivider({ onDrag }: { onDrag: (dy: number) => void }) {
 
 export default function App() {
   const loaded = useTilesetStore((s) => s.loaded);
-  const [panelWidth, setPanelWidth] = useState(DEFAULT_PANEL_W);
+  const panelWidth = useEditorStore((s) => s.panelWidth);
+  const setPanelWidth = useEditorStore((s) => s.setPanelWidth);
+  const layerH = useEditorStore((s) => s.layerH);
+  const setLayerH = useEditorStore((s) => s.setLayerH);
+  const objectH = useEditorStore((s) => s.objectH);
+  const setObjectH = useEditorStore((s) => s.setObjectH);
+  const buildingH = useEditorStore((s) => s.buildingH);
+  const setBuildingH = useEditorStore((s) => s.setBuildingH);
+  const npcH = useEditorStore((s) => s.npcH);
+  const setNpcH = useEditorStore((s) => s.setNpcH);
+  const npcCollapsed = useEditorStore((s) => s.npcCollapsed);
+  const setNpcCollapsed = useEditorStore((s) => s.setNpcCollapsed);
   const dragging = useRef(false);
-
-  // Heights for the fixed-height sections; tileset takes remaining space
-  const [layerH, setLayerH] = useState(140);
-  const [objectH, setObjectH] = useState(160);
-  const [buildingH, setBuildingH] = useState(160);
-  const [npcH, setNpcH] = useState(200);
-  const [npcCollapsed, setNpcCollapsed] = useState(false);
 
   useKeyboardShortcuts();
 
@@ -125,7 +130,7 @@ export default function App() {
     document.body.style.userSelect = "none";
     document.addEventListener("mousemove", onMove);
     document.addEventListener("mouseup", onUp);
-  }, [panelWidth]);
+  }, [panelWidth, setPanelWidth]);
 
   if (!loaded) {
     return <LoadingScreen />;
@@ -159,21 +164,30 @@ export default function App() {
             <LayerPanel />
           </div>
 
-          <HDivider onDrag={(dy) => setLayerH((h) => Math.max(MIN_SECTION_H, h + dy))} />
+          <HDivider onDrag={(dy) => {
+            const h = useEditorStore.getState().layerH;
+            setLayerH(Math.max(MIN_SECTION_H, h + dy));
+          }} />
 
           {/* Objects section */}
           <div className="overflow-auto flex-shrink-0" style={{ height: objectH }}>
             <ObjectPanel />
           </div>
 
-          <HDivider onDrag={(dy) => setObjectH((h) => Math.max(MIN_SECTION_H, h + dy))} />
+          <HDivider onDrag={(dy) => {
+            const h = useEditorStore.getState().objectH;
+            setObjectH(Math.max(MIN_SECTION_H, h + dy));
+          }} />
 
           {/* Buildings section */}
           <div className="overflow-auto flex-shrink-0" style={{ height: buildingH }}>
             <BuildingPanel />
           </div>
 
-          <HDivider onDrag={(dy) => setBuildingH((h) => Math.max(MIN_SECTION_H, h + dy))} />
+          <HDivider onDrag={(dy) => {
+            const h = useEditorStore.getState().buildingH;
+            setBuildingH(Math.max(MIN_SECTION_H, h + dy));
+          }} />
 
           {/* NPCs section */}
           <div
@@ -182,12 +196,15 @@ export default function App() {
           >
             <NPCBrowser
               collapsed={npcCollapsed}
-              onToggle={() => setNpcCollapsed((c) => !c)}
+              onToggle={() => setNpcCollapsed(!npcCollapsed)}
             />
           </div>
 
           {!npcCollapsed && (
-            <HDivider onDrag={(dy) => setNpcH((h) => Math.max(MIN_SECTION_H, h + dy))} />
+            <HDivider onDrag={(dy) => {
+              const h = useEditorStore.getState().npcH;
+              setNpcH(Math.max(MIN_SECTION_H, h + dy));
+            }} />
           )}
 
           {/* Tileset section — takes remaining space */}

--- a/editor/src/stores/editorStore.ts
+++ b/editor/src/stores/editorStore.ts
@@ -40,6 +40,14 @@ interface EditorStore {
   viewportOffsetY: number;
   viewportZoom: number;
 
+  // Panel layout
+  panelWidth: number;
+  layerH: number;
+  objectH: number;
+  buildingH: number;
+  npcH: number;
+  npcCollapsed: boolean;
+
   // Actions
   setActiveTool: (tool: EditorTool) => void;
   setActiveLayer: (index: number) => void;
@@ -77,6 +85,14 @@ interface EditorStore {
   setViewport: (offsetX: number, offsetY: number, zoom: number) => void;
   panViewport: (dx: number, dy: number) => void;
   zoomViewport: (delta: number, centerX: number, centerY: number) => void;
+
+  // Panel layout
+  setPanelWidth: (w: number) => void;
+  setLayerH: (h: number) => void;
+  setObjectH: (h: number) => void;
+  setBuildingH: (h: number) => void;
+  setNpcH: (h: number) => void;
+  setNpcCollapsed: (collapsed: boolean) => void;
 
   // Undo/Redo
   undo: () => void;
@@ -130,6 +146,13 @@ export const useEditorStore = create<EditorStore>()(
   viewportOffsetX: 0,
   viewportOffsetY: 0,
   viewportZoom: 2,
+
+  panelWidth: 320,
+  layerH: 140,
+  objectH: 160,
+  buildingH: 160,
+  npcH: 200,
+  npcCollapsed: false,
 
   _undoManager: new UndoManager(),
   _pendingDelta: null,
@@ -318,6 +341,13 @@ export const useEditorStore = create<EditorStore>()(
       };
     }),
 
+  setPanelWidth: (w) => set({ panelWidth: w }),
+  setLayerH: (h) => set({ layerH: h }),
+  setObjectH: (h) => set({ objectH: h }),
+  setBuildingH: (h) => set({ buildingH: h }),
+  setNpcH: (h) => set({ npcH: h }),
+  setNpcCollapsed: (collapsed) => set({ npcCollapsed: collapsed }),
+
   undo: () => {
     const { _undoManager, layers, mapWidth } = get();
     const delta = _undoManager.undo(layers);
@@ -407,6 +437,12 @@ export const useEditorStore = create<EditorStore>()(
         viewportOffsetX: state.viewportOffsetX,
         viewportOffsetY: state.viewportOffsetY,
         viewportZoom: state.viewportZoom,
+        panelWidth: state.panelWidth,
+        layerH: state.layerH,
+        objectH: state.objectH,
+        buildingH: state.buildingH,
+        npcH: state.npcH,
+        npcCollapsed: state.npcCollapsed,
       }),
       migrate: (persisted: unknown, version: number) => {
         if (version < 2) {


### PR DESCRIPTION
## Summary
- Move panel layout state (`panelWidth`, `layerH`, `objectH`, `buildingH`, `npcH`, `npcCollapsed`) from React `useState` in App.tsx to the persisted Zustand `editorStore`
- Panel sizes now survive page reloads via localStorage (same persistence mechanism as viewport pan/zoom)
- HDivider callbacks use `getState()` to read fresh values during drag, avoiding stale closure issues

## Root cause
Panel sizes were stored in component-level `useState`, which resets to hardcoded defaults on every page reload. The Zustand store already had persistence middleware but panel layout wasn't included.

## Test plan
- [ ] Open editor, resize right panel width and section heights
- [ ] Reload page — panel sizes should be preserved
- [ ] Collapse NPC panel, reload — should stay collapsed
- [ ] Drag dividers rapidly — no jank or stale-value jumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)