### PR TITLE
cleanup: remove dead building-walking code

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  An animated pixel-art avatar walks between tool stations in a Phaser 3 village while you chat via an RPG-style dialog box. Persistent identity, long-term memory, hierarchical goals, proactive scheduling, screen awareness, and plug-and-play MCP server integration.
+  An animated pixel-art avatar casts magic effects when using tools in a Phaser 3 village while you chat via an RPG-style dialog box. Persistent identity, long-term memory, hierarchical goals, proactive scheduling, screen awareness, and plug-and-play MCP server integration.
 </p>
 
 ---
@@ -62,7 +62,7 @@ frontend/src/
   hooks/             useWebSocket, useAgentAnimation
   stores/            Zustand stores — chat, quest
   lib/               Tool parser, animation state machine
-  config/            Constants, building positions, waypoints
+  config/            Constants, default positions, waypoints
 
 backend/src/
   api/               REST + WebSocket endpoints (chat, sessions, goals, tools, mcp)
@@ -83,18 +83,12 @@ docs/                Docusaurus docs site
 ## Village & Avatar
 
 ```
-User sends message  -->  THINKING at bench
-  Tool detected:
-    web_search       -->  walks to WELL
-    shell_execute    -->  walks to FORGE
-    browse_webpage   -->  walks to TOWER
-    read/write_file  -->  walks to SIGNPOST
-    soul/goals       -->  walks to CHURCH
-    MCP tools        -->  walks to assigned building
-  Response ready     -->  walks back  -->  SPEAKING  -->  IDLE  -->  WANDERING
+User sends message  -->  THINKING
+  Tool detected     -->  CASTING + magic effect overlay
+  Response ready    -->  SPEAKING  -->  IDLE  -->  WANDERING
 ```
 
-MCP tools automatically animate to their assigned village building.
+Tool use triggers a casting animation with a magic effect overlay at the agent's position.
 
 ---
 
