### PR TITLE
fix: mcp.sh live-reload and frontend MCP polling

### DIFF
--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -453,6 +453,13 @@ export function SettingsPanel() {
     }
   }, [settingsPanelOpen, fetchSkills, fetchServers, fetchCatalog]);
 
+  // Poll MCP servers while panel is open to catch external changes (mcp.sh, API)
+  useEffect(() => {
+    if (!settingsPanelOpen) return;
+    const id = setInterval(fetchServers, 5000);
+    return () => clearInterval(id);
+  }, [settingsPanelOpen, fetchServers]);
+
   const handleSkillToggle = async (name: string, enabled: boolean) => {
     try {
       await fetch(`${API_URL}/api/skills/${name}`, {


### PR DESCRIPTION
## Summary
- `mcp.sh` now calls the backend API directly when it's running, so `add`/`remove`/`enable`/`disable` take effect immediately (falls back to file editing when offline)
- Frontend SettingsPanel polls MCP servers every 5s while open, catching external changes without manual refresh

## Test plan
- [ ] `./mcp.sh add test http://example.com/mcp` with backend running → shows "Live-reloaded in backend"
- [ ] Server appears in Settings UI within 5 seconds without page refresh
- [ ] `./mcp.sh remove test` → disappears from Settings UI within 5 seconds
- [ ] `./mcp.sh add test http://example.com/mcp` with backend stopped → falls back to file editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)