### PR TITLE
feat: quest search/filter, font bumps, Shift+key shortcuts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Seraph is an AI agent with a retro 16-bit RPG village UI. A Phaser 3 canvas rend
   - `src/lib/animationStateMachine.ts` - Tool → casting animation mapping; triggers magic effects on tool use
   - `src/config/constants.ts` - Scene dimensions, tool names, default agent position, wandering waypoints
   - `src/components/chat/` - ChatPanel, SessionList, MessageList, MessageBubble, ChatInput, ThinkingIndicator, DialogFrame (RPG frame with optional maximize/close buttons)
-  - `src/components/quest/` - QuestPanel, GoalTree, DomainStats
+  - `src/components/quest/` - QuestPanel (search/filter by title, level, domain), GoalTree, GoalForm, DomainStats
   - `src/components/SettingsPanel.tsx` - Standalone settings overlay panel (restart onboarding, skills management, MCP server management UI, version)
   - `src/components/HudButtons.tsx` - Floating RPG-styled buttons to reopen closed Chat/Quest/Settings panels + ambient state indicator dot (color-coded, pulsing)
   - `src/index.css` - CRT scanlines/vignette, pixel borders, RPG frame, chat-overlay maximized state
@@ -246,7 +246,10 @@ deliver_or_queue()  ← attention guardian (Phase 3.3)
 - **Maximize/Minimize**: ▲/▼ button on DialogFrame expands chat overlay to nearly full screen (16px margins all sides) with CSS transition
 - **Close**: ✕ button on DialogFrame hides the panel
 - **Reopen**: Floating HudButtons at bottom-left appear when panels are closed ("Chat", "Quests", "Settings")
+- **Keyboard shortcuts**: Shift+C (chat), Shift+Q (quests), Shift+S (settings), Escape (close). Shift modifier prevents conflict with WASD avatar movement. Ignored when focus is in INPUT/TEXTAREA.
+- **Quest search/filter**: QuestPanel includes text search, level dropdown, and domain dropdown. Client-side recursive filter preserves parent chain when descendants match.
 - **Session persistence**: Last selected `sessionId` stored in `localStorage` (`seraph_last_session_id`); restored on page load via `switchSession()` in WS `onopen`
+- **Font sizing**: Minimum 9px throughout all panels (Press Start 2P pixel font). Headers/labels 10-11px, body text 10-11px, secondary/meta text 9-10px.
 
 ## Design Decisions
 1. **Phaser 3 canvas** — Village scene rendered via Phaser with tile-based map. React overlays for chat/quest panels.