@@ -104,7 +98,7 @@ Add external tool servers with zero code changes:
 
 ```bash
 ./mcp.sh add things3 http://host.docker.internal:9100/mcp \
-  --building church --desc "Things3 task manager"
+  --desc "Things3 task manager"
 
 ./mcp.sh list              # View configured servers
 ./mcp.sh test things3      # Test connection
@@ -115,8 +109,6 @@ Add external tool servers with zero code changes:
 Also available via the **Settings UI** in the browser or the **REST API** (`/api/mcp/servers`).
 
 Config: `data/mcp-servers.json` | Example: `data/mcp-servers.example.json`
-
-Available buildings: `house-1` `church` `house-2` `forge` `tower` `clock` `mailbox`
 
 ---
 

--- a/REPORT.md
+++ b/REPORT.md
@@ -45,7 +45,7 @@ However, significant work remains to reach the stated vision of being "better th
 - Polished RPG aesthetic: CRT scanlines, pixel borders, retro scrollbars, message animations
 - Robust WebSocket hook with auto-reconnect, exponential backoff, session restoration
 - 125 distinct asset files (54 characters, 55 enemies, 22 tilesets, 15 animation sheets)
-- All animation states working: idle, thinking, walking, wandering, at-well/signpost/bench/tower/forge/clock/mailbox, speaking, casting
+- All animation states working: idle, thinking, walking, wandering, casting, speaking
 
 **Issues Found:**
 - No goal creation UI in the frontend (backend supports it, but users can only create goals through chat)
@@ -210,7 +210,7 @@ This is critical - these are Seraph's unique advantages that should be doubled d
 No other AI agent has a user state machine + attention budget + delivery gating. OpenClaw is purely reactive. Manus is purely reactive. Seraph actively reasons about your life every 15 minutes and decides whether/when to speak. This is genuinely novel.
 
 ### 2. The RPG Village Metaphor
-Every other AI agent is a chat window or terminal. Seraph's village creates a psychological framework for life management that is unique in the space. The avatar walking to tool stations, the quest log, the ambient state indicators - this is a completely different paradigm for human-AI interaction.
+Every other AI agent is a chat window or terminal. Seraph's village creates a psychological framework for life management that is unique in the space. The avatar casting magic effects during tool use, the quest log, the ambient state indicators - this is a completely different paradigm for human-AI interaction.
 
 ### 3. Five-Pillar Life Model
 OpenClaw optimizes for task execution. Manus optimizes for workflows. Seraph optimizes for the *human* across productivity, performance, health, influence, and growth. No competitor has this breadth.

--- a/backend/data/mcp-servers.example.json
+++ b/backend/data/mcp-servers.example.json
@@ -3,13 +3,11 @@
     "things3": {
       "url": "http://host.docker.internal:9100/mcp",
       "enabled": true,
-      "building": "church",
       "description": "Things3 task manager"
     },
     "github": {
       "url": "http://github-mcp:8090/mcp",
       "enabled": false,
-      "building": "tower",
       "description": "GitHub integration"
     }
   }

--- a/docs/docs/architecture/feature-comparison.md
+++ b/docs/docs/architecture/feature-comparison.md
@@ -12,7 +12,7 @@ sidebar_position: 2
 
 **OpenClaw** is a self-hosted gateway connecting messaging platforms (WhatsApp, Telegram, Discord, etc.) to AI agents. It's headless — text-in/text-out with no visual UI.
 
-**Seraph** is a self-contained web app with a retro 16-bit RPG village UI. A Phaser 3 canvas renders a tile-based village where an animated pixel-art avatar walks between tool stations while the user chats via an RPG-style dialog box. Persistent identity, long-term memory, hierarchical goals.
+**Seraph** is a self-contained web app with a retro 16-bit RPG village UI. A Phaser 3 canvas renders a tile-based village where an animated pixel-art avatar casts magic effects when using tools while the user chats via an RPG-style dialog box. Persistent identity, long-term memory, hierarchical goals.
 
 Different philosophies, but many of OpenClaw's features are worth adopting.
 
@@ -21,7 +21,7 @@ Different philosophies, but many of OpenClaw's features are worth adopting.
 ## What Seraph Has (Phase 0-2 Complete)
 
 - Real-time chat with AI agent (WebSocket streaming with step/final/error/proactive/ambient types)
-- Tool execution with visual feedback (animated RPG avatar walks to tool stations in village)
+- Tool execution with visual feedback (animated RPG avatar casts magic effects in village)
 - **16 auto-discovered tools + MCP integrations**: web search, file I/O, template fill, soul view/update, goal CRUD, shell execute (snekbox sandbox), browser automation (Playwright), calendar (Google), email (Gmail), task management (Things3 via MCP)
 - **Persistent sessions** — SQLite-backed, survive restarts, session list UI with switch/delete
 - **Persistent memory** — Soul file (soul.md) + LanceDB vector store with sentence-transformer embeddings
@@ -137,8 +137,8 @@ These were gaps in the original analysis that have since been implemented:
 
 OpenClaw is headless. Seraph's **visual RPG experience** has no equivalent:
 
-- Phaser 3 village scene with 7 buildings mapped to tool categories
-- Animated pixel-art avatar walking between tool stations
+- Phaser 3 village scene with 7 buildings and magic effect animations
+- Animated pixel-art avatar with casting effects on tool use
 - Day/night cycle based on system time
 - Idle wandering between 12 waypoints
 - Speech bubbles with step content

--- a/docs/docs/development/phase-2-capable-executor.md
+++ b/docs/docs/development/phase-2-capable-executor.md
@@ -26,22 +26,9 @@ backend/src/plugins/
 - Supports hot-reload via `reload_tools()`
 
 **Tool registry** (`registry.py`):
-- Maps tool names to village metadata:
-  ```python
-  TOOL_METADATA = {
-      "web_search":             {"building": "house-1",  "pixel_x": 192, "pixel_y": 280, "animation": "at-well"},
-      "read_file":              {"building": "house-2",  "pixel_x": 832, "pixel_y": 280, "animation": "at-signpost"},
-      "shell_execute":          {"building": "forge",    "pixel_x": 384, "pixel_y": 320, "animation": "at-forge"},
-      "browse_webpage":         {"building": "tower",    "pixel_x": 640, "pixel_y": 200, "animation": "at-tower"},
-      "get_calendar_events":    {"building": "clock",    "pixel_x": 576, "pixel_y": 340, "animation": "at-clock"},
-      "create_calendar_event":  {"building": "clock",    "pixel_x": 576, "pixel_y": 340, "animation": "at-clock"},
-      "read_emails":            {"building": "mailbox",  "pixel_x": 128, "pixel_y": 340, "animation": "at-mailbox"},
-      "send_email":             {"building": "mailbox",  "pixel_x": 128, "pixel_y": 340, "animation": "at-mailbox"},
-      # ... plus all Phase 1 tools
-  }
-  ```
+- Maps tool names to metadata for the `GET /api/tools` endpoint
 
-**API endpoint**: `GET /api/tools` — returns available tools with village metadata
+**API endpoint**: `GET /api/tools` — returns available tools with metadata
 
 **Modified**: `backend/src/agent/factory.py`
 - `get_tools()` now calls `discover_tools()` from plugin loader + `mcp_manager.get_tools()` for MCP tools
@@ -66,8 +53,6 @@ sandbox-dev:
 - Calls snekbox HTTP API (`http://sandbox:8060/eval`)
 - Returns stdout/stderr, handles timeouts (35s default)
 - Sandboxed — no network access, limited resources
