### PR TITLE
feat: draggable and resizable panels

### DIFF
--- a/frontend/src/components/ResizeHandles.tsx
+++ b/frontend/src/components/ResizeHandles.tsx
@@ -1,0 +1,71 @@
+import type { CSSProperties, PointerEventHandler } from "react";
+import type { ResizeEdge } from "../hooks/useDragResize";
+
+interface ResizeHandlesProps {
+  resizeHandleProps: (edge: ResizeEdge) => {
+    onPointerDown: PointerEventHandler;
+    style: CSSProperties;
+  };
+}
+
+const EDGE_SIZE = 6;
+
+const edgeStyles: Record<ResizeEdge, CSSProperties> = {
+  n: { position: "absolute", top: -EDGE_SIZE / 2, left: EDGE_SIZE, right: EDGE_SIZE, height: EDGE_SIZE },
+  s: { position: "absolute", bottom: -EDGE_SIZE / 2, left: EDGE_SIZE, right: EDGE_SIZE, height: EDGE_SIZE },
+  e: { position: "absolute", right: -EDGE_SIZE / 2, top: EDGE_SIZE, bottom: EDGE_SIZE, width: EDGE_SIZE },
+  w: { position: "absolute", left: -EDGE_SIZE / 2, top: EDGE_SIZE, bottom: EDGE_SIZE, width: EDGE_SIZE },
+  nw: { position: "absolute", top: -EDGE_SIZE / 2, left: -EDGE_SIZE / 2, width: EDGE_SIZE * 2, height: EDGE_SIZE * 2 },
+  ne: { position: "absolute", top: -EDGE_SIZE / 2, right: -EDGE_SIZE / 2, width: EDGE_SIZE * 2, height: EDGE_SIZE * 2 },
+  sw: { position: "absolute", bottom: -EDGE_SIZE / 2, left: -EDGE_SIZE / 2, width: EDGE_SIZE * 2, height: EDGE_SIZE * 2 },
+  se: { position: "absolute", bottom: -EDGE_SIZE / 2, right: -EDGE_SIZE / 2, width: EDGE_SIZE * 2, height: EDGE_SIZE * 2 },
+};
+
+const corners: ResizeEdge[] = ["nw", "ne", "sw", "se"];
+const edges: ResizeEdge[] = ["n", "s", "e", "w"];
+
+const cornerDotPositions: Record<string, CSSProperties> = {
+  nw: { position: "absolute", top: -3, left: -3 },
+  ne: { position: "absolute", top: -3, right: -3 },
+  sw: { position: "absolute", bottom: -3, left: -3 },
+  se: { position: "absolute", bottom: -3, right: -3 },
+};
+
+export function ResizeHandles({ resizeHandleProps }: ResizeHandlesProps) {
+  return (
+    <>
+      {edges.map((edge) => {
+        const props = resizeHandleProps(edge);
+        return (
+          <div
+            key={edge}
+            onPointerDown={props.onPointerDown}
+            style={{ ...edgeStyles[edge], ...props.style, zIndex: 1 }}
+          />
+        );
+      })}
+      {corners.map((corner) => {
+        const props = resizeHandleProps(corner);
+        return (
+          <div
+            key={corner}
+            className="group"
+            onPointerDown={props.onPointerDown}
+            style={{ ...edgeStyles[corner], ...props.style, zIndex: 2 }}
+          >
+            <div
+              className="opacity-0 group-hover:opacity-100 transition-opacity"
+              style={{
+                ...cornerDotPositions[corner],
+                width: 6,
+                height: 6,
+                background: "#e2b714",
+                pointerEvents: "none",
+              }}
+            />
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { API_URL } from "../config/constants";
 import { useChatStore } from "../stores/chatStore";
+import { useDragResize } from "../hooks/useDragResize";
+import { ResizeHandles } from "./ResizeHandles";
 import { EventBus } from "../game/EventBus";
 import { DialogFrame } from "./chat/DialogFrame";
 import { InterruptionModeToggle } from "./settings/InterruptionModeToggle";
@@ -401,6 +403,11 @@ export function SettingsPanel() {
   const [installing, setInstalling] = useState<string | null>(null);
   const [configuringServer, setConfiguringServer] = useState<McpServer | null>(null);
 
+  const { dragHandleProps, resizeHandleProps, style, bringToFront } = useDragResize("settings", {
+    minWidth: 240,
+    minHeight: 200,
+  });
+
   const fetchSkills = useCallback(async () => {
     try {
       const res = await fetch(`${API_URL}/api/skills`);
@@ -525,11 +532,17 @@ export function SettingsPanel() {
   if (!settingsPanelOpen) return null;
 
   return (
-    <div className="settings-overlay">
+    <div
+      className="settings-overlay"
+      style={style}
+      onPointerDown={bringToFront}
+    >
+      <ResizeHandles resizeHandleProps={resizeHandleProps} />
       <DialogFrame
         title="Settings"
         className="flex-1 min-h-0 flex flex-col"
         onClose={() => setSettingsPanelOpen(false)}
+        dragHandleProps={dragHandleProps}
       >
         <div className="flex-1 min-h-0 overflow-y-auto retro-scrollbar flex flex-col gap-2 pb-1">
           <div className="px-1">

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1,4 +1,6 @@
 import { useChatStore } from "../../stores/chatStore";
+import { useDragResize } from "../../hooks/useDragResize";
+import { ResizeHandles } from "../ResizeHandles";
 import { DialogFrame } from "./DialogFrame";
 import { MessageList } from "./MessageList";
 import { ChatInput } from "./ChatInput";
@@ -20,16 +22,27 @@ export function ChatPanel({ onSend, onSkipOnboarding }: ChatPanelProps) {
   const onboardingCompleted = useChatStore((s) => s.onboardingCompleted);
   const isConnected = connectionStatus === "connected";
 
+  const { dragHandleProps, resizeHandleProps, style, bringToFront } = useDragResize("chat", {
+    minWidth: 400,
+    minHeight: 200,
+  });
+
   if (!chatPanelOpen) return null;
 
   return (
-    <div className={`chat-overlay${chatMaximized ? " maximized" : ""}`}>
+    <div
+      className={`chat-overlay${chatMaximized ? " maximized" : ""}`}
+      style={chatMaximized ? undefined : style}
+      onPointerDown={bringToFront}
+    >
+      {!chatMaximized && <ResizeHandles resizeHandleProps={resizeHandleProps} />}
       <DialogFrame
         title="Chat Log"
         className="flex-1 min-h-0 flex flex-row relative"
         onMaximize={toggleChatMaximized}
         maximized={chatMaximized}
         onClose={() => setChatPanelOpen(false)}
+        dragHandleProps={chatMaximized ? undefined : dragHandleProps}
       >
         <ChatSidebar />
         <div className="flex-1 min-w-0 min-h-0 flex flex-col">

--- a/frontend/src/components/chat/DialogFrame.tsx
+++ b/frontend/src/components/chat/DialogFrame.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { PointerEventHandler, ReactNode } from "react";
 
 interface DialogFrameProps {
   children: ReactNode;
@@ -7,34 +7,47 @@ interface DialogFrameProps {
   onMaximize?: () => void;
   maximized?: boolean;
   onClose?: () => void;
+  dragHandleProps?: { onPointerDown: PointerEventHandler };
 }
 
-export function DialogFrame({ children, title, className = "", onMaximize, maximized, onClose }: DialogFrameProps) {
+export function DialogFrame({ children, title, className = "", onMaximize, maximized, onClose, dragHandleProps }: DialogFrameProps) {
+  const hasButtons = onMaximize || onClose;
+
   return (
     <div className={`rpg-frame p-3 ${className}`}>
-      {title && (
-        <div className="absolute -top-3 left-4 bg-retro-panel px-2 text-retro-border text-[11px] uppercase tracking-wider">
-          {title}
-        </div>
-      )}
-      <div className="absolute -top-3 right-4 flex gap-1">
-        {onMaximize && (
-          <button
-            onClick={onMaximize}
-            className="bg-retro-panel px-2 text-retro-border hover:text-retro-highlight text-[11px] uppercase tracking-wider transition-colors"
-            title={maximized ? "Minimize" : "Maximize"}
-          >
-            {maximized ? "▼" : "▲"}
-          </button>
-        )}
-        {onClose && (
-          <button
-            onClick={onClose}
-            className="bg-retro-panel px-2 text-retro-border hover:text-retro-highlight text-[11px] uppercase tracking-wider transition-colors"
-            title="Close"
-          >
-            ✕
-          </button>
+      <div
+        className="absolute -top-3 left-0 right-0 h-6 flex items-center justify-between px-4"
+        style={dragHandleProps ? { cursor: "move", userSelect: "none", zIndex: 10 } : { zIndex: 10 }}
+        {...dragHandleProps}
+      >
+        {title ? (
+          <span className="bg-retro-panel px-2 text-retro-border text-[11px] uppercase tracking-wider">
+            {title}
+          </span>
+        ) : <span />}
+        {hasButtons && (
+          <div className="flex gap-1">
+            {onMaximize && (
+              <button
+                onClick={onMaximize}
+                onPointerDown={(e) => e.stopPropagation()}
+                className="bg-retro-panel px-2 text-retro-border hover:text-retro-highlight text-[11px] uppercase tracking-wider transition-colors"
+                title={maximized ? "Minimize" : "Maximize"}
+              >
+                {maximized ? "▼" : "▲"}
+              </button>
+            )}
+            {onClose && (
+              <button
+                onClick={onClose}
+                onPointerDown={(e) => e.stopPropagation()}
+                className="bg-retro-panel px-2 text-retro-border hover:text-retro-highlight text-[11px] uppercase tracking-wider transition-colors"
+                title="Close"
+              >
+                ✕
+              </button>
+            )}
+          </div>
         )}
       </div>
       {children}

--- a/frontend/src/components/quest/QuestPanel.tsx
+++ b/frontend/src/components/quest/QuestPanel.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { useChatStore } from "../../stores/chatStore";
 import { useQuestStore } from "../../stores/questStore";
+import { useDragResize } from "../../hooks/useDragResize";
+import { ResizeHandles } from "../ResizeHandles";
 import { DialogFrame } from "../chat/DialogFrame";
 import { DomainStats } from "./DomainStats";
 import { GoalTree } from "./GoalTree";
@@ -46,6 +48,11 @@ export function QuestPanel() {
   const [filterLevel, setFilterLevel] = useState("");
   const [filterDomain, setFilterDomain] = useState("");
 
+  const { dragHandleProps, resizeHandleProps, style, bringToFront } = useDragResize("quest", {
+    minWidth: 240,
+    minHeight: 200,
+  });
+
   useEffect(() => {
     if (questPanelOpen) refresh();
   }, [questPanelOpen, refresh]);
@@ -63,11 +70,17 @@ export function QuestPanel() {
   if (!questPanelOpen) return null;
 
   return (
-    <div className="quest-overlay">
+    <div
+      className="quest-overlay"
+      style={style}
+      onPointerDown={bringToFront}
+    >
+      <ResizeHandles resizeHandleProps={resizeHandleProps} />
       <DialogFrame
         title="Quest Log"
         className="flex-1 min-h-0 flex flex-col"
         onClose={() => setQuestPanelOpen(false)}
+        dragHandleProps={dragHandleProps}
       >
         <div className="flex-1 min-h-0 overflow-y-auto retro-scrollbar flex flex-col gap-2 pb-1">
           {dashboard && <DomainStats dashboard={dashboard} />}

--- a/frontend/src/hooks/useDragResize.ts
+++ b/frontend/src/hooks/useDragResize.ts
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useRef, type CSSProperties, type PointerEventHandler } from "react";
+import { usePanelLayoutStore, PANEL_MIN_SIZES } from "../stores/panelLayoutStore";
+
+export type ResizeEdge = "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw";
+
+const VISIBLE_MIN = 80;
+
+function clampRect(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  minW: number,
+  minH: number,
+) {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const w = Math.max(width, minW);
+  const h = Math.max(height, minH);
+  const cx = Math.max(-(w - VISIBLE_MIN), Math.min(x, vw - VISIBLE_MIN));
+  // Top: keep drag bar on screen (y >= 0); bottom/sides: keep 80px visible
+  const cy = Math.max(0, Math.min(y, vh - VISIBLE_MIN));
+  return { x: cx, y: cy, width: w, height: h };
+}
+
+const CURSOR_MAP: Record<ResizeEdge, string> = {
+  n: "n-resize",
+  s: "s-resize",
+  e: "e-resize",
+  w: "w-resize",
+  ne: "ne-resize",
+  nw: "nw-resize",
+  se: "se-resize",
+  sw: "sw-resize",
+};
+
+export function useDragResize(
+  panelId: string,
+  opts: { minWidth: number; minHeight: number },
+) {
+  const { setRect, bringToFront, getZIndex, panels } = usePanelLayoutStore();
+  const rect = panels[panelId];
+  const minW = opts.minWidth ?? PANEL_MIN_SIZES[panelId]?.width ?? 200;
+  const minH = opts.minHeight ?? PANEL_MIN_SIZES[panelId]?.height ?? 200;
+
+  const dragState = useRef<{ startX: number; startY: number; origX: number; origY: number } | null>(null);
+  const resizeState = useRef<{
+    edge: ResizeEdge;
+    startX: number;
+    startY: number;
+    origX: number;
+    origY: number;
+    origW: number;
+    origH: number;
+  } | null>(null);
+
+  const onDragPointerDown: PointerEventHandler = useCallback(
+    (e) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      bringToFront(panelId);
+      const r = panels[panelId];
+      dragState.current = { startX: e.clientX, startY: e.clientY, origX: r.x, origY: r.y };
+    },
+    [panelId, bringToFront, panels],
+  );
+
+  const onResizePointerDown = useCallback(
+    (edge: ResizeEdge): PointerEventHandler =>
+      (e) => {
+        if (e.button !== 0) return;
+        e.preventDefault();
+        e.stopPropagation();
+        (e.target as HTMLElement).setPointerCapture(e.pointerId);
+        bringToFront(panelId);
+        const r = panels[panelId];
+        resizeState.current = {
+          edge,
+          startX: e.clientX,
+          startY: e.clientY,
+          origX: r.x,
+          origY: r.y,
+          origW: r.width,
+          origH: r.height,
+        };
+      },
+    [panelId, bringToFront, panels],
+  );
+
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      if (dragState.current) {
+        const dx = e.clientX - dragState.current.startX;
+        const dy = e.clientY - dragState.current.startY;
+        const clamped = clampRect(
+          dragState.current.origX + dx,
+          dragState.current.origY + dy,
+          rect.width,
+          rect.height,
+          minW,
+          minH,
+        );
+        setRect(panelId, { x: clamped.x, y: clamped.y });
+        return;
+      }
+
+      if (resizeState.current) {
+        const s = resizeState.current;
+        const dx = e.clientX - s.startX;
+        const dy = e.clientY - s.startY;
+
+        let newX = s.origX;
+        let newY = s.origY;
+        let newW = s.origW;
+        let newH = s.origH;
+
+        if (s.edge.includes("e")) newW = s.origW + dx;
+        if (s.edge.includes("w")) { newW = s.origW - dx; newX = s.origX + dx; }
+        if (s.edge.includes("s")) newH = s.origH + dy;
+        if (s.edge.includes("n")) { newH = s.origH - dy; newY = s.origY + dy; }
+
+        // Enforce min sizes before clamping — adjust position if shrinking past min
+        if (newW < minW) {
+          if (s.edge.includes("w")) newX = s.origX + s.origW - minW;
+          newW = minW;
+        }
+        if (newH < minH) {
+          if (s.edge.includes("n")) newY = s.origY + s.origH - minH;
+          newH = minH;
+        }
+
+        const clamped = clampRect(newX, newY, newW, newH, minW, minH);
+        setRect(panelId, clamped);
+      }
+    };
+
+    const onUp = () => {
+      dragState.current = null;
+      resizeState.current = null;
+    };
+
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp);
+    return () => {
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onUp);
+    };
+  }, [panelId, setRect, rect, minW, minH]);
+
+  // Reclamp on window resize
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    const onResize = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        const r = usePanelLayoutStore.getState().panels[panelId];
+        if (!r) return;
+        const clamped = clampRect(r.x, r.y, r.width, r.height, minW, minH);
+        setRect(panelId, clamped);
+      }, 150);
+    };
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      clearTimeout(timer);
+    };
+  }, [panelId, setRect, minW, minH]);
+
+  const style: CSSProperties = {
+    position: "fixed",
+    left: rect.x,
+    top: rect.y,
+    width: rect.width,
+    height: rect.height,
+    zIndex: getZIndex(panelId),
+  };
+
+  const dragHandleProps = { onPointerDown: onDragPointerDown };
+
+  const resizeHandleProps = (edge: ResizeEdge) => ({
+    onPointerDown: onResizePointerDown(edge),
+    style: { cursor: CURSOR_MAP[edge] } as CSSProperties,
+  });
+
+  return { dragHandleProps, resizeHandleProps, style, bringToFront: () => bringToFront(panelId) };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -130,13 +130,6 @@ body {
 /* ── Chat Overlay ────────────────────────────────────── */
 .chat-overlay {
   position: fixed;
-  bottom: 16px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 760px;
-  max-width: calc(100vw - 32px);
-  height: 350px;
-  max-height: 40vh;
   z-index: 50;
   display: flex;
   flex-direction: column;
@@ -144,20 +137,16 @@ body {
 }
 
 .chat-overlay.maximized {
-  width: calc(100vw - 32px);
-  height: calc(100vh - 32px);
-  max-height: calc(100vh - 32px);
+  left: 16px !important;
+  top: 16px !important;
+  width: calc(100vw - 32px) !important;
+  height: calc(100vh - 32px) !important;
+  z-index: 60 !important;
 }
 
 /* ── Quest Overlay ───────────────────────────────────── */
 .quest-overlay {
   position: fixed;
-  bottom: 16px;
-  right: 16px;
-  width: 320px;
-  max-width: calc(100vw - 32px);
-  height: 420px;
-  max-height: 55vh;
   z-index: 50;
   display: flex;
   flex-direction: column;
@@ -166,12 +155,6 @@ body {
 /* ── Settings Overlay ───────────────────────────────── */
 .settings-overlay {
   position: fixed;
-  bottom: 16px;
-  right: 16px;
-  width: 280px;
-  max-width: calc(100vw - 32px);
-  height: 340px;
-  max-height: 45vh;
   z-index: 50;
   display: flex;
   flex-direction: column;

--- a/frontend/src/stores/panelLayoutStore.ts
+++ b/frontend/src/stores/panelLayoutStore.ts
@@ -1,0 +1,94 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export interface PanelRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export const PANEL_MIN_SIZES: Record<string, { width: number; height: number }> = {
+  chat: { width: 400, height: 200 },
+  quest: { width: 240, height: 200 },
+  settings: { width: 240, height: 200 },
+};
+
+function defaultPanels(): Record<string, PanelRect> {
+  const w = typeof window !== "undefined" ? window.innerWidth : 1280;
+  const h = typeof window !== "undefined" ? window.innerHeight : 720;
+  return {
+    chat: {
+      x: Math.round((w - 760) / 2),
+      y: h - 350 - 16,
+      width: 760,
+      height: 350,
+    },
+    quest: {
+      x: w - 320 - 16,
+      y: h - 420 - 16,
+      width: 320,
+      height: 420,
+    },
+    settings: {
+      x: w - 280 - 16,
+      y: h - 340 - 16,
+      width: 280,
+      height: 340,
+    },
+  };
+}
+
+interface PanelLayoutStore {
+  panels: Record<string, PanelRect>;
+  zStack: string[];
+
+  setRect: (id: string, rect: Partial<PanelRect>) => void;
+  bringToFront: (id: string) => void;
+  resetPanel: (id: string) => void;
+  getZIndex: (id: string) => number;
+}
+
+export const usePanelLayoutStore = create<PanelLayoutStore>()(
+  persist(
+    (set, get) => ({
+      panels: defaultPanels(),
+      zStack: ["chat", "quest", "settings"],
+
+      setRect: (id, rect) =>
+        set((state) => ({
+          panels: {
+            ...state.panels,
+            [id]: { ...state.panels[id], ...rect },
+          },
+        })),
+
+      bringToFront: (id) =>
+        set((state) => {
+          const stack = state.zStack.filter((s) => s !== id);
+          stack.push(id);
+          return { zStack: stack };
+        }),
+
+      resetPanel: (id) =>
+        set((state) => ({
+          panels: {
+            ...state.panels,
+            [id]: defaultPanels()[id],
+          },
+        })),
+
+      getZIndex: (id) => {
+        const idx = get().zStack.indexOf(id);
+        return 50 + (idx === -1 ? 0 : idx);
+      },
+    }),
+    {
+      name: "seraph_panel_layout",
+      partialize: (state) => ({
+        panels: state.panels,
+        zStack: state.zStack,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
- All three overlay panels (Chat, Quest, Settings) can now be freely dragged by their full-width title bar and resized from any edge or corner
- Panel positions, sizes, and z-ordering persist in localStorage across sessions
- Maximized chat panel renders above all other panels (z-index 60)
- Edge clamping ensures panels stay reachable (top edge pinned to viewport, 80px minimum visible on other sides)
- Retro gold corner dots appear on hover for resize affordance

## Test plan
- [ ] Drag each panel by its title bar — moves freely, top edge never leaves viewport
- [ ] Resize from any edge or corner — respects minimum sizes (chat 400x200, quest/settings 240x200)
- [ ] Click on a panel behind another — it comes to front (z-index reorder)
- [ ] Maximize chat — fills screen above all panels; minimize — returns to dragged position
- [ ] Refresh page — panel positions restored from localStorage
- [ ] Close and reopen a panel — position preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)