### PR TITLE
fix: bind http-mcp to 0.0.0.0 for Docker network access

### DIFF
--- a/mcp-servers/http-request/server.py
+++ b/mcp-servers/http-request/server.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 import httpx
 from fastmcp import FastMCP
 
-mcp = FastMCP("http-request", port=9200)
+mcp = FastMCP("http-request", host="0.0.0.0", port=9200)
 
 _BLOCKED_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "[::1]"}
 


### PR DESCRIPTION
## Summary

- FastMCP defaults to binding on `127.0.0.1`, making the http-mcp server unreachable from other Docker containers
- Changed to `0.0.0.0` so the backend can connect via `http://http-mcp:9200/mcp`

## Test plan

- [x] `docker logs http-mcp` shows `Uvicorn running on http://0.0.0.0:9200`
- [x] MCP test from Settings UI returns `OK — 1 tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)