-
-**Village element**: Forge building at position (384, 320)
 
 **Settings**:
 - `sandbox_url`: URL of the snekbox service (default `http://sandbox:8060`)
@@ -103,8 +88,6 @@ RUN uv run playwright install chromium
 - 30s timeout, single-page context per call
 - Real browser user agent for JavaScript-rendered pages
 
-**Village element**: Tower building at position (640, 200)
-
 ---
 
 ## 2.4 Calendar Integration
@@ -117,8 +100,6 @@ RUN uv run playwright install chromium
 - Uses gcsa (Google Calendar Simple API)
 - OAuth credentials at `/app/config/google_credentials.json`
 - Token stored at `/app/data/google_calendar_token.json`
-
-**Village element**: Town clock at position (576, 340)
 
 **Settings**:
 - `google_credentials_path`: Path to OAuth credentials JSON
@@ -136,8 +117,6 @@ RUN uv run playwright install chromium
 - Shares Google OAuth credentials with calendar
 - Separate token: `/app/data/google_gmail_token.json`
 
-**Village element**: Mailbox at position (128, 340)
-
 ---
 
 ## 2.6 Village Expansion
@@ -148,21 +127,11 @@ RUN uv run playwright install chromium
 - Props placement system for smaller objects (clock, mailbox)
 - Extended wandering waypoints to include new building areas
 
-**Modified**: `frontend/src/game/objects/AgentSprite.ts`
-- 4 new animation states:
-  - `at-forge`: Facing down, medium cycle (hammering motion)
-  - `at-tower`: Facing up, slow cycle (looking/observing)
-  - `at-clock`: Facing right, slow cycle (checking time)
-  - `at-mailbox`: Facing left, slow cycle (reading letter)
-
 **Modified**: `frontend/src/config/constants.ts`
 - New `TOOL_NAMES`: `SHELL_EXECUTE`, `BROWSE_WEBPAGE`, `GET_CALENDAR_EVENTS`, `CREATE_CALENDAR_EVENT`, `READ_EMAILS`, `SEND_EMAIL` (plus Phase 1 soul/goal tools)
-- New `POSITIONS`: forge (35%), tower (60%), clock (55%), mailbox (10%)
-- New `SCENE.POSITIONS`: forge, tower, clock, mailbox with pixel coords
-- Extended wandering waypoints
 
 **Modified**: `frontend/src/lib/animationStateMachine.ts`
-- Full `TOOL_TARGETS` mapping for all 16 native tools + Things3 MCP tools to village positions and animations
+- Tool detection triggers casting animation with magic effect overlay
 
 ---
 
@@ -191,21 +160,21 @@ RUN uv run playwright install chromium
 
 ## All 16 Tools (auto-discovered)
 
