### PR TITLE
fix: resize handles obscured by drag bar at panel edges

### DIFF
--- a/frontend/src/components/ResizeHandles.tsx
+++ b/frontend/src/components/ResizeHandles.tsx
@@ -40,7 +40,7 @@ export function ResizeHandles({ resizeHandleProps }: ResizeHandlesProps) {
           <div
             key={edge}
             onPointerDown={props.onPointerDown}
-            style={{ ...edgeStyles[edge], ...props.style, zIndex: 1 }}
+            style={{ ...edgeStyles[edge], ...props.style, zIndex: 11 }}
           />
         );
       })}
@@ -51,7 +51,7 @@ export function ResizeHandles({ resizeHandleProps }: ResizeHandlesProps) {
             key={corner}
             className="group"
             onPointerDown={props.onPointerDown}
-            style={{ ...edgeStyles[corner], ...props.style, zIndex: 2 }}
+            style={{ ...edgeStyles[corner], ...props.style, zIndex: 20 }}
           >
             <div
               className="opacity-0 group-hover:opacity-100 transition-opacity"


### PR DESCRIPTION
## Summary
- Bump resize edge z-index from 1 → 11 and corner z-index from 2 → 20, above the drag bar's z-index of 10
- Fixes inability to resize panels from top-left/top-right corners and north edge where the drag bar was capturing pointer events

## Test plan
- [ ] Hover top-left and top-right corners of any panel — cursor should show `nw-resize` / `ne-resize`
- [ ] Drag from those corners to resize — should resize, not drag
- [ ] Drag from the middle of the title bar — should still drag the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)