### PR TITLE
fix: MCP auth detection for ExceptionGroup, clickable hints, toggle colors

### DIFF
--- a/backend/src/defaults/mcp-servers.default.json
+++ b/backend/src/defaults/mcp-servers.default.json
@@ -12,7 +12,7 @@
       "headers": {
         "Authorization": "Bearer ${GITHUB_TOKEN}"
       },
-      "auth_hint": "Create a Personal Access Token at github.com/settings/tokens (classic, repo scope)"
+      "auth_hint": "Create a Personal Access Token at https://github.com/settings/tokens (classic, repo scope)"
     }
   }
 }

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -177,7 +177,7 @@ function McpServerRow({
       </button>
       <button
         onClick={() => onToggle(server.name, !server.enabled)}
-        className={`text-[9px] px-0.5 ${server.enabled ? "text-green-400 hover:text-red-400" : "text-retro-text/40 hover:text-green-400"}`}
+        className={`text-[9px] px-0.5 ${!server.enabled ? "text-retro-text/40 hover:text-green-400" : server.status === "connected" ? "text-green-400 hover:text-red-400" : server.status === "auth_required" ? "text-yellow-400 hover:text-red-400" : server.status === "error" ? "text-red-400 hover:text-red-400" : "text-retro-text/40 hover:text-red-400"}`}
       >
         {server.enabled ? "on" : "off"}
       </button>
@@ -239,7 +239,15 @@ function TokenConfigForm({
   return (
     <div className="px-1 py-1 border border-retro-text/10 rounded space-y-1 mx-1 mb-1 bg-retro-bg/50">
       {server.auth_hint && (
-        <div className="text-[9px] text-retro-highlight/70">{server.auth_hint}</div>
+        <div className="text-[9px] text-retro-highlight/70">
+          {server.auth_hint.split(/(https?:\/\/[^\s)]+)/).map((part, i) =>
+            part.match(/^https?:\/\//) ? (
+              <a key={i} href={part} target="_blank" rel="noopener noreferrer" className="underline hover:text-retro-text">{part}</a>
+            ) : (
+              <span key={i}>{part}</span>
+            )
+          )}
+        </div>
       )}
       <input
         type="password"


### PR DESCRIPTION
## Summary
Follow-up fixes from live testing of #96:
- **ExceptionGroup handling** — `_flatten_exception_text` now follows `__cause__`/`__context__` chains so `TimeoutError` wrapping a 401 is correctly detected as `auth_required`
- **Clickable auth hints** — URLs in `auth_hint` are auto-linked in the TokenConfigForm
- **Toggle colors** — on/off button matches server status (green only when `connected`, yellow for `auth_required`)
- **Full URL in hint** — default GitHub `auth_hint` uses `https://` prefix

## Test plan
- [ ] Enable GitHub MCP without token → yellow dot, yellow "on", setup button with clickable URL
- [ ] `uv run pytest tests/test_mcp_manager.py -v` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)