### PR TITLE
docs: fix 34 documentation discrepancies

### DIFF
--- a/docs/docs/development/phase-1-persistent-identity.md
+++ b/docs/docs/development/phase-1-persistent-identity.md
@@ -37,7 +37,9 @@ backend/src/db/
 | `Message` | id, session_id (FK), role, content, metadata_json, step_number, tool_used, created_at | All chat messages |
 | `Memory` | id, content, category, source_session_id, embedding_id, created_at | Long-term memory entries |
 | `Goal` | id, parent_id (FK self), path, level, title, description, status, domain, start_date, due_date, sort_order, created_at, updated_at | Hierarchical goal tree |
-| `UserProfile` | id (singleton), name, soul_text, preferences_json, onboarding_completed, created_at, updated_at | User identity |
+| `UserProfile` | id (singleton), name, soul_text, preferences_json, onboarding_completed, interruption_mode, created_at, updated_at | User identity |
+| `QueuedInsight` | id, content, urgency, intervention_type, reasoning, created_at, expires_at | Queued proactive insights (24h expiry) |
+| `Secret` | id, key (unique), encrypted_value, description, created_at, updated_at | Encrypted key-value vault entries |
 
 **Goal hierarchy** uses materialized path + adjacency list:
 - `parent_id` for direct parent reference
@@ -233,5 +235,5 @@ frontend/src/components/chat/DialogFrame.tsx
 - [x] Create goals via chat, verify quest panel shows them with progress
 - [x] Click User avatar → quest panel opens; click Seraph → chat opens
 - [x] TypeScript compiles clean
-- [x] All 10 tools register
-- [x] All 18 routes verified
+- [x] All 16 tools register
+- [x] All 35 routes verified

--- a/docs/docs/development/phase-2-capable-executor.md
+++ b/docs/docs/development/phase-2-capable-executor.md
@@ -125,12 +125,12 @@ RUN uv run playwright install chromium
 - [x] `browse_webpage("https://example.com")` returns page content
 - [x] Drop a new `.py` tool file in `src/tools/`, verify auto-discovered
 - [x] New tools trigger correct village casting animations
-- [x] 12 tools auto-discovered by plugin loader
-- [x] 18 routes registered (including `GET /api/tools`)
+- [x] 16 tools auto-discovered by plugin loader
+- [x] 35 routes registered (including `GET /api/tools`)
 - [x] TypeScript compiles clean
 - [x] Lock file updated
 
-## All 12 Tools (auto-discovered)
+## All 16 Tools (auto-discovered)
 
 | Tool | File |
 |------|------|
@@ -146,3 +146,7 @@ RUN uv run playwright install chromium
 | `get_goal_progress` | goal_tools.py |
 | `shell_execute` | shell_tool.py |
 | `browse_webpage` | browser_tool.py |
+| `store_secret` | vault_tools.py |
+| `get_secret` | vault_tools.py |
+| `list_secrets` | vault_tools.py |
+| `delete_secret` | vault_tools.py |

--- a/docs/docs/development/phase-4-the-network.md
+++ b/docs/docs/development/phase-4-the-network.md
@@ -20,9 +20,8 @@ Phase 2's `@tool` auto-discovery requires Python code. OpenClaw's SKILL.md appro
 ```
 backend/src/skills/
   __init__.py
-  loader.py              # Scan workspace/skills/ for SKILL.md files
-  registry.py            # Merge SKILL.md skills with @tool plugins
-  validator.py           # Validate frontmatter, check requirements
+  loader.py              # Skill dataclass, YAML frontmatter parser, directory scanner
+  manager.py             # Singleton skill_manager; runtime enable/disable, config persistence
 ```
 
 **SKILL.md format**:
@@ -32,7 +31,7 @@ name: daily-standup
 description: Generate a standup report from git, calendar, and goals
 requires:
   tools: [shell_execute, get_calendar_events, get_goals]
