### PR TITLE
docs: fix cross-document misalignments

### DIFF
--- a/docs/docs/architecture/feature-comparison.md
+++ b/docs/docs/architecture/feature-comparison.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 > **Date**: 2026-02-09 (updated)
 > **OpenClaw version context**: v2026.1.x (145k+ GitHub stars, formerly Clawdbot/Moltbot)
-> **Seraph branch**: `develop` (Phase 1 + 2 complete)
+> **Seraph branch**: `main` (Phases 0–3.5 mostly complete, Phase 4 partial)
 
 ## Overview
 
@@ -22,7 +22,7 @@ Different philosophies, but many of OpenClaw's features are worth adopting.
 
 - Real-time chat with AI agent (WebSocket streaming with step/final/error/proactive/ambient types)
 - Tool execution with visual feedback (animated RPG avatar casts magic effects in village)
-- **16 auto-discovered tools + MCP integrations**: web search, file I/O, template fill, soul view/update, goal CRUD, shell execute (snekbox sandbox), browser automation (Playwright), calendar (Google), email (Gmail), task management (Things3 via MCP)
+- **12 auto-discovered tools + MCP integrations**: web search, file I/O, template fill, soul view/update, goal CRUD, shell execute (snekbox sandbox), browser automation (Playwright) + SKILL.md plugins
 - **Persistent sessions** — SQLite-backed, survive restarts, session list UI with switch/delete
 - **Persistent memory** — Soul file (soul.md) + LanceDB vector store with sentence-transformer embeddings
 - **Memory consolidation** — Background extraction of facts/preferences/decisions after each conversation
@@ -30,7 +30,7 @@ Different philosophies, but many of OpenClaw's features are worth adopting.
 - **Onboarding flow** — Specialized agent for first-time users, skip/restart controls, welcome message
 - **Plugin system** — Auto-discovery of tools from `src/tools/`, tool registry with village metadata
 - **Sandboxed execution** — snekbox Docker sidecar for shell commands, Playwright for browser
-- Phaser 3 village scene with 7 buildings, day/night cycle, idle wandering, 12 waypoints, speech bubbles
+- Phaser 3 village scene with dynamically loaded buildings from Tiled JSON, day/night cycle, idle wandering, 12 waypoints, speech bubbles
 - Multi-model support via OpenRouter/LiteLLM
 - Docker Compose dev environment (3 services: backend, frontend, sandbox)
 - React 19 + Vite 6 + TypeScript + Tailwind + Zustand + Phaser 3 frontend
@@ -51,38 +51,34 @@ Different philosophies, but many of OpenClaw's features are worth adopting.
 
 | # | Feature | OpenClaw | Seraph Status |
 |---|---------|----------|---------------|
-| 4 | **Proactive heartbeat** | Cron-like scheduled tasks (check email, RSS, summaries) | WS protocol scaffolding exists (proactive/ambient types), but no scheduler or reasoning engine yet (Phase 3) |
-| 5 | **Multi-channel messaging** | WhatsApp, Telegram, Discord, Slack, Signal, iMessage, Mattermost, Google Chat | Web UI only |
-| 6 | **Multi-agent routing** | Multiple isolated agents per gateway, deterministic routing | Single agent (+ onboarding agent) |
-| 7 | **Subagents** | Spawnable child agents with concurrency limits, agent-level restrictions | None |
-| 8 | **Note-taking / Knowledge base** | N/A (not an OpenClaw feature) | Planned in roadmap (Phase 2.4) but not implemented — no Obsidian/markdown vault integration |
+| 4 | **Multi-channel messaging** | WhatsApp, Telegram, Discord, Slack, Signal, iMessage, Mattermost, Google Chat | Web UI only |
+| 5 | **Note-taking / Knowledge base** | N/A (not an OpenClaw feature) | Planned in roadmap (Phase 2.4) but not implemented — no Obsidian/markdown vault integration |
 
 ### Tier 3 — Important Gaps (UX & operational)
 
 | # | Feature | OpenClaw | Seraph Status |
 |---|---------|----------|---------------|
