### PR TITLE
feat: HTTP MCP server, default skills, seed config & Discover catalog

### DIFF
--- a/backend/data/mcp-servers.default.json
+++ b/backend/data/mcp-servers.default.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "http-request": {
+      "url": "http://http-mcp:9200/mcp",
+      "enabled": false,
+      "description": "Make HTTP requests to external APIs"
+    },
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "enabled": false,
+      "description": "GitHub integration (requires GITHUB_TOKEN env var)"
+    }
+  }
+}

--- a/backend/data/skill-catalog.json
+++ b/backend/data/skill-catalog.json
@@ -1,0 +1,76 @@
+{
+  "skills": [
+    {
+      "name": "daily-standup",
+      "description": "Generate a standup report from git and goals",
+      "category": "productivity",
+      "requires_tools": ["shell_execute", "get_goals"],
+      "bundled": true
+    },
+    {
+      "name": "code-review",
+      "description": "Review a file with structured feedback",
+      "category": "development",
+      "requires_tools": ["shell_execute", "read_file"],
+      "bundled": true
+    },
+    {
+      "name": "goal-reflection",
+      "description": "Weekly goal reflection comparing progress to soul values",
+      "category": "productivity",
+      "requires_tools": ["get_goals", "get_goal_progress", "view_soul"],
+      "bundled": true
+    },
+    {
+      "name": "weekly-planner",
+      "description": "Plan the week from soul priorities and active goals",
+      "category": "productivity",
+      "requires_tools": ["get_goals", "create_goal", "view_soul"],
+      "bundled": true
+    },
+    {
+      "name": "morning-intention",
+      "description": "Set a soul-aligned daily intention with top 3 tasks",
+      "category": "productivity",
+      "requires_tools": ["get_goals", "view_soul"],
+      "bundled": true
+    },
+    {
+      "name": "evening-journal",
+      "description": "Guided evening reflection on wins, learnings, and gratitude",
+      "category": "productivity",
+      "requires_tools": ["get_goals", "get_goal_progress"],
+      "bundled": true
+    },
+    {
+      "name": "moltbook",
+      "description": "Interact with the Moltbook social API — post, comment, browse feed",
+      "category": "integration",
+      "requires_tools": ["http_request"],
+      "bundled": true
+    },
+    {
+      "name": "web-briefing",
+      "description": "Fetch URLs and summarize into a structured briefing",
+      "category": "research",
+      "requires_tools": ["http_request", "web_search"],
+      "bundled": true
+    }
+  ],
+  "mcp_servers": [
+    {
+      "name": "http-request",
+      "description": "Make HTTP requests to external APIs",
+      "category": "integration",
+      "url": "http://http-mcp:9200/mcp",
+      "bundled": true
+    },
+    {
+      "name": "github",
+      "description": "GitHub integration (requires GITHUB_TOKEN env var)",
+      "category": "development",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "bundled": false
+    }
+  ]
+}

--- a/backend/data/skills/evening-journal.md
+++ b/backend/data/skills/evening-journal.md
@@ -1,0 +1,19 @@
+---
+name: evening-journal
+description: Guided evening reflection on wins, learnings, and gratitude
+requires:
+  tools: [get_goals, get_goal_progress]
+user_invocable: true
+---
+
+When the user asks for an evening reflection or journal prompt, follow these steps:
+
+1. Use `get_goals` to fetch today's active goals
+2. Use `get_goal_progress` to check what was accomplished
+3. Guide the user through a structured reflection:
+   - **Wins**: what goals advanced or completed today? Celebrate progress.
+   - **Learnings**: what surprised you? What would you do differently?
+   - **Gratitude**: name one thing from today you're grateful for
+   - **Tomorrow**: one thing to carry forward or start fresh
+4. Keep the tone warm and reflective — this is a wind-down ritual
+5. Summarize their responses into a brief journal entry they can keep