-user-invocable: true
+user_invocable: true
 ---
 
 # Daily Standup Generator
@@ -44,15 +43,13 @@ When the user asks for a standup report:
 4. Format as: Yesterday / Today / Blockers
 ```
 
-**Loading precedence**:
-1. Workspace skills (`data/skills/`) — highest priority, user-created
-2. Managed skills (`~/.seraph/skills/`) — installed from registry
-3. Bundled skills (shipped with Seraph) — defaults
+**Skill loading**:
+- Skills are `.md` files in workspace `data/skills/` directory
+- Bundled defaults in `src/defaults/skills/` are seeded to workspace on first run (existing files never overwritten)
+- No multi-directory override hierarchy — workspace directory is the single source
 
 **Skill gating**:
-- `requires.tools` — only load if listed tools are available
-- `requires.env` — only load if env vars are set
-- `os` — platform restrictions (darwin/linux)
+- `requires.tools` — only load if listed tools are available (e.g., `moltbook` requires `http_request`)
 
 **Skill creation tool**:
 - Agent can create new skills on the fly via `write_file` to `data/skills/`

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Testing Guide
 
-Seraph has 520 automated tests (396 backend, 124 frontend) with CI running on every push and PR.
+Seraph has 624 automated tests (500 backend, 124 frontend) with CI running on every push and PR.
 
 ## Running Tests
 
@@ -45,37 +45,67 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 
 | File | Tests | Coverage |
 |---|---|---|
-| `test_session.py` | 18 | SessionManager — async DB-backed CRUD, history, pagination, title generation |
-| `test_goals_repository.py` | 18 | GoalRepository — CRUD, tree building, dashboard stats, cascading deletes |
-| `test_goals_api.py` | 10 | Goals HTTP endpoints — create, list, filter, tree, dashboard, update, delete |
-| `test_sessions_api.py` | 8 | Session HTTP endpoints — list, messages, update title, delete |
-| `test_profile.py` | 7 | User profile + onboarding — get/create, mark/reset complete, HTTP endpoints |
-| `test_soul.py` | 7 | Soul file persistence — read/write, section update, ensure exists |
-| `test_shell_tool.py` | 7 | Shell execution — success, errors, size limits, timeout, connection errors |
-| `test_consolidator.py` | 5 | Memory consolidation — extract facts, soul updates, markdown fences, LLM failure |
-| `test_plugin_loader.py` | 5 | Tool auto-discovery — scan, expected tools, no duplicates, caching, reload |
-| `test_mcp_manager.py` | 5 | MCP server integration — connect, disconnect, failure handling |
+| `test_agent.py` | 8 | Agent factory — tool count, model creation, context injection |
+| `test_catalog_api.py` | 9 | Catalog API — browse catalog, install skills/MCP servers |
 | `test_chat_api.py` | 5 | REST chat endpoint — success, session continuity, errors |
-| `test_agent.py` | 4 | Agent factory — tool count, model creation, context injection |
-| `test_tool_registry.py` | 4 | Tool metadata registry — lookup, required fields, copy safety |
-| `test_tools.py` | 9 | Filesystem tools, template tool, web search |
-| `test_websocket.py` | 3 | WebSocket — ping/pong, invalid JSON, skip onboarding |
-| `test_delivery.py` | 9 | Delivery coordinator — deliver/queue/drop routing, budget decrement, bundle formatting |
-| `test_insight_queue.py` | 9 | Insight queue — enqueue, drain, peek, ordering, expiry |
-| `test_observer_manager.py` | 5 | ContextManager — refresh, state transitions, budget reset |
-| `test_user_state.py` | 13 | User state machine — derive_state (incl. IDE deep work detection), should_deliver, budget management |
-| `test_strategist.py` | 12 | Strategist agent — JSON parsing (valid, fenced, invalid, empty, partial), agent creation |
+| `test_consolidation_reliability.py` | 6 | Memory consolidation reliability — edge cases, retry behavior |
+| `test_consolidator.py` | 5 | Memory consolidation — extract facts, soul updates, markdown fences, LLM failure |
+| `test_context_window.py` | 17 | Token-aware context window — budget management, keep first/last, summarization |
 | `test_daily_briefing.py` | 5 | Daily briefing — happy path, context/LLM failure, empty data, events in prompt |
+| `test_delegation.py` | 10 | Delegation architecture — orchestrator, specialist routing, depth limits |
+| `test_delivery.py` | 9 | Delivery coordinator — deliver/queue/drop routing, budget decrement, bundle formatting |
+| `test_e2e_conversation.py` | 3 | End-to-end conversation flow — full agent interaction paths |
 | `test_evening_review.py` | 8 | Evening review — happy path, no goals/messages, DB/LLM failure, date filtering |
+| `test_goal_tree_integrity.py` | 12 | Goal tree integrity — parent-child relationships, path consistency, cascading |
+| `test_goals_api.py` | 10 | Goals HTTP endpoints — create, list, filter, tree, dashboard, update, delete |
+| `test_goals_repository.py` | 21 | GoalRepository — CRUD, tree building, dashboard stats, cascading deletes |
+| `test_http_mcp_server.py` | 16 | HTTP MCP server — request handling, internal URL blocking, timeout, truncation |
+| `test_insight_queue.py` | 12 | Insight queue — enqueue, drain, peek, ordering, expiry |
+| `test_insight_queue_expiry.py` | 8 | Insight queue expiry — TTL, cleanup, edge cases |
+| `test_mcp_api.py` | 3 | MCP HTTP API endpoints — list, add, remove servers |
+| `test_mcp_manager.py` | 31 | MCP server integration — connect, disconnect, failure handling, token auth, env var resolution |
+| `test_observer_api.py` | 7 | Observer API endpoints — state, context POST, daemon status |
+| `test_observer_calendar.py` | 3 | Calendar observer source — event parsing, caching |
+| `test_observer_git.py` | 6 | Git observer source — commit parsing, branch detection |
+| `test_observer_goals.py` | 4 | Goals observer source — active goals summary |
+| `test_observer_manager.py` | 20 | ContextManager — refresh, state transitions, budget reset |
+| `test_observer_time.py` | 12 | Time observer source — time-of-day, working hours, timezone |
+| `test_onboarding_edge_cases.py` | 2 | Onboarding edge cases — skip, restart |
+| `test_plugin_loader.py` | 5 | Tool auto-discovery — scan, expected tools, no duplicates, caching, reload |
+| `test_profile.py` | 7 | User profile + onboarding — get/create, mark/reset complete, HTTP endpoints |
+| `test_scheduler.py` | 12 | Scheduler engine — job registration, start/stop, job execution |
+| `test_seed_config.py` | 7 | Seed config — default MCP servers, default skills, first-run seeding |
+| `test_session.py` | 23 | SessionManager — async DB-backed CRUD, history, pagination, title generation |
+| `test_sessions_api.py` | 8 | Session HTTP endpoints — list, messages, update title, delete |
+| `test_settings_api.py` | 6 | Settings API — interruption mode get/set |
+| `test_shell_tool.py` | 7 | Shell execution — success, errors, size limits, timeout, connection errors |
+| `test_skills.py` | 27 | Skills system — loading, gating, enable/disable, frontmatter parsing, API |
+| `test_soul.py` | 9 | Soul file persistence — read/write, section update, ensure exists |
+| `test_specialists.py` | 28 | Specialist agents — factory, tool domains, MCP specialist generation |
+| `test_strategist.py` | 12 | Strategist agent — JSON parsing (valid, fenced, invalid, empty, partial), agent creation |
+| `test_timeouts.py` | 5 | Execution timeouts — agent, briefing, consolidation timeouts |
+| `test_tool_registry.py` | 4 | Tool metadata registry — lookup, required fields, copy safety |
+| `test_tools.py` | 11 | Filesystem tools, template tool, web search |
+| `test_user_state.py` | 57 | User state machine — derive_state, IDE deep work, should_deliver, budget, interruption modes |
+| `test_vault_api.py` | 4 | Vault API — list keys, delete keys |
+| `test_vault_crypto.py` | 4 | Vault crypto — Fernet encrypt/decrypt, key generation |
+| `test_vault_repository.py` | 11 | Vault repository — store, get, list, delete, upsert |
+| `test_vault_tools.py` | 7 | Vault agent tools — store_secret, get_secret, list_secrets, delete_secret |
+| `test_websocket.py` | 3 | WebSocket — ping/pong, invalid JSON, skip onboarding |
 
 ### Frontend (`frontend/src/`)
 
 | File | Tests | Coverage |
 |---|---|---|
+| `game/objects/SpeechBubble.test.ts` | 25 | Speech bubble — show/hide, positioning, text wrapping, timeout, animation |
 | `stores/chatStore.test.ts` | 16 | Zustand chat store — sync actions (messages, panels, visual state) + async actions (profile, sessions, onboarding) |
-| `lib/toolParser.test.ts` | 15 | Tool detection — all 5 regex patterns, fallback substring match, Phase 1/2/Things3 tools |
-| `lib/animationStateMachine.test.ts` | 12 | Animation targets — tool→position mapping, facing direction, idle/thinking states |
-| `stores/questStore.test.ts` | 8 | Zustand quest store — goal CRUD, tree, dashboard, filters, refresh |
+| `game/lib/mapParsers.test.ts` | 15 | Map parsers — magic effect pool building, animation parsing, custom properties |
+| `hooks/useKeyboardShortcuts.test.ts` | 14 | Keyboard shortcuts — Shift+C/Q/S, Escape, input focus exclusion |
+| `lib/toolParser.test.ts` | 12 | Tool detection — regex patterns, fallback substring match, Phase 1/2/MCP tools |
+| `game/objects/MagicEffect.test.ts` | 12 | Magic effects — pool cycling, spawn, fade, destroy lifecycle |
+| `stores/questStore.test.ts` | 10 | Zustand quest store — goal CRUD, tree, dashboard, filters, refresh |
+| `lib/animationStateMachine.test.ts` | 10 | Animation targets — tool→position mapping, facing direction, idle/thinking states |
+| `hooks/useWebSocket.test.ts` | 6 | WebSocket hook — connect, reconnect, message dispatch, ping |
 | `config/constants.test.ts` | 4 | Constant integrity — tool count, position ranges, scene keys, waypoint count |
 
 ## Writing New Tests
@@ -130,7 +160,7 @@ These areas are intentionally excluded from the test suite:
 
 ## CI/CD
 
-Tests run automatically on every push and PR to `main` and `develop` via GitHub Actions (`.github/workflows/test.yml`).
+Tests run automatically on every push and PR to `main` via GitHub Actions (`.github/workflows/test.yml`).
 
 Two parallel jobs:
 - **backend-tests**: Ubuntu, Python 3.12, `uv sync --group dev`, `uv run pytest -v`

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -16,10 +16,10 @@ See the **[Setup Guide](./setup)** for complete installation and configuration i
 - **Frontend**: React 19, Vite 6, TypeScript 5.6, Tailwind CSS 3, Zustand 5, Phaser 3.90
 - **Backend**: Python 3.12, FastAPI, uvicorn, smolagents, LiteLLM (OpenRouter)
 - **Database**: SQLModel + SQLite (aiosqlite), LanceDB (vector memory)
-- **Tools**: 12 built-in tools (auto-discovered) + MCP integrations — web search, file I/O, shell (snekbox sandbox), browser (Playwright), soul/memory, goals
+- **Tools**: 16 built-in tools (auto-discovered) + MCP integrations — web search, file I/O, shell (snekbox sandbox), browser (Playwright), soul/memory, goals, vault
 - **Scheduler**: APScheduler — 6 background jobs (memory consolidation, goal check, calendar scan, strategist tick, daily briefing, evening review)
 - **Observer**: Native macOS daemon → context manager → user state machine → attention guardian → insight queue
-- **Infra**: Docker Compose (3 services: backend, frontend, snekbox sandbox), uv package manager
+- **Infra**: Docker Compose (4 services: backend, frontend, snekbox sandbox, http-mcp), uv package manager
 
 ## Project Structure
 
@@ -46,15 +46,16 @@ backend/
 ├── config/settings.py   # Pydantic Settings (env vars)
 ├── src/
 │   ├── app.py           # FastAPI app factory (lifespan: DB init, soul file)
-│   ├── api/             # REST + WebSocket endpoints (chat, sessions, goals, profile, tools, mcp, skills, observer, settings)
+│   ├── api/             # REST + WebSocket endpoints (chat, sessions, goals, profile, tools, mcp, skills, observer, settings, vault, catalog)
 │   ├── agent/           # Agent factory, onboarding, strategist, specialists, context window, session manager
-│   ├── tools/           # 12 @tool implementations (auto-discovered) + MCP manager
+│   ├── tools/           # 16 @tool implementations (auto-discovered) + MCP manager
 │   ├── plugins/         # Tool auto-discovery loader + registry
 │   ├── skills/          # SKILL.md plugin loader + manager
-│   ├── db/              # SQLModel engine + models (Session, Message, Goal, UserProfile, Memory, QueuedInsight)
+│   ├── db/              # SQLModel engine + models (Session, Message, Goal, UserProfile, Memory, QueuedInsight, Secret)
 │   ├── memory/          # Soul file, LanceDB vector store, embedder, consolidator
 │   ├── goals/           # Hierarchical goal CRUD repository
 │   ├── observer/        # Context manager, user state machine, delivery gate, insight queue, data sources
+│   ├── vault/           # Fernet-encrypted secret store (crypto, repository)
 │   └── scheduler/       # APScheduler engine, connection manager, 6 background jobs
 ├── data/
 │   ├── skills/          # SKILL.md plugin files (YAML frontmatter + instructions)

--- a/docs/docs/overview/next-steps.md
+++ b/docs/docs/overview/next-steps.md
@@ -9,7 +9,7 @@ sidebar_position: 4
 
 ## Current State
 
-Phases 0-3 are complete and functional. 520 automated tests (396 backend, 124 frontend). Clean codebase with no TODOs/FIXMEs. The project's unique advantages — proactive intelligence, RPG village metaphor, five-pillar life model, screen awareness — are implemented but not fully leveraged in the UI.
+Phases 0-3 are complete and functional. 624 automated tests (500 backend, 124 frontend). Clean codebase with no TODOs/FIXMEs. The project's unique advantages — proactive intelligence, RPG village metaphor, five-pillar life model, screen awareness — are implemented but not fully leveraged in the UI.
 
 ---
 
@@ -23,7 +23,7 @@ Phases 0-3 are complete and functional. 520 automated tests (396 backend, 124 fr
 
 4. ~~**Frontend Accessibility**~~ (3.5.9) — Done. Font sizes bumped to 9px minimum across all panels. Keyboard shortcuts: Shift+C (chat), Shift+Q (quests), Shift+S (settings), Escape (close). Shift modifier prevents WASD avatar movement conflict.
 
-7. ~~**SKILL.md Plugin Ecosystem**~~ (4.1) — Done. Zero-code markdown plugins in `data/skills/`. YAML frontmatter, tool gating, runtime enable/disable via API + Settings UI. 3 bundled examples.
+7. ~~**SKILL.md Plugin Ecosystem**~~ (4.1) — Done. Zero-code markdown plugins in `data/skills/`. YAML frontmatter, tool gating, runtime enable/disable via API + Settings UI. 8 bundled skills.
 
 5. ~~**Agent Execution Timeout**~~ (3.5.6) — Done. `asyncio.wait_for` timeouts on REST chat (504), daily briefing, evening review, memory consolidation LLM + add_memory calls. DDGS web search timeout via constructor. 3 new settings: `agent_briefing_timeout` (60s), `consolidation_llm_timeout` (30s), `web_search_timeout` (15s). 5 new tests.
 

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -302,7 +302,7 @@ Everything that exists is robust, polished, and installable. Ready to expand.
 - Zero-code markdown plugins in `data/skills/` with YAML frontmatter (`name`, `description`, `requires.tools`, `user_invocable`, `enabled`)
 - Tool gating: skills only loaded when required tools are available
 - Runtime enable/disable via `GET/PUT /api/skills` + Settings UI
-- 3 bundled examples: `daily-standup.md`, `code-review.md`, `goal-reflection.md`
+- 8 bundled skills: `daily-standup`, `code-review`, `goal-reflection`, `weekly-planner`, `morning-intention`, `evening-journal`, `moltbook` (requires `http_request`), `web-briefing` (requires `http_request` + `web_search`)
 
 ### 4.9 Recursive Delegation Architecture ✅
 - Orchestrator (no tools) delegates to domain specialists behind feature flag (`USE_DELEGATION=true`)

--- a/docs/docs/overview/status-report.md
+++ b/docs/docs/overview/status-report.md
@@ -11,7 +11,7 @@ sidebar_position: 3
 
 ## Executive Summary
 
-Seraph is in strong shape. Phases 0-3 are implemented and functional, delivering a proactive AI guardian with persistent identity, 12 tools, MCP extensibility, a sophisticated observer system, and a visually polished RPG village interface. The codebase is well-architected, clean, and production-quality for a single-user application.
+Seraph is in strong shape. Phases 0-3 are implemented and functional, delivering a proactive AI guardian with persistent identity, 16 tools, MCP extensibility, a sophisticated observer system, and a visually polished RPG village interface. The codebase is well-architected, clean, and production-quality for a single-user application.
 
 However, significant work remains to reach the stated vision of being "better than OpenClaw." OpenClaw exploded in late January 2026 (145k+ GitHub stars, millions of installs) and has become the defining AI agent of the moment. The competitive landscape has shifted dramatically. This report maps exactly where Seraph stands, what's missing, and what to prioritize.
 
@@ -25,7 +25,7 @@ However, significant work remains to reach the stated vision of being "better th
 |-------|--------|-----------------|
 | **0 - Foundation** | COMPLETE | Chat UI, WebSocket streaming, Phaser village, day/night cycle, wandering avatar |
 | **1 - Persistent Identity** | COMPLETE | Soul file, LanceDB vector memory, memory consolidation, hierarchical goals, onboarding |
-| **2 - Capable Executor** | COMPLETE | 12 auto-discovered tools, shell sandbox, browser automation, MCP support, tool registry |
+| **2 - Capable Executor** | COMPLETE | 16 auto-discovered tools, shell sandbox, browser automation, MCP support, tool registry, encrypted vault |
 | **3 - The Observer** | COMPLETE | APScheduler (6 jobs), user state machine (6 states), attention guardian, insight queue, macOS daemon |
 
 ### Backend Assessment: 85-90% Complete
@@ -35,7 +35,7 @@ However, significant work remains to reach the stated vision of being "better th
 - Robust async WebSocket streaming with step visibility
 - Full observer pipeline: daemon -> context manager -> user state machine -> delivery gate -> insight queue
 - 6 background jobs: memory consolidation (30min), goal check (4h), calendar scan (15min), strategist tick (15min), daily briefing (8AM), evening review (9PM)
-- Clean API surface: 15+ endpoints covering chat, sessions, goals, tools, MCP, observer, settings
+- Clean API surface: 35+ endpoints covering chat, sessions, goals, tools, MCP, skills, observer, settings, vault, catalog
 
 **Issues Found:**
 - `calendar_scan` job is registered in the scheduler but the implementation file appears incomplete/missing
@@ -53,12 +53,12 @@ However, significant work remains to reach the stated vision of being "better th
 - 125 distinct asset files (54 characters, 55 enemies, 22 tilesets, 15 animation sheets)
 - All animation states working: idle, thinking, walking, wandering, casting, speaking
 
-**Issues Found:**
-- No goal creation UI in the frontend (backend supports it, but users can only create goals through chat)
-- No interruption mode toggle in settings (backend API exists at `/api/settings/interruption-mode`, no frontend UI)
-- Quest panel has no search/filter/sort capabilities
-- Font sizes are tiny (7-9px) which may be hard to read
-- No keyboard shortcuts for panel toggling
+**Issues Found (all resolved):**
+- ~~No goal creation UI in the frontend~~ → Resolved: `GoalForm.tsx` with create/edit modal
+- ~~No interruption mode toggle in settings~~ → Resolved: `InterruptionModeToggle.tsx` in Settings panel
+- ~~Quest panel has no search/filter/sort capabilities~~ → Resolved: text search + level/domain dropdowns
+- ~~Font sizes are tiny (7-9px)~~ → Resolved: 9px minimum across all panels
+- ~~No keyboard shortcuts for panel toggling~~ → Resolved: Shift+C/Q/S, Escape
 
 ### Editor Assessment: Production-Ready
 

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -28,7 +28,7 @@ OPENROUTER_API_KEY=sk-or-v1-your-key-here
 
 | Variable | Default | Description |
 |---|---|---|
-| `DEFAULT_MODEL` | `openrouter/x-ai/grok-4.1-fast` | LLM model for the agent (any OpenRouter model) |
+| `DEFAULT_MODEL` | `openrouter/anthropic/claude-sonnet-4` | LLM model for the agent (any OpenRouter model) |
 | `MODEL_TEMPERATURE` | `0.7` | Sampling temperature |
 | `MODEL_MAX_TOKENS` | `4096` | Max tokens per response |
 | `AGENT_MAX_STEPS` | `10` | Max reasoning steps per turn |
@@ -101,9 +101,10 @@ All settings with their defaults are defined in `backend/config/settings.py`.
 ./manage.sh -e dev up -d
 ```
 