-| Tool | File | Village Building | Animation |
-|------|------|-----------------|-----------|
-| `web_search` | web_search_tool.py | house-1 | at-well |
-| `read_file` | filesystem_tool.py | house-2 | at-signpost |
-| `write_file` | filesystem_tool.py | house-2 | at-signpost |
-| `fill_template` | template_tool.py | church | at-bench |
-| `view_soul` | soul_tool.py | church | at-bench |
-| `update_soul` | soul_tool.py | church | at-bench |
-| `create_goal` | goal_tools.py | church | at-bench |
-| `update_goal` | goal_tools.py | church | at-bench |
-| `get_goals` | goal_tools.py | church | at-bench |
-| `get_goal_progress` | goal_tools.py | church | at-bench |
-| `shell_execute` | shell_tool.py | forge | at-forge |
-| `browse_webpage` | browser_tool.py | tower | at-tower |
-| `get_calendar_events` | calendar_tool.py | clock | at-clock |
-| `create_calendar_event` | calendar_tool.py | clock | at-clock |
-| `read_emails` | email_tool.py | mailbox | at-mailbox |
-| `send_email` | email_tool.py | mailbox | at-mailbox |
+| Tool | File |
+|------|------|
+| `web_search` | web_search_tool.py |
+| `read_file` | filesystem_tool.py |
+| `write_file` | filesystem_tool.py |
+| `fill_template` | template_tool.py |
+| `view_soul` | soul_tool.py |
+| `update_soul` | soul_tool.py |
+| `create_goal` | goal_tools.py |
+| `update_goal` | goal_tools.py |
+| `get_goals` | goal_tools.py |
+| `get_goal_progress` | goal_tools.py |
+| `shell_execute` | shell_tool.py |
+| `browse_webpage` | browser_tool.py |
+| `get_calendar_events` | calendar_tool.py |
+| `create_calendar_event` | calendar_tool.py |
+| `read_emails` | email_tool.py |
+| `send_email` | email_tool.py |

--- a/docs/docs/development/phase-4-the-network.md
+++ b/docs/docs/development/phase-4-the-network.md
@@ -205,7 +205,7 @@ backend/src/agents/
 - Seraph can delegate to sub-agents: "Let me have my researcher look into that..."
 - Channel-based routing: Telegram → Seraph, Discord #code → Coder
 
-**Village element**: NPCs at different buildings represent sub-agents (blacksmith at forge = Coder, scholar at library = Researcher)
+**Village element**: NPCs in the village represent sub-agents visually
 
 ---
 
@@ -407,7 +407,7 @@ backend/src/tools/canvas_tool.py
 - Project timeline (Gantt-style)
 - Email/calendar analytics
 
-**Village element**: Seraph walks to the notice board to post visualizations
+**Village element**: Notice board building in village for visualizations
 
 ---
 