--- a/backend/data/skills/moltbook.md
+++ b/backend/data/skills/moltbook.md
@@ -1,0 +1,27 @@
+---
+name: moltbook
+description: Interact with the Moltbook social API — post, comment, browse feed
+requires:
+  tools: [http_request]
+user_invocable: true
+---
+
+Moltbook is a social platform API. Use `http_request` to interact with it.
+
+**Base URL**: The user must provide the Moltbook API base URL (e.g. `https://moltbook.example.com/api`).
+
+**Available actions**:
+
+1. **Register**: `POST /register` with `{"username": "...", "password": "..."}`
+2. **Login**: `POST /login` with `{"username": "...", "password": "..."}` — returns a token
+3. **View feed**: `GET /feed` with `Authorization: Bearer <token>` header
+4. **Create post**: `POST /posts` with `{"content": "..."}` and auth header
+5. **Comment on post**: `POST /posts/{id}/comments` with `{"content": "..."}` and auth header
+6. **Search users**: `GET /users?q=...` with auth header
+7. **View profile**: `GET /users/{username}` with auth header
+
+**Guidelines**:
+- Always ask the user for credentials or use stored token
+- Format feed posts and comments readably
+- Summarize long feeds rather than dumping raw JSON
+- Handle errors gracefully and explain API error messages

--- a/backend/data/skills/morning-intention.md
+++ b/backend/data/skills/morning-intention.md
@@ -1,0 +1,17 @@
+---
+name: morning-intention
+description: Set a soul-aligned daily intention with top 3 tasks
+requires:
+  tools: [get_goals, view_soul]
+user_invocable: true
+---
+
+When the user asks to set a morning intention or start their day, follow these steps:
+
+1. Use `view_soul` to review the user's identity and values
+2. Use `get_goals` to fetch active daily and weekly goals
+3. Synthesize a morning briefing with:
+   - **Intention**: one sentence capturing the day's spirit, aligned with soul values
+   - **Top 3 tasks**: the most impactful goals/tasks to focus on today
+   - **Mindset note**: a brief encouragement tied to their identity
+4. Keep it concise and energizing — this should feel like a quick morning ritual

--- a/backend/data/skills/web-briefing.md
+++ b/backend/data/skills/web-briefing.md
@@ -1,0 +1,19 @@
+---
+name: web-briefing
+description: Fetch URLs and summarize into a structured briefing
+requires:
+  tools: [http_request, web_search]
+user_invocable: true
+---
+
+When the user asks for a web briefing or to summarize web content, follow these steps:
+
+1. If the user provides specific URLs, use `http_request` with `GET` to fetch each page
+2. If the user provides a topic instead, use `web_search` to find relevant sources first, then fetch the top results with `http_request`
+3. Extract the key content from each fetched page (ignore navigation, ads, boilerplate)
+4. Synthesize a structured briefing with:
+   - **Summary**: 2-3 sentence overview of the topic
+   - **Key points**: bullet points of the most important information
+   - **Sources**: list of URLs consulted with one-line descriptions
+5. If a page fails to load, note it and continue with available sources
+6. Keep the briefing concise — aim for a 2-minute read

--- a/backend/data/skills/weekly-planner.md
+++ b/backend/data/skills/weekly-planner.md
@@ -1,0 +1,20 @@
+---
+name: weekly-planner
+description: Plan the week from soul priorities and active goals
+requires:
+  tools: [get_goals, create_goal, view_soul]
+user_invocable: true
+---
+
+When the user asks to plan their week, follow these steps:
+
+1. Use `view_soul` to review the user's identity, values, and current priorities
+2. Use `get_goals` to fetch all active goals across all levels (mission, monthly, weekly, daily)
+3. Identify gaps: which soul priorities lack corresponding weekly/daily goals?
+4. Propose a weekly plan with:
+   - **Focus areas**: 2-3 themes aligned with soul values
+   - **Key goals**: existing goals to advance this week
+   - **New goals**: suggest 2-3 new weekly/daily goals to fill gaps
+5. Ask the user which suggestions to adopt
+6. Use `create_goal` to create any approved new goals
+7. Summarize the final weekly plan in a clean format

