### PR TITLE
docs: update Getting Started and Setup Guide to reflect current codebase

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -5,7 +5,7 @@ slug: /
 
 # Getting Started
 
-Seraph is a proactive AI guardian with a retro 16-bit RPG village UI. A Phaser 3 canvas renders a tile-based village where an animated pixel-art avatar casts magic effects when using tools while you chat via an RPG-style dialog box. The agent has persistent identity, long-term memory, and a hierarchical goal/quest system.
+Seraph is a proactive AI guardian with a retro 16-bit RPG village UI. A Phaser 3 canvas renders a tile-based village where an animated pixel-art avatar casts magic effects when using tools while you chat via an RPG-style dialog box. The agent has persistent identity, long-term memory, a hierarchical goal/quest system, SKILL.md plugins, and plug-and-play MCP server integration.
 
 ## Setup
 
@@ -13,10 +13,12 @@ See the **[Setup Guide](./setup)** for complete installation and configuration i
 
 ## Architecture
 
-- **Frontend**: React 19, Vite 6, TypeScript, Tailwind CSS, Zustand, Phaser 3.90
+- **Frontend**: React 19, Vite 6, TypeScript 5.6, Tailwind CSS 3, Zustand 5, Phaser 3.90
 - **Backend**: Python 3.12, FastAPI, uvicorn, smolagents, LiteLLM (OpenRouter)
 - **Database**: SQLModel + SQLite (aiosqlite), LanceDB (vector memory)
-- **Tools**: 16 auto-discovered tools + MCP integrations — web search, file I/O, shell (snekbox sandbox), browser (Playwright), calendar (Google), email (Gmail), soul/memory, goals, Things3 (via MCP)
+- **Tools**: 12 built-in tools (auto-discovered) + MCP integrations — web search, file I/O, shell (snekbox sandbox), browser (Playwright), soul/memory, goals
+- **Scheduler**: APScheduler — 6 background jobs (memory consolidation, goal check, calendar scan, strategist tick, daily briefing, evening review)
+- **Observer**: Native macOS daemon → context manager → user state machine → attention guardian → insight queue
 - **Infra**: Docker Compose (3 services: backend, frontend, snekbox sandbox), uv package manager
 
 ## Project Structure
@@ -24,28 +26,45 @@ See the **[Setup Guide](./setup)** for complete installation and configuration i
 ```
 frontend/
 ├── src/
-│   ├── game/            # Phaser 3 village scene, sprites, EventBus
-│   ├── components/      # React overlays (chat sidebar + messages, quest, ui)
-│   ├── hooks/           # useWebSocket, useAgentAnimation
+│   ├── game/            # Phaser 3 village scene, sprites, pathfinding, EventBus
+│   ├── components/      # React overlays (chat, quest, settings, HUD buttons)
+│   ├── hooks/           # useWebSocket, useAgentAnimation, useKeyboardShortcuts
 │   ├── stores/          # Zustand stores (chat, quest)
 │   ├── lib/             # Tool parser, animation state machine
 │   ├── types/           # TypeScript interfaces
 │   └── config/          # Constants, scene dimensions, tool names
+
+editor/                  # Standalone village map editor (React + Vite)
+├── src/
+│   ├── components/      # MapCanvas, ToolBar, TilesetPanel, BuildingPanel, etc.
+│   ├── stores/          # Editor state, tileset management
+│   ├── lib/             # Canvas renderer, flood fill, Tiled JSON I/O
+│   └── types/           # CellStack, BuildingDef, Tiled JSON schema
 
 backend/
 ├── main.py              # Uvicorn entry point
 ├── config/settings.py   # Pydantic Settings (env vars)
 ├── src/
 │   ├── app.py           # FastAPI app factory (lifespan: DB init, soul file)
-│   ├── models/schemas.py
-│   ├── api/             # REST + WebSocket endpoints (chat, sessions, goals, profile, tools)
-│   ├── agent/           # smolagents factory, onboarding agent, session manager
-│   ├── tools/           # 16 @tool implementations (auto-discovered) + MCP tools
-│   ├── db/              # SQLModel engine + models (Session, Message, Goal, UserProfile, Memory)
+│   ├── api/             # REST + WebSocket endpoints (chat, sessions, goals, profile, tools, mcp, skills, observer, settings)
+│   ├── agent/           # Agent factory, onboarding, strategist, specialists, context window, session manager
+│   ├── tools/           # 12 @tool implementations (auto-discovered) + MCP manager
+│   ├── plugins/         # Tool auto-discovery loader + registry
+│   ├── skills/          # SKILL.md plugin loader + manager
+│   ├── db/              # SQLModel engine + models (Session, Message, Goal, UserProfile, Memory, QueuedInsight)
 │   ├── memory/          # Soul file, LanceDB vector store, embedder, consolidator
 │   ├── goals/           # Hierarchical goal CRUD repository
-│   └── plugins/         # Tool auto-discovery loader + registry
+│   ├── observer/        # Context manager, user state machine, delivery gate, insight queue, data sources
+│   └── scheduler/       # APScheduler engine, connection manager, 6 background jobs
+├── data/
+│   ├── skills/          # SKILL.md plugin files (YAML frontmatter + instructions)
+│   └── mcp-servers.json # MCP server configuration (runtime-managed)
 └── tests/
+
+daemon/                  # Native macOS screen daemon (outside Docker)
+├── seraph_daemon.py     # Dual-loop: window polling + optional OCR
+├── ocr/                 # Pluggable OCR providers (Apple Vision, OpenRouter)
+└── run.sh               # Quick start script
 ```
 
 ## Management
