### PR TITLE
feat: recursive delegation architecture (4.4)

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -38,7 +38,7 @@ Phases 0-3 are complete and functional. 414 automated tests (359 backend, 55 fro
 ## What to skip for now
 
 - **Calendar scan** (3.5.4) — Already more complete than REPORT.md claimed. Works when credentials are configured.
-- **Multi-agent architecture** (4.4) — Premature until single-agent is polished.
+- ~~**Multi-agent architecture** (4.4) — Premature until single-agent is polished.~~ → Implemented as recursive delegation behind feature flag (`USE_DELEGATION=true`).
 - **Voice** (4.8) — Not a differentiator yet.
 - **Workflow engine** (4.3) — Wait for SKILL.md; workflows build on skills.
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -30,6 +30,11 @@ class Settings(BaseSettings):
     consolidation_llm_timeout: int = 30  # memory consolidation LiteLLM call
     web_search_timeout: int = 15  # DDGS web search per-call
 
+    # Phase 4 — Recursive Delegation
+    use_delegation: bool = False             # feature flag: orchestrator + specialists
+    delegation_max_depth: int = 1            # 1 = orchestrator → specialists
+    orchestrator_max_steps: int = 8          # max delegation steps for orchestrator
+
     # Phase 3 — Scheduler & Proactivity
     scheduler_enabled: bool = True
     proactivity_level: int = 3  # 1-5 scale

--- a/backend/src/agent/factory.py
+++ b/backend/src/agent/factory.py
@@ -68,3 +68,79 @@ def create_agent(
         instructions=instructions,
     )
     return agent
+
+
+def create_orchestrator(
+    additional_context: str = "",
+    soul_context: str = "",
+    memory_context: str = "",
+) -> ToolCallingAgent:
+    """Create an orchestrator agent that delegates to specialist sub-agents.
+
+    The orchestrator has NO tools itself — it delegates all execution to
+    specialist managed_agents (memory_keeper, goal_planner, web_researcher,
+    file_worker, and one per MCP server).
+    """
+    from src.agent.specialists import build_all_specialists
+
+    model = get_model()
+    specialists = build_all_specialists()
+
+    # Collect all tool names across specialists for skill gating
+    all_tool_names = []
+    for specialist in specialists:
+        all_tool_names.extend(t.name for t in specialist.tools)
+
+    instructions = (
+        "You are Seraph, a proactive guardian intelligence dedicated to elevating "
+        "your human counterpart. You observe, think, and act to help them achieve "
+        "their highest potential across productivity, performance, health, influence, "
+        "and growth. Be concise, strategic, and helpful.\n\n"
+        "You do NOT have any tools yourself. Instead, you have a team of specialists.\n"
+        "Analyze the user's request, decide which specialist(s) to delegate to, and\n"
+        "synthesize their results into a coherent, helpful response.\n"
+        "Guidelines:\n"
+        "- For simple questions that need no tools, answer directly.\n"
+        "- Delegate to ONE specialist when possible.\n"
+        "- Give clear, specific task descriptions when delegating.\n"
+        "- Synthesize specialist results into a natural response."
+    )
+    if soul_context:
+        instructions += f"\n\n--- USER IDENTITY ---\n{soul_context}"
+    if memory_context:
+        instructions += f"\n\n--- RELEVANT MEMORIES ---\n{memory_context}"
+
+    # Inject active skills into instructions
+    active_skills = skill_manager.get_active_skills(all_tool_names)
+    if active_skills:
+        skill_lines = []
+        for s in active_skills:
+            invocable = " [user-invocable]" if s.user_invocable else ""
+            skill_lines.append(f"### Skill: {s.name}{invocable}\n{s.instructions}")
+        instructions += "\n\n## Available Skills\n\n" + "\n\n".join(skill_lines)
+
+    if additional_context:
+        instructions += f"\n\n--- CONVERSATION HISTORY ---\n{additional_context}"
+
+    agent = ToolCallingAgent(
+        tools=[],
+        managed_agents=specialists,
+        model=model,
+        max_steps=settings.orchestrator_max_steps,
+        instructions=instructions,
+    )
+    return agent
+
+
+def build_agent(
+    additional_context: str = "",
+    soul_context: str = "",
+    memory_context: str = "",
+) -> ToolCallingAgent:
+    """Build the appropriate agent based on delegation feature flag.
+
+    Drop-in replacement for create_agent() at call sites.
+    """
+    if settings.use_delegation:
+        return create_orchestrator(additional_context, soul_context, memory_context)
+    return create_agent(additional_context, soul_context, memory_context)

--- a/backend/src/agent/specialists.py
+++ b/backend/src/agent/specialists.py
@@ -1,0 +1,201 @@
+"""Specialist agent factories for recursive delegation architecture.
+
+When delegation mode is enabled, the root orchestrator delegates to domain-specific
+specialist agents rather than calling tools directly. Each specialist has a focused
+tool set and tuned temperature for its domain.
+
+Tier 1 (built-in): memory_keeper, goal_planner, web_researcher, file_worker
+Tier 2 (dynamic): one specialist per connected MCP server
+"""
+
+import re
+
+from smolagents import LiteLLMModel, ToolCallingAgent
+
+from config.settings import settings
+from src.plugins.loader import discover_tools
+from src.tools.mcp_manager import mcp_manager
+
+# --- Tool → domain mapping ---
+
+TOOL_DOMAINS: dict[str, str] = {
+    "view_soul": "memory",
+    "update_soul": "memory",
+    "create_goal": "goals",
+    "update_goal": "goals",
+    "get_goals": "goals",
+    "get_goal_progress": "goals",
+    "web_search": "research",
+    "browse_webpage": "research",
+    "read_file": "files",
+    "write_file": "files",
+    "fill_template": "files",
+    "shell_execute": "files",
+}
+
+# Reverse index: domain → list of tool names
+DOMAIN_TOOLS: dict[str, list[str]] = {}
+for _tool, _domain in TOOL_DOMAINS.items():
+    DOMAIN_TOOLS.setdefault(_domain, []).append(_tool)
+
+# --- Specialist configurations ---
+
+SPECIALIST_CONFIGS: dict[str, dict] = {
+    "memory_keeper": {
+        "domain": "memory",
+        "description": (
+            "Manages the user's identity file (soul). Can view and update "
+            "the soul file sections (identity, values, goals, preferences)."
+        ),
+        "temperature": 0.5,
+        "max_steps": 3,
+    },
+    "goal_planner": {
+        "domain": "goals",
+        "description": (
+            "Manages the user's goal/quest system. Can create, update, list goals "
+            "and check goal progress across all domains."
+        ),
+        "temperature": 0.4,
+        "max_steps": 5,
+    },
+    "web_researcher": {
+        "domain": "research",
+        "description": (
+            "Searches the web and browses webpages for information. "
+            "Use for any research, fact-finding, or web content retrieval."
+        ),
+        "temperature": 0.3,
+        "max_steps": 8,
+    },
+    "file_worker": {
+        "domain": "files",
+        "description": (
+            "Reads, writes, and manages files in the workspace. "
+            "Can also execute code in a sandboxed environment and fill templates."
+        ),
+        "temperature": 0.3,
+        "max_steps": 6,
+    },
+}
+
+
+def _sanitize_agent_name(name: str) -> str:
+    """Convert a string to a valid Python identifier for use as agent name."""
+    # Replace hyphens and other non-alphanumeric chars with underscores
+    sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+    # Collapse multiple underscores
+    sanitized = re.sub(r"_+", "_", sanitized).strip("_")
+    # Prefix with mcp_ if starts with a digit
+    if sanitized and sanitized[0].isdigit():
+        sanitized = f"mcp_{sanitized}"
+    return sanitized or "unnamed_agent"
+
+
+def _create_model(temperature: float) -> LiteLLMModel:
+    """Create a LiteLLMModel with specialist-specific temperature."""
+    return LiteLLMModel(
+        model_id=settings.default_model,
+        api_key=settings.openrouter_api_key,
+        api_base="https://openrouter.ai/api/v1",
+        temperature=temperature,
+        max_tokens=settings.model_max_tokens,
+    )
+
+
+def create_specialist(
+    name: str,
+    description: str,
+    tools: list,
+    temperature: float,
+    max_steps: int,
+) -> ToolCallingAgent:
+    """Create a specialist agent with the given tools and settings."""
+    model = _create_model(temperature)
+    return ToolCallingAgent(
+        tools=tools,
+        model=model,
+        name=name,
+        description=description,
+        max_steps=max_steps,
+    )
+
+
+# --- Named factories for built-in specialists ---
+
+def create_memory_keeper(tools_by_name: dict) -> ToolCallingAgent | None:
+    cfg = SPECIALIST_CONFIGS["memory_keeper"]
+    tools = [tools_by_name[n] for n in DOMAIN_TOOLS["memory"] if n in tools_by_name]
+    if not tools:
+        return None
+    return create_specialist("memory_keeper", cfg["description"], tools, cfg["temperature"], cfg["max_steps"])
+
+
+def create_goal_planner(tools_by_name: dict) -> ToolCallingAgent | None:
+    cfg = SPECIALIST_CONFIGS["goal_planner"]
+    tools = [tools_by_name[n] for n in DOMAIN_TOOLS["goals"] if n in tools_by_name]
+    if not tools:
+        return None
+    return create_specialist("goal_planner", cfg["description"], tools, cfg["temperature"], cfg["max_steps"])
+
+
+def create_web_researcher(tools_by_name: dict) -> ToolCallingAgent | None:
+    cfg = SPECIALIST_CONFIGS["web_researcher"]
+    tools = [tools_by_name[n] for n in DOMAIN_TOOLS["research"] if n in tools_by_name]
+    if not tools:
+        return None
+    return create_specialist("web_researcher", cfg["description"], tools, cfg["temperature"], cfg["max_steps"])
+
+
+def create_file_worker(tools_by_name: dict) -> ToolCallingAgent | None:
+    cfg = SPECIALIST_CONFIGS["file_worker"]
+    tools = [tools_by_name[n] for n in DOMAIN_TOOLS["files"] if n in tools_by_name]
+    if not tools:
+        return None
+    return create_specialist("file_worker", cfg["description"], tools, cfg["temperature"], cfg["max_steps"])
+
+
+# --- MCP specialist factory ---
+
+def create_mcp_specialist(
+    server_name: str,
+    tools: list,
+    description: str = "",
+) -> ToolCallingAgent:
+    """Create a specialist agent for a single MCP server's tools."""
+    name = _sanitize_agent_name(f"mcp_{server_name}")
+    if not description:
+        tool_names = [getattr(t, "name", str(t)) for t in tools]
+        description = f"MCP server '{server_name}' with tools: {', '.join(tool_names)}"
+    return create_specialist(name, description, tools, temperature=0.3, max_steps=6)
+
+
+# --- Build all specialists ---
+
+def build_all_specialists() -> list[ToolCallingAgent]:
+    """Assemble the full list of specialist agents (built-in + MCP)."""
+    # Build tools_by_name from discovered tools
+    all_tools = discover_tools()
+    tools_by_name = {t.name: t for t in all_tools}
+
+    specialists: list[ToolCallingAgent] = []
+
+    # Tier 1: built-in specialists
+    for factory in (create_memory_keeper, create_goal_planner, create_web_researcher, create_file_worker):
+        agent = factory(tools_by_name)
+        if agent is not None:
+            specialists.append(agent)
+
+    # Tier 2: one specialist per connected MCP server
+    server_configs = mcp_manager.get_config()
+    for server_info in server_configs:
+        name = server_info["name"]
+        if not mcp_manager.is_connected(name):
+            continue
+        server_tools = mcp_manager.get_server_tools(name)
+        if not server_tools:
+            continue
+        desc = server_info.get("description", "")
+        specialists.append(create_mcp_specialist(name, server_tools, desc))
+
+    return specialists

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -4,7 +4,7 @@ import logging
 from fastapi import APIRouter, HTTPException
 
 from config.settings import settings
-from src.agent.factory import create_agent
+from src.agent.factory import build_agent
 from src.agent.onboarding import create_onboarding_agent
 from src.agent.session import session_manager
 from src.api.profile import get_or_create_profile, mark_onboarding_complete
@@ -31,7 +31,7 @@ async def chat(request: ChatRequest):
         history = await session_manager.get_history_text(session.id)
         soul = read_soul()
         memories = await asyncio.to_thread(search_formatted, request.message)
-        agent = create_agent(
+        agent = build_agent(
             additional_context=history,
             soul_context=soul,
             memory_context=memories,

--- a/backend/src/api/tools.py
+++ b/backend/src/api/tools.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from config.settings import settings
 from src.agent.factory import get_tools
 from src.plugins.registry import get_tool_metadata
 
@@ -18,4 +19,21 @@ async def list_tools():
             "name": tool.name,
             "description": meta.get("description") if meta else getattr(tool, "description", ""),
         })
+
+    # When delegation is active, also include specialist names so the frontend
+    # toolRegistry recognizes them for animation triggers.
+    if settings.use_delegation:
+        from src.agent.specialists import SPECIALIST_CONFIGS, _sanitize_agent_name
+        from src.tools.mcp_manager import mcp_manager
+
+        for name, cfg in SPECIALIST_CONFIGS.items():
+            result.append({"name": name, "description": cfg["description"]})
+
+        for server_info in mcp_manager.get_config():
+            if mcp_manager.is_connected(server_info["name"]):
+                result.append({
+                    "name": _sanitize_agent_name(f"mcp_{server_info['name']}"),
+                    "description": server_info.get("description", ""),
+                })
+
     return result

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -6,7 +6,7 @@ import pytest
 @pytest.mark.asyncio
 class TestChatAPI:
     @patch("src.memory.vector_store.search_formatted", return_value="")
-    @patch("src.api.chat.create_agent")
+    @patch("src.api.chat.build_agent")
     @patch("src.api.chat.create_onboarding_agent")
     async def test_chat_success(self, mock_onboarding, mock_create_agent, mock_search, client):
         mock_agent = MagicMock()
@@ -20,7 +20,7 @@ class TestChatAPI:
         assert "session_id" in data
 
     @patch("src.memory.vector_store.search_formatted", return_value="")
-    @patch("src.api.chat.create_agent")
+    @patch("src.api.chat.build_agent")
     @patch("src.api.chat.create_onboarding_agent")
     async def test_chat_with_session(self, mock_onboarding, mock_create_agent, mock_search, client):
         mock_agent = MagicMock()
@@ -41,7 +41,7 @@ class TestChatAPI:
         assert response.status_code == 422
 
     @patch("src.memory.vector_store.search_formatted", return_value="")
-    @patch("src.api.chat.create_agent")
+    @patch("src.api.chat.build_agent")
     @patch("src.api.chat.create_onboarding_agent")
     async def test_chat_agent_error(self, mock_onboarding, mock_create_agent, mock_search, client):
         mock_agent = MagicMock()

--- a/backend/tests/test_delegation.py
+++ b/backend/tests/test_delegation.py
@@ -1,0 +1,251 @@
+"""Tests for the delegation architecture feature flag and orchestrator."""
+
+from unittest.mock import MagicMock, patch
+
+from config.settings import settings
+from src.agent.factory import build_agent, create_orchestrator
+from src.api.ws import _format_tool_step
+
+
+class TestFeatureFlag:
+    @patch("src.agent.factory.create_agent")
+    def test_flag_off_calls_create_agent(self, mock_create):
+        mock_create.return_value = MagicMock()
+        with patch.object(settings, "use_delegation", False):
+            agent = build_agent(soul_context="test soul")
+        mock_create.assert_called_once_with("", "test soul", "")
+        assert agent is mock_create.return_value
+
+    @patch("src.agent.factory.create_orchestrator")
+    def test_flag_on_calls_create_orchestrator(self, mock_create_orch):
+        mock_create_orch.return_value = MagicMock()
+        with patch.object(settings, "use_delegation", True):
+            agent = build_agent(soul_context="test soul")
+        mock_create_orch.assert_called_once_with("", "test soul", "")
+        assert agent is mock_create_orch.return_value
+
+
+class TestCreateOrchestrator:
+    @patch("src.agent.factory.ToolCallingAgent")
+    @patch("src.agent.factory.get_model")
+    @patch("src.agent.factory.skill_manager")
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    @patch("src.agent.specialists.mcp_manager")
+    @patch("src.agent.specialists.discover_tools")
+    def test_orchestrator_has_no_tools(
+        self, mock_discover, mock_mcp, mock_spec_model, mock_spec_agent,
+        mock_skill_mgr, mock_get_model, mock_agent_cls,
+    ):
+        # Set up specialist mocks
+        mock_spec_model.return_value = MagicMock()
+        mock_mcp.get_config.return_value = []
+        mock_skill_mgr.get_active_skills.return_value = []
+
+        from src.agent.specialists import TOOL_DOMAINS
+        tools = []
+        for name in TOOL_DOMAINS:
+            tool = MagicMock()
+            tool.name = name
+            tools.append(tool)
+        mock_discover.return_value = tools
+
+        specialist_agents = []
+
+        def _make_specialist(**kwargs):
+            agent = MagicMock()
+            agent.name = kwargs.get("name", "unknown")
+            agent.tools = kwargs.get("tools", [])
+            specialist_agents.append(agent)
+            return agent
+
+        mock_spec_agent.side_effect = _make_specialist
+
+        # Set up orchestrator mock
+        mock_get_model.return_value = MagicMock()
+        mock_orch = MagicMock()
+        mock_agent_cls.return_value = mock_orch
+
+        create_orchestrator(soul_context="test soul")
+
+        # Orchestrator should be created with tools=[]
+        orch_kwargs = mock_agent_cls.call_args[1]
+        assert orch_kwargs["tools"] == []
+
+    @patch("src.agent.factory.ToolCallingAgent")
+    @patch("src.agent.factory.get_model")
+    @patch("src.agent.factory.skill_manager")
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    @patch("src.agent.specialists.mcp_manager")
+    @patch("src.agent.specialists.discover_tools")
+    def test_orchestrator_receives_managed_agents(
+        self, mock_discover, mock_mcp, mock_spec_model, mock_spec_agent,
+        mock_skill_mgr, mock_get_model, mock_agent_cls,
+    ):
+        mock_spec_model.return_value = MagicMock()
+        mock_mcp.get_config.return_value = []
+        mock_skill_mgr.get_active_skills.return_value = []
+
+        from src.agent.specialists import TOOL_DOMAINS
+        tools = []
+        for name in TOOL_DOMAINS:
+            tool = MagicMock()
+            tool.name = name
+            tools.append(tool)
+        mock_discover.return_value = tools
+
+        def _make_specialist(**kwargs):
+            agent = MagicMock()
+            agent.name = kwargs.get("name", "unknown")
+            agent.tools = kwargs.get("tools", [])
+            return agent
+
+        mock_spec_agent.side_effect = _make_specialist
+        mock_get_model.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+
+        create_orchestrator()
+
+        orch_kwargs = mock_agent_cls.call_args[1]
+        assert len(orch_kwargs["managed_agents"]) == 4
+
+    @patch("src.agent.factory.ToolCallingAgent")
+    @patch("src.agent.factory.get_model")
+    @patch("src.agent.factory.skill_manager")
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    @patch("src.agent.specialists.mcp_manager")
+    @patch("src.agent.specialists.discover_tools")
+    def test_orchestrator_includes_soul_and_memory(
+        self, mock_discover, mock_mcp, mock_spec_model, mock_spec_agent,
+        mock_skill_mgr, mock_get_model, mock_agent_cls,
+    ):
+        mock_spec_model.return_value = MagicMock()
+        mock_mcp.get_config.return_value = []
+        mock_skill_mgr.get_active_skills.return_value = []
+
+        from src.agent.specialists import TOOL_DOMAINS
+        tools = []
+        for name in TOOL_DOMAINS:
+            tool = MagicMock()
+            tool.name = name
+            tools.append(tool)
+        mock_discover.return_value = tools
+
+        def _make_specialist(**kwargs):
+            agent = MagicMock()
+            agent.name = kwargs.get("name", "unknown")
+            agent.tools = kwargs.get("tools", [])
+            return agent
+
+        mock_spec_agent.side_effect = _make_specialist
+        mock_get_model.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+
+        create_orchestrator(
+            soul_context="user soul content",
+            memory_context="relevant memories",
+        )
+
+        orch_kwargs = mock_agent_cls.call_args[1]
+        assert "USER IDENTITY" in orch_kwargs["instructions"]
+        assert "user soul content" in orch_kwargs["instructions"]
+        assert "RELEVANT MEMORIES" in orch_kwargs["instructions"]
+        assert "relevant memories" in orch_kwargs["instructions"]
+
+    @patch("src.agent.factory.ToolCallingAgent")
+    @patch("src.agent.factory.get_model")
+    @patch("src.agent.factory.skill_manager")
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    @patch("src.agent.specialists.mcp_manager")
+    @patch("src.agent.specialists.discover_tools")
+    def test_orchestrator_uses_settings_max_steps(
+        self, mock_discover, mock_mcp, mock_spec_model, mock_spec_agent,
+        mock_skill_mgr, mock_get_model, mock_agent_cls,
+    ):
+        mock_spec_model.return_value = MagicMock()
+        mock_mcp.get_config.return_value = []
+        mock_skill_mgr.get_active_skills.return_value = []
+
+        from src.agent.specialists import TOOL_DOMAINS
+        tools = []
+        for name in TOOL_DOMAINS:
+            tool = MagicMock()
+            tool.name = name
+            tools.append(tool)
+        mock_discover.return_value = tools
+
+        def _make_specialist(**kwargs):
+            agent = MagicMock()
+            agent.name = kwargs.get("name", "unknown")
+            agent.tools = kwargs.get("tools", [])
+            return agent
+
+        mock_spec_agent.side_effect = _make_specialist
+        mock_get_model.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+
+        create_orchestrator()
+
+        orch_kwargs = mock_agent_cls.call_args[1]
+        from config.settings import settings
+        assert orch_kwargs["max_steps"] == settings.orchestrator_max_steps
+
+    @patch("src.agent.factory.ToolCallingAgent")
+    @patch("src.agent.factory.get_model")
+    @patch("src.agent.factory.skill_manager")
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    @patch("src.agent.specialists.mcp_manager")
+    @patch("src.agent.specialists.discover_tools")
+    def test_orchestrator_delegation_preamble(
+        self, mock_discover, mock_mcp, mock_spec_model, mock_spec_agent,
+        mock_skill_mgr, mock_get_model, mock_agent_cls,
+    ):
+        mock_spec_model.return_value = MagicMock()
+        mock_mcp.get_config.return_value = []
+        mock_skill_mgr.get_active_skills.return_value = []
+
+        from src.agent.specialists import TOOL_DOMAINS
+        tools = []
+        for name in TOOL_DOMAINS:
+            tool = MagicMock()
+            tool.name = name
+            tools.append(tool)
+        mock_discover.return_value = tools
+
+        def _make_specialist(**kwargs):
+            agent = MagicMock()
+            agent.name = kwargs.get("name", "unknown")
+            agent.tools = kwargs.get("tools", [])
+            return agent
+
+        mock_spec_agent.side_effect = _make_specialist
+        mock_get_model.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+
+        create_orchestrator()
+
+        orch_kwargs = mock_agent_cls.call_args[1]
+        instructions = orch_kwargs["instructions"]
+        assert "You do NOT have any tools yourself" in instructions
+        assert "team of specialists" in instructions
+
+
+class TestStepFormatting:
+    def test_specialist_delegation_format(self):
+        names = {"web_researcher", "memory_keeper"}
+        result = _format_tool_step("web_researcher", {"task": "search for AI news"}, names)
+        assert result == "Delegating to web_researcher: search for AI news"
+
+    def test_regular_tool_format(self):
+        names = {"web_researcher", "memory_keeper"}
+        result = _format_tool_step("web_search", {"query": "AI news"}, names)
+        assert "Calling tool: web_search" in result
+        assert '"query": "AI news"' in result
+
+    def test_empty_specialist_set(self):
+        result = _format_tool_step("web_researcher", {"task": "search"}, set())
+        assert result.startswith("Calling tool:")

--- a/backend/tests/test_e2e_conversation.py
+++ b/backend/tests/test_e2e_conversation.py
@@ -37,7 +37,7 @@ class TestE2EConversation:
             mock_agent = MagicMock()
             mock_agent.run.return_value = iter(_make_agent_steps())
 
-            with patch("src.api.ws._build_agent", return_value=(mock_agent, False)), \
+            with patch("src.api.ws._build_agent", return_value=(mock_agent, False, set())), \
                  patch("src.memory.consolidator.consolidate_session"):
                 with client.websocket_connect("/ws/chat") as ws:
                     # Drain welcome message
@@ -92,7 +92,7 @@ class TestE2EConversation:
             mock_agent = MagicMock()
             mock_agent.run.return_value = iter(_make_agent_steps())
 
-            with patch("src.api.ws._build_agent", return_value=(mock_agent, False)), \
+            with patch("src.api.ws._build_agent", return_value=(mock_agent, False, set())), \
                  patch("src.memory.consolidator.consolidate_session"):
                 with client.websocket_connect("/ws/chat") as ws:
                     _ = ws.receive_text()  # welcome
@@ -129,7 +129,7 @@ class TestE2EConversation:
             mock_agent = MagicMock()
             mock_agent.run.return_value = iter(_make_agent_steps())
 
-            with patch("src.api.ws._build_agent", return_value=(mock_agent, False)), \
+            with patch("src.api.ws._build_agent", return_value=(mock_agent, False, set())), \
                  patch("src.memory.consolidator.consolidate_session"):
                 with client.websocket_connect("/ws/chat") as ws:
                     _ = ws.receive_text()

--- a/backend/tests/test_onboarding_edge_cases.py
+++ b/backend/tests/test_onboarding_edge_cases.py
@@ -37,7 +37,7 @@ class TestOnboardingEdgeCases:
                 full_agent.run.return_value = iter([
                     FinalAnswerStep(output="Full agent response"),
                 ])
-                with patch("src.api.ws._build_agent", return_value=(full_agent, False)), \
+                with patch("src.api.ws._build_agent", return_value=(full_agent, False, set())), \
                      patch("src.memory.consolidator.consolidate_session"):
                     ws.send_text(json.dumps({
                         "type": "message",

--- a/backend/tests/test_specialists.py
+++ b/backend/tests/test_specialists.py
@@ -1,0 +1,313 @@
+"""Tests for specialist agent factories and tool domain mapping."""
+
+from unittest.mock import MagicMock, patch
+
+from src.agent.specialists import (
+    DOMAIN_TOOLS,
+    SPECIALIST_CONFIGS,
+    TOOL_DOMAINS,
+    _sanitize_agent_name,
+    build_all_specialists,
+    create_file_worker,
+    create_goal_planner,
+    create_mcp_specialist,
+    create_memory_keeper,
+    create_specialist,
+    create_web_researcher,
+)
+
+
+class TestToolDomainMapping:
+    def test_all_builtin_tools_have_domains(self):
+        expected_tools = {
+            "view_soul", "update_soul",
+            "create_goal", "update_goal", "get_goals", "get_goal_progress",
+            "web_search", "browse_webpage",
+            "read_file", "write_file", "fill_template", "shell_execute",
+        }
+        assert set(TOOL_DOMAINS.keys()) == expected_tools
+
+    def test_reverse_index_covers_all_domains(self):
+        assert set(DOMAIN_TOOLS.keys()) == {"memory", "goals", "research", "files"}
+
+    def test_reverse_index_matches_forward(self):
+        for tool, domain in TOOL_DOMAINS.items():
+            assert tool in DOMAIN_TOOLS[domain]
+
+    def test_configs_cover_all_domains(self):
+        config_domains = {cfg["domain"] for cfg in SPECIALIST_CONFIGS.values()}
+        assert config_domains == set(DOMAIN_TOOLS.keys())
+
+
+class TestSanitizeAgentName:
+    def test_simple_name(self):
+        assert _sanitize_agent_name("github") == "github"
+
+    def test_hyphens_to_underscores(self):
+        assert _sanitize_agent_name("my-server") == "my_server"
+
+    def test_numeric_prefix(self):
+        result = _sanitize_agent_name("123abc")
+        assert result == "mcp_123abc"
+        assert result.isidentifier()
+
+    def test_special_chars(self):
+        result = _sanitize_agent_name("my@server!v2")
+        assert result == "my_server_v2"
+        assert result.isidentifier()
+
+    def test_empty_string(self):
+        assert _sanitize_agent_name("") == "unnamed_agent"
+
+    def test_collapses_multiple_underscores(self):
+        assert _sanitize_agent_name("a---b") == "a_b"
+
+
+class TestCreateSpecialist:
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    def test_creates_agent_with_correct_params(self, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+        mock_agent = MagicMock()
+        mock_agent.name = "test_agent"
+        mock_agent.max_steps = 3
+        mock_agent_cls.return_value = mock_agent
+        tool = MagicMock()
+        tool.name = "test_tool"
+
+        agent = create_specialist(
+            name="test_agent",
+            description="A test agent",
+            tools=[tool],
+            temperature=0.5,
+            max_steps=3,
+        )
+
+        assert agent.name == "test_agent"
+        assert agent.max_steps == 3
+        mock_model_cls.assert_called_once()
+        call_kwargs = mock_model_cls.call_args[1]
+        assert call_kwargs["temperature"] == 0.5
+        mock_agent_cls.assert_called_once()
+        agent_kwargs = mock_agent_cls.call_args[1]
+        assert agent_kwargs["name"] == "test_agent"
+        assert agent_kwargs["max_steps"] == 3
+
+
+class TestNamedFactories:
+    def _make_tools_by_name(self):
+        tools = {}
+        for name in TOOL_DOMAINS:
+            tool = MagicMock()
+            tool.name = name
+            tools[name] = tool
+        return tools
+
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    def test_memory_keeper_filters_tools(self, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+        tools_by_name = self._make_tools_by_name()
+        create_memory_keeper(tools_by_name)
+        agent_kwargs = mock_agent_cls.call_args[1]
+        tool_names = {t.name for t in agent_kwargs["tools"]}
+        assert tool_names == {"view_soul", "update_soul"}
+
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    def test_goal_planner_filters_tools(self, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+        tools_by_name = self._make_tools_by_name()
+        create_goal_planner(tools_by_name)
+        agent_kwargs = mock_agent_cls.call_args[1]
+        tool_names = {t.name for t in agent_kwargs["tools"]}
+        assert tool_names == {"create_goal", "update_goal", "get_goals", "get_goal_progress"}
+
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    def test_web_researcher_filters_tools(self, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+        tools_by_name = self._make_tools_by_name()
+        create_web_researcher(tools_by_name)
+        agent_kwargs = mock_agent_cls.call_args[1]
+        tool_names = {t.name for t in agent_kwargs["tools"]}
+        assert tool_names == {"web_search", "browse_webpage"}
+
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    def test_file_worker_filters_tools(self, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+        tools_by_name = self._make_tools_by_name()
+        create_file_worker(tools_by_name)
+        agent_kwargs = mock_agent_cls.call_args[1]
+        tool_names = {t.name for t in agent_kwargs["tools"]}
+        assert tool_names == {"read_file", "write_file", "fill_template", "shell_execute"}
+
+    def test_factory_returns_none_with_no_tools(self):
+        agent = create_memory_keeper({})
+        assert agent is None
+
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    def test_memory_keeper_temperature(self, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+        tools_by_name = self._make_tools_by_name()
+        create_memory_keeper(tools_by_name)
+        call_kwargs = mock_model_cls.call_args[1]
+        assert call_kwargs["temperature"] == 0.5
+
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    def test_web_researcher_max_steps(self, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+        tools_by_name = self._make_tools_by_name()
+        create_web_researcher(tools_by_name)
+        agent_kwargs = mock_agent_cls.call_args[1]
+        assert agent_kwargs["max_steps"] == 8
+
+
+class TestMcpSpecialist:
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    def test_name_sanitization(self, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+        tool = MagicMock()
+        tool.name = "do_thing"
+        create_mcp_specialist("my-server", [tool])
+        agent_kwargs = mock_agent_cls.call_args[1]
+        assert agent_kwargs["name"] == "mcp_my_server"
+
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    def test_auto_generated_description(self, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+        tool = MagicMock()
+        tool.name = "list_tasks"
+        create_mcp_specialist("things3", [tool])
+        agent_kwargs = mock_agent_cls.call_args[1]
+        assert "list_tasks" in agent_kwargs["description"]
+        assert "things3" in agent_kwargs["description"]
+
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    def test_custom_description(self, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+        tool = MagicMock()
+        tool.name = "list_tasks"
+        create_mcp_specialist("things3", [tool], description="Task manager")
+        agent_kwargs = mock_agent_cls.call_args[1]
+        assert agent_kwargs["description"] == "Task manager"
+
+
+class TestBuildAllSpecialists:
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    @patch("src.agent.specialists.mcp_manager")
+    @patch("src.agent.specialists.discover_tools")
+    def test_without_mcp_returns_builtin(self, mock_discover, mock_mcp, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+        mock_mcp.get_config.return_value = []
+
+        # Track created agents
+        created = []
+
+        def _make_agent(**kwargs):
+            agent = MagicMock()
+            agent.name = kwargs.get("name", "unknown")
+            created.append(agent)
+            return agent
+
+        mock_agent_cls.side_effect = _make_agent
+
+        # Create mock tools for all built-in domains
+        tools = []
+        for name in TOOL_DOMAINS:
+            tool = MagicMock()
+            tool.name = name
+            tools.append(tool)
+        mock_discover.return_value = tools
+
+        specialists = build_all_specialists()
+        assert len(specialists) == 4
+        names = {s.name for s in specialists}
+        assert names == {"memory_keeper", "goal_planner", "web_researcher", "file_worker"}
+
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    @patch("src.agent.specialists.mcp_manager")
+    @patch("src.agent.specialists.discover_tools")
+    def test_with_mcp_returns_builtin_plus_mcp(self, mock_discover, mock_mcp, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+
+        created = []
+
+        def _make_agent(**kwargs):
+            agent = MagicMock()
+            agent.name = kwargs.get("name", "unknown")
+            created.append(agent)
+            return agent
+
+        mock_agent_cls.side_effect = _make_agent
+
+        # Built-in tools
+        tools = []
+        for name in TOOL_DOMAINS:
+            tool = MagicMock()
+            tool.name = name
+            tools.append(tool)
+        mock_discover.return_value = tools
+
+        # MCP server
+        mcp_tool = MagicMock()
+        mcp_tool.name = "list_tasks"
+        mock_mcp.get_config.return_value = [
+            {"name": "things3", "url": "http://...", "enabled": True, "connected": True, "tool_count": 1, "description": "Task manager"},
+        ]
+        mock_mcp.is_connected.return_value = True
+        mock_mcp.get_server_tools.return_value = [mcp_tool]
+
+        specialists = build_all_specialists()
+        assert len(specialists) == 5
+        names = {s.name for s in specialists}
+        assert "mcp_things3" in names
+
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    @patch("src.agent.specialists.mcp_manager")
+    @patch("src.agent.specialists.discover_tools")
+    def test_skips_disconnected_mcp(self, mock_discover, mock_mcp, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+
+        created = []
+
+        def _make_agent(**kwargs):
+            agent = MagicMock()
+            agent.name = kwargs.get("name", "unknown")
+            created.append(agent)
+            return agent
+
+        mock_agent_cls.side_effect = _make_agent
+
+        tools = []
+        for name in TOOL_DOMAINS:
+            tool = MagicMock()
+            tool.name = name
+            tools.append(tool)
+        mock_discover.return_value = tools
+
+        mock_mcp.get_config.return_value = [
+            {"name": "offline", "url": "http://...", "enabled": True, "connected": False, "tool_count": 0, "description": ""},
+        ]
+        mock_mcp.is_connected.return_value = False
+
+        specialists = build_all_specialists()
+        assert len(specialists) == 4  # only built-in

--- a/backend/tests/test_timeouts.py
+++ b/backend/tests/test_timeouts.py
@@ -35,7 +35,7 @@ def _make_context(**overrides) -> CurrentContext:
 @pytest.mark.asyncio
 class TestRestChatTimeout:
     @patch("src.memory.vector_store.search_formatted", return_value="")
-    @patch("src.api.chat.create_agent")
+    @patch("src.api.chat.build_agent")
     @patch("src.api.chat.create_onboarding_agent")
     async def test_returns_504_on_timeout(
         self, mock_onboarding, mock_create_agent, mock_search, client

--- a/frontend/src/lib/toolParser.ts
+++ b/frontend/src/lib/toolParser.ts
@@ -2,6 +2,7 @@ import { TOOL_NAMES } from "../config/constants";
 import { useChatStore } from "../stores/chatStore";
 
 const TOOL_PATTERNS = [
+  /Delegating to\s+(\w+):/i,
   /ToolCall\(\s*name\s*=\s*['"](\w+)['"]/i,
   /tool_name\s*[:=]\s*['"](\w+)['"]/i,
   /Calling tool:\s*['"]?(\w+)['"]?/i,


### PR DESCRIPTION
## Summary
- Implement feature-flagged orchestrator + specialist delegation mode based on the [Recursive Language Models paper](https://arxiv.org/pdf/2512.24601)
- When `USE_DELEGATION=true`, the root agent has zero tools and delegates to domain-specific specialists (`memory_keeper`, `goal_planner`, `web_researcher`, `file_worker`) plus one auto-generated specialist per connected MCP server
- Defaults to off — zero runtime change when flag is not set

## Changes
- **Settings**: 3 new delegation settings (`use_delegation`, `delegation_max_depth`, `orchestrator_max_steps`)
- **`specialists.py`** (new): Tool domain mapping, specialist factories, `build_all_specialists()`
- **`factory.py`**: `create_orchestrator()` and `build_agent()` feature-flag router
- **`ws.py`**: `_format_tool_step()` for delegation-aware step display, `_build_agent()` returns specialist names
- **`chat.py`**: Wired to use `build_agent()`
- **`tools.py`**: Includes specialist names in `/api/tools` response when delegation active
- **`toolParser.ts`**: Delegation regex pattern for frontend animation triggers
- **Docs**: CLAUDE.md delegation architecture section + settings, NEXT_STEPS.md updated

## Test plan
- [x] 24 new specialist tests (`test_specialists.py`)
- [x] 10 new delegation tests (`test_delegation.py`) — feature flag, orchestrator, step formatting
- [x] All 396 backend tests pass
- [x] All 124 frontend tests pass
- [ ] Manual: `USE_DELEGATION=false` (default) — existing behavior unchanged
- [ ] Manual: `USE_DELEGATION=true` — agent delegates to specialists, WS steps show "Delegating to X: ..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)