--- a/docs/docs/development/phase-5-security.md
+++ b/docs/docs/development/phase-5-security.md
@@ -35,7 +35,6 @@ backend/src/security/
     "github": {
       "url": "https://api.githubcopilot.com/mcp/",
       "enabled": true,
-      "building": "tower",
       "auth": {
         "type": "bearer",
         "credential_id": "github-pat"

--- a/docs/docs/integrations/things3-mcp.md
+++ b/docs/docs/integrations/things3-mcp.md
@@ -130,8 +130,6 @@ Once connected, ask Seraph anything about your Things3 tasks:
 - "Show me all tasks tagged 'urgent'"
 - "What did I complete this week?"
 
-The village avatar walks to the church/bench area (tasks & goals station) when using Things3 tools.
-
 ## Available Tools
 
 All 22 tools from things-mcp are exposed to the agent:
@@ -160,14 +158,6 @@ All 22 tools from things-mcp are exposed to the agent:
 | `update_project` | Update an existing project |
 | `show_item` | Open a Things item by ID |
 | `search_items` | Search via Things URL scheme |
-
-## Village Animation
-
-All Things3 tools map to the **church/bench** station (the tasks & goals area):
-
-- **Building**: church
-- **Position**: (512, 240)
-- **Animation**: `at-bench`
 
 ## Implementation Details
 
@@ -210,5 +200,5 @@ All Things3 tools map to the **church/bench** station (the tasks & goals area):
 - Things3 must be open on the Mac (URL scheme requires the app to be running)
 - Check things-mcp terminal for errors
 
-**Agent doesn't walk to church when using Things tools**
+**Agent doesn't show magic effects when using Things tools**
 - Clear browser cache and reload — the frontend tool names may be stale

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -5,7 +5,7 @@ slug: /
 
 # Getting Started
 
-Seraph is a proactive AI guardian with a retro 16-bit RPG village UI. A Phaser 3 canvas renders a tile-based village where an animated pixel-art avatar walks between tool stations (well for web search, forge for shell, mailbox for email, etc.) while you chat via an RPG-style dialog box. The agent has persistent identity, long-term memory, and a hierarchical goal/quest system.
+Seraph is a proactive AI guardian with a retro 16-bit RPG village UI. A Phaser 3 canvas renders a tile-based village where an animated pixel-art avatar casts magic effects when using tools while you chat via an RPG-style dialog box. The agent has persistent identity, long-term memory, and a hierarchical goal/quest system.
 
 ## Setup
 

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -72,13 +72,13 @@ Seraph knows who you are, what you want, and remembers everything.
 - Sandboxed shell command execution (Docker-based)
 - Configurable permissions (read-only, workspace-scoped, full)
 - Output streaming to chat
-- New village location: **Forge** (avatar walks to anvil/forge for code/shell tasks)
+- New village location: **Forge** (visual element in village)
 
 ### 2.2 Browser Automation Tool
 - Playwright-based browser control
 - Navigate, extract, fill forms, screenshot
 - Sandboxed browser instance (no access to user's real browser)
-- New village location: **Observatory/Tower** (avatar climbs tower for web exploration)
+- New village location: **Observatory/Tower** (visual element in village)
 
 ### 2.3 Calendar & Email Integration
 - Google Calendar / Outlook read/write

--- a/docs/docs/tools/village-editor.md
+++ b/docs/docs/tools/village-editor.md
@@ -116,20 +116,6 @@ Open the animation definer from the tileset panel to create animated tiles:
 
 Objects live on a separate layer and define game-logic entities.
 
-### Tool Stations
-
-Where the agent avatar walks when using a tool:
-
-| Station | Tool Key | Animation State |
-|---------|----------|-----------------|
-| Well | web_search | at-well |
-| Scroll-desk | read_file | at-signpost |
-| Shrine | view_soul | at-bench |
-| Anvil | shell_execute | at-forge |
-| Telescope-tower | browse_webpage | at-tower |
-| Sundial | calendar | at-clock |
-| Pigeon-post | email | at-mailbox |
-
 ### Spawn Points
 
 Starting positions for `agent_spawn` and `user_spawn`. Spawn points can be assigned a character sprite via the inline sprite picker (format: `Character_XXX_Y` where XXX = sheet number, Y = character 1-4).

--- a/editor/README.md
+++ b/editor/README.md
@@ -152,20 +152,6 @@ Open the animation definer from the tileset panel to create animated tiles:
 
 Objects live on a separate layer and define game-logic entities.
 
-### Tool Stations
-
-Where the agent avatar walks when using a tool:
-
-| Station | Tool Key | Animation State |
-|---------|----------|-----------------|
-| Well | web_search | at-well |
-| Scroll-desk | read_file | at-signpost |
-| Shrine | view_soul | at-bench |
-| Anvil | shell_execute | at-forge |
-| Telescope-tower | browse_webpage | at-tower |
-| Sundial | calendar | at-clock |
-| Pigeon-post | email | at-mailbox |
-
 ### Spawn Points
 
 Starting positions for `agent_spawn` and `user_spawn`. Spawn points can be assigned a character sprite via the inline sprite picker.

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -8,13 +8,7 @@ export const WS_PING_INTERVAL_MS = 30000;
 
 // Percentage-based positions for animation state machine (fallback)
 export const POSITIONS = {
-  mailbox: 10,
-  well: 15,
-  forge: 35,
   bench: 50,
-  tower: 60,
-  clock: 55,
-  signpost: 85,
 } as const;
 
 // Native tool names (static fallback — dynamic tools loaded from API)

--- a/frontend/src/game/objects/AgentSprite.ts
+++ b/frontend/src/game/objects/AgentSprite.ts
@@ -188,96 +188,6 @@ export class AgentSprite {
       repeat: -1,
     });
 
-    // At-well: facing left, slow idle
-    scene.anims.create({
-      key: "at-well",
-      frames: scene.anims.generateFrameNames(SPRITE_KEY, {
-        prefix: "left-walk.",
-        start: 0,
-        end: 5,
-        zeroPad: 3,
-      }),
-      frameRate: 4,
-      repeat: -1,
-    });
-
-    // At-signpost: facing right, slow idle
-    scene.anims.create({
-      key: "at-signpost",
-      frames: scene.anims.generateFrameNames(SPRITE_KEY, {
-        prefix: "right-walk.",
-        start: 0,
-        end: 5,
-        zeroPad: 3,
-      }),
-      frameRate: 4,
-      repeat: -1,
-    });
-
-    // At-bench: facing up, slow cycle
-    scene.anims.create({
-      key: "at-bench",
-      frames: scene.anims.generateFrameNames(SPRITE_KEY, {
-        prefix: "up-walk.",
-        start: 0,
-        end: 5,
-        zeroPad: 3,
-      }),
-      frameRate: 3,
-      repeat: -1,
-    });
-
-    // At-forge: facing down, medium cycle (hammering)
-    scene.anims.create({
-      key: "at-forge",
-      frames: scene.anims.generateFrameNames(SPRITE_KEY, {
-        prefix: "down-walk.",
-        start: 0,
-        end: 5,
-        zeroPad: 3,
-      }),
-      frameRate: 5,
-      repeat: -1,
-    });
-
-    // At-tower: facing up, slow cycle (looking up/observing)
-    scene.anims.create({
-      key: "at-tower",
-      frames: scene.anims.generateFrameNames(SPRITE_KEY, {
-        prefix: "up-walk.",
-        start: 0,
-        end: 5,
-        zeroPad: 3,
-      }),
-      frameRate: 4,
-      repeat: -1,
-    });
-
-    // At-clock: facing right, slow cycle (checking time)
-    scene.anims.create({
-      key: "at-clock",
-      frames: scene.anims.generateFrameNames(SPRITE_KEY, {
-        prefix: "right-walk.",
-        start: 0,
-        end: 5,
-        zeroPad: 3,
-      }),
-      frameRate: 3,
-      repeat: -1,
-    });
-
-    // At-mailbox: facing left, slow cycle (reading letter)
-    scene.anims.create({
-      key: "at-mailbox",
-      frames: scene.anims.generateFrameNames(SPRITE_KEY, {
-        prefix: "left-walk.",
-        start: 0,
-        end: 5,
-        zeroPad: 3,
-      }),
-      frameRate: 3,
-      repeat: -1,
-    });
   }
 
   private createCharSheetAnimations(config: SpriteConfig) {
@@ -317,13 +227,6 @@ export class AgentSprite {
     });
 
     scene.anims.create({ key: "think", frames: framesByDir["down"], frameRate: 3, repeat: -1 });
-    scene.anims.create({ key: "at-well", frames: framesByDir["left"], frameRate: 4, repeat: -1 });
-    scene.anims.create({ key: "at-mailbox", frames: framesByDir["left"], frameRate: 3, repeat: -1 });
-    scene.anims.create({ key: "at-signpost", frames: framesByDir["right"], frameRate: 4, repeat: -1 });
-    scene.anims.create({ key: "at-clock", frames: framesByDir["right"], frameRate: 3, repeat: -1 });
-    scene.anims.create({ key: "at-bench", frames: framesByDir["up"], frameRate: 3, repeat: -1 });
-    scene.anims.create({ key: "at-tower", frames: framesByDir["up"], frameRate: 4, repeat: -1 });
-    scene.anims.create({ key: "at-forge", frames: framesByDir["down"], frameRate: 5, repeat: -1 });
   }
 
   moveTo(x: number, y: number, onComplete?: () => void) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -38,13 +38,6 @@ export type AgentAnimationState =
   | "walking"
   | "wandering"
   | "casting"