@@ -56,6 +75,19 @@ backend/
 ./manage.sh -e dev logs -f     # Tail logs
 ./manage.sh -e dev build       # Rebuild
 ```
+
+## MCP Server Management
+
+```bash
+./mcp.sh list                         # List configured MCP servers
+./mcp.sh add <name> <url> --desc "…"  # Add a server
+./mcp.sh remove <name>                # Remove a server
+./mcp.sh enable <name>                # Enable a server
+./mcp.sh disable <name>               # Disable a server
+./mcp.sh test <name>                  # Test connectivity
+```
+
+MCP servers can also be managed via the Settings panel in the UI or the REST API (`/api/mcp/servers`).
 
 ## Testing
 
@@ -76,7 +108,8 @@ See [Testing Guide](./development/testing) for full details.
 ## Current Status
 
 - **Phase 0** (Foundation): Complete — chat, WebSocket streaming, Phaser village, day/night cycle
-- **Phase 1** (Persistent Identity): Complete — DB, soul/memory, goals, onboarding, quest UI, two-pane chat sidebar, session auto-naming, sprite tooltips, chat maximize/close controls, HUD panel buttons, session persistence (localStorage)
-- **Phase 2** (Capable Executor): Complete — shell, browser, calendar, email, plugin system, MCP integrations (Things3)
-- **Phase 3** (The Observer): Complete (3.1–3.5) — background scheduler, context awareness, user state machine, proactive strategist, daily briefing, evening review, attention guardian, insight queue, ambient/nudge frontend, native macOS screen daemon
-- **Phase 4** (The Network): Planned — SKILL.md ecosystem, multi-channel messaging, workflows, multi-agent, voice, canvas, remote access
+- **Phase 1** (Persistent Identity): Complete — DB, soul/memory, goals, onboarding, quest UI, chat sidebar, session management, sprite system
+- **Phase 2** (Capable Executor): Complete — shell, browser, plugin system, MCP integrations
+- **Phase 3** (The Observer): Complete — background scheduler, context awareness, user state machine, proactive strategist, daily briefing, evening review, attention guardian, insight queue, ambient/nudge frontend, native macOS screen daemon
+- **Phase 3.5** (Polish): Mostly complete — goal management UI, interruption mode toggle, token-aware context window, agent execution timeouts, frontend accessibility. Tauri desktop app and infra hardening remain planned.
+- **Phase 4** (The Strategist): Partially complete — proactive reasoning engine, interruption intelligence, morning briefing, evening review, SKILL.md plugins, recursive delegation architecture are done. Decision support, mistake prevention, weekly strategy remain planned.


### PR DESCRIPTION
## Summary
- Update intro.md: fix phase statuses (3.5 mostly complete, 4 partially complete), add missing modules to project structure (observer, scheduler, skills, plugins, editor, daemon), add MCP management section
- Update setup.md: fix default model, replace Things3 env var with mcp-servers.json approach, add MCP server management, SKILL.md plugins, and village editor sections

## Test plan
- [x] `cd docs && npm run build` passes
- [x] All info cross-referenced against CLAUDE.md and source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)