-| 9 | **Streaming/chunking** | Block streaming with configurable chunk size, human-like delay | Raw WebSocket step streaming |
-| 10 | **Media support** | Send/receive images, audio, documents bidirectionally | Text only |
-| 11 | **TTS** | ElevenLabs/OpenAI providers, auto/inbound/tagged modes | None |
-| 12 | **Voice transcription** | Inbound voice note transcription hook | None |
-| 13 | **Message queuing** | Steer/followup/collect/interrupt modes, debouncing for rapid messages | No queue, one-at-a-time |
-| 14 | **Security audit CLI** | `openclaw security audit --deep`, permission hardening, log redaction | None |
-| 15 | **User auth/identity** | DM pairing, allowlists, identity links across channels, access groups | Anonymous singleton user, no auth |
-| 16 | **Configuration UI** | Web control dashboard, config editing via chat | No settings UI |
-| 17 | **Remote access** | SSH, Tailscale, mDNS discovery | Localhost only |
-| 18 | **Structured logging** | Redaction, pretty/compact/json styles, per-file output | Basic console logging |
+| 6 | **Streaming/chunking** | Block streaming with configurable chunk size, human-like delay | Raw WebSocket step streaming |
+| 7 | **Media support** | Send/receive images, audio, documents bidirectionally | Text only |
+| 8 | **TTS** | ElevenLabs/OpenAI providers, auto/inbound/tagged modes | None |
+| 9 | **Voice transcription** | Inbound voice note transcription hook | None |
+| 10 | **Message queuing** | Steer/followup/collect/interrupt modes, debouncing for rapid messages | No queue, one-at-a-time |
+| 11 | **Security audit CLI** | `openclaw security audit --deep`, permission hardening, log redaction | None |
+| 12 | **User auth/identity** | DM pairing, allowlists, identity links across channels, access groups | Anonymous singleton user, no auth |
+| 13 | **Remote access** | SSH, Tailscale, mDNS discovery | Localhost only |
+| 14 | **Structured logging** | Redaction, pretty/compact/json styles, per-file output | Basic console logging |
 
 ### Tier 4 — Nice-to-Have
 
 | # | Feature | OpenClaw |
 |---|---------|----------|
-| 19 | Mobile nodes (iOS/Android with Canvas) |
-| 20 | macOS menubar companion app |
-| 21 | Group chat mention gating & policies |
-| 22 | Config includes with deep merge (10 levels) |
-| 23 | Response prefix templates (`{model}`, `{identity.name}`) |
-| 24 | Ack reactions (emoji confirmations) |
-| 25 | Custom chat commands (`/command` in chat) |
+| 15 | Mobile nodes (iOS/Android with Canvas) |
+| 16 | macOS menubar companion app |
+| 17 | Group chat mention gating & policies |
+| 18 | Config includes with deep merge (10 levels) |
+| 19 | Response prefix templates (`{model}`, `{identity.name}`) |
+| 20 | Ack reactions (emoji confirmations) |
+| 21 | Custom chat commands (`/command` in chat) |
 
 ---
 
@@ -97,7 +93,10 @@ These were gaps in the original analysis that have since been implemented:
 | **Sandboxed execution** | No sandboxing | snekbox Docker sidecar (Phase 2) |
 | **Browser automation** | DuckDuckGo text search only | Playwright with headless Chromium (Phase 2) |
 | **Shell command execution** | No shell tool | snekbox-based sandboxed execution (Phase 2) |
