### PR TITLE
feat: make context window configurable via settings (3.5.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ Seraph is an AI agent with a retro 16-bit RPG village UI. A Phaser 3 canvas rend
   - `factory.py` — Creates full agent with all tools + context (history, soul, memories, active skills)
   - `onboarding.py` — Specialized onboarding agent (limited to soul/goal tools, 5-point discovery)
   - `strategist.py` — Strategist agent factory (restricted to `view_soul`, `get_goals`, `get_goal_progress`, temp=0.4, max_steps=5) + `StrategistDecision` dataclass + `parse_strategist_response()` JSON parser
+  - `context_window.py` — Token-aware context window builder (keep first N + last M, summarize middle; reads defaults from settings)
   - `session.py` — Async session manager (SQLite-backed)
 - **Database** (`src/db/`): SQLModel + aiosqlite. Models: `UserProfile`, `Session`, `Message`, `Goal`, `Memory`, `QueuedInsight`
 - **Scheduler** (`src/scheduler/`):
@@ -158,6 +159,10 @@ Seraph is an AI agent with a retro 16-bit RPG village UI. A Phaser 3 canvas rend
   - `agent_briefing_timeout: int = 60` — daily briefing + evening review LiteLLM calls
   - `consolidation_llm_timeout: int = 30` — memory consolidation LiteLLM call
   - `web_search_timeout: int = 15` — DDGS web search per-call
+- **Context window settings** (`config/settings.py`):
+  - `context_window_token_budget: int = 12000` — max tokens for conversation history
+  - `context_window_keep_first: int = 2` — always keep first N messages
+  - `context_window_keep_recent: int = 20` — always keep last N messages
 
 ## WebSocket Protocol
 - **Client sends**: `{type: "message" | "ping" | "skip_onboarding", message, session_id}`

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -23,9 +23,7 @@ Phases 0-3 are complete and functional. 414 automated tests (359 backend, 55 fro
 
 5. ~~**Agent Execution Timeout**~~ (3.5.6) — Done. `asyncio.wait_for` timeouts on REST chat (504), daily briefing, evening review, memory consolidation LLM + add_memory calls. DDGS web search timeout via constructor. 3 new settings: `agent_briefing_timeout` (60s), `consolidation_llm_timeout` (30s), `web_search_timeout` (15s). 5 new tests.
 
-## Tier 2: Robustness (prevents real user frustration)
-
-6. **Token-Aware Context Window** (3.5.5) — Replace fixed 50-message window with adaptive token counting. Keep first 2 + last 20 messages, summarize the middle. Prevents silent quality degradation in long conversations.
+6. ~~**Token-Aware Context Window**~~ (3.5.5) — Done. Token-aware context window with configurable budget. Keeps first N + last M messages, summarizes middle via LLM. 3 new settings: `context_window_token_budget` (12000), `context_window_keep_first` (2), `context_window_keep_recent` (20). Info logging on both return paths. 3 new settings integration tests.
 
 ## Tier 3: The growth engine (Phase 4)
 
@@ -51,4 +49,4 @@ Seraph's biggest advantages are **proactive intelligence** and **the RPG village
 - Village avatar doesn't reflect agent state → ambient states fix this
 - ~~Users can't control interruptions → interruption mode UI fixes this~~ ✓
 
-**Next priorities**: ~~Agent execution timeout (prevents user frustration)~~ ✓, token-aware context (prevents quality degradation), then Telegram bot (makes proactive intelligence useful in daily life).
+**Next priorities**: ~~Agent execution timeout (prevents user frustration)~~ ✓, ~~token-aware context (prevents quality degradation)~~ ✓, then Telegram bot (makes proactive intelligence useful in daily life).

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -14,7 +14,9 @@ class Settings(BaseSettings):
     soul_file: str = "soul.md"
     embedding_model: str = "all-MiniLM-L6-v2"
     memory_search_top_k: int = 5
-    session_history_window: int = 50
+    context_window_token_budget: int = 12000  # max tokens for conversation history
+    context_window_keep_first: int = 2        # always keep first N messages
+    context_window_keep_recent: int = 20      # always keep last N messages
 
     # Phase 2 — Capable Executor
     sandbox_url: str = "http://sandbox:8060"

--- a/backend/src/agent/session.py
+++ b/backend/src/agent/session.py
@@ -153,7 +153,6 @@ class SessionManager:
                 return await asyncio.to_thread(
                     build_context_window,
                     msg_dicts,
-                    token_budget=12000,
                     session_id=session_id,
                 )
             except Exception:


### PR DESCRIPTION
## Summary
- Replace hardcoded values in token-aware context window with 3 new settings: `context_window_token_budget` (12000), `context_window_keep_first` (2), `context_window_keep_recent` (20)
- Add info logging on both return paths (all-kept and summarized) for observability
- Remove dead `session_history_window` setting and hardcoded `token_budget=12000` in session.py

## Test plan
- [x] All 362 backend tests pass (3 new settings integration tests + 359 existing)
- [x] Defaults match previous hardcoded values — zero behavior change
- [x] Settings overridable via env vars (`CONTEXT_WINDOW_TOKEN_BUDGET`, etc.)
- [x] Explicit kwargs still override settings values

🤖 Generated with [Claude Code](https://claude.com/claude-code)