### PR TITLE
fix: magic effects, speech bubble, and keyboard input

### DIFF
--- a/frontend/src/game/objects/MagicEffect.ts
+++ b/frontend/src/game/objects/MagicEffect.ts
@@ -29,7 +29,6 @@ export class MagicEffect {
 
     this.sprite = scene.add.sprite(x + OFFSET_X, y + OFFSET_Y, def.tilesetKey, def.frames[0]);
     this.sprite.setDepth(50);
-    this.sprite.setScale(2);
     this.sprite.play(this.animKey);
   }
 


### PR DESCRIPTION
## Summary
- **Magic effect animations**: Load all tilesets as spritesheets (not plain images) so MagicEffect sprites have frame data. Read animation frames from `tileset.tileData` (same source as tile animations like sunflowers) instead of parsing raw JSON entries. Removed duplicate `setScale(2)` that stacked with camera zoom.
- **Speech bubble rewrite**: Added message queue with 2s minimum display time to prevent flashing during rapid tool steps. Use `resolution: 2` for crisp text at small world-pixel sizes. Removed scale animation that caused blurriness. Tuned dimensions (5px font, 80px max width, 4px padding).
- **Keyboard input fix**: Added `disableGlobalCapture()` so Phaser doesn't swallow spacebar/arrow keys when typing in chat. Added DOM focus guard to skip game input when a text field is focused.

## Test plan
- [ ] Verify magic effect animations play correctly when MCP tools are invoked (individual frames, not whole tileset)
- [ ] Verify speech bubbles display at correct size with crisp text
- [ ] Verify rapid tool steps queue messages instead of flashing
- [ ] Verify spacebar works in chat input
- [ ] Verify WASD/arrow movement still works when chat is not focused
- [ ] Verify all existing tile animations (sunflowers, water) still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)