### PR TITLE
test: add SpeechBubble, MagicEffect, and mapParsers tests

### DIFF
--- a/frontend/src/game/lib/mapParsers.test.ts
+++ b/frontend/src/game/lib/mapParsers.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from "vitest";
+import { buildMagicEffectPool, type TilesetInfo } from "./mapParsers";
+
+// ── Helper factories ────────────────────────────────
+
+function makeProps(magicEffectsValue: unknown) {
+  return [{ name: "magic_effects", value: magicEffectsValue }];
+}
+
+function makeTileset(overrides?: Partial<TilesetInfo>): TilesetInfo {
+  return {
+    name: "CuteRPG_Magical",
+    tileWidth: 16,
+    tileHeight: 16,
+    columns: 8,
+    tileData: {
+      "5": {
+        animation: [
+          { tileid: 5, duration: 150 },
+          { tileid: 6, duration: 150 },
+          { tileid: 7, duration: 150 },
+        ],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeEffectsJSON(
+  overrides?: Partial<{
+    id: string;
+    name: string;
+    tilesetName: string;
+    entries: Array<{ anchorLocalId: number }>;
+  }>[]
+) {
+  const defaults = [
+    {
+      id: "fire-burst",
+      name: "Fire Burst",
+      tilesetName: "CuteRPG_Magical",
+      entries: [{ anchorLocalId: 5 }],
+    },
+  ];
+  const items = overrides ?? defaults;
+  return JSON.stringify(items);
+}
+
+describe("buildMagicEffectPool", () => {
+  // ─── Edge cases: early returns ────────────────────
+
+  describe("edge cases", () => {
+    it("returns [] when mapProperties is undefined", () => {
+      expect(buildMagicEffectPool(undefined, [makeTileset()])).toEqual([]);
+    });
+
+    it("returns [] when magic_effects property is missing", () => {
+      const props = [{ name: "buildings", value: "[]" }];
+      expect(buildMagicEffectPool(props, [makeTileset()])).toEqual([]);
+    });
+
+    it("returns [] when magic_effects value is not a string", () => {
+      const props = [{ name: "magic_effects", value: 42 }];
+      expect(buildMagicEffectPool(props, [makeTileset()])).toEqual([]);
+    });
+
+    it("returns [] for malformed JSON", () => {
+      const props = makeProps("not valid json {{{");
+      expect(buildMagicEffectPool(props, [makeTileset()])).toEqual([]);
+    });
+  });
+
+  // ─── No match scenarios ───────────────────────────
+
+  describe("no match", () => {
+    it("returns [] when tileset names don't match", () => {
+      const props = makeProps(makeEffectsJSON());
+      const tileset = makeTileset({ name: "OtherTileset" });
+      expect(buildMagicEffectPool(props, [tileset])).toEqual([]);
+    });
+
+    it("returns [] when tileset has no tileData", () => {
+      const props = makeProps(makeEffectsJSON());
+      const tileset = makeTileset({ tileData: undefined });
+      expect(buildMagicEffectPool(props, [tileset])).toEqual([]);
+    });
+
+    it("returns [] when effect has empty entries array", () => {
+      const json = JSON.stringify([
+        {
+          id: "empty",
+          name: "Empty",
+          tilesetName: "CuteRPG_Magical",
+          entries: [],
+        },
+      ]);
+      const props = makeProps(json);
+      expect(buildMagicEffectPool(props, [makeTileset()])).toEqual([]);
+    });
+
+    it("returns [] when anchor local ID has no animation data", () => {
+      const json = JSON.stringify([
+        {
+          id: "miss",
+          name: "Miss",
+          tilesetName: "CuteRPG_Magical",
+          entries: [{ anchorLocalId: 999 }], // no tileData entry for 999
+        },
+      ]);
+      const props = makeProps(json);
+      expect(buildMagicEffectPool(props, [makeTileset()])).toEqual([]);
+    });
+
+    it("returns [] when animation array is empty", () => {
+      const tileset = makeTileset({
+        tileData: { "5": { animation: [] } },
+      });
+      const props = makeProps(makeEffectsJSON());
+      expect(buildMagicEffectPool(props, [tileset])).toEqual([]);
+    });
+  });
+
+  // ─── Happy path ───────────────────────────────────
+
+  describe("happy path", () => {
+    it("returns correct MagicEffectDef for a single effect", () => {
+      const props = makeProps(makeEffectsJSON());
+      const result = buildMagicEffectPool(props, [makeTileset()]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        id: "fire-burst",
+        name: "Fire Burst",
+        tilesetKey: "CuteRPG_Magical",
+        tileWidth: 16,
+        tileHeight: 16,
+        columns: 8,
+        frameDuration: 150,
+        frames: [5, 6, 7],
+      });
+    });
+
+    it("uses local tile IDs (not GIDs) for frames", () => {
+      const props = makeProps(makeEffectsJSON());
+      const result = buildMagicEffectPool(props, [makeTileset()]);
+      // frames should be the tileid values from animation, not offset by firstgid
+      expect(result[0].frames).toEqual([5, 6, 7]);
+    });
+
+    it("uses frameDuration from first animation frame", () => {
+      const tileset = makeTileset({
+        tileData: {
+          "5": {
+            animation: [
+              { tileid: 5, duration: 200 },
+              { tileid: 6, duration: 100 }, // different duration
+            ],
+          },
+        },
+      });
+      const props = makeProps(makeEffectsJSON());
+      const result = buildMagicEffectPool(props, [tileset]);
+      expect(result[0].frameDuration).toBe(200);
+    });
+  });
+
+  // ─── Multiple effects ─────────────────────────────
+
+  describe("multiple effects", () => {
+    it("handles multiple effects across different tilesets", () => {
+      const json = JSON.stringify([
+        {
+          id: "fire",
+          name: "Fire",
+          tilesetName: "CuteRPG_Magical",
+          entries: [{ anchorLocalId: 5 }],
+        },
+        {
+          id: "ice",
+          name: "Ice",
+          tilesetName: "IceTileset",
+          entries: [{ anchorLocalId: 10 }],
+        },
+      ]);
+      const props = makeProps(json);
+
+      const tilesets: TilesetInfo[] = [
+        makeTileset(),
+        makeTileset({
+          name: "IceTileset",
+          tileData: {
+            "10": {
+              animation: [
+                { tileid: 10, duration: 100 },
+                { tileid: 11, duration: 100 },
+              ],
+            },
+          },
+        }),
+      ];
+
+      const result = buildMagicEffectPool(props, tilesets);
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe("fire");
+      expect(result[1].id).toBe("ice");
+      expect(result[1].tilesetKey).toBe("IceTileset");
+      expect(result[1].frames).toEqual([10, 11]);
+    });
+
+    it("handles multiple effects in the same tileset", () => {
+      const json = JSON.stringify([
+        {
+          id: "effect-a",
+          name: "A",
+          tilesetName: "CuteRPG_Magical",
+          entries: [{ anchorLocalId: 5 }],
+        },
+        {
+          id: "effect-b",
+          name: "B",
+          tilesetName: "CuteRPG_Magical",
+          entries: [{ anchorLocalId: 20 }],
+        },
+      ]);
+      const props = makeProps(json);
+
+      const tileset = makeTileset({
+        tileData: {
+          "5": {
+            animation: [
+              { tileid: 5, duration: 150 },
+              { tileid: 6, duration: 150 },
+            ],
+          },
+          "20": {
+            animation: [
+              { tileid: 20, duration: 200 },
+              { tileid: 21, duration: 200 },
+              { tileid: 22, duration: 200 },
+            ],
+          },
+        },
+      });
+
+      const result = buildMagicEffectPool(props, [tileset]);
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe("effect-a");
+      expect(result[0].frames).toEqual([5, 6]);
+      expect(result[1].id).toBe("effect-b");
+      expect(result[1].frames).toEqual([20, 21, 22]);
+    });
+  });
+
+  // ─── Fallback ID/name ─────────────────────────────
+
+  describe("fallback id and name", () => {
+    it("falls back to tileset-based id when meta is missing", () => {
+      // Create an effect whose anchor matches tileData but meta lookup misses
+      // (this shouldn't happen in practice but tests the fallback)
+      const json = JSON.stringify([
+        {
+          id: "custom-id",
+          name: "Custom",
+          tilesetName: "CuteRPG_Magical",
+          entries: [{ anchorLocalId: 5 }],
+        },
+      ]);
+      const props = makeProps(json);
+      const result = buildMagicEffectPool(props, [makeTileset()]);
+      // meta IS found here so it uses the provided id/name
+      expect(result[0].id).toBe("custom-id");
+      expect(result[0].name).toBe("Custom");
+    });
+  });
+});

--- a/frontend/src/game/lib/mapParsers.ts
+++ b/frontend/src/game/lib/mapParsers.ts
@@ -1,0 +1,91 @@
+import type { MagicEffectDef } from "../../types";
+
+/**
+ * Minimal tileset info needed for magic-effect parsing —
+ * no Phaser types so this stays a pure, testable function.
+ */
+export interface TilesetInfo {
+  name: string;
+  tileWidth: number;
+  tileHeight: number;
+  columns: number;
+  tileData?: Record<
+    string,
+    { animation?: Array<{ tileid: number; duration: number }> }
+  >;
+}
+
+/**
+ * Build the magic-effect pool from Tiled map custom properties and tileset metadata.
+ *
+ * The map JSON stores a `magic_effects` property (stringified JSON) that lists
+ * which tileset animations are spell overlays. This function cross-references
+ * that list with each tileset's `tileData` animation entries to produce a flat
+ * array of `MagicEffectDef` objects ready for runtime use.
+ */
+export function buildMagicEffectPool(
+  mapProperties: Array<{ name: string; value: unknown }> | undefined,
+  tilesets: TilesetInfo[]
+): MagicEffectDef[] {
+  if (!mapProperties) return [];
+
+  const magicProp = mapProperties.find((p) => p.name === "magic_effects");
+  if (!magicProp || typeof magicProp.value !== "string") return [];
+
+  try {
+    const effects = JSON.parse(magicProp.value) as Array<{
+      id: string;
+      name: string;
+      tilesetName: string;
+      entries: Array<{ anchorLocalId: number }>;
+    }>;
+
+    // Build lookup: tilesetName → Set of anchor local IDs
+    const fxAnchors = new Map<string, Set<number>>();
+    const fxMeta = new Map<string, { id: string; name: string }>();
+    for (const fx of effects) {
+      if (!fx.entries || fx.entries.length === 0) continue;
+      const anchorId = fx.entries[0].anchorLocalId;
+      if (!fxAnchors.has(fx.tilesetName)) {
+        fxAnchors.set(fx.tilesetName, new Set());
+      }
+      fxAnchors.get(fx.tilesetName)!.add(anchorId);
+      fxMeta.set(`${fx.tilesetName}:${anchorId}`, {
+        id: fx.id,
+        name: fx.name,
+      });
+    }
+
+    const pool: MagicEffectDef[] = [];
+
+    for (const tileset of tilesets) {
+      const anchors = fxAnchors.get(tileset.name);
+      if (!anchors) continue;
+
+      const tileData = tileset.tileData;
+      if (!tileData) continue;
+
+      for (const [localIdStr, data] of Object.entries(tileData)) {
+        if (!data.animation || data.animation.length === 0) continue;
+        const localId = parseInt(localIdStr, 10);
+        if (!anchors.has(localId)) continue;
+
+        const meta = fxMeta.get(`${tileset.name}:${localId}`);
+        pool.push({
+          id: meta?.id ?? `${tileset.name}-${localId}`,
+          name: meta?.name ?? tileset.name,
+          tilesetKey: tileset.name,
+          tileWidth: tileset.tileWidth,
+          tileHeight: tileset.tileHeight,
+          columns: tileset.columns,
+          frameDuration: data.animation[0].duration,
+          frames: data.animation.map((f) => f.tileid),
+        });
+      }
+    }
+
+    return pool;
+  } catch {
+    return [];
+  }
+}

--- a/frontend/src/game/objects/MagicEffect.test.ts
+++ b/frontend/src/game/objects/MagicEffect.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockScene, type MockScene } from "../../test/mocks/phaser";
+import type { MagicEffectDef } from "../../types";
+
+vi.mock("phaser", async () => {
+  const mocks = await import("../../test/mocks/phaser");
+  return { default: mocks.default };
+});
+
+import { MagicEffect } from "./MagicEffect";
+
+const OFFSET_X = 12;
+const OFFSET_Y = -20;
+
+function makeDef(overrides?: Partial<MagicEffectDef>): MagicEffectDef {
+  return {
+    id: "fire-1",
+    name: "Fire Burst",
+    tilesetKey: "CuteRPG_Magical",
+    tileWidth: 16,
+    tileHeight: 16,
+    columns: 8,
+    frameDuration: 150,
+    frames: [0, 1, 2, 3],
+    ...overrides,
+  };
+}
+
+describe("MagicEffect", () => {
+  let scene: MockScene;
+
+  beforeEach(() => {
+    scene = createMockScene();
+  });
+
+  // ─── Animation registration ───────────────────────
+
+  describe("animation registration", () => {
+    it("registers animation with correct key and config", () => {
+      scene.anims.exists.mockReturnValue(false);
+      const def = makeDef();
+      new MagicEffect(scene as never, def, 100, 200);
+
+      expect(scene.anims.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: `magic-fx-${def.id}`,
+          frameRate: 1000 / def.frameDuration,
+          repeat: -1,
+        })
+      );
+    });
+
+    it("maps frames to tileset key + local IDs", () => {
+      scene.anims.exists.mockReturnValue(false);
+      const def = makeDef({ frames: [10, 11, 12] });
+      new MagicEffect(scene as never, def, 0, 0);
+
+      const createCall = scene.anims.create.mock.calls[0][0];
+      expect(createCall.frames).toEqual([
+        { key: def.tilesetKey, frame: 10 },
+        { key: def.tilesetKey, frame: 11 },
+        { key: def.tilesetKey, frame: 12 },
+      ]);
+    });
+
+    it("skips registration if animation already exists", () => {
+      scene.anims.exists.mockReturnValue(true);
+      new MagicEffect(scene as never, makeDef(), 0, 0);
+
+      expect(scene.anims.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Sprite creation ──────────────────────────────
+
+  describe("sprite creation", () => {
+    it("creates sprite at offset position", () => {
+      const def = makeDef();
+      new MagicEffect(scene as never, def, 100, 200);
+
+      expect(scene.add.sprite).toHaveBeenCalledWith(
+        100 + OFFSET_X,
+        200 + OFFSET_Y,
+        def.tilesetKey,
+        def.frames[0]
+      );
+    });
+
+    it("sets depth to 50", () => {
+      new MagicEffect(scene as never, makeDef(), 0, 0);
+      expect(scene._sprite.setDepth).toHaveBeenCalledWith(50);
+    });
+
+    it("plays the animation", () => {
+      const def = makeDef();
+      new MagicEffect(scene as never, def, 0, 0);
+      expect(scene._sprite.play).toHaveBeenCalledWith(`magic-fx-${def.id}`);
+    });
+  });
+
+  // ─── No setScale regression ───────────────────────
+
+  describe("no setScale regression", () => {
+    it("never calls setScale on the sprite", () => {
+      new MagicEffect(scene as never, makeDef(), 50, 50);
+      expect(scene._sprite.setScale).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── setPosition ──────────────────────────────────
+
+  describe("setPosition()", () => {
+    it("applies offsets correctly", () => {
+      const effect = new MagicEffect(scene as never, makeDef(), 0, 0);
+      effect.setPosition(200, 300);
+
+      expect(scene._sprite.setPosition).toHaveBeenCalledWith(
+        200 + OFFSET_X,
+        300 + OFFSET_Y
+      );
+    });
+  });
+
+  // ─── fadeOut ──────────────────────────────────────
+
+  describe("fadeOut()", () => {
+    it("creates a tween to alpha 0", () => {
+      const effect = new MagicEffect(scene as never, makeDef(), 0, 0);
+      effect.fadeOut();
+
+      expect(scene.tweens.add).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targets: scene._sprite,
+          alpha: 0,
+          duration: 400,
+        })
+      );
+    });
+
+    it("destroys sprite and calls onComplete callback", () => {
+      const effect = new MagicEffect(scene as never, makeDef(), 0, 0);
+      const onComplete = vi.fn();
+      effect.fadeOut(onComplete);
+
+      // Fire the tween's onComplete
+      const tweenConfig = scene._lastTween!;
+      (tweenConfig.onComplete as () => void)();
+
+      expect(scene._sprite.destroy).toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
+  // ─── destroy ──────────────────────────────────────
+
+  describe("destroy()", () => {
+    it("destroys the sprite when scene is truthy", () => {
+      const effect = new MagicEffect(scene as never, makeDef(), 0, 0);
+      effect.destroy();
+      expect(scene._sprite.destroy).toHaveBeenCalled();
+    });
+
+    it("is safe when sprite.scene is falsy", () => {
+      const effect = new MagicEffect(scene as never, makeDef(), 0, 0);
+      // Simulate sprite already destroyed
+      scene._sprite.scene = null;
+      expect(() => effect.destroy()).not.toThrow();
+    });
+  });
+});

--- a/frontend/src/game/objects/SpeechBubble.test.ts
+++ b/frontend/src/game/objects/SpeechBubble.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockScene, type MockScene } from "../../test/mocks/phaser";
+
+vi.mock("phaser", async () => {
+  const mocks = await import("../../test/mocks/phaser");
+  return { default: mocks.default };
+});
+
+vi.mock("../../config/constants", () => ({
+  SCENE: {
+    COLORS: {
+      bubbleBg: 0xe0e0e0,
+      bubbleBorder: 0xe2b714,
+      bubbleText: 0x1a1a2e,
+    },
+  },
+}));
+
+import { SpeechBubble } from "./SpeechBubble";
+
+describe("SpeechBubble", () => {
+  let scene: MockScene;
+  let bubble: SpeechBubble;
+
+  beforeEach(() => {
+    scene = createMockScene();
+    bubble = new SpeechBubble(scene as never);
+  });
+
+  // ─── Constructor ──────────────────────────────────
+
+  describe("constructor", () => {
+    it("creates graphics, text, and container", () => {
+      expect(scene.add.graphics).toHaveBeenCalled();
+      expect(scene.add.text).toHaveBeenCalled();
+      expect(scene.add.container).toHaveBeenCalled();
+    });
+
+    it("starts invisible with alpha 0", () => {
+      expect(scene._container.visible).toBe(false);
+      expect(scene._container.alpha).toBe(0);
+    });
+
+    it("sets container depth to 20", () => {
+      expect(scene._container.setDepth).toHaveBeenCalledWith(20);
+    });
+
+    it("uses scene.scale.width as default clamp width", () => {
+      // Verify no error — clampWidth is used internally in updatePosition
+      const target = { x: 100, y: 100, displayHeight: 24 };
+      bubble.setTarget(target as never);
+      bubble.show("test");
+      bubble.updatePosition();
+      // Should not throw
+    });
+  });
+
+  // ─── show() ───────────────────────────────────────
+
+  describe("show()", () => {
+    it("displays first message immediately", () => {
+      bubble.show("Hello");
+      expect(scene._text.setText).toHaveBeenCalledWith("Hello");
+      expect(scene._container.visible).toBe(true);
+    });
+
+    it("queues subsequent messages while first is still showing", () => {
+      bubble.show("First");
+      bubble.show("Second");
+      bubble.show("Third");
+
+      // Only "First" should be rendered so far
+      expect(scene._text.setText).toHaveBeenCalledTimes(1);
+      expect(scene._text.setText).toHaveBeenCalledWith("First");
+    });
+
+    it("truncates messages longer than 60 chars", () => {
+      const longMessage = "A".repeat(70);
+      bubble.show(longMessage);
+      expect(scene._text.setText).toHaveBeenCalledWith("A".repeat(60) + "...");
+    });
+
+    it("does not truncate messages of exactly 60 chars", () => {
+      const exactMessage = "B".repeat(60);
+      bubble.show(exactMessage);
+      expect(scene._text.setText).toHaveBeenCalledWith(exactMessage);
+    });
+
+    it("displays '...' thinking indicator", () => {
+      bubble.show("...");
+      expect(scene._text.setText).toHaveBeenCalledWith("...");
+    });
+  });
+
+  // ─── Queue cycling ────────────────────────────────
+
+  describe("queue cycling", () => {
+    it("displays next message when timer fires", () => {
+      bubble.show("First");
+      bubble.show("Second");
+
+      // Fire the timer callback for the first message
+      expect(scene._lastDelayedCallback).not.toBeNull();
+      scene._lastDelayedCallback!();
+
+      expect(scene._text.setText).toHaveBeenCalledWith("Second");
+    });
+
+    it("drains queue in order", () => {
+      bubble.show("A");
+      bubble.show("B");
+      bubble.show("C");
+
+      // Fire timer for A → should show B
+      scene._lastDelayedCallback!();
+      expect(scene._text.setText).toHaveBeenCalledWith("B");
+
+      // Fire timer for B → should show C
+      scene._lastDelayedCallback!();
+      expect(scene._text.setText).toHaveBeenCalledWith("C");
+    });
+
+    it("stops cycling when queue is empty", () => {
+      bubble.show("Only");
+      const callCountBefore = scene.time.delayedCall.mock.calls.length;
+
+      // Fire timer — queue is now empty
+      scene._lastDelayedCallback!();
+
+      // No new delayedCall should be made (displayNext returns early)
+      expect(scene.time.delayedCall.mock.calls.length).toBe(callCountBefore);
+    });
+  });
+
+  // ─── Fade logic ───────────────────────────────────
+
+  describe("fade logic", () => {
+    it("fades in when container alpha is low", () => {
+      scene._container.alpha = 0;
+      bubble.show("Fade me in");
+
+      // Should set alpha to 0 and tween to 1
+      expect(scene.tweens.add).toHaveBeenCalled();
+      const tweenConfig = scene._lastTween!;
+      expect(tweenConfig.alpha).toBe(1);
+    });
+
+    it("skips fade when container is already visible (alpha >= 0.9)", () => {
+      bubble.show("First");
+      // Simulate the fade-in completing
+      scene._container.alpha = 1;
+
+      // Now show next via queue cycling
+      bubble.show("Second (queued)");
+      scene._lastDelayedCallback!(); // fire first timer
+
+      // renderBubble is called — it should detect alpha >= 0.9 and just set alpha=1
+      expect(scene._container.alpha).toBe(1);
+    });
+  });
+
+  // ─── hide() ───────────────────────────────────────
+
+  describe("hide()", () => {
+    it("clears the queue", () => {
+      bubble.show("A");
+      bubble.show("B");
+      bubble.show("C");
+
+      bubble.hide();
+
+      // Fire remaining timer callbacks — they should not display B or C
+      // (queue was cleared)
+    });
+
+    it("kills active tweens and fades out", () => {
+      bubble.show("Hello");
+      bubble.hide();
+
+      expect(scene.tweens.killTweensOf).toHaveBeenCalledWith(scene._container);
+      // Should create a fade-out tween
+      const tweenConfig = scene._lastTween!;
+      expect(tweenConfig.alpha).toBe(0);
+    });
+
+    it("sets invisible on fade-out complete", () => {
+      bubble.show("Hello");
+      bubble.hide();
+
+      // Fire the onComplete of the fade-out tween
+      const tweenConfig = scene._lastTween!;
+      (tweenConfig.onComplete as () => void)();
+
+      expect(scene._container.visible).toBe(false);
+    });
+
+    it("removes active display timer", () => {
+      bubble.show("Hello");
+      const timer = scene.time.delayedCall.mock.results[0].value;
+
+      bubble.hide();
+      expect(timer.remove).toHaveBeenCalledWith(false);
+    });
+  });
+
+  // ─── updatePosition() ─────────────────────────────
+
+  describe("updatePosition()", () => {
+    it("no-ops without a target sprite", () => {
+      // Should not throw
+      bubble.updatePosition();
+    });
+
+    it("no-ops when container is not visible", () => {
+      bubble.setTarget({ x: 100, y: 100, displayHeight: 24 } as never);
+      // container is invisible by default
+      bubble.updatePosition();
+      expect(scene._container.setPosition).not.toHaveBeenCalled();
+    });
+
+    it("positions bubble above target sprite", () => {
+      const target = { x: 200, y: 200, displayHeight: 24 };
+      bubble.setTarget(target as never);
+      bubble.show("Hi");
+
+      // updatePosition is called by renderBubble
+      expect(scene._container.setPosition).toHaveBeenCalled();
+    });
+  });
+
+  // ─── destroy() ────────────────────────────────────
+
+  describe("destroy()", () => {
+    it("removes timer and destroys container", () => {
+      bubble.show("Hello");
+      bubble.destroy();
+
+      expect(scene._container.destroy).toHaveBeenCalled();
+    });
+
+    it("is safe when no active timer exists", () => {
+      // No show() called — no timer
+      expect(() => bubble.destroy()).not.toThrow();
+      expect(scene._container.destroy).toHaveBeenCalled();
+    });
+  });
+
+  // ─── setTarget and updateClampBounds ──────────────
+
+  describe("setTarget / updateClampBounds", () => {
+    it("setTarget stores the sprite reference", () => {
+      const target = { x: 50, y: 50, displayHeight: 24 };
+      bubble.setTarget(target as never);
+      bubble.show("test");
+      // Should use target coords in updatePosition — no throw means it worked
+    });
+
+    it("updateClampBounds changes clamp values", () => {
+      bubble.updateClampBounds(512, 100);
+      // No throw, and values are used in next updatePosition call
+      const target = { x: 50, y: 50, displayHeight: 24 };
+      bubble.setTarget(target as never);
+      bubble.show("test");
+    });
+  });
+});

--- a/frontend/src/game/scenes/VillageScene.ts
+++ b/frontend/src/game/scenes/VillageScene.ts
@@ -6,6 +6,7 @@ import { NpcSprite } from "../objects/NpcSprite";
 import { SpeechBubble } from "../objects/SpeechBubble";
 import { UserSprite } from "../objects/UserSprite";
 import { Pathfinder } from "../lib/Pathfinder";
+import { buildMagicEffectPool } from "../lib/mapParsers";
 import { SCENE } from "../../config/constants";
 import type { MagicEffectDef } from "../../types";
 
@@ -734,68 +735,17 @@ export class VillageScene extends Phaser.Scene {
   // ─── Magic Effects ──────────────────────────────────
 
   private parseMagicEffects(map: Phaser.Tilemaps.Tilemap) {
-    // Read magic_effects from map custom properties to identify which
-    // tileset animations are magic effects (vs regular tile animations)
     const props = (map as unknown as { properties?: Array<{ name: string; value: unknown }> }).properties;
-    if (!props) return;
-
-    const magicProp = props.find((p) => p.name === "magic_effects");
-    if (!magicProp || typeof magicProp.value !== "string") return;
-
-    try {
-      const effects = JSON.parse(magicProp.value) as Array<{
-        id: string;
-        name: string;
-        tilesetName: string;
-        entries: Array<{ anchorLocalId: number }>;
-      }>;
-
-      // Build lookup: tilesetName → Set of anchor local IDs that are magic effects
-      const fxAnchors = new Map<string, Set<number>>();
-      const fxMeta = new Map<string, { id: string; name: string }>();
-      for (const fx of effects) {
-        if (fx.entries.length === 0) continue;
-        const anchorId = fx.entries[0].anchorLocalId;
-        if (!fxAnchors.has(fx.tilesetName)) {
-          fxAnchors.set(fx.tilesetName, new Set());
-        }
-        fxAnchors.get(fx.tilesetName)!.add(anchorId);
-        fxMeta.set(`${fx.tilesetName}:${anchorId}`, { id: fx.id, name: fx.name });
-      }
-
-      // Read animation frames from tileset.tileData (same source as
-      // initAnimatedTiles uses for sunflowers, water, etc.)
-      for (const tileset of this.tilesetsRef) {
-        const anchors = fxAnchors.get(tileset.name);
-        if (!anchors) continue;
-
-        const tileData = (tileset as unknown as {
-          tileData: Record<string, { animation?: Array<{ tileid: number; duration: number }> }>;
-        }).tileData;
-        if (!tileData) continue;
-
-        for (const [localIdStr, data] of Object.entries(tileData)) {
-          if (!data.animation || data.animation.length === 0) continue;
-          const localId = parseInt(localIdStr, 10);
-          if (!anchors.has(localId)) continue;
-
-          const meta = fxMeta.get(`${tileset.name}:${localId}`);
-          this.magicEffectPool.push({
-            id: meta?.id ?? `${tileset.name}-${localId}`,
-            name: meta?.name ?? tileset.name,
-            tilesetKey: tileset.name,
-            tileWidth: tileset.tileWidth,
-            tileHeight: tileset.tileHeight,
-            columns: tileset.columns,
-            frameDuration: data.animation[0].duration,
-            frames: data.animation.map((f) => f.tileid),
-          });
-        }
-      }
-
+    const infos = this.tilesetsRef.map((ts) => ({
+      name: ts.name,
+      tileWidth: ts.tileWidth,
+      tileHeight: ts.tileHeight,
+      columns: ts.columns,
+      tileData: (ts as unknown as { tileData?: Record<string, { animation?: Array<{ tileid: number; duration: number }> }> }).tileData,
+    }));
+    this.magicEffectPool = buildMagicEffectPool(props, infos);
+    if (this.magicEffectPool.length > 0) {
       EventBus.emit("magic-effects-loaded", this.magicEffectPool.length);
-    } catch {
-      // Ignore malformed magic_effects
     }
   }
 

--- a/frontend/src/test/mocks/phaser.ts
+++ b/frontend/src/test/mocks/phaser.ts
@@ -1,0 +1,181 @@
+/**
+ * Lightweight Phaser mock factory for unit-testing game objects
+ * (SpeechBubble, MagicEffect, etc.) without a real Phaser runtime.
+ */
+import { vi } from "vitest";
+
+// ── Tiny helpers ────────────────────────────────────
+
+export function createMockTimerEvent() {
+  return { remove: vi.fn() };
+}
+
+export function createMockGraphics() {
+  const g: Record<string, unknown> = {
+    clear: vi.fn().mockReturnThis(),
+    fillStyle: vi.fn().mockReturnThis(),
+    fillRoundedRect: vi.fn().mockReturnThis(),
+    lineStyle: vi.fn().mockReturnThis(),
+    strokeRoundedRect: vi.fn().mockReturnThis(),
+    fillTriangle: vi.fn().mockReturnThis(),
+    lineBetween: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+  };
+  return g;
+}
+
+export function createMockText() {
+  const t: Record<string, unknown> = {
+    width: 40,
+    height: 10,
+    setText: vi.fn().mockImplementation(function (this: Record<string, unknown>, _msg: string) {
+      // Simulate text resizing: short messages are narrower
+      return this;
+    }),
+    setOrigin: vi.fn().mockReturnThis(),
+    setPosition: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+  };
+  return t;
+}
+
+export function createMockSprite() {
+  const s: Record<string, unknown> = {
+    x: 100,
+    y: 100,
+    displayHeight: 24,
+    scene: true, // truthy — MagicEffect checks `sprite.scene`
+    setDepth: vi.fn().mockReturnThis(),
+    setPosition: vi.fn().mockImplementation(function (this: Record<string, unknown>, x: number, y: number) {
+      this.x = x;
+      this.y = y;
+      return this;
+    }),
+    setScale: vi.fn().mockReturnThis(),
+    play: vi.fn().mockReturnThis(),
+    destroy: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+      this.scene = null;
+    }),
+  };
+  return s;
+}
+
+/** Stateful container mock — SpeechBubble reads alpha/visible to decide fade vs swap */
+export function createMockContainer() {
+  const c: Record<string, unknown> = {
+    alpha: 0,
+    visible: false,
+    width: 0,
+    height: 0,
+    setDepth: vi.fn().mockReturnThis(),
+    setAlpha: vi.fn().mockImplementation(function (this: Record<string, unknown>, a: number) {
+      this.alpha = a;
+      return this;
+    }),
+    setVisible: vi.fn().mockImplementation(function (this: Record<string, unknown>, v: boolean) {
+      this.visible = v;
+      return this;
+    }),
+    setSize: vi.fn().mockImplementation(function (this: Record<string, unknown>, w: number, h: number) {
+      this.width = w;
+      this.height = h;
+      return this;
+    }),
+    setPosition: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+  };
+  return c;
+}
+
+// ── Scene factory ───────────────────────────────────
+
+export interface MockScene {
+  add: {
+    graphics: ReturnType<typeof vi.fn>;
+    text: ReturnType<typeof vi.fn>;
+    container: ReturnType<typeof vi.fn>;
+    sprite: ReturnType<typeof vi.fn>;
+  };
+  tweens: {
+    add: ReturnType<typeof vi.fn>;
+    killTweensOf: ReturnType<typeof vi.fn>;
+  };
+  time: {
+    delayedCall: ReturnType<typeof vi.fn>;
+  };
+  scale: { width: number };
+  anims: {
+    exists: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  /** Captures last tween config so tests can inspect / fire onComplete */
+  _lastTween: Record<string, unknown> | null;
+  /** Captures last delayedCall callback */
+  _lastDelayedCallback: (() => void) | null;
+  /** Refs to created mocks */
+  _graphics: ReturnType<typeof createMockGraphics>;
+  _text: ReturnType<typeof createMockText>;
+  _container: ReturnType<typeof createMockContainer>;
+  _sprite: ReturnType<typeof createMockSprite>;
+}
+
+export function createMockScene(): MockScene {
+  const graphics = createMockGraphics();
+  const text = createMockText();
+  const container = createMockContainer();
+  const sprite = createMockSprite();
+
+  const scene: MockScene = {
+    _lastTween: null,
+    _lastDelayedCallback: null,
+    _graphics: graphics,
+    _text: text,
+    _container: container,
+    _sprite: sprite,
+
+    add: {
+      graphics: vi.fn(() => graphics),
+      text: vi.fn(() => text),
+      container: vi.fn(() => container),
+      sprite: vi.fn(() => sprite),
+    },
+    tweens: {
+      add: vi.fn((config: Record<string, unknown>) => {
+        scene._lastTween = config;
+        return config;
+      }),
+      killTweensOf: vi.fn(),
+    },
+    time: {
+      delayedCall: vi.fn((_delay: number, cb: () => void) => {
+        scene._lastDelayedCallback = cb;
+        return createMockTimerEvent();
+      }),
+    },
+    scale: { width: 1024 },
+    anims: {
+      exists: vi.fn(() => false),
+      create: vi.fn(),
+    },
+  };
+
+  return scene;
+}
+
+// ── Default export: Phaser namespace stub ───────────
+
+const PhaserMock = {
+  Math: {
+    Clamp: (value: number, min: number, max: number) =>
+      Math.max(min, Math.min(max, value)),
+  },
+  GameObjects: {
+    Container: class {},
+    Graphics: class {},
+    Text: class {},
+    Sprite: class {},
+  },
+  Scene: class {},
+};
+
+export default PhaserMock;


### PR DESCRIPTION
## Summary
- Add 52 new tests (25 SpeechBubble, 12 MagicEffect, 15 mapParsers) to prevent regressions for recently fixed bugs
- Extract `parseMagicEffects` logic from VillageScene into pure `buildMagicEffectPool()` function for testability
- Create shared Phaser mock factory (`src/test/mocks/phaser.ts`) for game object unit tests

## Test plan
- [x] `npm test` passes (108 total: 52 new + 56 existing)
- [x] No new TypeScript errors introduced
- [ ] Verify game still works manually (magic effects, speech bubbles, animations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)