--- a/backend/src/api/catalog.py
+++ b/backend/src/api/catalog.py
@@ -1,0 +1,118 @@
+"""Discover catalog API — browse and install skills/MCP servers."""
+
+import json
+import logging
+import os
+import shutil
+
+from fastapi import APIRouter, HTTPException
+
+from config.settings import settings
+from src.skills.manager import skill_manager
+from src.tools.mcp_manager import mcp_manager
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_CATALOG_PATH = os.path.join(os.path.dirname(__file__), "../../data/skill-catalog.json")
+_BUNDLED_SKILLS_DIR = os.path.join(os.path.dirname(__file__), "../../data/skills")
+
+
+def _load_catalog() -> dict:
+    """Load the catalog JSON file."""
+    path = os.path.normpath(_CATALOG_PATH)
+    if not os.path.isfile(path):
+        return {"skills": [], "mcp_servers": []}
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _skill_installed(name: str) -> bool:
+    """Check if a skill .md file exists in the workspace skills directory."""
+    skills_dir = os.path.join(settings.workspace_dir, "skills")
+    return os.path.isfile(os.path.join(skills_dir, f"{name}.md"))
+
+
+def _mcp_installed(name: str) -> bool:
+    """Check if an MCP server exists in the current config."""
+    return name in mcp_manager._config
+
+
+@router.get("/catalog")
+async def get_catalog():
+    """Return catalog items enriched with install status."""
+    catalog = _load_catalog()
+    items = []
+
+    for skill in catalog.get("skills", []):
+        items.append({
+            "name": skill["name"],
+            "type": "skill",
+            "description": skill.get("description", ""),
+            "category": skill.get("category", ""),
+            "requires_tools": skill.get("requires_tools", []),
+            "installed": _skill_installed(skill["name"]),
+            "bundled": skill.get("bundled", False),
+        })
+
+    for server in catalog.get("mcp_servers", []):
+        items.append({
+            "name": server["name"],
+            "type": "mcp_server",
+            "description": server.get("description", ""),
+            "category": server.get("category", ""),
+            "requires_tools": [],
+            "installed": _mcp_installed(server["name"]),
+            "bundled": server.get("bundled", False),
+        })
+
+    return {"items": items}
+
+
+@router.post("/catalog/install/{name}", status_code=201)
+async def install_item(name: str):
+    """Install a skill or MCP server from the catalog."""
+    catalog = _load_catalog()
+
+    # Check skills first
+    for skill in catalog.get("skills", []):
+        if skill["name"] == name:
+            if _skill_installed(name):
+                raise HTTPException(status_code=409, detail=f"Skill '{name}' is already installed")
+
+            if not skill.get("bundled", False):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Skill '{name}' is not bundled and cannot be auto-installed",
+                )
+
+            # Copy from bundled skills dir to workspace
+            src = os.path.join(os.path.normpath(_BUNDLED_SKILLS_DIR), f"{name}.md")
+            if not os.path.isfile(src):
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Bundled skill file for '{name}' not found",
+                )
+
+            dst_dir = os.path.join(settings.workspace_dir, "skills")
+            os.makedirs(dst_dir, exist_ok=True)
+            shutil.copy2(src, os.path.join(dst_dir, f"{name}.md"))
+            skill_manager.reload()
+            return {"status": "installed", "name": name, "type": "skill"}
+
+    # Check MCP servers
+    for server in catalog.get("mcp_servers", []):
+        if server["name"] == name:
+            if _mcp_installed(name):
+                raise HTTPException(status_code=409, detail=f"MCP server '{name}' is already installed")
+
+            mcp_manager.add_server(
+                name=name,
+                url=server["url"],
+                description=server.get("description", ""),
+                enabled=False,
+            )
+            return {"status": "installed", "name": name, "type": "mcp_server"}
+
+    raise HTTPException(status_code=404, detail=f"'{name}' not found in catalog")

--- a/backend/src/api/router.py
+++ b/backend/src/api/router.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from src.api.catalog import router as catalog_router
 from src.api.chat import router as chat_router
 from src.api.goals import router as goals_router
 from src.api.mcp import router as mcp_router
@@ -13,6 +14,7 @@ from src.api.ws import router as ws_router
 
 api_router = APIRouter()
 
+api_router.include_router(catalog_router, prefix="/api", tags=["catalog"])
 api_router.include_router(chat_router, prefix="/api", tags=["chat"])
 api_router.include_router(sessions_router, prefix="/api", tags=["sessions"])
 api_router.include_router(goals_router, prefix="/api", tags=["goals"])

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -39,6 +39,12 @@ async def lifespan(app: FastAPI):
         import logging
         logging.getLogger(__name__).warning("Initial context refresh failed", exc_info=True)
     mcp_config = os.path.join(settings.workspace_dir, "mcp-servers.json")
