### PR TITLE
feat: show thinking speech bubble

### DIFF
--- a/frontend/src/game/scenes/VillageScene.ts
+++ b/frontend/src/game/scenes/VillageScene.ts
@@ -348,6 +348,7 @@ export class VillageScene extends Phaser.Scene {
       this.speechBubble.hide();
       this.agent.moveAlongPath(this.pathfinder, this.agentSpawn.x, this.agentSpawn.y, () => {
         this.agent.playAnim("think");
+        this.speechBubble.show("...");
       });
 
       // User walks toward agent


### PR DESCRIPTION
## Summary
- Show a "..." speech bubble when the agent arrives at the bench and starts thinking
- Uses the existing speech bubble queue — tool step messages queue after it, final answer clears everything

## Test plan
- [ ] Send a message and verify "..." bubble appears while agent thinks
- [ ] Verify tool step bubbles queue correctly after the "..." 
- [ ] Verify final answer clears the bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)