### PR TITLE
feat: daemon management, observer context in chat agent

### DIFF
--- a/backend/src/agent/factory.py
+++ b/backend/src/agent/factory.py
@@ -26,6 +26,7 @@ def create_agent(
     additional_context: str = "",
     soul_context: str = "",
     memory_context: str = "",
+    observer_context: str = "",
 ) -> ToolCallingAgent:
     """Create a ToolCallingAgent with LiteLLM model and tools.
 
@@ -33,6 +34,7 @@ def create_agent(
         additional_context: Conversation history to include in the system prompt.
         soul_context: Soul file content (user identity, values, goals).
         memory_context: Relevant long-term memories for this conversation.
+        observer_context: Current observer context (time, window, screen, etc.).
     """
     model = get_model()
     tools = get_tools()
@@ -48,6 +50,8 @@ def create_agent(
         instructions += f"\n\n--- USER IDENTITY ---\n{soul_context}"
     if memory_context:
         instructions += f"\n\n--- RELEVANT MEMORIES ---\n{memory_context}"
+    if observer_context:
+        instructions += f"\n\n--- CURRENT CONTEXT ---\n{observer_context}"
 
     # Inject active skills into instructions
     active_skills = skill_manager.get_active_skills(tool_names)
@@ -74,6 +78,7 @@ def create_orchestrator(
     additional_context: str = "",
     soul_context: str = "",
     memory_context: str = "",
+    observer_context: str = "",
 ) -> ToolCallingAgent:
     """Create an orchestrator agent that delegates to specialist sub-agents.
 
@@ -109,6 +114,8 @@ def create_orchestrator(
         instructions += f"\n\n--- USER IDENTITY ---\n{soul_context}"
     if memory_context:
         instructions += f"\n\n--- RELEVANT MEMORIES ---\n{memory_context}"
+    if observer_context:
+        instructions += f"\n\n--- CURRENT CONTEXT ---\n{observer_context}"
 
     # Inject active skills into instructions
     active_skills = skill_manager.get_active_skills(all_tool_names)
@@ -136,11 +143,12 @@ def build_agent(
     additional_context: str = "",
     soul_context: str = "",
     memory_context: str = "",
+    observer_context: str = "",
 ) -> ToolCallingAgent:
     """Build the appropriate agent based on delegation feature flag.
 
     Drop-in replacement for create_agent() at call sites.
     """
     if settings.use_delegation:
-        return create_orchestrator(additional_context, soul_context, memory_context)
-    return create_agent(additional_context, soul_context, memory_context)
+        return create_orchestrator(additional_context, soul_context, memory_context, observer_context)
+    return create_agent(additional_context, soul_context, memory_context, observer_context)

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -31,10 +31,15 @@ async def chat(request: ChatRequest):
         history = await session_manager.get_history_text(session.id)
         soul = read_soul()
         memories = await asyncio.to_thread(search_formatted, request.message)
+
+        from src.observer.manager import context_manager as obs_manager
+        observer_context = obs_manager.get_context().to_prompt_block()
+
         agent = build_agent(
             additional_context=history,
             soul_context=soul,
             memory_context=memories,
+            observer_context=observer_context,
         )
 
     try:

--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -1,5 +1,7 @@
 """Observer API — context state and daemon integration endpoints."""
 
+import time
+
 from fastapi import APIRouter
 from pydantic import BaseModel
 
@@ -24,6 +26,22 @@ async def post_screen_context(body: ScreenContextRequest):
     """Receive screen context from native daemon."""
     context_manager.update_screen_context(body.active_window, body.screen_context)
     return {"status": "ok"}
+
+
+@router.get("/observer/daemon-status")
+async def daemon_status():
+    """Return daemon connectivity status based on heartbeat timestamp."""
+    ctx = context_manager.get_context()
+    connected = (
+        ctx.last_daemon_post is not None
+        and (time.time() - ctx.last_daemon_post) < 30
+    )
+    return {
+        "connected": connected,
+        "last_post": ctx.last_daemon_post,
+        "active_window": ctx.active_window,
+        "has_screen_context": bool(ctx.screen_context),
+    }
 
 
 @router.post("/observer/refresh")

--- a/backend/src/api/ws.py
+++ b/backend/src/api/ws.py
@@ -56,10 +56,14 @@ async def _build_agent(session_id: str, message: str):
     soul = read_soul()
     memories = await asyncio.to_thread(search_formatted, message)
 
+    from src.observer.manager import context_manager as obs_manager
+    observer_context = obs_manager.get_context().to_prompt_block()
+
     agent = build_agent(
         additional_context=history,
         soul_context=soul,
         memory_context=memories,
+        observer_context=observer_context,
     )
     specialist_names = (
         set(agent.managed_agents.keys())

--- a/backend/src/observer/context.py
+++ b/backend/src/observer/context.py
@@ -34,6 +34,9 @@ class CurrentContext:
     active_window: Optional[str] = None
     screen_context: Optional[str] = None
 
+    # Daemon heartbeat — Unix timestamp of last POST from daemon
+    last_daemon_post: Optional[float] = None
+
     # Phase 3.3 — State machine tracking
     previous_user_state: str = "available"
     attention_budget_last_reset: Optional[datetime] = None

--- a/backend/src/observer/manager.py
+++ b/backend/src/observer/manager.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import time
 from datetime import datetime, timezone
 
 from src.observer.context import CurrentContext
@@ -116,6 +117,7 @@ class ContextManager:
                 attention_budget_remaining=budget,
                 active_window=old.active_window,
                 screen_context=old.screen_context,
+                last_daemon_post=old.last_daemon_post,
                 # Phase 3.3 tracking
                 previous_user_state=old.user_state,
                 attention_budget_last_reset=last_reset,
@@ -191,11 +193,13 @@ class ContextManager:
 
         Supports partial updates — only overwrites fields that are non-None,
         so the window loop and OCR loop don't clobber each other's data.
+        Records timestamp for daemon heartbeat tracking.
         """
         if active_window is not None:
             self._context.active_window = active_window
         if screen_context is not None:
             self._context.screen_context = screen_context
+        self._context.last_daemon_post = time.time()
 
     def decrement_attention_budget(self) -> None:
         """Reduce attention budget by 1 (minimum 0)."""

--- a/backend/tests/test_agent.py
+++ b/backend/tests/test_agent.py
@@ -78,3 +78,24 @@ class TestAgentFactory:
         create_agent()
         call_kwargs = mock_agent_cls.call_args[1]
         assert "Available Skills" not in call_kwargs["instructions"]
+
+    @patch("src.agent.factory.ToolCallingAgent")
+    @patch("src.agent.factory.get_model")
+    def test_create_agent_with_observer_context(self, mock_get_model, mock_agent_cls):
+        mock_get_model.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+
+        create_agent(observer_context="User is in: VS Code — main.py\nTime: morning (Monday)")
+        call_kwargs = mock_agent_cls.call_args[1]
+        assert "CURRENT CONTEXT" in call_kwargs["instructions"]
+        assert "VS Code" in call_kwargs["instructions"]
+
+    @patch("src.agent.factory.ToolCallingAgent")
+    @patch("src.agent.factory.get_model")
+    def test_create_agent_empty_observer_context_omitted(self, mock_get_model, mock_agent_cls):
+        mock_get_model.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+
+        create_agent(observer_context="")
+        call_kwargs = mock_agent_cls.call_args[1]
+        assert "CURRENT CONTEXT" not in call_kwargs["instructions"]

--- a/backend/tests/test_delegation.py
+++ b/backend/tests/test_delegation.py
@@ -13,7 +13,7 @@ class TestFeatureFlag:
         mock_create.return_value = MagicMock()
         with patch.object(settings, "use_delegation", False):
             agent = build_agent(soul_context="test soul")
-        mock_create.assert_called_once_with("", "test soul", "")
+        mock_create.assert_called_once_with("", "test soul", "", "")
         assert agent is mock_create.return_value
 
     @patch("src.agent.factory.create_orchestrator")
@@ -21,7 +21,7 @@ class TestFeatureFlag:
         mock_create_orch.return_value = MagicMock()
         with patch.object(settings, "use_delegation", True):
             agent = build_agent(soul_context="test soul")
-        mock_create_orch.assert_called_once_with("", "test soul", "")
+        mock_create_orch.assert_called_once_with("", "test soul", "", "")
         assert agent is mock_create_orch.return_value
 
 

--- a/daemon/.gitignore
+++ b/daemon/.gitignore
@@ -1,0 +1,2 @@
+.seraph-daemon.pid
+seraph-daemon.log

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -6,6 +6,7 @@ import { ResizeHandles } from "./ResizeHandles";
 import { EventBus } from "../game/EventBus";
 import { DialogFrame } from "./chat/DialogFrame";
 import { InterruptionModeToggle } from "./settings/InterruptionModeToggle";
+import { DaemonStatus } from "./settings/DaemonStatus";
 
 interface SkillInfo {
   name: string;
@@ -565,6 +566,8 @@ export function SettingsPanel() {
           </div>
 
           <InterruptionModeToggle />
+
+          <DaemonStatus />
 
           <div className="px-1">
             <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-1">

--- a/frontend/src/components/settings/DaemonStatus.tsx
+++ b/frontend/src/components/settings/DaemonStatus.tsx
@@ -1,0 +1,66 @@
+import { useState, useEffect } from "react";
+import { API_URL } from "../../config/constants";
+
+interface DaemonStatusData {
+  connected: boolean;
+  last_post: number | null;
+  active_window: string | null;
+  has_screen_context: boolean;
+}
+
+export function DaemonStatus() {
+  const [status, setStatus] = useState<DaemonStatusData | null>(null);
+
+  useEffect(() => {
+    const fetchStatus = () => {
+      fetch(`${API_URL}/api/observer/daemon-status`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => {
+          if (data) setStatus(data);
+        })
+        .catch(() => {});
+    };
+
+    fetchStatus();
+    const interval = setInterval(fetchStatus, 10_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const connected = status?.connected ?? false;
+  const dotColor = connected ? "bg-green-400" : "bg-retro-text/30";
+  const activeWindow = status?.active_window;
+
+  // Truncate long window titles
+  const displayWindow =
+    activeWindow && activeWindow.length > 40
+      ? activeWindow.slice(0, 37) + "..."
+      : activeWindow;
+
+  return (
+    <div className="px-1">
+      <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-2">
+        Screen Observer
+      </div>
+      <div className="flex items-center gap-1.5 px-1">
+        <div className={`w-2 h-2 rounded-full flex-shrink-0 ${dotColor}`} />
+        <div className="flex-1 min-w-0">
+          {connected ? (
+            <>
+              <div className="text-[10px] text-retro-text">Connected</div>
+              {displayWindow && (
+                <div className="text-[9px] text-retro-text/40 truncate">
+                  {displayWindow}
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="text-[10px] text-retro-text/40">Not running</div>
+          )}
+        </div>
+        {connected && status?.has_screen_context && (
+          <div className="text-[9px] text-retro-text/30">OCR</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/manage.sh
+++ b/manage.sh
@@ -6,32 +6,38 @@
 #
 # ==============================================================================
 #
-# This script is the single entry point for managing all Docker environments.
-# It ensures that the correct .env file and docker-compose files are used
-# for the specified environment (dev or prod).
+# This script is the single entry point for managing all Docker environments
+# and the native macOS screen daemon.
 #
 #
 # Usage:
-#   ./manage.sh up -e [dev|prod]   - Start the services for the specified environment.
-#   ./manage.sh down -e [dev|prod] - Stop the services for the specified environment.
-#   ./manage.sh logs -e [dev|prod] - View the logs for the specified environment.
-#   ./manage.sh build -e [dev|prod] - Build or rebuild the services.
+#   ./manage.sh -e [dev|prod] up -d     - Start Docker services (+ daemon if DAEMON_ENABLED=true).
+#   ./manage.sh -e [dev|prod] down      - Stop Docker services + daemon.
+#   ./manage.sh -e [dev|prod] logs      - View Docker logs.
+#   ./manage.sh -e [dev|prod] build     - Build or rebuild Docker services.
+#   ./manage.sh -e [dev|prod] daemon start|stop|status|logs - Manage screen daemon.
 #
 # Examples:
-#   ./manage.sh up -e dev          - Starts the development stack.
-#   ./manage.sh logs -e prod       - Tails the logs of the production stack.
+#   ./manage.sh -e dev up -d            - Starts the development stack.
+#   ./manage.sh -e dev daemon status    - Check if daemon is running.
+#   ./manage.sh -e dev daemon logs      - Tail daemon log file.
+#   ./manage.sh -e prod down            - Stop everything.
 #
 # ==============================================================================
 
 # --- Configuration ---
-DEFAULT_ENV="dev"
 PROG_NAME=$(basename "$0")
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DAEMON_DIR="$SCRIPT_DIR/daemon"
+DAEMON_PID_FILE="$DAEMON_DIR/.seraph-daemon.pid"
+DAEMON_LOG_FILE="$DAEMON_DIR/seraph-daemon.log"
 
 # --- Helper Functions ---
 function display_help() {
     echo "Usage: $PROG_NAME -e [dev|prod] [COMMAND] [ARGS...]"
     echo
-    echo "This script is the official entry point for managing the project's Docker environments."
+    echo "This script is the official entry point for managing the project's Docker environments"
+    echo "and the native macOS screen daemon."
     echo
     echo "Options:"
     echo "  -e      Specify the environment (dev or prod). Required."
@@ -39,14 +45,20 @@ function display_help() {
     echo
     echo "Commands:"
     echo "  up      Create and start containers (e.g., 'up -d' to detach)."
+    echo "          Also starts daemon if DAEMON_ENABLED=true in .env file."
     echo "  down    Stop and remove containers, networks, and volumes."
+    echo "          Also stops daemon if running."
     echo "  logs    Follow log output (e.g., 'logs -f backend')."
     echo "  build   Build or rebuild services."
+    echo "  daemon  Manage screen daemon: start, stop, status, logs."
     echo
     echo "Examples:"
     echo "  $PROG_NAME -e dev up -d"
     echo "  $PROG_NAME -e prod down"
     echo "  $PROG_NAME -e dev logs -f backend"
+    echo "  $PROG_NAME -e dev daemon start"
+    echo "  $PROG_NAME -e dev daemon status"
+    echo "  $PROG_NAME -e dev daemon logs"
 }
 
 function error_exit() {
@@ -55,9 +67,87 @@ function error_exit() {
     exit 1
 }
 
+# --- Daemon Functions ---
+function daemon_is_running() {
+    if [ -f "$DAEMON_PID_FILE" ]; then
+        local pid
+        pid=$(cat "$DAEMON_PID_FILE")
+        if kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+        # Stale PID file
+        rm -f "$DAEMON_PID_FILE"
+    fi
+    return 1
+}
+
+function start_daemon() {
+    if daemon_is_running; then
+        local pid
+        pid=$(cat "$DAEMON_PID_FILE")
+        echo "Daemon already running (PID $pid)"
+        return 0
+    fi
+
+    local daemon_args="${DAEMON_ARGS:-}"
+    echo "Starting screen daemon... (args: ${daemon_args:-none})"
+
+    # shellcheck disable=SC2086
+    nohup "$DAEMON_DIR/run.sh" $daemon_args >> "$DAEMON_LOG_FILE" 2>&1 &
+    local pid=$!
+    echo "$pid" > "$DAEMON_PID_FILE"
+    echo "Daemon started (PID $pid), logging to $DAEMON_LOG_FILE"
+}
+
+function stop_daemon() {
+    if ! daemon_is_running; then
+        echo "Daemon is not running"
+        rm -f "$DAEMON_PID_FILE"
+        return 0
+    fi
+
+    local pid
+    pid=$(cat "$DAEMON_PID_FILE")
+    echo "Stopping daemon (PID $pid)..."
+    kill "$pid" 2>/dev/null
+
+    # Wait up to 5 seconds for graceful shutdown
+    local waited=0
+    while kill -0 "$pid" 2>/dev/null && [ $waited -lt 5 ]; do
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "Daemon didn't stop gracefully, sending SIGKILL..."
+        kill -9 "$pid" 2>/dev/null
+    fi
+
+    rm -f "$DAEMON_PID_FILE"
+    echo "Daemon stopped"
+}
+
+function daemon_status() {
+    if daemon_is_running; then
+        local pid
+        pid=$(cat "$DAEMON_PID_FILE")
+        echo "Daemon is running (PID $pid)"
+    else
+        echo "Daemon is not running"
+    fi
+}
+
+function daemon_logs() {
+    if [ ! -f "$DAEMON_LOG_FILE" ]; then
+        echo "No daemon log file found at $DAEMON_LOG_FILE"
+        return 1
+    fi
+    tail -f "$DAEMON_LOG_FILE"
+}
+
 # --- Main Script Logic ---
 
-# New argument parsing logic
+# Argument parsing
 ENV=""
 while getopts ":e:h" opt; do
   case ${opt} in
@@ -76,39 +166,63 @@ while getopts ":e:h" opt; do
       ;;
   esac
 done
-shift "$((OPTIND-1))" # Shift off the options and optional --.
+shift "$((OPTIND-1))"
 
-# After `getopts`, the first argument is now the command (up, down, etc.)
 COMMAND=$1
 if [[ -z "$COMMAND" ]]; then
     error_exit "No command specified."
 fi
-shift # Remove command from arguments list
+shift
 
 # --- Environment Setup ---
-# Set environment to default if not provided
-# Make environment selection mandatory
 if [ -z "$ENV" ]; then
     error_exit "No environment specified. You must use '-e dev' or '-e prod'."
 fi
 
-# Validate environment
 if [ "$ENV" != "dev" ] && [ "$ENV" != "prod" ]; then
     error_exit "Invalid environment '$ENV'. Please use 'dev' or 'prod'."
 fi
 
-# Define the environment file and compose files based on the chosen environment
 ENV_FILE=".env.$ENV"
 COMPOSE_FILES=(
     -f docker-compose.$ENV.yaml
 )
 
-# Check if the required .env file exists
 if [ ! -f "$ENV_FILE" ]; then
     error_exit "$ENV_FILE not found. Please create it by copying from $ENV_FILE.example and filling in the values."
 fi
 
+# Source env file for daemon config
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
 # --- Execution ---
+
+# Handle daemon subcommand
+if [ "$COMMAND" = "daemon" ]; then
+    DAEMON_SUB="${1:-}"
+    case "$DAEMON_SUB" in
+        start)
+            start_daemon
+            ;;
+        stop)
+            stop_daemon
+            ;;
+        status)
+            daemon_status
+            ;;
+        logs)
+            daemon_logs
+            ;;
+        *)
+            error_exit "Unknown daemon subcommand '$DAEMON_SUB'. Use: start, stop, status, logs"
+            ;;
+    esac
+    exit 0
+fi
+
 echo "=========================================================="
 echo "          Running command '$COMMAND' in '$ENV' environment"
 echo "=========================================================="
@@ -116,5 +230,24 @@ echo "Using env file: $ENV_FILE"
 echo "Using compose files: ${COMPOSE_FILES[*]}"
 echo "----------------------------------------------------------"
 
-# Execute the docker-compose command with all specified files and arguments
+# Execute docker compose
 docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" "$COMMAND" "$@"
+
+# After docker compose up: optionally start daemon
+if [ "$COMMAND" = "up" ]; then
+    if [ "${DAEMON_ENABLED:-false}" = "true" ]; then
+        echo "----------------------------------------------------------"
+        start_daemon
+    else
+        echo "----------------------------------------------------------"
+        echo "Screen daemon disabled (set DAEMON_ENABLED=true in $ENV_FILE to enable)"
+    fi
+fi
+
+# After docker compose down: stop daemon if running
+if [ "$COMMAND" = "down" ]; then
+    if daemon_is_running; then
+        echo "----------------------------------------------------------"
+        stop_daemon
+    fi
+fi


### PR DESCRIPTION
## Summary
- **Daemon lifecycle in `manage.sh`**: Added `daemon start/stop/status/logs` subcommands with PID tracking and log file. `up` auto-starts daemon when `DAEMON_ENABLED=true`, `down` auto-stops it.
- **Observer context wired into chat agent**: The chat agent (both WS and REST) now receives current context (time of day, active window, screen content, goals) so Seraph can see what the user is working on.
- **Daemon heartbeat tracking**: New `last_daemon_post` field on `CurrentContext` + `GET /api/observer/daemon-status` endpoint for connectivity checks.
- **Settings UI**: New `DaemonStatus` component showing green/gray dot + active window name, polling every 10s.

## Test plan
- [ ] `./manage.sh -e dev daemon start` → starts daemon, prints PID
- [ ] `./manage.sh -e dev daemon status` → shows "running" with PID
- [ ] `./manage.sh -e dev daemon logs` → tails daemon log
- [ ] `./manage.sh -e dev daemon stop` → stops daemon gracefully
- [ ] `./manage.sh -e dev up -d` with `DAEMON_ENABLED=true` → starts Docker + daemon
- [ ] `./manage.sh -e dev down` → stops Docker + daemon
- [ ] Settings panel shows green dot + active window when daemon is running
- [ ] Settings panel shows gray dot + "Not running" when daemon is stopped
- [ ] Ask Seraph "what am I working on?" → response references active window/screen context
- [ ] All 461 tests pass: `cd backend && .venv/bin/python -m pytest tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)