### PR TITLE
docs: add LLM call logging documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Seraph is an AI agent with a retro 16-bit RPG village UI. A Phaser 3 canvas rend
 
 ### Backend (`backend/`)
 - **Stack**: Python 3.12, FastAPI, uvicorn, smolagents, LiteLLM (OpenRouter)
-- **Entry**: `main.py` → `src/app.py` (factory pattern with lifespan: init DB, ensure soul file)
+- **Entry**: `main.py` → `src/app.py` (factory pattern with lifespan: init DB, ensure soul file, init LLM logging)
 - **API routes** (`src/api/router.py`):
   - `src/api/chat.py` — `POST /api/chat` (REST chat, secondary to WS)
   - `src/api/ws.py` — `WS /ws/chat` (primary streaming interface)
@@ -242,6 +242,12 @@ Seraph is an AI agent with a retro 16-bit RPG village UI. A Phaser 3 canvas rend
   - `working_hours_start: int = 9`, `working_hours_end: int = 17`
   - `observer_git_repo_path: str = ""` — git repo to monitor
   - `deep_work_apps: str = ""` — custom app names that trigger deep_work state
+- **LLM call logging settings** (`config/settings.py`):
+  - `llm_log_enabled: bool = True` — enable LLM call logging
+  - `llm_log_content: bool = False` — include messages/response (large, privacy-sensitive)
+  - `llm_log_dir: str = "/app/logs"` — log file directory
+  - `llm_log_max_bytes: int = 52_428_800` — 50 MB per file
+  - `llm_log_backup_count: int = 5` — keep 5 rotated files
 - **Sandbox / browser settings** (`config/settings.py`):
   - `sandbox_url: str = "http://sandbox:8060"`, `sandbox_timeout: int = 35`
   - `browser_timeout: int = 30`

--- a/backend/README.md
+++ b/backend/README.md
@@ -68,6 +68,11 @@ Receive (streamed):
 | `AGENT_MAX_STEPS` | `10` | Max agent reasoning steps |
 | `DEBUG` | `false` | Enable debug mode |
 | `WORKSPACE_DIR` | `/app/data` | Agent file workspace |
+| `LLM_LOG_ENABLED` | `true` | Enable LLM call logging to JSONL file |
+| `LLM_LOG_CONTENT` | `false` | Include full messages/response in log |
+| `LLM_LOG_DIR` | `/app/logs` | Log file directory |
+| `LLM_LOG_MAX_BYTES` | `52428800` | Max bytes per log file before rotation (50 MB) |
+| `LLM_LOG_BACKUP_COUNT` | `5` | Number of rotated log files to keep |
 
 ## Testing
 

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -93,6 +93,18 @@ Recursive delegation is an experimental feature where the agent delegates to spe
 | `DELEGATION_MAX_DEPTH` | `1` | Max nesting depth (1 = orchestrator → specialists) |
 | `ORCHESTRATOR_MAX_STEPS` | `8` | Max delegation steps for orchestrator |
 
+### Optional LLM call logging settings
+
+These control per-call observability logging for all LiteLLM calls (direct and via smolagents):
+
+| Variable | Default | Description |
+|---|---|---|
+| `LLM_LOG_ENABLED` | `true` | Enable LLM call logging to JSONL file |
+| `LLM_LOG_CONTENT` | `false` | Include full messages and response text (large, privacy-sensitive) |
+| `LLM_LOG_DIR` | `/app/logs` | Directory for log files |
+| `LLM_LOG_MAX_BYTES` | `52428800` | Max bytes per log file before rotation (default 50 MB) |
+| `LLM_LOG_BACKUP_COUNT` | `5` | Number of rotated log files to keep |
+
 All settings with their defaults are defined in `backend/config/settings.py`.
 
 ## Start the stack


### PR DESCRIPTION
## Summary
- Add LLM logging settings table to setup guide (`docs/docs/setup.md`)
- Add LLM logging env vars to backend README
- Add section 3.5.10 (LLM Call Logging) to phase 3.5 doc with verification checklist item
- Update CLAUDE.md with lifespan description and settings block for LLM logging

## Test plan
- [ ] Docs build without errors
- [ ] All new env vars match `backend/config/settings.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)