-| **Plugin/skill system** | 4 hardcoded tools | Auto-discovery from `src/tools/` (16 native tools) + MCP integrations (Phase 2) |
+| **Plugin/skill system** | 4 hardcoded tools | Auto-discovery from `src/tools/` (12 native tools) + MCP integrations + SKILL.md plugins (Phase 2 + 4) |
+| **Proactive heartbeat** | No scheduler or reasoning engine | APScheduler with 6 jobs: strategist tick, daily briefing, evening review, memory consolidation, goal check, calendar scan (Phase 3) |
+| **Multi-agent / subagents** | Single agent (+ onboarding agent) | Recursive delegation with orchestrator + domain specialists behind feature flag (Phase 4) |
+| **Configuration UI** | No settings UI | Settings panel with interruption mode toggle, SKILL.md management, MCP server management (Phase 3.5) |
 
 ---
 
@@ -137,7 +136,7 @@ These were gaps in the original analysis that have since been implemented:
 
 OpenClaw is headless. Seraph's **visual RPG experience** has no equivalent:
 
-- Phaser 3 village scene with 7 buildings and magic effect animations
+- Phaser 3 village scene with dynamically loaded buildings and magic effect animations
 - Animated pixel-art avatar with casting effects on tool use
 - Day/night cycle based on system time
 - Idle wandering between 12 waypoints

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Testing Guide
 
-Seraph has 336 automated tests (281 backend, 55 frontend) with CI running on every push and PR.
+Seraph has 520 automated tests (396 backend, 124 frontend) with CI running on every push and PR.
 
 ## Running Tests
 
