### PR TITLE
feat: add Toggl Track MCP integration

### DIFF
--- a/backend/src/defaults/mcp-servers.default.json
+++ b/backend/src/defaults/mcp-servers.default.json
@@ -13,6 +13,15 @@
         "Authorization": "Bearer ${GITHUB_TOKEN}"
       },
       "auth_hint": "Create a Personal Access Token at https://github.com/settings/tokens (classic, repo scope)"
+    },
+    "toggl": {
+      "url": "http://toggl-mcp:9300/mcp",
+      "enabled": false,
+      "description": "Toggl Track time tracking (20–40 tools)",
+      "headers": {
+        "Authorization": "Bearer ${TOGGL_API_KEY}"
+      },
+      "auth_hint": "Get your API token from https://track.toggl.com/profile (scroll to API Token)"
     }
   }
 }

--- a/backend/src/defaults/skill-catalog.json
+++ b/backend/src/defaults/skill-catalog.json
@@ -71,6 +71,13 @@
       "category": "development",
       "url": "https://api.githubcopilot.com/mcp/",
       "bundled": false
+    },
+    {
+      "name": "toggl",
+      "description": "Toggl Track time tracking (20–40 tools)",
+      "category": "productivity",
+      "url": "http://toggl-mcp:9300/mcp",
+      "bundled": true
     }
   ]
 }

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -47,6 +47,13 @@ services:
       - seraph-network-dev
     restart: unless-stopped
 
+  toggl-mcp:
+    container_name: toggl-mcp
+    image: ghcr.io/seraph-quest/toggl-mcp:latest
+    networks:
+      - seraph-network-dev
+    restart: unless-stopped
+
   # github-mcp:
   #   container_name: github-mcp
   #   image: ghcr.io/github/github-mcp-server:latest

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -290,6 +290,40 @@ On the first calendar scan, the backend will initiate an OAuth consent flow in t
 
 After initial authorization, the token refreshes automatically. If no credentials are configured, the calendar source silently returns empty — no errors are raised.
 
+## Optional: Toggl Track
+
+Toggl Track integration provides 20–40 MCP tools for time tracking (entries, projects, clients, tags, reports, and more).
+
+### Enable via Settings UI
+
+1. Open the **Settings** panel in the UI
+2. Find **toggl** in the MCP Servers section and toggle it **on**
+3. Click the token field and paste your Toggl API token
+4. Click **Save & Test** — the status dot should turn green
+
+Get your API token from [track.toggl.com/profile](https://track.toggl.com/profile) (scroll to "API Token").
+
+### Or via environment variable
+
+Set `TOGGL_API_KEY` in `.env.dev`:
+
+```bash
+TOGGL_API_KEY=your_toggl_api_token
+```
+
+Then rebuild: `./manage.sh -e dev up -d`
+
+### Read/write mode
+
+By default, toggl-mcp starts in **read-only** mode (20 tools). To enable write tools (create/update/delete time entries, projects, etc.), add to `docker-compose.dev.yaml` under the `toggl-mcp` service:
+
+```yaml
+environment:
+  TOGGL_MODE: readwrite
+```
+
+See the [toggl-mcp repo](https://github.com/seraph-quest/toggl-mcp) for the full tool reference.
+
 ## Optional: GitHub MCP
 
 GitHub MCP integration is **currently disabled** (commented out in `docker-compose.dev.yaml`). The official `github-mcp-server` image only supports stdio transport, which doesn't work in a container network.


### PR DESCRIPTION
## Summary
- Add toggl-mcp as a Docker service via GHCR image (`ghcr.io/seraph-quest/toggl-mcp`)
- Add MCP seed config entry with auth hint and `Bearer ${TOGGL_API_KEY}` header pattern
- Add to skill catalog (bundled, productivity category)
- Document setup in `docs/docs/setup.md` (Settings UI + env var + read/write mode)
- Update CLAUDE.md with new service, updated counts, and architecture section

## Test plan
- [ ] `docker compose -f docker-compose.dev.yaml config` validates without errors
- [ ] toggl-mcp container starts and responds on internal network
- [ ] Enable toggl in Settings UI, set API token, verify connection goes green
- [ ] Verify toggl tools appear in agent tool list

🤖 Generated with [Claude Code](https://claude.com/claude-code)