-This starts three containers:
+This starts four containers:
 - **backend-dev** (`localhost:8004`) — FastAPI + uvicorn
 - **sandbox-dev** — snekbox (sandboxed shell execution)
+- **http-mcp** — FastMCP HTTP request tool server (internal network only)
 - **frontend-dev** (`localhost:3000`) — Vite dev server
 
 Verify everything is running:
@@ -324,7 +325,7 @@ Skills can be managed via:
 - **REST API**: `GET /api/skills`, `PUT /api/skills/{name}`, `POST /api/skills/reload`
 - **Tool gating**: Skills with `requires.tools` only activate when required tools are available
 
-Three bundled examples: `daily-standup.md`, `code-review.md`, `goal-reflection.md`.
+Eight bundled skills: `daily-standup`, `code-review`, `goal-reflection`, `weekly-planner`, `morning-intention`, `evening-journal`, `moltbook` (requires `http_request`), `web-briefing` (requires `http_request` + `web_search`).
 
 ## Optional: Village Map Editor
 


### PR DESCRIPTION
## Summary
- Syncs Docusaurus docs with actual codebase after vault, http-mcp, new tests, and skills additions
- Updates tool counts (12→16), service counts (3→4), test counts (520→624) across 10 files
- Rebuilds test tables with all 47 backend + 10 frontend test files
- Fixes observer/skills file structures, daemon OCR status, intervention type enums, and marks resolved frontend issues

## Test plan
- [x] `cd docs && npm run build` passes with no broken links or build errors
- [x] Cross-referenced all changes against CLAUDE.md and actual codebase files

🤖 Generated with [Claude Code](https://claude.com/claude-code)