### PR TITLE
docs: update documentation for PRs #96–#102

### DIFF
--- a/docs/docs/integrations/things3-mcp.md
+++ b/docs/docs/integrations/things3-mcp.md
@@ -72,6 +72,33 @@ launchctl bootout gui/$(id -u)/com.seraph.things-mcp
 rm ~/Library/LaunchAgents/com.seraph.things-mcp.plist
 ```
 
+#### Alternative: Stdio Proxy
+
+The stdio proxy (`mcp-servers/stdio-proxy/`) is a simpler alternative to the LaunchAgent. It wraps things-mcp as an HTTP endpoint automatically.
+
+1. Add to `data/stdio-proxies.json`:
+   ```json
+   {
+     "proxies": {
+       "things3": {
+         "command": "uvx",
+         "args": ["things-mcp"],
+         "port": 8100,
+         "enabled": true,
+         "description": "Things3 task manager"
+       }
+     }
+   }
+   ```
+
+2. Start the proxy and register:
+   ```bash
+   ./manage.sh -e dev proxy start
+   ./mcp.sh add things3 http://host.docker.internal:8100/mcp --desc "Things3 task manager"
+   ```
+
+**Note:** The `uvx` binary still needs Full Disk Access to read the Things3 database (see step above).
+
 #### Alternative: run manually in a terminal
 
 If you prefer not to use a LaunchAgent, you can run things-mcp directly — but the terminal app (iTerm, Terminal.app, etc.) will need Full Disk Access:

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -164,7 +164,7 @@ Seraph sees what you're doing, understands your patterns, and its avatar mirrors
 
 **Theme**: Make what exists production-quality. Complete unfinished UI, fix backend gaps, harden infrastructure, eliminate adoption barriers.
 
-**Status**: Mostly complete. Goal UI, interruption mode, accessibility, timeouts, token-aware context, and SKILL.md plugins are done. Avatar state reflection and Tauri desktop remain planned.
+**Status**: Mostly complete. Goal UI, interruption mode, accessibility, timeouts, token-aware context, SKILL.md plugins, draggable panels, MCP auth UX, and stdio proxy are done. Avatar state reflection and Tauri desktop remain planned.
 
 ### 3.5.1 Goal Management UI ✅
 - ~~Create/edit/delete goals via dedicated form (not just chat)~~ — `GoalForm.tsx` with create/edit modal
@@ -218,6 +218,21 @@ Seraph sees what you're doing, understands your patterns, and its avatar mirrors
 ### 3.5.9 Frontend Accessibility ✅
 - ~~Increase minimum font sizes (7-9px → 11-12px)~~ — 9px minimum across all panels (Press Start 2P pixel font)
 - ~~Keyboard shortcuts for panel toggling (C/Q/S/Esc)~~ — Shift+C (chat), Shift+Q (quests), Shift+S (settings), Escape (close). Shift modifier prevents WASD conflict.
+
+### 3.5.10 Draggable & Resizable Panels ✅
+- All panels (chat, quest, settings) draggable via title bar, resizable from 8 edges/corners
+- Layout (position/size) persisted in localStorage via `panelLayoutStore`
+- Z-ordering: clicking a panel brings it to front
+
+### 3.5.11 MCP Auth UX ✅
+- 4-state status indicator per server: gray (disabled), green (connected), yellow pulsing (auth needed), red (error)
+- Inline token config form with save-and-test flow
+- Clickable auth hints guide users through token setup
+
+### 3.5.12 Stdio-to-HTTP MCP Proxy ✅
+- Native macOS proxy (`mcp-servers/stdio-proxy/`) wraps stdio-only MCP servers as HTTP endpoints
+- `manage.sh` integration: `proxy start|stop|status|logs`
+- Backend connects to proxied servers as normal HTTP MCP servers — no backend changes needed
 
 ### Milestone
 Everything that exists is robust, polished, and installable. Ready to expand.


### PR DESCRIPTION
## Summary
- Update CLAUDE.md with draggable/resizable panels (`panelLayoutStore`, `useDragResize`, `ResizeHandles`), MCP polling in SettingsPanel, `mcp.sh` live-reload, observer context in agent factory, and design decision #15
- Add "Stdio MCP Proxy" section to setup guide, update MCP Servers and GitHub MCP sections
- Add stdio proxy alternative to Things3 MCP integration docs
- Add 3.5.10–3.5.12 completed items to roadmap (draggable panels, MCP auth UX, stdio proxy)

## Test plan
- [ ] Verify all links and code examples in docs render correctly
- [ ] Confirm no broken cross-references between setup guide and integration docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)