--- a/frontend/src/components/HudButtons.tsx
+++ b/frontend/src/components/HudButtons.tsx
@@ -24,8 +24,8 @@ export function HudButtons() {
       {!chatPanelOpen && (
         <button
           onClick={() => setChatPanelOpen(true)}
-          className="rpg-frame px-3 py-2 text-[10px] text-retro-border hover:text-retro-highlight uppercase tracking-wider transition-colors cursor-pointer"
-          title="Open Chat Log (C)"
+          className="rpg-frame px-3 py-2 text-[11px] text-retro-border hover:text-retro-highlight uppercase tracking-wider transition-colors cursor-pointer"
+          title="Open Chat Log (Shift+C)"
         >
           Chat
         </button>
@@ -33,8 +33,8 @@ export function HudButtons() {
       {!questPanelOpen && (
         <button
           onClick={() => setQuestPanelOpen(true)}
-          className="rpg-frame px-3 py-2 text-[10px] text-retro-border hover:text-retro-highlight uppercase tracking-wider transition-colors cursor-pointer"
-          title="Open Quest Log (Q)"
+          className="rpg-frame px-3 py-2 text-[11px] text-retro-border hover:text-retro-highlight uppercase tracking-wider transition-colors cursor-pointer"
+          title="Open Quest Log (Shift+Q)"
         >
           Quests
         </button>
@@ -42,8 +42,8 @@ export function HudButtons() {
       {!settingsPanelOpen && (
         <button
           onClick={() => setSettingsPanelOpen(true)}
-          className="rpg-frame px-3 py-2 text-[10px] text-retro-border hover:text-retro-highlight uppercase tracking-wider transition-colors cursor-pointer"
-          title="Open Settings (S)"
+          className="rpg-frame px-3 py-2 text-[11px] text-retro-border hover:text-retro-highlight uppercase tracking-wider transition-colors cursor-pointer"
+          title="Open Settings (Shift+S)"
         >
           Settings
         </button>

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -26,13 +26,13 @@ function SkillRow({
     <div className="flex items-center gap-1 px-1 py-0.5 border-b border-retro-text/10 last:border-b-0">
       <div className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${statusColor}`} />
       <div className="flex-1 min-w-0">
-        <div className="text-[9px] font-bold text-retro-text truncate">
+        <div className="text-[10px] font-bold text-retro-text truncate">
           {skill.name}
           {skill.user_invocable && (
             <span className="text-retro-highlight/60 ml-1 font-normal">invocable</span>
           )}
         </div>
-        <div className="text-[8px] text-retro-text/40 truncate">
+        <div className="text-[9px] text-retro-text/40 truncate">
           {skill.description}
           {skill.requires_tools.length > 0 && (
             <span> · needs: {skill.requires_tools.join(", ")}</span>
@@ -41,7 +41,7 @@ function SkillRow({
       </div>
       <button
         onClick={() => onToggle(skill.name, !skill.enabled)}
-        className={`text-[8px] px-0.5 ${skill.enabled ? "text-green-400 hover:text-red-400" : "text-retro-text/40 hover:text-green-400"}`}
+        className={`text-[9px] px-0.5 ${skill.enabled ? "text-green-400 hover:text-red-400" : "text-retro-text/40 hover:text-green-400"}`}
       >
         {skill.enabled ? "on" : "off"}
       </button>
@@ -79,28 +79,28 @@ function McpServerRow({
     <div className="flex items-center gap-1 px-1 py-0.5 border-b border-retro-text/10 last:border-b-0">
       <div className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${statusColor}`} />
       <div className="flex-1 min-w-0">
-        <div className="text-[9px] font-bold text-retro-text truncate">{server.name}</div>
-        <div className="text-[8px] text-retro-text/40 truncate">
+        <div className="text-[10px] font-bold text-retro-text truncate">{server.name}</div>
+        <div className="text-[9px] text-retro-text/40 truncate">
           {server.description || server.url}
           {server.connected && ` · ${server.tool_count} tools`}
         </div>
       </div>
       <button
         onClick={() => onTest(server.name)}
-        className="text-[8px] text-retro-text/40 hover:text-retro-highlight px-0.5"
+        className="text-[9px] text-retro-text/40 hover:text-retro-highlight px-0.5"
         title="Test connection"
       >
         test
       </button>
       <button
         onClick={() => onToggle(server.name, !server.enabled)}
-        className={`text-[8px] px-0.5 ${server.enabled ? "text-green-400 hover:text-red-400" : "text-retro-text/40 hover:text-green-400"}`}
+        className={`text-[9px] px-0.5 ${server.enabled ? "text-green-400 hover:text-red-400" : "text-retro-text/40 hover:text-green-400"}`}
       >
         {server.enabled ? "on" : "off"}
       </button>
       <button
         onClick={() => onRemove(server.name)}
-        className="text-[8px] text-retro-text/30 hover:text-red-400 px-0.5"
+        className="text-[9px] text-retro-text/30 hover:text-red-400 px-0.5"
         title="Remove server"
       >
         x
@@ -152,7 +152,7 @@ function AddServerForm({ onAdd }: { onAdd: () => void }) {
     return (
       <button
         onClick={() => setShow(true)}
-        className="text-[8px] text-retro-text/40 hover:text-retro-highlight px-1 py-0.5 uppercase tracking-wider"
+        className="text-[9px] text-retro-text/40 hover:text-retro-highlight px-1 py-0.5 uppercase tracking-wider"
       >
         + Add server
       </button>
@@ -182,17 +182,17 @@ function AddServerForm({ onAdd }: { onAdd: () => void }) {
         onChange={(e) => setDescription(e.target.value)}
         className="w-full bg-transparent text-[9px] text-retro-text border-b border-retro-text/20 px-0.5 py-0.5 outline-none focus:border-retro-highlight"
       />
-      {error && <div className="text-[8px] text-red-400">{error}</div>}
+      {error && <div className="text-[9px] text-red-400">{error}</div>}
       <div className="flex gap-1">
         <button
           onClick={handleSubmit}
-          className="text-[8px] text-retro-highlight hover:text-retro-text uppercase tracking-wider"
+          className="text-[9px] text-retro-highlight hover:text-retro-text uppercase tracking-wider"
         >
           Add
         </button>
         <button
           onClick={() => { setShow(false); setError(""); }}
-          className="text-[8px] text-retro-text/40 hover:text-retro-text uppercase tracking-wider"
+          className="text-[9px] text-retro-text/40 hover:text-retro-text uppercase tracking-wider"
         >
           Cancel
         </button>
@@ -318,7 +318,7 @@ export function SettingsPanel() {
       >
         <div className="flex-1 min-h-0 overflow-y-auto retro-scrollbar flex flex-col gap-2 pb-1">
           <div className="px-1">
-            <div className="text-[9px] uppercase tracking-wider text-retro-border font-bold mb-2">
+            <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-2">
               General
             </div>
             {onboardingCompleted === true && (
@@ -328,7 +328,7 @@ export function SettingsPanel() {
                   loadSessions();
                   setSettingsPanelOpen(false);
                 }}
-                className="text-[9px] text-retro-text/60 hover:text-retro-highlight text-left px-1 py-1 uppercase tracking-wider"
+                className="text-[10px] text-retro-text/60 hover:text-retro-highlight text-left px-1 py-1 uppercase tracking-wider"
               >
                 Restart intro
               </button>
@@ -338,7 +338,7 @@ export function SettingsPanel() {
           <InterruptionModeToggle />
 
           <div className="px-1">
-            <div className="text-[9px] uppercase tracking-wider text-retro-border font-bold mb-1">
+            <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-1">
               Skills
             </div>
             {skills.length > 0 ? (
@@ -352,11 +352,11 @@ export function SettingsPanel() {
                 ))}
               </div>
             ) : (
-              <div className="text-[8px] text-retro-text/30 mb-1 px-1">No skills loaded</div>
+              <div className="text-[9px] text-retro-text/30 mb-1 px-1">No skills loaded</div>
             )}
             <button
               onClick={handleSkillReload}
-              className="text-[8px] text-retro-text/40 hover:text-retro-highlight px-1 py-0.5 uppercase tracking-wider"
+              className="text-[9px] text-retro-text/40 hover:text-retro-highlight px-1 py-0.5 uppercase tracking-wider"
             >
               Reload skills
             </button>
@@ -364,7 +364,7 @@ export function SettingsPanel() {
 
           {import.meta.env.DEV && (
             <div className="px-1">
-              <div className="text-[9px] uppercase tracking-wider text-retro-border font-bold mb-1">
+              <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-1">
                 Debug
               </div>
               <button
@@ -373,7 +373,7 @@ export function SettingsPanel() {
                   setDebugWalkability(next);
                   EventBus.emit("toggle-debug-walkability", next);
                 }}
-                className="text-[9px] text-retro-text/60 hover:text-retro-highlight text-left px-1 py-1 uppercase tracking-wider"
+                className="text-[10px] text-retro-text/60 hover:text-retro-highlight text-left px-1 py-1 uppercase tracking-wider"
               >
                 {debugWalkability ? "\u2611" : "\u2610"} Show walkability grid
               </button>
@@ -381,7 +381,7 @@ export function SettingsPanel() {
           )}
 
           <div className="px-1">
-            <div className="text-[9px] uppercase tracking-wider text-retro-border font-bold mb-1">
+            <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-1">
               MCP Servers
             </div>
             {servers.length > 0 ? (
@@ -397,10 +397,10 @@ export function SettingsPanel() {
                 ))}
               </div>
             ) : (
-              <div className="text-[8px] text-retro-text/30 mb-1 px-1">No servers configured</div>
+              <div className="text-[9px] text-retro-text/30 mb-1 px-1">No servers configured</div>
             )}
             {testResult && (
-              <div className="text-[8px] text-retro-highlight px-1 mb-1">{testResult}</div>
+              <div className="text-[9px] text-retro-highlight px-1 mb-1">{testResult}</div>
             )}
             <AddServerForm onAdd={() => {
               fetchServers();
@@ -409,7 +409,7 @@ export function SettingsPanel() {
           </div>
 
           <div className="flex-1" />
-          <div className="text-[8px] text-retro-text/20 px-1 pb-1">
+          <div className="text-[9px] text-retro-text/20 px-1 pb-1">
             Seraph v0.1
           </div>
         </div>

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -39,7 +39,7 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
       <button
         type="submit"
         disabled={disabled || !value.trim()}
-        className="pixel-border-thin bg-retro-accent text-retro-border font-pixel text-[10px] px-4 py-2 hover:bg-retro-border hover:text-retro-bg transition-colors disabled:opacity-30 disabled:cursor-not-allowed uppercase tracking-wider"
+        className="pixel-border-thin bg-retro-accent text-retro-border font-pixel text-[11px] px-4 py-2 hover:bg-retro-border hover:text-retro-bg transition-colors disabled:opacity-30 disabled:cursor-not-allowed uppercase tracking-wider"
       >
         Send
       </button>

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -36,7 +36,7 @@ export function ChatPanel({ onSend, onSkipOnboarding }: ChatPanelProps) {
           {onboardingCompleted === false && onSkipOnboarding && (
             <button
               onClick={onSkipOnboarding}
-              className="text-[7px] text-retro-text/40 hover:text-retro-highlight px-2 py-0.5 text-right uppercase tracking-wider"
+              className="text-[9px] text-retro-text/40 hover:text-retro-highlight px-2 py-0.5 text-right uppercase tracking-wider"
             >
               Skip intro &gt;&gt;
             </button>
@@ -48,7 +48,7 @@ export function ChatPanel({ onSend, onSkipOnboarding }: ChatPanelProps) {
           <ChatInput onSend={onSend} disabled={!isConnected || isAgentBusy} />
         </div>
         {!isConnected && (
-          <div className="absolute top-2 right-4 text-[7px] text-retro-error uppercase animate-blink">
+          <div className="absolute top-2 right-4 text-[9px] text-retro-error uppercase animate-blink">
             Disconnected
           </div>
         )}

--- a/frontend/src/components/chat/DialogFrame.tsx
+++ b/frontend/src/components/chat/DialogFrame.tsx
@@ -13,7 +13,7 @@ export function DialogFrame({ children, title, className = "", onMaximize, maxim
   return (
     <div className={`rpg-frame p-3 ${className}`}>
       {title && (
-        <div className="absolute -top-3 left-4 bg-retro-panel px-2 text-retro-border text-[10px] uppercase tracking-wider">
+        <div className="absolute -top-3 left-4 bg-retro-panel px-2 text-retro-border text-[11px] uppercase tracking-wider">
           {title}
         </div>
       )}
@@ -21,7 +21,7 @@ export function DialogFrame({ children, title, className = "", onMaximize, maxim
         {onMaximize && (
           <button
             onClick={onMaximize}
-            className="bg-retro-panel px-2 text-retro-border hover:text-retro-highlight text-[10px] uppercase tracking-wider transition-colors"
+            className="bg-retro-panel px-2 text-retro-border hover:text-retro-highlight text-[11px] uppercase tracking-wider transition-colors"
             title={maximized ? "Minimize" : "Maximize"}
           >
             {maximized ? "▼" : "▲"}
@@ -30,7 +30,7 @@ export function DialogFrame({ children, title, className = "", onMaximize, maxim
         {onClose && (
           <button
             onClick={onClose}
-            className="bg-retro-panel px-2 text-retro-border hover:text-retro-highlight text-[10px] uppercase tracking-wider transition-colors"
+            className="bg-retro-panel px-2 text-retro-border hover:text-retro-highlight text-[11px] uppercase tracking-wider transition-colors"
             title="Close"
           >
             ✕

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -28,12 +28,12 @@ export function MessageBubble({ message }: MessageBubbleProps) {
   return (
     <div className={`message-enter px-3 py-2 rounded-sm ${style}`}>
       <div className="flex items-center gap-2 mb-1">
-        <span className="text-[9px] uppercase tracking-wider text-retro-border font-bold">
+        <span className="text-[10px] uppercase tracking-wider text-retro-border font-bold">
           {label}
           {isStep && message.stepNumber ? ` ${message.stepNumber}` : ""}
         </span>
         {isStep && message.toolUsed && (
-          <span className="text-[8px] text-retro-highlight/80 uppercase">
+          <span className="text-[9px] text-retro-highlight/80 uppercase">
             [{message.toolUsed}]
           </span>
         )}

--- a/frontend/src/components/chat/SessionList.tsx
+++ b/frontend/src/components/chat/SessionList.tsx
@@ -39,14 +39,14 @@ export function SessionList() {
           newSession();
           loadSessions();
         }}
-        className="text-[8px] text-retro-highlight hover:text-retro-border text-left px-2 py-1 uppercase tracking-wider"
+        className="text-[9px] text-retro-highlight hover:text-retro-border text-left px-2 py-1 uppercase tracking-wider"
       >
         + New Chat
       </button>
       {sessions.map((s) => (
         <div
           key={s.id}
-          className={`flex items-center gap-1 px-2 py-1 cursor-pointer text-[8px] hover:bg-retro-accent/30 rounded-sm ${
+          className={`flex items-center gap-1 px-2 py-1 cursor-pointer text-[9px] hover:bg-retro-accent/30 rounded-sm ${
             s.id === sessionId ? "bg-retro-accent/50 text-retro-highlight" : "text-retro-text/60"
           }`}
         >
@@ -60,7 +60,7 @@ export function SessionList() {
                 if (e.key === "Escape") setEditingId(null);
               }}
               onBlur={commitRename}
-              className="flex-1 bg-retro-panel border border-retro-border/40 text-[8px] text-retro-text px-1 py-0 outline-none"
+              className="flex-1 bg-retro-panel border border-retro-border/40 text-[9px] text-retro-text px-1 py-0 outline-none"
             />
           ) : (
             <button
@@ -79,7 +79,7 @@ export function SessionList() {
               e.stopPropagation();
               deleteSession(s.id);
             }}
-            className="text-retro-error/60 hover:text-retro-error text-[7px] px-1"
+            className="text-retro-error/60 hover:text-retro-error text-[9px] px-1"
           >
             x
           </button>

--- a/frontend/src/components/chat/ThinkingIndicator.tsx
+++ b/frontend/src/components/chat/ThinkingIndicator.tsx
@@ -1,11 +1,11 @@
 export function ThinkingIndicator() {
   return (
     <div className="flex items-center gap-1 px-3 py-2 text-retro-highlight">
-      <span className="text-[10px] uppercase tracking-wider">Thinking</span>
+      <span className="text-[11px] uppercase tracking-wider">Thinking</span>
       <span className="flex gap-[2px]">
-        <span className="thinking-dot text-[10px]">.</span>
-        <span className="thinking-dot text-[10px]">.</span>
-        <span className="thinking-dot text-[10px]">.</span>
+        <span className="thinking-dot text-[11px]">.</span>
+        <span className="thinking-dot text-[11px]">.</span>
+        <span className="thinking-dot text-[11px]">.</span>
       </span>
     </div>
   );

--- a/frontend/src/components/quest/DomainStats.tsx
+++ b/frontend/src/components/quest/DomainStats.tsx
@@ -27,7 +27,7 @@ interface Props {
 export function DomainStats({ dashboard }: Props) {
   return (
     <div className="px-1">
-      <div className="text-[9px] uppercase tracking-wider text-retro-border font-bold mb-2">
+      <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-2">
         Five Pillars
       </div>
       <div className="flex flex-col gap-1">
@@ -37,7 +37,7 @@ export function DomainStats({ dashboard }: Props) {
           const label = DOMAIN_LABELS[domain] ?? domain;
 
           return (
-            <div key={domain} className="flex items-center gap-2 text-[10px]">
+            <div key={domain} className="flex items-center gap-2 text-[11px]">
               <span className="w-[80px] text-retro-text/70 truncate">{label}</span>
               <div className="flex-1 h-[6px] bg-retro-bg rounded-sm overflow-hidden pixel-border-thin">
                 <div
@@ -45,14 +45,14 @@ export function DomainStats({ dashboard }: Props) {
                   style={{ width: `${progress}%` }}
                 />
               </div>
-              <span className="w-[28px] text-right text-retro-highlight text-[9px]">
+              <span className="w-[28px] text-right text-retro-highlight text-[10px]">
                 {progress}%
               </span>
             </div>
           );
         })}
       </div>
-      <div className="mt-1 text-[9px] text-retro-text/40 text-center">
+      <div className="mt-1 text-[10px] text-retro-text/40 text-center">
         {dashboard.completed_count}/{dashboard.total_count} quests completed
       </div>
     </div>

--- a/frontend/src/components/quest/GoalForm.tsx
+++ b/frontend/src/components/quest/GoalForm.tsx
@@ -60,7 +60,7 @@ export function GoalForm({ goal, onClose }: Props) {
     <div className="fixed inset-0 z-[60] flex items-center justify-center">
       <div className="absolute inset-0 bg-black/50" onClick={onClose} />
       <div className="rpg-frame p-3 w-[280px] max-w-[90vw] relative z-10 space-y-2">
-        <div className="text-[10px] uppercase tracking-wider text-retro-highlight font-bold mb-2">
+        <div className="text-[11px] uppercase tracking-wider text-retro-highlight font-bold mb-2">
           {isEdit ? "Edit Quest" : "New Quest"}
         </div>
 
@@ -69,17 +69,17 @@ export function GoalForm({ goal, onClose }: Props) {
           placeholder="Quest title"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          className="w-full bg-transparent text-[9px] text-retro-text border-b border-retro-text/20 px-0.5 py-1 outline-none focus:border-retro-highlight"
+          className="w-full bg-transparent text-[10px] text-retro-text border-b border-retro-text/20 px-0.5 py-1 outline-none focus:border-retro-highlight"
           autoFocus
         />
 
         <div className="flex gap-2">
           <div className="flex-1">
-            <div className="text-[8px] text-retro-text/40 mb-0.5">Level</div>
+            <div className="text-[9px] text-retro-text/40 mb-0.5">Level</div>
             <select
               value={level}
               onChange={(e) => setLevel(e.target.value)}
-              className="w-full bg-retro-bg text-[9px] text-retro-text border border-retro-text/20 rounded-sm px-0.5 py-0.5 outline-none focus:border-retro-highlight"
+              className="w-full bg-retro-bg text-[10px] text-retro-text border border-retro-text/20 rounded-sm px-0.5 py-0.5 outline-none focus:border-retro-highlight"
             >
               {LEVELS.map((l) => (
                 <option key={l} value={l}>{l}</option>
@@ -87,11 +87,11 @@ export function GoalForm({ goal, onClose }: Props) {
             </select>
           </div>
           <div className="flex-1">
-            <div className="text-[8px] text-retro-text/40 mb-0.5">Domain</div>
+            <div className="text-[9px] text-retro-text/40 mb-0.5">Domain</div>
             <select
               value={domain}
               onChange={(e) => setDomain(e.target.value)}
-              className="w-full bg-retro-bg text-[9px] text-retro-text border border-retro-text/20 rounded-sm px-0.5 py-0.5 outline-none focus:border-retro-highlight"
+              className="w-full bg-retro-bg text-[10px] text-retro-text border border-retro-text/20 rounded-sm px-0.5 py-0.5 outline-none focus:border-retro-highlight"
             >
               {DOMAINS.map((d) => (
                 <option key={d} value={d}>{d}</option>
@@ -105,32 +105,32 @@ export function GoalForm({ goal, onClose }: Props) {
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           rows={2}
-          className="w-full bg-transparent text-[9px] text-retro-text border border-retro-text/20 rounded-sm px-1 py-1 outline-none focus:border-retro-highlight resize-none"
+          className="w-full bg-transparent text-[10px] text-retro-text border border-retro-text/20 rounded-sm px-1 py-1 outline-none focus:border-retro-highlight resize-none"
         />
 
         <div>
-          <div className="text-[8px] text-retro-text/40 mb-0.5">Due date (optional)</div>
+          <div className="text-[9px] text-retro-text/40 mb-0.5">Due date (optional)</div>
           <input
             type="date"
             value={dueDate}
             onChange={(e) => setDueDate(e.target.value)}
-            className="bg-retro-bg text-[9px] text-retro-text border border-retro-text/20 rounded-sm px-1 py-0.5 outline-none focus:border-retro-highlight"
+            className="bg-retro-bg text-[10px] text-retro-text border border-retro-text/20 rounded-sm px-1 py-0.5 outline-none focus:border-retro-highlight"
           />
         </div>
 
-        {error && <div className="text-[8px] text-red-400">{error}</div>}
+        {error && <div className="text-[9px] text-red-400">{error}</div>}
 
         <div className="flex gap-2 pt-1">
           <button
             onClick={handleSubmit}
             disabled={saving}
-            className="text-[9px] text-retro-highlight hover:text-retro-text uppercase tracking-wider font-bold"
+            className="text-[10px] text-retro-highlight hover:text-retro-text uppercase tracking-wider font-bold"
           >
             {saving ? "Saving..." : isEdit ? "Update" : "Create"}
           </button>
           <button
             onClick={onClose}
-            className="text-[9px] text-retro-text/40 hover:text-retro-text uppercase tracking-wider"
+            className="text-[10px] text-retro-text/40 hover:text-retro-text uppercase tracking-wider"
           >
             Cancel
           </button>

--- a/frontend/src/components/quest/GoalTree.tsx
+++ b/frontend/src/components/quest/GoalTree.tsx
@@ -38,7 +38,7 @@ export function GoalTree({ goals, depth, onEdit }: Props) {
           <div key={goal.id} className="mb-1">
             <div className="flex items-start gap-1 group">
               <button
-                className={`text-[10px] font-mono shrink-0 ${
+                className={`text-[11px] font-mono shrink-0 ${
                   isCompleted ? "text-green-400/70" : "text-retro-text/50"
                 } hover:text-retro-highlight`}
                 onClick={() => {
@@ -51,21 +51,21 @@ export function GoalTree({ goals, depth, onEdit }: Props) {
               </button>
               <div className="flex-1 min-w-0">
                 <span
-                  className={`text-[10px] ${color} ${
+                  className={`text-[11px] ${color} ${
                     isCompleted ? "line-through opacity-50" : ""
                   }`}
                 >
                   {goal.title}
                 </span>
                 {goal.due_date && (
-                  <span className="text-[8px] text-retro-text/30 ml-1">
+                  <span className="text-[9px] text-retro-text/30 ml-1">
                     {new Date(goal.due_date).toLocaleDateString("en-US", {
                       month: "short",
                       day: "numeric",
                     })}
                   </span>
                 )}
-                <span className="text-[8px] text-retro-text/20 ml-1 hidden group-hover:inline">
+                <span className="text-[9px] text-retro-text/20 ml-1 hidden group-hover:inline">
                   {goal.level}
                 </span>
               </div>
@@ -73,7 +73,7 @@ export function GoalTree({ goals, depth, onEdit }: Props) {
                 {onEdit && (
                   <button
                     onClick={() => onEdit(goal)}
-                    className="text-[8px] text-retro-text/30 hover:text-retro-highlight px-0.5"
+                    className="text-[9px] text-retro-text/30 hover:text-retro-highlight px-0.5"
                     title="Edit quest"
                   >
                     /
@@ -85,7 +85,7 @@ export function GoalTree({ goals, depth, onEdit }: Props) {
                       deleteGoal(goal.id);
                     }
                   }}
-                  className="text-[8px] text-retro-text/30 hover:text-red-400 px-0.5"
+                  className="text-[9px] text-retro-text/30 hover:text-red-400 px-0.5"
                   title="Delete quest"
                 >
                   x

--- a/frontend/src/components/quest/QuestPanel.tsx
+++ b/frontend/src/components/quest/QuestPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useChatStore } from "../../stores/chatStore";
 import { useQuestStore } from "../../stores/questStore";
 import { DialogFrame } from "../chat/DialogFrame";
@@ -7,15 +7,58 @@ import { GoalTree } from "./GoalTree";
 import { GoalForm } from "./GoalForm";
 import type { GoalInfo } from "../../types";
 
+const LEVELS = ["daily", "weekly", "monthly", "quarterly", "annual", "vision"] as const;
+const DOMAINS = ["productivity", "performance", "health", "influence", "growth"] as const;
+
+function filterGoals(
+  goals: GoalInfo[],
+  search: string,
+  level: string,
+  domain: string,
+): GoalInfo[] {
+  const lowerSearch = search.toLowerCase();
+  return goals.reduce<GoalInfo[]>((acc, goal) => {
+    const filteredChildren = goal.children
+      ? filterGoals(goal.children, search, level, domain)
+      : [];
+    const matchesSearch =
+      !search || goal.title.toLowerCase().includes(lowerSearch);
+    const matchesLevel = !level || goal.level === level;
+    const matchesDomain = !domain || goal.domain === domain;
+    const selfMatches = matchesSearch && matchesLevel && matchesDomain;
+    if (selfMatches || filteredChildren.length > 0) {
+      acc.push({
+        ...goal,
+        children: filteredChildren.length > 0 ? filteredChildren : selfMatches ? goal.children : [],
+      });
+    }
+    return acc;
+  }, []);
+}
+
 export function QuestPanel() {
   const questPanelOpen = useChatStore((s) => s.questPanelOpen);
   const setQuestPanelOpen = useChatStore((s) => s.setQuestPanelOpen);
   const { goalTree, dashboard, refresh, loading } = useQuestStore();
   const [editingGoal, setEditingGoal] = useState<GoalInfo | "new" | null>(null);
 
+  const [search, setSearch] = useState("");
+  const [filterLevel, setFilterLevel] = useState("");
+  const [filterDomain, setFilterDomain] = useState("");
+
   useEffect(() => {
     if (questPanelOpen) refresh();
   }, [questPanelOpen, refresh]);
+
+  const filteredTree = useMemo(
+    () =>
+      search || filterLevel || filterDomain
+        ? filterGoals(goalTree, search, filterLevel, filterDomain)
+        : goalTree,
+    [goalTree, search, filterLevel, filterDomain],
+  );
+
+  const hasFilters = !!(search || filterLevel || filterDomain);
 
   if (!questPanelOpen) return null;
 
@@ -33,26 +76,61 @@ export function QuestPanel() {
 
           <div className="px-1">
             <div className="flex items-center justify-between mb-2">
-              <div className="text-[9px] uppercase tracking-wider text-retro-border font-bold">
+              <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold">
                 Active Quests
               </div>
               <button
                 onClick={() => setEditingGoal("new")}
-                className="text-[10px] text-retro-text/40 hover:text-retro-highlight px-1"
+                className="text-[11px] text-retro-text/40 hover:text-retro-highlight px-1"
                 title="Add new quest"
               >
                 +
               </button>
             </div>
+
+            <div className="flex flex-col gap-1 mb-2">
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search quests..."
+                className="w-full bg-transparent text-[10px] text-retro-text border border-retro-text/20 rounded-sm px-1.5 py-0.5 outline-none focus:border-retro-highlight placeholder:text-retro-text/30"
+              />
+              <div className="flex gap-1">
+                <select
+                  value={filterLevel}
+                  onChange={(e) => setFilterLevel(e.target.value)}
+                  className="flex-1 bg-retro-bg text-[9px] text-retro-text border border-retro-text/20 rounded-sm px-0.5 py-0.5 outline-none focus:border-retro-highlight"
+                >
+                  <option value="">All levels</option>
+                  {LEVELS.map((l) => (
+                    <option key={l} value={l}>{l}</option>
+                  ))}
+                </select>
+                <select
+                  value={filterDomain}
+                  onChange={(e) => setFilterDomain(e.target.value)}
+                  className="flex-1 bg-retro-bg text-[9px] text-retro-text border border-retro-text/20 rounded-sm px-0.5 py-0.5 outline-none focus:border-retro-highlight"
+                >
+                  <option value="">All domains</option>
+                  {DOMAINS.map((d) => (
+                    <option key={d} value={d}>{d}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
             {loading ? (
-              <div className="text-[9px] text-retro-text/40 italic">Loading...</div>
-            ) : goalTree.length === 0 ? (
-              <div className="text-[9px] text-retro-text/40 italic">
-                No quests yet. Chat with Seraph to set goals!
+              <div className="text-[10px] text-retro-text/40 italic">Loading...</div>
+            ) : filteredTree.length === 0 ? (
+              <div className="text-[10px] text-retro-text/40 italic">
+                {hasFilters
+                  ? "No quests match filters."
+                  : "No quests yet. Chat with Seraph to set goals!"}
               </div>
             ) : (
               <GoalTree
-                goals={goalTree}
+                goals={filteredTree}
                 depth={0}
                 onEdit={(goal) => setEditingGoal(goal)}
               />

--- a/frontend/src/components/settings/InterruptionModeToggle.tsx
+++ b/frontend/src/components/settings/InterruptionModeToggle.tsx
@@ -41,7 +41,7 @@ export function InterruptionModeToggle() {
 
   return (
     <div className="px-1">
-      <div className="text-[9px] uppercase tracking-wider text-retro-border font-bold mb-2">
+      <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-2">
         Interruption Mode
       </div>
       <div className="flex gap-1">
@@ -58,8 +58,8 @@ export function InterruptionModeToggle() {
                   : "text-retro-text/40 border-retro-text/20 hover:text-retro-text/60 hover:border-retro-text/40"
               }`}
             >
-              <div className="text-[9px] font-bold uppercase tracking-wider">{m.label}</div>
-              <div className="text-[7px] mt-0.5 opacity-70">{m.desc}</div>
+              <div className="text-[10px] font-bold uppercase tracking-wider">{m.label}</div>
+              <div className="text-[9px] mt-0.5 opacity-70">{m.desc}</div>
             </button>
           );
         })}

--- a/frontend/src/hooks/useKeyboardShortcuts.test.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.test.ts
@@ -1,8 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { useChatStore } from "../stores/chatStore";
-
-// We test the keyboard handler logic directly by dispatching KeyboardEvents
-// and checking the store state, since the hook just registers a window listener.
 
 function resetStore() {
   useChatStore.setState({
@@ -12,35 +9,43 @@ function resetStore() {
   });
 }
 
-function fireKey(key: string, target?: Partial<HTMLElement>) {
-  const event = new KeyboardEvent("keydown", { key, bubbles: true });
-  if (target) {
-    Object.defineProperty(event, "target", { value: target });
+function fireKey(
+  key: string,
+  options?: { target?: Partial<HTMLElement>; shiftKey?: boolean },
+) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    shiftKey: options?.shiftKey ?? false,
+    bubbles: true,
+  });
+  if (options?.target) {
+    Object.defineProperty(event, "target", { value: options.target });
   }
   window.dispatchEvent(event);
 }
 
 describe("useKeyboardShortcuts", () => {
+  let cleanup: (() => void) | undefined;
+
   beforeEach(async () => {
     resetStore();
-    // Import and init the hook's listener (the module registers on import via useEffect,
-    // but we can simulate by importing the handler pattern directly)
-    // We'll mount the listener manually the same way the hook does
-    const { useKeyboardShortcuts } = await import("./useKeyboardShortcuts");
 
-    // Simulate the effect by running the handler registration
+    // Register handler matching the hook logic (with shiftKey requirement)
     const handler = (e: KeyboardEvent) => {
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA") return;
       const s = useChatStore.getState();
       switch (e.key.toLowerCase()) {
         case "c":
+          if (!e.shiftKey) return;
           s.setChatPanelOpen(!s.chatPanelOpen);
           break;
         case "q":
+          if (!e.shiftKey) return;
           s.setQuestPanelOpen(!s.questPanelOpen);
           break;
         case "s":
+          if (!e.shiftKey) return;
           s.setSettingsPanelOpen(!s.settingsPanelOpen);
           break;
         case "escape":
@@ -51,41 +56,53 @@ describe("useKeyboardShortcuts", () => {
       }
     };
     window.addEventListener("keydown", handler);
-    // Store cleanup for afterEach
-    (globalThis as any).__testCleanup = () =>
-      window.removeEventListener("keydown", handler);
+    cleanup = () => window.removeEventListener("keydown", handler);
   });
 
   afterEach(() => {
-    (globalThis as any).__testCleanup?.();
+    cleanup?.();
   });
 
-  it("C toggles chat panel open", () => {
-    fireKey("c");
+  it("Shift+C toggles chat panel open", () => {
+    fireKey("c", { shiftKey: true });
     expect(useChatStore.getState().chatPanelOpen).toBe(true);
   });
 
-  it("C toggles chat panel closed", () => {
+  it("Shift+C toggles chat panel closed", () => {
     useChatStore.setState({ chatPanelOpen: true });
+    fireKey("c", { shiftKey: true });
+    expect(useChatStore.getState().chatPanelOpen).toBe(false);
+  });
+
+  it("Shift+Q toggles quest panel", () => {
+    fireKey("q", { shiftKey: true });
+    expect(useChatStore.getState().questPanelOpen).toBe(true);
+  });
+
+  it("Shift+S toggles settings panel", () => {
+    fireKey("s", { shiftKey: true });
+    expect(useChatStore.getState().settingsPanelOpen).toBe(true);
+  });
+
+  it("bare C without Shift does NOT toggle chat", () => {
     fireKey("c");
     expect(useChatStore.getState().chatPanelOpen).toBe(false);
   });
 
-  it("Q toggles quest panel", () => {
+  it("bare Q without Shift does NOT toggle quests", () => {
     fireKey("q");
-    expect(useChatStore.getState().questPanelOpen).toBe(true);
+    expect(useChatStore.getState().questPanelOpen).toBe(false);
   });
 
-  it("S toggles settings panel", () => {
+  it("bare S without Shift does NOT toggle settings (no WASD conflict)", () => {
     fireKey("s");
-    expect(useChatStore.getState().settingsPanelOpen).toBe(true);
+    expect(useChatStore.getState().settingsPanelOpen).toBe(false);
   });
 
   it("Escape closes chat panel first", () => {
     useChatStore.setState({ chatPanelOpen: true, questPanelOpen: true });
     fireKey("Escape");
     expect(useChatStore.getState().chatPanelOpen).toBe(false);
-    // Quest stays open (priority: chat first)
     expect(useChatStore.getState().questPanelOpen).toBe(true);
   });
 
@@ -109,20 +126,17 @@ describe("useKeyboardShortcuts", () => {
   });
 
   it("ignores keys when target is INPUT", () => {
-    fireKey("c", { tagName: "INPUT" });
+    fireKey("c", { target: { tagName: "INPUT" }, shiftKey: true });
     expect(useChatStore.getState().chatPanelOpen).toBe(false);
   });
 
   it("ignores keys when target is TEXTAREA", () => {
-    fireKey("s", { tagName: "TEXTAREA" });
+    fireKey("s", { target: { tagName: "TEXTAREA" }, shiftKey: true });
     expect(useChatStore.getState().settingsPanelOpen).toBe(false);
   });
 
-  it("handles uppercase key", () => {
-    fireKey("C");
+  it("handles uppercase Shift+C", () => {
+    fireKey("C", { shiftKey: true });
     expect(useChatStore.getState().chatPanelOpen).toBe(true);
   });
 });
-
-// Need to import afterEach
-import { afterEach } from "vitest";

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -11,12 +11,15 @@ export function useKeyboardShortcuts() {
 
       switch (e.key.toLowerCase()) {
         case "c":
+          if (!e.shiftKey) return;
           s.setChatPanelOpen(!s.chatPanelOpen);
           break;
         case "q":
+          if (!e.shiftKey) return;
           s.setQuestPanelOpen(!s.questPanelOpen);
           break;
         case "s":
+          if (!e.shiftKey) return;
           s.setSettingsPanelOpen(!s.settingsPanelOpen);
           break;
         case "escape":


### PR DESCRIPTION
## Summary
- **Quest search & filter**: Added text search input and level/domain dropdown filters to QuestPanel. Recursive client-side filtering preserves parent chain when descendants match.
- **Font size bumps**: Raised minimum font size from 7-8px to 9px across all panels for better readability with Press Start 2P pixel font. Headers/labels bumped to 10-11px.
- **Shift+key shortcuts**: Changed panel toggle shortcuts from bare C/Q/S to Shift+C/Q/S to prevent conflict with WASD avatar movement. Updated HudButtons tooltips accordingly.

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [x] `vitest run` — all 124 tests pass (14 keyboard shortcut tests, including 3 new bare-key rejection tests)
- [ ] Visual check: no text smaller than 9px in any panel
- [ ] Shift+S toggles settings, bare S moves avatar without side effects
- [ ] Quest filter: search by title, filter by level/domain dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)