-  | "at-well"
-  | "at-signpost"
-  | "at-bench"
-  | "at-tower"
-  | "at-forge"
-  | "at-clock"
-  | "at-mailbox"
   | "speaking";
 
 export type FacingDirection = "left" | "right";
@@ -54,12 +47,6 @@ export interface AgentVisualState {
   positionX: number; // percentage 0-100
   facing: FacingDirection;
   speechText: string | null;
-}
-
-export interface ToolTarget {
-  tool: string;
-  positionX: number;
-  animationState: AgentAnimationState;
 }
 
 export type AmbientState = "idle" | "has_insight" | "goal_behind" | "on_track" | "waiting";


### PR DESCRIPTION
## Summary

- Remove 7 dead `at-*` animation states from `AgentAnimationState` and the unused `ToolTarget` interface
- Remove 14 `at-*` animation definitions from `AgentSprite.ts` (both `createAnimations` and `createCharSheetAnimations`)
- Reduce `POSITIONS` in constants to just `bench` (only one still referenced)
- Remove `building` fields from `mcp-servers.example.json`
- Update CLAUDE.md, README.md, REPORT.md, editor/README.md, and 7 docs files to reflect magic-effect-based tool visualization instead of building-walking

## Test plan

- [ ] `npx tsc --noEmit` passes (no code references removed types)
- [ ] `npx vitest run` — all 121 tests pass
- [ ] Grep for `at-well|at-forge|at-tower|at-signpost|at-bench|at-clock|at-mailbox` — zero results
- [ ] Grep for `walks to|tool station` in docs — zero stale references

🤖 Generated with [Claude Code](https://claude.com/claude-code)