### PR TITLE
fix: pass headers and auth_hint through catalog MCP install

### DIFF
--- a/backend/src/api/catalog.py
+++ b/backend/src/api/catalog.py
@@ -113,6 +113,8 @@ async def install_item(name: str):
                 url=server["url"],
                 description=server.get("description", ""),
                 enabled=False,
+                headers=server.get("headers"),
+                auth_hint=server.get("auth_hint", ""),
             )
             return {"status": "installed", "name": name, "type": "mcp_server"}
 

--- a/backend/src/defaults/skill-catalog.json
+++ b/backend/src/defaults/skill-catalog.json
@@ -70,14 +70,22 @@
       "description": "GitHub integration (requires GITHUB_TOKEN env var)",
       "category": "development",
       "url": "https://api.githubcopilot.com/mcp/",
-      "bundled": false
+      "bundled": false,
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_TOKEN}"
+      },
+      "auth_hint": "Create a Personal Access Token at https://github.com/settings/tokens (classic, repo scope)"
     },
     {
       "name": "toggl",
       "description": "Toggl Track time tracking (20–40 tools)",
       "category": "productivity",
       "url": "http://toggl-mcp:9300/mcp",
-      "bundled": true
+      "bundled": true,
+      "headers": {
+        "Authorization": "Bearer ${TOGGL_API_KEY}"
+      },
+      "auth_hint": "Get your API token from https://track.toggl.com/profile (scroll to API Token)"
     }
   ]
 }

--- a/backend/src/tools/mcp_manager.py
+++ b/backend/src/tools/mcp_manager.py
@@ -204,7 +204,8 @@ class MCPManager:
 
     def add_server(self, name: str, url: str,
                    description: str = "", enabled: bool = True,
-                   headers: dict[str, str] | None = None) -> None:
+                   headers: dict[str, str] | None = None,
+                   auth_hint: str = "") -> None:
         """Add a new server to config and optionally connect it."""
         self._config[name] = {
             "url": url,
@@ -213,6 +214,8 @@ class MCPManager:
         }
         if headers:
             self._config[name]["headers"] = headers
+        if auth_hint:
+            self._config[name]["auth_hint"] = auth_hint
         if enabled:
             self.connect(name, url, headers=headers)
         self._save_config()


### PR DESCRIPTION
## Summary
- Catalog install was calling `add_server()` without `headers` or `auth_hint`, so MCP servers installed from the Discover catalog had no "key" button in the Settings UI
- Add `headers` and `auth_hint` fields to toggl and github entries in `skill-catalog.json`
- Pass them through in `catalog.py` → `add_server()`
- Add `auth_hint` parameter to `MCPManager.add_server()`

## Test plan
- [ ] New test: `test_install_mcp_passes_headers_and_auth_hint`
- [ ] Existing test updated to match new call signature
- [ ] Install toggl from catalog → verify "key" button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)