+    if not os.path.exists(mcp_config):
+        default_config = os.path.join(os.path.dirname(__file__), "../data/mcp-servers.default.json")
+        if os.path.isfile(default_config):
+            import shutil
+            os.makedirs(os.path.dirname(mcp_config), exist_ok=True)
+            shutil.copy2(default_config, mcp_config)
     mcp_manager.load_config(mcp_config)
     skills_dir = os.path.join(settings.workspace_dir, "skills")
     os.makedirs(skills_dir, exist_ok=True)

--- a/backend/tests/test_catalog_api.py
+++ b/backend/tests/test_catalog_api.py
@@ -1,0 +1,194 @@
+"""Tests for the Discover catalog API."""
+
+import json
+import os
+import shutil
+
+import pytest
+import pytest_asyncio
+from unittest.mock import patch, MagicMock
+
+from src.skills.manager import SkillManager
+
+
+# ── Fixtures ─────────────────────────────────────────────
+
+
+@pytest.fixture
+def catalog_data():
+    """Sample catalog data for testing."""
+    return {
+        "skills": [
+            {
+                "name": "test-catalog-skill",
+                "description": "A test skill",
+                "category": "test",
+                "requires_tools": ["web_search"],
+                "bundled": True,
+            },
+        ],
+        "mcp_servers": [
+            {
+                "name": "test-mcp",
+                "description": "A test MCP server",
+                "category": "test",
+                "url": "http://test-mcp:9200/mcp",
+                "bundled": True,
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def workspace_dir(tmp_path):
+    """Create a temporary workspace directory."""
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    (ws / "skills").mkdir()
+    return str(ws)
+
+
+@pytest.fixture
+def bundled_skills_dir(tmp_path):
+    """Create a temp directory with a bundled skill file."""
+    d = tmp_path / "bundled"
+    d.mkdir()
+    (d / "test-catalog-skill.md").write_text(
+        "---\n"
+        "name: test-catalog-skill\n"
+        "description: A test skill\n"
+        "requires:\n"
+        "  tools: [web_search]\n"
+        "user_invocable: true\n"
+        "---\n\n"
+        "Do something useful."
+    )
+    return str(d)
+
+
+# ── TestCatalogAPI ───────────────────────────────────────
+
+
+class TestCatalogAPI:
+    @pytest.mark.asyncio
+    async def test_get_catalog_returns_items(self, client, catalog_data, workspace_dir):
+        with patch("src.api.catalog._load_catalog", return_value=catalog_data), \
+             patch("src.api.catalog.settings") as mock_settings, \
+             patch("src.api.catalog.mcp_manager") as mock_mcp:
+            mock_settings.workspace_dir = workspace_dir
+            mock_mcp._config = {}
+
+            resp = await client.get("/api/catalog")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "items" in data
+            assert len(data["items"]) == 2
+
+            skill_item = next(i for i in data["items"] if i["type"] == "skill")
+            assert skill_item["name"] == "test-catalog-skill"
+            assert skill_item["installed"] is False
+
+            mcp_item = next(i for i in data["items"] if i["type"] == "mcp_server")
+            assert mcp_item["name"] == "test-mcp"
+            assert mcp_item["installed"] is False
+
+    @pytest.mark.asyncio
+    async def test_get_catalog_shows_installed_status(self, client, catalog_data, workspace_dir):
+        # Create the skill file to simulate installation
+        skills_dir = os.path.join(workspace_dir, "skills")
+        with open(os.path.join(skills_dir, "test-catalog-skill.md"), "w") as f:
+            f.write("---\nname: test-catalog-skill\ndescription: test\n---\nBody")
+
+        with patch("src.api.catalog._load_catalog", return_value=catalog_data), \
+             patch("src.api.catalog.settings") as mock_settings, \
+             patch("src.api.catalog.mcp_manager") as mock_mcp:
+            mock_settings.workspace_dir = workspace_dir
+            mock_mcp._config = {"test-mcp": {"url": "http://test:9200"}}
+
+            resp = await client.get("/api/catalog")
+            data = resp.json()
+            skill_item = next(i for i in data["items"] if i["type"] == "skill")
+            assert skill_item["installed"] is True
+            mcp_item = next(i for i in data["items"] if i["type"] == "mcp_server")
+            assert mcp_item["installed"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_catalog_handles_missing_file(self, client):
+        with patch("src.api.catalog._load_catalog", return_value={"skills": [], "mcp_servers": []}):
+            resp = await client.get("/api/catalog")
+            assert resp.status_code == 200
+            assert resp.json()["items"] == []
+
+    @pytest.mark.asyncio
+    async def test_install_skill_success(
+        self, client, catalog_data, workspace_dir, bundled_skills_dir
+    ):
+        with patch("src.api.catalog._load_catalog", return_value=catalog_data), \
+             patch("src.api.catalog.settings") as mock_settings, \
+             patch("src.api.catalog._BUNDLED_SKILLS_DIR", bundled_skills_dir), \
+             patch("src.api.catalog.skill_manager") as mock_skill_mgr:
+            mock_settings.workspace_dir = workspace_dir
+
+            resp = await client.post("/api/catalog/install/test-catalog-skill")
+            assert resp.status_code == 201
+            data = resp.json()
+            assert data["status"] == "installed"
+            assert data["type"] == "skill"
+
+            # Verify the file was copied
+            installed_path = os.path.join(workspace_dir, "skills", "test-catalog-skill.md")
+            assert os.path.isfile(installed_path)
+            mock_skill_mgr.reload.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_install_mcp_success(self, client, catalog_data, workspace_dir):
+        with patch("src.api.catalog._load_catalog", return_value=catalog_data), \
+             patch("src.api.catalog.settings") as mock_settings, \
+             patch("src.api.catalog.mcp_manager") as mock_mcp:
+            mock_settings.workspace_dir = workspace_dir
+            mock_mcp._config = {}
+
+            resp = await client.post("/api/catalog/install/test-mcp")
+            assert resp.status_code == 201
+            data = resp.json()
+            assert data["status"] == "installed"
+            assert data["type"] == "mcp_server"
+            mock_mcp.add_server.assert_called_once_with(
+                name="test-mcp",
+                url="http://test-mcp:9200/mcp",
+                description="A test MCP server",
+                enabled=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_install_not_found(self, client, catalog_data):
+        with patch("src.api.catalog._load_catalog", return_value=catalog_data):
+            resp = await client.post("/api/catalog/install/nonexistent")
+            assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_install_already_installed_skill(
+        self, client, catalog_data, workspace_dir
+    ):
+        # Pre-install the skill
+        skills_dir = os.path.join(workspace_dir, "skills")
+        with open(os.path.join(skills_dir, "test-catalog-skill.md"), "w") as f:
+            f.write("---\nname: test-catalog-skill\ndescription: test\n---\nBody")
+
+        with patch("src.api.catalog._load_catalog", return_value=catalog_data), \
+             patch("src.api.catalog.settings") as mock_settings:
+            mock_settings.workspace_dir = workspace_dir
+
+            resp = await client.post("/api/catalog/install/test-catalog-skill")
+            assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_install_already_installed_mcp(self, client, catalog_data, workspace_dir):
+        with patch("src.api.catalog._load_catalog", return_value=catalog_data), \
+             patch("src.api.catalog.settings") as mock_settings, \
+             patch("src.api.catalog.mcp_manager") as mock_mcp:
+            mock_settings.workspace_dir = workspace_dir
+            mock_mcp._config = {"test-mcp": {"url": "http://test:9200"}}
+
+            resp = await client.post("/api/catalog/install/test-mcp")
+            assert resp.status_code == 409

--- a/backend/tests/test_http_mcp_server.py
+++ b/backend/tests/test_http_mcp_server.py
@@ -1,0 +1,112 @@
+"""Tests for the HTTP Request MCP server."""
+
+import sys
+import os
+import types
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# Stub out fastmcp before importing server module — make @mcp.tool() a pass-through
+class _FakeMCP:
+    def __init__(self, *a, **kw):
+        pass
+    def tool(self):
+        def decorator(fn):
+            return fn
+        return decorator
+    def run(self, *a, **kw):
+        pass
+
+_fastmcp_stub = types.ModuleType("fastmcp")
+_fastmcp_stub.FastMCP = _FakeMCP
+sys.modules["fastmcp"] = _fastmcp_stub
+
+# Add MCP server to path so we can import it
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../mcp-servers/http-request"))
+
+from server import _is_internal_url, http_request
+
+
+class TestIsInternalUrl:
+    def test_blocks_localhost(self):
+        assert _is_internal_url("http://localhost:8080/api") is True
+
+    def test_blocks_127_0_0_1(self):
+        assert _is_internal_url("http://127.0.0.1:3000/") is True
+
+    def test_blocks_0_0_0_0(self):
+        assert _is_internal_url("http://0.0.0.0/test") is True
+
+    def test_blocks_private_ip_10(self):
+        assert _is_internal_url("http://10.0.0.1/api") is True
+
+    def test_blocks_private_ip_192(self):
+        assert _is_internal_url("http://192.168.1.1/") is True
+
+    def test_blocks_private_ip_172(self):
+        assert _is_internal_url("http://172.16.0.1/") is True
+
+    def test_blocks_dot_local(self):
+        assert _is_internal_url("http://myhost.local/api") is True
+
+    def test_blocks_dot_internal(self):
+        assert _is_internal_url("http://service.internal/api") is True
+
+    def test_allows_external_url(self):
+        assert _is_internal_url("https://api.example.com/v1") is False
+
+    def test_allows_external_ip(self):
+        assert _is_internal_url("http://8.8.8.8/dns") is False
+
+    def test_blocks_ipv6_loopback(self):
+        assert _is_internal_url("http://[::1]:8080/") is True
+
+
+class TestHttpRequest:
+    def test_rejects_invalid_method(self):
+        result = http_request("INVALID", "https://example.com")
+        assert "error" in result
+        assert "Invalid method" in result["error"]
+
+    def test_blocks_internal_url(self):
+        result = http_request("GET", "http://localhost:8080/secret")
+        assert "error" in result
+        assert "internal" in result["error"].lower()
+
+    @patch("server.httpx.Client")
+    def test_successful_get(self, mock_client_cls):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.text = '{"ok": true}'
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        result = http_request("GET", "https://api.example.com/test")
+        assert result["status"] == 200
+        assert result["body"] == '{"ok": true}'
+        assert "headers" in result
+
+    @patch("server.httpx.Client")
+    def test_timeout_handling(self, mock_client_cls):
+        import httpx
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.request.side_effect = httpx.TimeoutException("timed out")
+        mock_client_cls.return_value = mock_client
+
+        result = http_request("GET", "https://slow.example.com", timeout=5)
+        assert "error" in result
+        assert "timed out" in result["error"].lower()
+
+    def test_methods_case_insensitive(self):
+        # lowercase method should be uppercased, then blocked by internal URL check
+        result = http_request("get", "http://localhost/test")
+        assert "internal" in result["error"].lower()

--- a/backend/tests/test_seed_config.py
+++ b/backend/tests/test_seed_config.py
@@ -1,0 +1,88 @@
+"""Tests for MCP seed config logic in app lifespan."""
+
+import json
+import os
+import shutil
+
+import pytest
+
+
+class TestSeedConfig:
+    def test_first_run_creates_config_from_default(self, tmp_path):
+        """When mcp-servers.json doesn't exist, it should be copied from default."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        default_config = tmp_path / "default.json"
+        default_data = {
+            "mcpServers": {
+                "http-request": {
+                    "url": "http://http-mcp:9200/mcp",
+                    "enabled": False,
+                    "description": "Make HTTP requests to external APIs",
+                },
+                "github": {
+                    "url": "https://api.githubcopilot.com/mcp/",
+                    "enabled": False,
+                    "description": "GitHub integration",
+                },
+            }
+        }
+        default_config.write_text(json.dumps(default_data, indent=2))
+
+        mcp_config = str(workspace / "mcp-servers.json")
+
+        # Simulate the seed logic from app.py
+        if not os.path.exists(mcp_config):
+            if os.path.isfile(str(default_config)):
+                os.makedirs(os.path.dirname(mcp_config), exist_ok=True)
+                shutil.copy2(str(default_config), mcp_config)
+
+        assert os.path.isfile(mcp_config)
+        with open(mcp_config) as f:
+            data = json.load(f)
+        assert "http-request" in data["mcpServers"]
+        assert "github" in data["mcpServers"]
+
+    def test_existing_config_not_overwritten(self, tmp_path):
+        """Existing mcp-servers.json should not be touched by seed logic."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        existing_data = {
+            "mcpServers": {
+                "my-server": {
+                    "url": "http://custom:9999/mcp",
+                    "enabled": True,
+                    "description": "My custom server",
+                }
+            }
+        }
+        mcp_config = workspace / "mcp-servers.json"
+        mcp_config.write_text(json.dumps(existing_data, indent=2))
+
+        default_config = tmp_path / "default.json"
+        default_config.write_text(json.dumps({"mcpServers": {"new-server": {}}}))
+
+        # Simulate the seed logic — should NOT copy
+        if not os.path.exists(str(mcp_config)):
+            shutil.copy2(str(default_config), str(mcp_config))
+
+        with open(str(mcp_config)) as f:
+            data = json.load(f)
+        assert "my-server" in data["mcpServers"]
+        assert "new-server" not in data["mcpServers"]
+
+    def test_default_entries_all_disabled(self):
+        """All entries in the default config should have enabled: false."""
+        default_path = os.path.join(
+            os.path.dirname(__file__),
+            "../data/mcp-servers.default.json",
+        )
+        with open(default_path) as f:
+            data = json.load(f)
+
+        for name, server in data["mcpServers"].items():
+            assert server.get("enabled") is False, (
+                f"Default MCP server '{name}' should be disabled"
+            )

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -251,6 +251,48 @@ class TestSkillManager:
         assert all("enabled" in s for s in lst)
         assert all("requires_tools" in s for s in lst)
 
+    def test_mcp_dependent_skill_inactive_without_tool(self, tmp_path):
+        """A skill requiring http_request should be inactive when tool is unavailable."""
+        d = tmp_path / "skills"
+        d.mkdir()
+        (d / "mcp-skill.md").write_text(
+            "---\n"
+            "name: mcp-skill\n"
+            "description: Needs MCP tool\n"
+            "requires:\n"
+            "  tools: [http_request]\n"
+            "---\n\n"
+            "Use http_request to do things."
+        )
+        mgr = SkillManager()
+        mgr.init(str(d))
+
+        # Without http_request in available tools
+        active = mgr.get_active_skills(["web_search", "read_file"])
+        names = {s.name for s in active}
+        assert "mcp-skill" not in names
+
+    def test_mcp_dependent_skill_active_with_tool(self, tmp_path):
+        """A skill requiring http_request should be active when tool is available."""
+        d = tmp_path / "skills"
+        d.mkdir()
+        (d / "mcp-skill.md").write_text(
+            "---\n"
+            "name: mcp-skill\n"
+            "description: Needs MCP tool\n"
+            "requires:\n"
+            "  tools: [http_request]\n"
+            "---\n\n"
+            "Use http_request to do things."
+        )
+        mgr = SkillManager()
+        mgr.init(str(d))
+
+        # With http_request available
+        active = mgr.get_active_skills(["http_request", "web_search"])
+        names = {s.name for s in active}
+        assert "mcp-skill" in names
+
 
 # ── TestSkillAPI ─────────────────────────────────────────
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -212,6 +212,7 @@ dependencies = [
     { name = "slowapi" },
     { name = "smolagents", extra = ["litellm", "mcp"] },
     { name = "sqlmodel" },
+    { name = "tiktoken" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
 ]
@@ -245,6 +246,7 @@ requires-dist = [
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "smolagents", extras = ["litellm", "mcp"], specifier = ">=1.24.0" },
     { name = "sqlmodel", specifier = ">=0.0.22" },
+    { name = "tiktoken", specifier = ">=0.8" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -39,6 +39,14 @@ services:
       - seraph-network-dev
     # No ports exposed — backend connects via internal network
 
+  http-mcp:
+    container_name: http-mcp
+    build:
+      context: ./mcp-servers/http-request
+    networks:
+      - seraph-network-dev
+    restart: unless-stopped
+
   # github-mcp:
   #   container_name: github-mcp
   #   image: ghcr.io/github/github-mcp-server:latest

--- a/mcp-servers/http-request/Dockerfile
+++ b/mcp-servers/http-request/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py .
+
+EXPOSE 9200
+
+CMD ["python", "server.py"]

--- a/mcp-servers/http-request/requirements.txt
+++ b/mcp-servers/http-request/requirements.txt
@@ -1,0 +1,2 @@
+fastmcp
+httpx

--- a/mcp-servers/http-request/server.py
+++ b/mcp-servers/http-request/server.py
@@ -1,0 +1,83 @@
+"""HTTP Request MCP Server — exposes a single http_request tool via FastMCP."""
+
+import ipaddress
+from urllib.parse import urlparse
+
+import httpx
+from fastmcp import FastMCP
+
+mcp = FastMCP("http-request", port=9200)
+
+_BLOCKED_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "[::1]"}
+
+
+def _is_internal_url(url: str) -> bool:
+    """Check if a URL points to an internal/private network address."""
+    parsed = urlparse(url)
+    hostname = parsed.hostname or ""
+
+    if hostname in _BLOCKED_HOSTS:
+        return True
+
+    try:
+        ip = ipaddress.ip_address(hostname)
+        return ip.is_private or ip.is_loopback or ip.is_link_local
+    except ValueError:
+        pass
+
+    if hostname.endswith((".local", ".internal", ".localhost")):
+        return True
+
+    return False
+
+
+_ALLOWED_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"}
+
+
+@mcp.tool()
+def http_request(
+    method: str,
+    url: str,
+    headers: dict[str, str] | None = None,
+    body: str | None = None,
+    timeout: int = 30,
+) -> dict:
+    """Make an HTTP request to an external URL.
+
+    Args:
+        method: HTTP method (GET, POST, PUT, DELETE, PATCH, HEAD)
+        url: The URL to request
+        headers: Optional request headers
+        body: Optional request body (string)
+        timeout: Request timeout in seconds (1-60, default 30)
+    """
+    method = method.upper()
+    if method not in _ALLOWED_METHODS:
+        return {"error": f"Invalid method '{method}'. Allowed: {', '.join(sorted(_ALLOWED_METHODS))}"}
+
+    if _is_internal_url(url):
+        return {"error": "Requests to internal/private network addresses are blocked"}
+
+    timeout = max(1, min(60, timeout))
+
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            response = client.request(
+                method=method,
+                url=url,
+                headers=headers,
+                content=body,
+            )
+        return {
+            "status": response.status_code,
+            "headers": dict(response.headers),
+            "body": response.text[:50000],  # Cap response size
+        }
+    except httpx.TimeoutException:
+        return {"error": f"Request timed out after {timeout}s"}
+    except httpx.RequestError as e:
+        return {"error": f"Request failed: {e}"}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")


### PR DESCRIPTION
## Summary

- **HTTP MCP Server**: Bundled FastMCP server (`mcp-servers/http-request/`) with `http_request` tool for arbitrary REST API calls. Runs as Docker service on internal network with IP blocking security.
- **Default Skills**: 5 new skills — `weekly-planner`, `morning-intention`, `evening-journal`, `moltbook` (requires `http_request`), `web-briefing` (requires `http_request` + `web_search`). Total: 8 bundled skills.
- **Seed Config**: `mcp-servers.default.json` auto-copied to workspace on first run. Ships `http-request` + `github` entries (both disabled). Existing configs never overwritten.
- **Discover Catalog**: `GET /api/catalog` + `POST /api/catalog/install/{name}` API. Settings UI Discover section with install status dots and one-click install buttons.

## Test plan

- [x] All 425 tests pass (`uv run pytest` — 0 failures)
- [ ] `./manage.sh -e dev build && ./manage.sh -e dev up -d` — all 4 services start
- [ ] Fresh install creates `mcp-servers.json` with 2 disabled entries
- [ ] Settings UI → Discover section shows 10 catalog items
- [ ] Install button copies skill / adds MCP config entry
- [ ] Enable http-request MCP → moltbook + web-briefing skills activate

🤖 Generated with [Claude Code](https://claude.com/claude-code)