@@ -122,9 +122,9 @@ beforeEach(() => {
 
 These areas are intentionally excluded from the test suite:
 
-- **Phaser game objects** (StudyScene, AgentSprite, UserSprite, SpeechBubble) — require WebGL context, fragile mocking
+- **Phaser game objects** (VillageScene, AgentSprite, UserSprite, SpeechBubble) — require WebGL context, fragile mocking
 - **EventBus.ts** — single-line Phaser EventEmitter wrapper
-- **Browser/Calendar/Email tools** — thin wrappers around OAuth-dependent libraries
+- **Browser tool** — thin wrapper around Playwright
 - **LanceDB vector_store.py** — requires real embeddings model loaded
 - **Full WS message streaming** — complex sync/async interaction with agent streaming; basic WS tests cover ping, error handling, and skip_onboarding
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -113,3 +113,4 @@ See [Testing Guide](./development/testing) for full details.
 - **Phase 3** (The Observer): Complete — background scheduler, context awareness, user state machine, proactive strategist, daily briefing, evening review, attention guardian, insight queue, ambient/nudge frontend, native macOS screen daemon
 - **Phase 3.5** (Polish): Mostly complete — goal management UI, interruption mode toggle, token-aware context window, agent execution timeouts, frontend accessibility. Tauri desktop app and infra hardening remain planned.
 - **Phase 4** (The Strategist): Partially complete — proactive reasoning engine, interruption intelligence, morning briefing, evening review, SKILL.md plugins, recursive delegation architecture are done. Decision support, mistake prevention, weekly strategy remain planned.
+- **Phase 5** (Security): Planned — credential injection, leak detection, OAuth 2.1 for MCP, capability permissions

--- a/docs/docs/overview/next-steps.md
+++ b/docs/docs/overview/next-steps.md
@@ -9,7 +9,7 @@ sidebar_position: 4
 
 ## Current State
 
-Phases 0-3 are complete and functional. 414 automated tests (359 backend, 55 frontend). Clean codebase with no TODOs/FIXMEs. The project's unique advantages — proactive intelligence, RPG village metaphor, five-pillar life model, screen awareness — are implemented but not fully leveraged in the UI.
+Phases 0-3 are complete and functional. 520 automated tests (396 backend, 124 frontend). Clean codebase with no TODOs/FIXMEs. The project's unique advantages — proactive intelligence, RPG village metaphor, five-pillar life model, screen awareness — are implemented but not fully leveraged in the UI.
 
 ---
 

--- a/docs/docs/overview/status-report.md
+++ b/docs/docs/overview/status-report.md
@@ -11,7 +11,7 @@ sidebar_position: 3
 
 ## Executive Summary
 
-Seraph is in strong shape. Phases 0-3 are implemented and functional, delivering a proactive AI guardian with persistent identity, 16 tools, MCP extensibility, a sophisticated observer system, and a visually polished RPG village interface. The codebase is well-architected, clean, and production-quality for a single-user application.
+Seraph is in strong shape. Phases 0-3 are implemented and functional, delivering a proactive AI guardian with persistent identity, 12 tools, MCP extensibility, a sophisticated observer system, and a visually polished RPG village interface. The codebase is well-architected, clean, and production-quality for a single-user application.
 
 However, significant work remains to reach the stated vision of being "better than OpenClaw." OpenClaw exploded in late January 2026 (145k+ GitHub stars, millions of installs) and has become the defining AI agent of the moment. The competitive landscape has shifted dramatically. This report maps exactly where Seraph stands, what's missing, and what to prioritize.
 
@@ -25,7 +25,7 @@ However, significant work remains to reach the stated vision of being "better th
 |-------|--------|-----------------|
 | **0 - Foundation** | COMPLETE | Chat UI, WebSocket streaming, Phaser village, day/night cycle, wandering avatar |
 | **1 - Persistent Identity** | COMPLETE | Soul file, LanceDB vector memory, memory consolidation, hierarchical goals, onboarding |
-| **2 - Capable Executor** | COMPLETE | 16 auto-discovered tools, shell sandbox, browser automation, MCP support, tool registry |
+| **2 - Capable Executor** | COMPLETE | 12 auto-discovered tools, shell sandbox, browser automation, MCP support, tool registry |
 | **3 - The Observer** | COMPLETE | APScheduler (6 jobs), user state machine (6 states), attention guardian, insight queue, macOS daemon |
 
 ### Backend Assessment: 85-90% Complete
@@ -114,8 +114,8 @@ OpenClaw (formerly Clawdbot/Moltbot, created by Peter Steinberger) became "agent
 | Local-first / privacy | Yes | No (cloud) | Yes |
 | Persistent memory | Yes (weeks) | Limited | Yes (LanceDB + soul) |
 | Multi-channel | Yes (Telegram, Discord, Slack, etc.) | Web only | **No** (browser only) |
-| Plugin/skill ecosystem | 700+ community skills | Closed | **MCP only, no skill files** |
-| Multi-agent | Yes (specialized sub-agents) | Yes | **No** |
+| Plugin/skill ecosystem | 700+ community skills | Closed | **Yes** (SKILL.md plugins + MCP) |
+| Multi-agent | Yes (specialized sub-agents) | Yes | **Yes** (recursive delegation behind feature flag) |
 | Proactive behavior | **No** (reactive only) | **No** | **Yes** (strategist, briefings) |
 | Screen awareness | **No** | **No** | **Yes** (daemon + OCR) |
 | Visual interface | **No** (headless/terminal) | Basic web UI | **Yes** (RPG village) |


### PR DESCRIPTION
## Summary
- Fix "16 tools" → "12 tools" across status-report and feature-comparison
- Fix test counts to 520 (396 backend + 124 frontend) in testing and next-steps
- Fix StudyScene → VillageScene, remove stale calendar/email tool references
- Add Phase 5 (Security) to intro.md current status
- Update feature-comparison: branch develop→main, move resolved gaps (proactive heartbeat, multi-agent, settings UI) to resolved section, add SKILL.md plugins, fix hardcoded "7 buildings" to dynamic Tiled JSON

## Test plan
- [x] `cd docs && npm run build` — Docusaurus builds without errors
- [x] No stale references remain (grep for "16 tools", "StudyScene", "calendar_tool", "email_tool")
- [x] All docs consistently say "12 tools" for native tool count
- [x] Test counts match reality (520 = 396 + 124)

🤖 Generated with [Claude Code](https://claude.com/claude-code)