### PR TITLE
feat: screen activity tracking with structured analysis and daily/weekly digests

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -50,6 +50,11 @@ class Settings(BaseSettings):
     observer_git_repo_path: str = ""
     deep_work_apps: str = ""  # comma-separated extra app keywords for deep work detection
 
+    # Screen Activity Tracking
+    activity_digest_hour: int = 20                    # 8 PM daily digest
+    weekly_review_hour: int = 18                      # 6 PM Sunday weekly review
+    screen_observation_retention_days: int = 90        # keep 90 days of observations
+
     # Vault
     vault_encryption_key: str = ""  # Fernet key; auto-generates key file when empty
 

--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -1,18 +1,34 @@
 """Observer API — context state and daemon integration endpoints."""
 
+import logging
 import time
+from datetime import date, datetime, timezone
 
 from fastapi import APIRouter
 from pydantic import BaseModel
 
 from src.observer.manager import context_manager
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+
+class ScreenObservationData(BaseModel):
+    app: str | None = None
+    window_title: str | None = None
+    activity: str | None = None
+    project: str | None = None
+    summary: str | None = None
+    details: list[str] | None = None
+    blocked: bool = False
 
 
 class ScreenContextRequest(BaseModel):
     active_window: str | None = None
     screen_context: str | None = None
+    observation: ScreenObservationData | None = None
+    switch_timestamp: float | None = None
 
 
 @router.get("/observer/state")
@@ -25,6 +41,32 @@ async def get_observer_state():
 async def post_screen_context(body: ScreenContextRequest):
     """Receive screen context from native daemon."""
     context_manager.update_screen_context(body.active_window, body.screen_context)
+
+    # Persist structured observation if present
+    if body.observation is not None:
+        try:
+            from src.observer.screen_repository import screen_observation_repo
+
+            obs_data = body.observation
+            timestamp = (
+                datetime.fromtimestamp(body.switch_timestamp, tz=timezone.utc)
+                if body.switch_timestamp
+                else None
+            )
+
+            await screen_observation_repo.create(
+                app_name=obs_data.app or "",
+                window_title=obs_data.window_title or "",
+                activity_type=obs_data.activity or "other",
+                project=obs_data.project,
+                summary=obs_data.summary,
+                details=obs_data.details,
+                blocked=obs_data.blocked,
+                timestamp=timestamp,
+            )
+        except Exception:
+            logger.exception("Failed to persist screen observation")
+
     return {"status": "ok"}
 
 
@@ -42,6 +84,19 @@ async def daemon_status():
         "active_window": ctx.active_window,
         "has_screen_context": bool(ctx.screen_context),
     }
+
+
+@router.get("/observer/activity/today")
+async def get_activity_today():
+    """Return today's activity summary from screen observations."""
+    try:
+        from src.observer.screen_repository import screen_observation_repo
+
+        summary = await screen_observation_repo.get_daily_summary(date.today())
+        return summary
+    except Exception:
+        logger.exception("Failed to get daily activity summary")
+        return {"error": "Failed to retrieve activity summary"}
 
 
 @router.post("/observer/refresh")

--- a/backend/src/db/models.py
+++ b/backend/src/db/models.py
@@ -141,6 +141,24 @@ class QueuedInsight(SQLModel, table=True):
     created_at: datetime = Field(default_factory=_now)
 
 
+# ─── ScreenObservation ─────────────────────────────────
+
+class ScreenObservation(SQLModel, table=True):
+    __tablename__ = "screen_observations"
+
+    id: str = Field(default_factory=_uuid, primary_key=True)
+    timestamp: datetime = Field(default_factory=_now, index=True)
+    app_name: str = Field(index=True)
+    window_title: str = Field(default="")
+    activity_type: str = Field(default="other", index=True)
+    project: Optional[str] = Field(default=None, index=True)
+    summary: Optional[str] = Field(default=None)
+    details_json: Optional[str] = Field(default=None)
+    duration_s: Optional[int] = Field(default=None)
+    blocked: bool = Field(default=False)
+    created_at: datetime = Field(default_factory=_now)
+
+
 # ─── Secret (Vault) ─────────────────────────────────────
 
 class Secret(SQLModel, table=True):

--- a/backend/src/observer/screen_repository.py
+++ b/backend/src/observer/screen_repository.py
@@ -1,0 +1,205 @@
+"""Screen observation repository — CRUD and aggregation for activity tracking."""
+
+import json
+import logging
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from sqlmodel import select, func, col
+
+from src.db.engine import get_session
+from src.db.models import ScreenObservation
+
+logger = logging.getLogger(__name__)
+
+
+class ScreenObservationRepository:
+    """Async CRUD and aggregation for screen observations."""
+
+    async def create(
+        self,
+        app_name: str,
+        window_title: str = "",
+        activity_type: str = "other",
+        project: str | None = None,
+        summary: str | None = None,
+        details: list[str] | None = None,
+        blocked: bool = False,
+        timestamp: datetime | None = None,
+    ) -> ScreenObservation:
+        """Insert a new observation and backfill duration on the previous one."""
+        now = timestamp or datetime.now(timezone.utc)
+
+        obs = ScreenObservation(
+            timestamp=now,
+            app_name=app_name,
+            window_title=window_title,
+            activity_type=activity_type,
+            project=project,
+            summary=summary,
+            details_json=json.dumps(details) if details else None,
+            blocked=blocked,
+        )
+
+        async with get_session() as db:
+            # Backfill duration on the previous observation
+            result = await db.execute(
+                select(ScreenObservation)
+                .where(col(ScreenObservation.duration_s).is_(None))
+                .where(col(ScreenObservation.timestamp) < now)
+                .order_by(col(ScreenObservation.timestamp).desc())
+                .limit(1)
+            )
+            prev = result.scalar_one_or_none()
+            if prev is not None:
+                # SQLite strips timezone info; ensure both are tz-aware
+                prev_ts = prev.timestamp
+                if prev_ts.tzinfo is None:
+                    prev_ts = prev_ts.replace(tzinfo=timezone.utc)
+                delta = (now - prev_ts).total_seconds()
+                prev.duration_s = int(delta)
+                db.add(prev)
+
+            db.add(obs)
+
+        return obs
+
+    async def get_daily_summary(self, target_date: date) -> dict[str, Any]:
+        """Aggregate observations for a single day."""
+        start = datetime(target_date.year, target_date.month, target_date.day, tzinfo=timezone.utc)
+        end = start + timedelta(days=1)
+
+        async with get_session() as db:
+            result = await db.execute(
+                select(ScreenObservation)
+                .where(col(ScreenObservation.timestamp) >= start)
+                .where(col(ScreenObservation.timestamp) < end)
+                .where(col(ScreenObservation.blocked) == False)  # noqa: E712
+                .order_by(col(ScreenObservation.timestamp))
+            )
+            observations = list(result.scalars().all())
+
+        if not observations:
+            return {"date": target_date.isoformat(), "total_observations": 0}
+
+        # Aggregate by activity type
+        by_activity: dict[str, int] = {}
+        by_project: dict[str, int] = {}
+        by_app: dict[str, int] = {}
+        total_tracked_s = 0
+
+        for obs in observations:
+            dur = obs.duration_s or 0
+            total_tracked_s += dur
+
+            by_activity[obs.activity_type] = by_activity.get(obs.activity_type, 0) + dur
+
+            if obs.project:
+                by_project[obs.project] = by_project.get(obs.project, 0) + dur
+
+            by_app[obs.app_name] = by_app.get(obs.app_name, 0) + dur
+
+        # Find longest focus streaks (consecutive same-activity observations)
+        streaks = self._compute_streaks(observations)
+
+        return {
+            "date": target_date.isoformat(),
+            "total_observations": len(observations),
+            "total_tracked_minutes": total_tracked_s // 60,
+            "switch_count": len(observations),
+            "by_activity": dict(sorted(by_activity.items(), key=lambda x: -x[1])),
+            "by_project": dict(sorted(by_project.items(), key=lambda x: -x[1])),
+            "by_app": dict(sorted(by_app.items(), key=lambda x: -x[1])),
+            "longest_streaks": streaks[:3],
+        }
+
+    async def get_weekly_summary(self, week_start: date) -> dict[str, Any]:
+        """Aggregate observations for a 7-day period starting from week_start."""
+        daily_summaries = []
+        combined_activity: dict[str, int] = {}
+        combined_project: dict[str, int] = {}
+        total_observations = 0
+        total_minutes = 0
+
+        for i in range(7):
+            day = week_start + timedelta(days=i)
+            daily = await self.get_daily_summary(day)
+            daily_summaries.append(daily)
+            total_observations += daily.get("total_observations", 0)
+            total_minutes += daily.get("total_tracked_minutes", 0)
+
+            for act, secs in daily.get("by_activity", {}).items():
+                combined_activity[act] = combined_activity.get(act, 0) + secs
+            for proj, secs in daily.get("by_project", {}).items():
+                combined_project[proj] = combined_project.get(proj, 0) + secs
+
+        return {
+            "week_start": week_start.isoformat(),
+            "week_end": (week_start + timedelta(days=6)).isoformat(),
+            "total_observations": total_observations,
+            "total_tracked_minutes": total_minutes,
+            "by_activity": dict(sorted(combined_activity.items(), key=lambda x: -x[1])),
+            "by_project": dict(sorted(combined_project.items(), key=lambda x: -x[1])),
+            "daily_breakdown": [
+                {
+                    "date": d.get("date"),
+                    "observations": d.get("total_observations", 0),
+                    "tracked_minutes": d.get("total_tracked_minutes", 0),
+                }
+                for d in daily_summaries
+            ],
+        }
+
+    async def cleanup_old(self, retention_days: int) -> int:
+        """Delete observations older than retention_days. Returns count deleted."""
+        cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+
+        async with get_session() as db:
+            result = await db.execute(
+                select(ScreenObservation).where(col(ScreenObservation.timestamp) < cutoff)
+            )
+            old = list(result.scalars().all())
+            for obs in old:
+                await db.delete(obs)
+
+        if old:
+            logger.info("Cleaned up %d screen observations older than %d days", len(old), retention_days)
+        return len(old)
+
+    @staticmethod
+    def _compute_streaks(observations: list[ScreenObservation]) -> list[dict]:
+        """Find longest consecutive same-activity streaks."""
+        if not observations:
+            return []
+
+        streaks: list[dict] = []
+        current_activity = observations[0].activity_type
+        streak_start = observations[0].timestamp
+        streak_duration = observations[0].duration_s or 0
+
+        for obs in observations[1:]:
+            if obs.activity_type == current_activity:
+                streak_duration += obs.duration_s or 0
+            else:
+                if streak_duration > 0:
+                    streaks.append({
+                        "activity": current_activity,
+                        "duration_minutes": streak_duration // 60,
+                        "started_at": streak_start.isoformat(),
+                    })
+                current_activity = obs.activity_type
+                streak_start = obs.timestamp
+                streak_duration = obs.duration_s or 0
+
+        # Final streak
+        if streak_duration > 0:
+            streaks.append({
+                "activity": current_activity,
+                "duration_minutes": streak_duration // 60,
+                "started_at": streak_start.isoformat(),
+            })
+
+        return sorted(streaks, key=lambda s: -s["duration_minutes"])
+
+
+screen_observation_repo = ScreenObservationRepository()

--- a/backend/src/scheduler/engine.py
+++ b/backend/src/scheduler/engine.py
@@ -60,6 +60,9 @@ def init_scheduler() -> AsyncIOScheduler | None:
     from src.scheduler.jobs.strategist_tick import run_strategist_tick
     from src.scheduler.jobs.daily_briefing import run_daily_briefing
     from src.scheduler.jobs.evening_review import run_evening_review
+    from src.scheduler.jobs.activity_digest import run_activity_digest
+    from src.scheduler.jobs.weekly_activity_review import run_weekly_activity_review
+    from src.scheduler.jobs.screen_cleanup import run_screen_cleanup
 
     jobs = [
         {
@@ -103,6 +106,31 @@ def init_scheduler() -> AsyncIOScheduler | None:
             ),
             "id": "evening_review",
             "name": "Evening review",
+        },
+        {
+            "func": _async_job_wrapper(run_activity_digest, loop),
+            "trigger": CronTrigger(
+                hour=settings.activity_digest_hour,
+                timezone=validated_tz,
+            ),
+            "id": "activity_digest",
+            "name": "Activity digest",
+        },
+        {
+            "func": _async_job_wrapper(run_weekly_activity_review, loop),
+            "trigger": CronTrigger(
+                day_of_week="sun",
+                hour=settings.weekly_review_hour,
+                timezone=validated_tz,
+            ),
+            "id": "weekly_activity_review",
+            "name": "Weekly activity review",
+        },
+        {
+            "func": _async_job_wrapper(run_screen_cleanup, loop),
+            "trigger": CronTrigger(hour=3, timezone=validated_tz),
+            "id": "screen_cleanup",
+            "name": "Screen observation cleanup",
         },
     ]
 

--- a/backend/src/scheduler/jobs/activity_digest.py
+++ b/backend/src/scheduler/jobs/activity_digest.py
@@ -1,0 +1,115 @@
+"""Activity digest — generates and delivers a daily screen activity summary."""
+
+import asyncio
+import logging
+from datetime import date
+
+from config.settings import settings
+from src.models.schemas import WSResponse
+
+logger = logging.getLogger(__name__)
+
+_DIGEST_PROMPT = """\
+You are Seraph, a guardian intelligence. Generate a concise daily activity digest for your human.
+
+Keep the RPG framing light. Be observational and constructive.
+
+## User Identity
+{soul}
+
+## Today's Screen Activity
+- Total tracked time: {total_minutes} minutes
+- Context switches: {switch_count}
+
+## Time by Activity Type
+{activity_breakdown}
+
+## Time by Project
+{project_breakdown}
+
+## Longest Focus Streaks
+{streaks}
+
+Write a short activity digest (4-8 sentences) covering:
+1. Time distribution highlights (where did most time go?)
+2. Focus patterns (long streaks? frequent switching?)
+3. One concrete observation about work patterns
+4. One suggestion for tomorrow
+
+Be concise. No preamble. Just the digest text."""
+
+
+async def run_activity_digest() -> None:
+    """Generate and send the daily activity digest to connected clients."""
+    try:
+        from src.observer.screen_repository import screen_observation_repo
+        from src.memory.soul import read_soul
+
+        summary = await screen_observation_repo.get_daily_summary(date.today())
+
+        if summary.get("total_observations", 0) == 0:
+            logger.info("activity_digest: no observations today — skipping")
+            return
+
+        soul = read_soul()
+
+        # Format breakdowns
+        activity_breakdown = "\n".join(
+            f"- {act}: {secs // 60}m"
+            for act, secs in summary.get("by_activity", {}).items()
+        ) or "No data"
+
+        project_breakdown = "\n".join(
+            f"- {proj}: {secs // 60}m"
+            for proj, secs in summary.get("by_project", {}).items()
+        ) or "No projects detected"
+
+        streaks = "\n".join(
+            f"- {s['activity']}: {s['duration_minutes']}m (started {s['started_at'][:16]})"
+            for s in summary.get("longest_streaks", [])
+        ) or "No significant streaks"
+
+        prompt = _DIGEST_PROMPT.format(
+            soul=soul,
+            total_minutes=summary.get("total_tracked_minutes", 0),
+            switch_count=summary.get("switch_count", 0),
+            activity_breakdown=activity_breakdown,
+            project_breakdown=project_breakdown,
+            streaks=streaks,
+        )
+
+        import litellm
+
+        try:
+            response = await asyncio.wait_for(
+                asyncio.to_thread(
+                    litellm.completion,
+                    model=settings.default_model,
+                    messages=[{"role": "user", "content": prompt}],
+                    api_key=settings.openrouter_api_key,
+                    api_base="https://openrouter.ai/api/v1",
+                    temperature=0.6,
+                    max_tokens=768,
+                ),
+                timeout=settings.agent_briefing_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("activity_digest: LLM timed out after %ds", settings.agent_briefing_timeout)
+            return
+
+        digest_text = response.choices[0].message.content.strip()
+
+        from src.observer.delivery import deliver_or_queue
+
+        message = WSResponse(
+            type="proactive",
+            content=digest_text,
+            intervention_type="advisory",
+            urgency=2,
+            reasoning="Scheduled daily activity digest",
+        )
+        await deliver_or_queue(message, is_scheduled=True)
+        logger.info("activity_digest: delivered daily digest")
+
+    except Exception:
+        logger.exception("activity_digest failed")

--- a/backend/src/scheduler/jobs/screen_cleanup.py
+++ b/backend/src/scheduler/jobs/screen_cleanup.py
@@ -1,0 +1,25 @@
+"""Screen observation cleanup — deletes observations older than retention period."""
+
+import logging
+
+from config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def run_screen_cleanup() -> None:
+    """Delete screen observations older than the configured retention period."""
+    try:
+        from src.observer.screen_repository import screen_observation_repo
+
+        deleted = await screen_observation_repo.cleanup_old(
+            settings.screen_observation_retention_days
+        )
+        if deleted > 0:
+            logger.info(
+                "screen_cleanup: removed %d observations older than %d days",
+                deleted,
+                settings.screen_observation_retention_days,
+            )
+    except Exception:
+        logger.exception("screen_cleanup failed")

--- a/backend/src/scheduler/jobs/weekly_activity_review.py
+++ b/backend/src/scheduler/jobs/weekly_activity_review.py
@@ -1,0 +1,122 @@
+"""Weekly activity review — generates and delivers a weekly screen activity analysis."""
+
+import asyncio
+import logging
+from datetime import date, timedelta
+
+from config.settings import settings
+from src.models.schemas import WSResponse
+
+logger = logging.getLogger(__name__)
+
+_WEEKLY_PROMPT = """\
+You are Seraph, a guardian intelligence. Generate a weekly activity review for your human.
+
+Keep the RPG framing light. Be analytical and forward-looking.
+
+## User Identity
+{soul}
+
+## This Week's Screen Activity ({week_start} to {week_end})
+- Total tracked time: {total_minutes} minutes
+- Total context switches: {total_observations}
+
+## Weekly Activity Breakdown
+{activity_breakdown}
+
+## Project Allocation
+{project_breakdown}
+
+## Daily Breakdown
+{daily_breakdown}
+
+Write a weekly activity review (5-10 sentences) covering:
+1. Weekly overview — where did time go?
+2. Daily patterns — which days were most productive?
+3. Project allocation — balanced or lopsided?
+4. Two suggestions for next week
+5. One automation or workflow idea
+
+Be concise. No preamble. Just the review text."""
+
+
+async def run_weekly_activity_review() -> None:
+    """Generate and send the weekly activity review to connected clients."""
+    try:
+        from src.observer.screen_repository import screen_observation_repo
+        from src.memory.soul import read_soul
+
+        # Calculate the Monday of the current week
+        today = date.today()
+        week_start = today - timedelta(days=today.weekday())
+
+        summary = await screen_observation_repo.get_weekly_summary(week_start)
+
+        if summary.get("total_observations", 0) == 0:
+            logger.info("weekly_activity_review: no observations this week — skipping")
+            return
+
+        soul = read_soul()
+
+        activity_breakdown = "\n".join(
+            f"- {act}: {secs // 60}m"
+            for act, secs in summary.get("by_activity", {}).items()
+        ) or "No data"
+
+        project_breakdown = "\n".join(
+            f"- {proj}: {secs // 60}m"
+            for proj, secs in summary.get("by_project", {}).items()
+        ) or "No projects detected"
+
+        daily_breakdown = "\n".join(
+            f"- {d['date']}: {d['tracked_minutes']}m tracked, {d['observations']} switches"
+            for d in summary.get("daily_breakdown", [])
+            if d.get("observations", 0) > 0
+        ) or "No daily data"
+
+        prompt = _WEEKLY_PROMPT.format(
+            soul=soul,
+            week_start=summary.get("week_start", ""),
+            week_end=summary.get("week_end", ""),
+            total_minutes=summary.get("total_tracked_minutes", 0),
+            total_observations=summary.get("total_observations", 0),
+            activity_breakdown=activity_breakdown,
+            project_breakdown=project_breakdown,
+            daily_breakdown=daily_breakdown,
+        )
+
+        import litellm
+
+        try:
+            response = await asyncio.wait_for(
+                asyncio.to_thread(
+                    litellm.completion,
+                    model=settings.default_model,
+                    messages=[{"role": "user", "content": prompt}],
+                    api_key=settings.openrouter_api_key,
+                    api_base="https://openrouter.ai/api/v1",
+                    temperature=0.6,
+                    max_tokens=1024,
+                ),
+                timeout=settings.agent_briefing_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("weekly_activity_review: LLM timed out after %ds", settings.agent_briefing_timeout)
+            return
+
+        review_text = response.choices[0].message.content.strip()
+
+        from src.observer.delivery import deliver_or_queue
+
+        message = WSResponse(
+            type="proactive",
+            content=review_text,
+            intervention_type="advisory",
+            urgency=2,
+            reasoning="Scheduled weekly activity review",
+        )
+        await deliver_or_queue(message, is_scheduled=True)
+        logger.info("weekly_activity_review: delivered weekly review")
+
+    except Exception:
+        logger.exception("weekly_activity_review failed")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,6 +25,7 @@ _PATCH_TARGETS = [
     "src.scheduler.jobs.memory_consolidation.get_session",
     "src.observer.insight_queue.get_session",
     "src.vault.repository.get_session",
+    "src.observer.screen_repository.get_session",
 ]
 
 

--- a/backend/tests/test_activity_digest.py
+++ b/backend/tests/test_activity_digest.py
@@ -1,0 +1,95 @@
+"""Tests for the daily activity digest scheduler job."""
+
+import asyncio
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestActivityDigest:
+    @pytest.mark.asyncio
+    async def test_skips_when_no_observations(self):
+        """Digest should skip when there are no observations today."""
+        mock_repo = MagicMock()
+        mock_repo.get_daily_summary = AsyncMock(return_value={
+            "date": date.today().isoformat(),
+            "total_observations": 0,
+        })
+
+        with patch(
+            "src.observer.screen_repository.screen_observation_repo",
+            mock_repo,
+        ):
+            from src.scheduler.jobs.activity_digest import run_activity_digest
+            await run_activity_digest()
+
+        # LLM should NOT be called
+        mock_repo.get_daily_summary.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        """Digest should generate and deliver when observations exist."""
+        mock_repo = MagicMock()
+        mock_repo.get_daily_summary = AsyncMock(return_value={
+            "date": date.today().isoformat(),
+            "total_observations": 15,
+            "total_tracked_minutes": 120,
+            "switch_count": 15,
+            "by_activity": {"coding": 5400, "browsing": 1800},
+            "by_project": {"seraph": 3600},
+            "longest_streaks": [
+                {"activity": "coding", "duration_minutes": 45, "started_at": "2025-01-01T09:00"},
+            ],
+        })
+
+        mock_soul = "Test soul content"
+        mock_llm_response = MagicMock()
+        mock_llm_response.choices = [MagicMock()]
+        mock_llm_response.choices[0].message.content = "Your daily digest text here."
+
+        mock_deliver = AsyncMock()
+
+        with patch("src.observer.screen_repository.screen_observation_repo", mock_repo), \
+             patch("src.memory.soul.read_soul", return_value=mock_soul), \
+             patch("litellm.completion", return_value=mock_llm_response), \
+             patch("src.observer.delivery.deliver_or_queue", mock_deliver):
+
+            from src.scheduler.jobs.activity_digest import run_activity_digest
+            await run_activity_digest()
+
+        mock_deliver.assert_called_once()
+        call_args = mock_deliver.call_args
+        assert call_args[0][0].content == "Your daily digest text here."
+        assert call_args[1]["is_scheduled"] is True
+
+    @pytest.mark.asyncio
+    async def test_llm_timeout(self):
+        """Digest should handle LLM timeout gracefully."""
+        mock_repo = MagicMock()
+        mock_repo.get_daily_summary = AsyncMock(return_value={
+            "date": date.today().isoformat(),
+            "total_observations": 5,
+            "total_tracked_minutes": 60,
+            "switch_count": 5,
+            "by_activity": {"coding": 3600},
+            "by_project": {},
+            "longest_streaks": [],
+        })
+
+        async def slow_completion(*args, **kwargs):
+            await asyncio.sleep(999)
+
+        mock_deliver = AsyncMock()
+
+        with patch("src.observer.screen_repository.screen_observation_repo", mock_repo), \
+             patch("src.memory.soul.read_soul", return_value="soul"), \
+             patch("litellm.completion", side_effect=slow_completion), \
+             patch("src.observer.delivery.deliver_or_queue", mock_deliver), \
+             patch("config.settings.settings.agent_briefing_timeout", 0.01):
+
+            from src.scheduler.jobs.activity_digest import run_activity_digest
+            await run_activity_digest()
+
+        # Should NOT deliver on timeout
+        mock_deliver.assert_not_called()

--- a/backend/tests/test_observer_api.py
+++ b/backend/tests/test_observer_api.py
@@ -6,6 +6,7 @@ import pytest_asyncio
 
 from src.observer.context import CurrentContext
 from src.observer.manager import ContextManager
+from src.observer.screen_repository import ScreenObservationRepository
 
 
 class TestObserverAPI:
@@ -103,3 +104,86 @@ class TestObserverAPI:
         data = resp.json()
         assert data["time_of_day"] == "evening"
         mgr.refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_post_structured_observation(self, async_db, client):
+        """Posting with observation field should persist to screen_observations table."""
+        mgr = ContextManager()
+        with patch("src.api.observer.context_manager", mgr):
+            resp = await client.post("/api/observer/context", json={
+                "active_window": "VS Code — main.py",
+                "observation": {
+                    "app": "VS Code",
+                    "window_title": "main.py",
+                    "activity": "coding",
+                    "project": "seraph",
+                    "summary": "Editing Python file",
+                    "details": ["file: main.py"],
+                    "blocked": False,
+                },
+                "switch_timestamp": 1700000000.0,
+            })
+
+        assert resp.status_code == 200
+        assert mgr.get_context().active_window == "VS Code — main.py"
+
+        # Verify observation was persisted
+        from src.db.models import ScreenObservation
+        from sqlmodel import select
+        async with async_db() as db:
+            result = await db.execute(select(ScreenObservation))
+            obs = result.scalar_one()
+
+        assert obs.app_name == "VS Code"
+        assert obs.activity_type == "coding"
+        assert obs.project == "seraph"
+
+    @pytest.mark.asyncio
+    async def test_post_blocked_observation(self, async_db, client):
+        """Blocked observations should be persisted with blocked=True."""
+        mgr = ContextManager()
+        with patch("src.api.observer.context_manager", mgr):
+            resp = await client.post("/api/observer/context", json={
+                "active_window": "1Password — Vault",
+                "observation": {
+                    "app": "1Password",
+                    "blocked": True,
+                },
+            })
+
+        assert resp.status_code == 200
+
+        from src.db.models import ScreenObservation
+        from sqlmodel import select
+        async with async_db() as db:
+            result = await db.execute(select(ScreenObservation))
+            obs = result.scalar_one()
+
+        assert obs.app_name == "1Password"
+        assert obs.blocked is True
+        assert obs.activity_type == "other"
+
+    @pytest.mark.asyncio
+    async def test_legacy_compat_no_observation(self, client):
+        """Legacy POST without observation field should still work."""
+        mgr = ContextManager()
+        with patch("src.api.observer.context_manager", mgr):
+            resp = await client.post("/api/observer/context", json={
+                "active_window": "Terminal",
+                "screen_context": "Running tests",
+            })
+
+        assert resp.status_code == 200
+        assert mgr.get_context().active_window == "Terminal"
+        assert mgr.get_context().screen_context == "Running tests"
+
+    @pytest.mark.asyncio
+    async def test_get_activity_today(self, async_db, client):
+        """Activity today endpoint should return daily summary."""
+        mgr = ContextManager()
+        with patch("src.api.observer.context_manager", mgr):
+            resp = await client.get("/api/observer/activity/today")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "total_observations" in data

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -95,6 +95,8 @@ class TestSchedulerEngine:
             mock_settings.strategist_interval_min = 15
             mock_settings.morning_briefing_hour = 8
             mock_settings.evening_review_hour = 21
+            mock_settings.activity_digest_hour = 20
+            mock_settings.weekly_review_hour = 18
             mock_settings.user_timezone = "UTC"
 
             from src.scheduler.engine import init_scheduler, shutdown_scheduler
@@ -110,6 +112,9 @@ class TestSchedulerEngine:
                     "strategist_tick",
                     "daily_briefing",
                     "evening_review",
+                    "activity_digest",
+                    "weekly_activity_review",
+                    "screen_cleanup",
                 }
             finally:
                 shutdown_scheduler()

--- a/backend/tests/test_screen_observation.py
+++ b/backend/tests/test_screen_observation.py
@@ -1,0 +1,177 @@
+"""Tests for screen observation repository and model."""
+
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+
+from src.db.models import ScreenObservation
+from src.observer.screen_repository import ScreenObservationRepository
+
+
+class TestScreenObservationRepository:
+    @pytest.mark.asyncio
+    async def test_create_observation(self, async_db):
+        repo = ScreenObservationRepository()
+        obs = await repo.create(
+            app_name="VS Code",
+            window_title="main.py",
+            activity_type="coding",
+            project="seraph",
+            summary="Editing Python file",
+        )
+        assert obs.app_name == "VS Code"
+        assert obs.activity_type == "coding"
+        assert obs.project == "seraph"
+        assert obs.blocked is False
+
+    @pytest.mark.asyncio
+    async def test_create_blocked_observation(self, async_db):
+        repo = ScreenObservationRepository()
+        obs = await repo.create(
+            app_name="1Password",
+            blocked=True,
+        )
+        assert obs.app_name == "1Password"
+        assert obs.blocked is True
+        assert obs.activity_type == "other"
+
+    @pytest.mark.asyncio
+    async def test_backfill_duration(self, async_db):
+        repo = ScreenObservationRepository()
+        now = datetime.now(timezone.utc)
+
+        # Create first observation
+        obs1 = await repo.create(
+            app_name="VS Code",
+            activity_type="coding",
+            timestamp=now - timedelta(minutes=10),
+        )
+
+        # Create second observation — should backfill duration on first
+        obs2 = await repo.create(
+            app_name="Safari",
+            activity_type="browsing",
+            timestamp=now,
+        )
+
+        # Re-read obs1 from DB to check duration
+        async with async_db() as db:
+            from sqlmodel import select
+            result = await db.execute(
+                select(ScreenObservation).where(ScreenObservation.id == obs1.id)
+            )
+            refreshed = result.scalar_one()
+
+        assert refreshed.duration_s is not None
+        assert refreshed.duration_s == 600  # 10 minutes
+
+    @pytest.mark.asyncio
+    async def test_daily_summary_empty(self, async_db):
+        repo = ScreenObservationRepository()
+        summary = await repo.get_daily_summary(date.today())
+        assert summary["total_observations"] == 0
+
+    @pytest.mark.asyncio
+    async def test_daily_summary_with_data(self, async_db):
+        repo = ScreenObservationRepository()
+        now = datetime.now(timezone.utc)
+        today = now.date()
+        start = datetime(today.year, today.month, today.day, 9, 0, tzinfo=timezone.utc)
+
+        # Create a few observations
+        await repo.create(
+            app_name="VS Code", activity_type="coding",
+            project="seraph", timestamp=start,
+        )
+        await repo.create(
+            app_name="Safari", activity_type="browsing",
+            timestamp=start + timedelta(minutes=30),
+        )
+        await repo.create(
+            app_name="VS Code", activity_type="coding",
+            project="seraph", timestamp=start + timedelta(minutes=45),
+        )
+
+        summary = await repo.get_daily_summary(today)
+        assert summary["total_observations"] == 3
+        assert summary["switch_count"] == 3
+        assert "coding" in summary["by_activity"]
+        assert "browsing" in summary["by_activity"]
+
+    @pytest.mark.asyncio
+    async def test_daily_summary_excludes_blocked(self, async_db):
+        repo = ScreenObservationRepository()
+        now = datetime.now(timezone.utc)
+        today = now.date()
+        start = datetime(today.year, today.month, today.day, 9, 0, tzinfo=timezone.utc)
+
+        await repo.create(
+            app_name="VS Code", activity_type="coding", timestamp=start,
+        )
+        await repo.create(
+            app_name="1Password", blocked=True, timestamp=start + timedelta(minutes=5),
+        )
+
+        summary = await repo.get_daily_summary(today)
+        # Only 1 non-blocked observation
+        assert summary["total_observations"] == 1
+
+    @pytest.mark.asyncio
+    async def test_weekly_summary(self, async_db):
+        repo = ScreenObservationRepository()
+        today = date.today()
+        week_start = today - timedelta(days=today.weekday())
+        start = datetime(
+            week_start.year, week_start.month, week_start.day, 9, 0, tzinfo=timezone.utc
+        )
+
+        # Create observations on two different days
+        await repo.create(
+            app_name="VS Code", activity_type="coding",
+            project="seraph", timestamp=start,
+        )
+        await repo.create(
+            app_name="Safari", activity_type="browsing",
+            timestamp=start + timedelta(days=1, minutes=30),
+        )
+
+        summary = await repo.get_weekly_summary(week_start)
+        assert summary["total_observations"] == 2
+        assert len(summary["daily_breakdown"]) == 7
+
+    @pytest.mark.asyncio
+    async def test_cleanup_old(self, async_db):
+        repo = ScreenObservationRepository()
+        now = datetime.now(timezone.utc)
+
+        # Create an old observation (100 days ago)
+        await repo.create(
+            app_name="Old App",
+            timestamp=now - timedelta(days=100),
+        )
+        # Create a recent one
+        await repo.create(
+            app_name="New App",
+            timestamp=now,
+        )
+
+        deleted = await repo.cleanup_old(retention_days=90)
+        assert deleted == 1
+
+        # Verify only the recent one remains
+        summary = await repo.get_daily_summary(now.date())
+        assert summary["total_observations"] == 1
+
+    @pytest.mark.asyncio
+    async def test_details_json_round_trip(self, async_db):
+        repo = ScreenObservationRepository()
+        details = ["file: main.py", "branch: feature/test"]
+        obs = await repo.create(
+            app_name="VS Code",
+            details=details,
+        )
+        assert obs.details_json is not None
+        import json
+        assert json.loads(obs.details_json) == details

--- a/daemon/blocklist.py
+++ b/daemon/blocklist.py
@@ -1,0 +1,78 @@
+"""App blocklist for screen capture — prevents screenshots of sensitive apps."""
+
+import json
+import logging
+
+logger = logging.getLogger("seraph_daemon")
+
+DEFAULT_BLOCKLIST: set[str] = {
+    # Password managers
+    "1password",
+    "bitwarden",
+    "lastpass",
+    "keepassxc",
+    "keeper",
+    "dashlane",
+    "enpass",
+    # macOS system credentials
+    "keychain access",
+    # Banking (common patterns)
+    "chase",
+    "bank of america",
+    "wells fargo",
+    "capital one",
+    "schwab",
+    "fidelity",
+    "td ameritrade",
+    "robinhood",
+    # Encrypted messaging (privacy-sensitive)
+    "signal",
+    # Crypto wallets
+    "ledger live",
+    "trezor suite",
+    "metamask",
+}
+
+
+def load_blocklist(config_path: str | None = None) -> set[str]:
+    """Load blocklist from JSON file, merged with defaults.
+
+    Config format:
+        {"blocked_apps": ["TikTok"], "allowed_apps": ["Signal"]}
+
+    - blocked_apps: added to the default blocklist
+    - allowed_apps: removed from the default blocklist (overrides defaults)
+
+    Returns the final set of blocked app name patterns (all lowercased).
+    """
+    result = set(DEFAULT_BLOCKLIST)
+
+    if config_path is None:
+        return result
+
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+    except FileNotFoundError:
+        logger.warning("Blocklist config not found: %s — using defaults", config_path)
+        return result
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to load blocklist config: %s — using defaults", exc)
+        return result
+
+    for app in config.get("blocked_apps", []):
+        result.add(app.lower().strip())
+
+    for app in config.get("allowed_apps", []):
+        result.discard(app.lower().strip())
+
+    return result
+
+
+def is_blocked(app_name: str, blocklist: set[str]) -> bool:
+    """Check if an app name matches any entry in the blocklist.
+
+    Uses case-insensitive substring matching so "1Password 7" matches "1password".
+    """
+    app_lower = app_name.lower()
+    return any(blocked in app_lower for blocked in blocklist)

--- a/daemon/ocr/base.py
+++ b/daemon/ocr/base.py
@@ -1,7 +1,7 @@
 """OCR provider interface and result dataclass."""
 
 import abc
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -10,6 +10,15 @@ class OCRResult:
     provider: str
     duration_ms: int
     success: bool
+    error: str | None = None
+
+
+@dataclass
+class AnalysisResult:
+    """Structured screen analysis result from a vision model."""
+    success: bool
+    data: dict  # {activity, project, summary, details}
+    duration_ms: int
     error: str | None = None
 
 
@@ -29,3 +38,22 @@ class OCRProvider(abc.ABC):
     def is_available(self) -> bool:
         """Check if this provider can run (dependencies / keys present)."""
         ...
+
+    async def analyze_screen(self, png_bytes: bytes, app_name: str) -> AnalysisResult:
+        """Analyze a screenshot and return structured activity data.
+
+        Default implementation falls back to extract_text, wrapping output
+        as an unstructured summary. Subclasses can override for structured analysis.
+        """
+        result = await self.extract_text(png_bytes)
+        return AnalysisResult(
+            success=result.success,
+            data={
+                "activity": "other",
+                "project": None,
+                "summary": result.text[:200] if result.text else "",
+                "details": [],
+            },
+            duration_ms=result.duration_ms,
+            error=result.error,
+        )

--- a/daemon/ocr/openrouter.py
+++ b/daemon/ocr/openrouter.py
@@ -6,7 +6,7 @@ import time
 
 import httpx
 
-from ocr.base import OCRProvider, OCRResult
+from ocr.base import AnalysisResult, OCRProvider, OCRResult
 
 logger = logging.getLogger("seraph_daemon")
 
@@ -94,6 +94,93 @@ class OpenRouterProvider(OCRProvider):
                 text="", provider=self.name, duration_ms=duration_ms,
                 success=False, error=str(exc),
             )
+
+    async def analyze_screen(self, png_bytes: bytes, app_name: str) -> AnalysisResult:
+        """Analyze screenshot and return structured activity data via vision model."""
+        start = time.monotonic()
+        try:
+            b64 = base64.b64encode(png_bytes).decode("ascii")
+            client = self._get_client()
+
+            prompt = (
+                "You are a screen activity analyzer. Analyze this screenshot and return JSON:\n"
+                '{"activity": "coding|browsing|communication|reading|design|terminal|entertainment|other",\n'
+                ' "project": "project name or null",\n'
+                ' "summary": "one sentence, max 100 chars",\n'
+                ' "details": ["notable items, max 5"]}\n'
+                f"The user's current app is: {app_name}\n"
+                "IMPORTANT: Never include passwords, API keys, tokens, credit card numbers, "
+                "or private message content. Describe the activity without reproducing sensitive data.\n"
+                "Return ONLY valid JSON."
+            )
+
+            response = await client.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": self._model,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": prompt},
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": f"data:image/png;base64,{b64}",
+                                        "detail": "low",
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                    "max_tokens": 300,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+            raw_text = data["choices"][0]["message"]["content"].strip()
+            duration_ms = int((time.monotonic() - start) * 1000)
+
+            # Parse JSON from response (handle markdown code fences)
+            json_text = raw_text
+            if json_text.startswith("```"):
+                lines = json_text.split("\n")
+                # Remove first and last lines (``` markers)
+                lines = [l for l in lines if not l.strip().startswith("```")]
+                json_text = "\n".join(lines)
+
+            import json
+            parsed = json.loads(json_text)
+
+            # Validate and normalize fields
+            valid_activities = {
+                "coding", "browsing", "communication", "reading",
+                "design", "terminal", "entertainment", "other",
+            }
+            activity = parsed.get("activity", "other")
+            if activity not in valid_activities:
+                activity = "other"
+
+            return AnalysisResult(
+                success=True,
+                data={
+                    "activity": activity,
+                    "project": parsed.get("project"),
+                    "summary": str(parsed.get("summary", ""))[:200],
+                    "details": list(parsed.get("details", []))[:5],
+                },
+                duration_ms=duration_ms,
+            )
+
+        except Exception as exc:
+            duration_ms = int((time.monotonic() - start) * 1000)
+            logger.debug("analyze_screen failed: %s", exc)
+            # Fall back to base implementation
+            return await super().analyze_screen(png_bytes, app_name)
 
     async def close(self) -> None:
         """Close the HTTP client."""

--- a/daemon/run.sh
+++ b/daemon/run.sh
@@ -13,12 +13,11 @@
 #   ./daemon/run.sh --verbose           # Log every context POST
 #   ./daemon/run.sh --interval 3        # Poll every 3 seconds
 #
-# OCR (opt-in, requires Screen Recording permission):
+# Screen analysis (opt-in, captures on context switch, requires Screen Recording permission):
 #   ./daemon/run.sh --ocr --verbose                        # Local Apple Vision (free, offline, ~200ms)
-#   ./daemon/run.sh --ocr --ocr-interval 15 --verbose      # Local OCR every 15s instead of 30s
-#   ./daemon/run.sh --ocr --ocr-provider openrouter        # Cloud via Gemini 2.5 Flash Lite (~$0.15/mo)
+#   ./daemon/run.sh --ocr --ocr-provider openrouter        # Cloud via Gemini (structured JSON, ~$1.30/mo)
 #   ./daemon/run.sh --ocr --ocr-provider openrouter \
-#     --ocr-model google/gemini-2.5-flash-lite --verbose         # Cloud with explicit model
+#     --blocklist-file ~/blocklist.json --verbose           # Cloud with custom app blocklist
 #
 #   ./daemon/run.sh --help              # Show all options
 #

--- a/daemon/tests/test_blocklist.py
+++ b/daemon/tests/test_blocklist.py
@@ -1,0 +1,125 @@
+"""Tests for the app blocklist module."""
+
+import json
+import os
+import platform
+import tempfile
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Darwin",
+    reason="Daemon tests require macOS",
+)
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from blocklist import DEFAULT_BLOCKLIST, is_blocked, load_blocklist
+
+
+class TestDefaultBlocklist:
+    def test_contains_password_managers(self):
+        assert "1password" in DEFAULT_BLOCKLIST
+        assert "bitwarden" in DEFAULT_BLOCKLIST
+        assert "lastpass" in DEFAULT_BLOCKLIST
+
+    def test_contains_banking(self):
+        assert "chase" in DEFAULT_BLOCKLIST
+        assert "wells fargo" in DEFAULT_BLOCKLIST
+
+    def test_contains_crypto(self):
+        assert "ledger live" in DEFAULT_BLOCKLIST
+        assert "metamask" in DEFAULT_BLOCKLIST
+
+    def test_all_lowercase(self):
+        for app in DEFAULT_BLOCKLIST:
+            assert app == app.lower(), f"Entry {app!r} should be lowercase"
+
+
+class TestIsBlocked:
+    def test_exact_match(self):
+        blocklist = {"1password"}
+        assert is_blocked("1password", blocklist)
+
+    def test_case_insensitive(self):
+        blocklist = {"1password"}
+        assert is_blocked("1Password", blocklist)
+        assert is_blocked("1PASSWORD", blocklist)
+
+    def test_substring_match(self):
+        blocklist = {"1password"}
+        assert is_blocked("1Password 7", blocklist)
+        assert is_blocked("1Password — Vault", blocklist)
+
+    def test_not_blocked(self):
+        blocklist = {"1password"}
+        assert not is_blocked("VS Code", blocklist)
+        assert not is_blocked("Safari", blocklist)
+
+    def test_empty_blocklist(self):
+        assert not is_blocked("1Password", set())
+
+    def test_multi_word_entry(self):
+        blocklist = {"bank of america"}
+        assert is_blocked("Bank of America", blocklist)
+        assert is_blocked("Bank Of America Online", blocklist)
+
+
+class TestLoadBlocklist:
+    def test_defaults_when_no_config(self):
+        result = load_blocklist(None)
+        assert result == DEFAULT_BLOCKLIST
+
+    def test_defaults_when_file_not_found(self):
+        result = load_blocklist("/nonexistent/path.json")
+        assert result == DEFAULT_BLOCKLIST
+
+    def test_adds_blocked_apps(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"blocked_apps": ["TikTok", "Instagram"]}, f)
+            f.flush()
+            try:
+                result = load_blocklist(f.name)
+                assert "tiktok" in result
+                assert "instagram" in result
+                # Defaults still present
+                assert "1password" in result
+            finally:
+                os.unlink(f.name)
+
+    def test_removes_allowed_apps(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"allowed_apps": ["Signal"]}, f)
+            f.flush()
+            try:
+                result = load_blocklist(f.name)
+                assert "signal" not in result
+                # Other defaults still present
+                assert "1password" in result
+            finally:
+                os.unlink(f.name)
+
+    def test_add_and_remove(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({
+                "blocked_apps": ["MyBank"],
+                "allowed_apps": ["Signal"],
+            }, f)
+            f.flush()
+            try:
+                result = load_blocklist(f.name)
+                assert "mybank" in result
+                assert "signal" not in result
+            finally:
+                os.unlink(f.name)
+
+    def test_invalid_json(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("not json")
+            f.flush()
+            try:
+                result = load_blocklist(f.name)
+                assert result == DEFAULT_BLOCKLIST
+            finally:
+                os.unlink(f.name)

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -49,6 +49,9 @@ These control when proactive features run (briefings, reviews, working hours):
 | `GOAL_CHECK_INTERVAL_HOURS` | `4` | Hours between goal progress checks |
 | `CALENDAR_SCAN_INTERVAL_MIN` | `15` | Minutes between calendar scans |
 | `STRATEGIST_INTERVAL_MIN` | `15` | Minutes between strategist ticks |
+| `ACTIVITY_DIGEST_HOUR` | `20` | Hour for the daily screen activity digest |
+| `WEEKLY_REVIEW_HOUR` | `18` | Hour for the Sunday weekly activity review |
+| `SCREEN_OBSERVATION_RETENTION_DAYS` | `90` | Days to keep screen observations before cleanup |
 | `SCHEDULER_ENABLED` | `true` | Enable/disable background scheduler |
 
 ### Optional observer settings
@@ -157,32 +160,37 @@ This is a one-time grant. The daemon will then report the frontmost app and wind
 | `--idle-timeout` | `300` | Seconds of inactivity before skipping POSTs |
 | `--verbose` | off | Log every context POST |
 
-## Optional: Screen OCR
+## Optional: Screen Activity Tracking
 
-OCR mode extracts visible text from the screen so the strategist agent can reason about what you're working on.
+Screen analysis captures and analyzes screenshots **on context switch** (when you change apps), producing structured activity data: activity type, project, summary. Observations are persisted to the database and power daily/weekly activity digests.
+
+Sensitive apps (password managers, banking, crypto wallets) are automatically blocked from screenshots.
 
 ```bash
 # Apple Vision (local, free, ~200ms per capture)
 ./daemon/run.sh --ocr --verbose
 
-# OpenRouter cloud OCR (Gemini 2.5 Flash Lite, ~$0.15/month at default 30s interval)
+# OpenRouter cloud analysis (Gemini 2.5 Flash Lite, structured JSON, ~$1.30/mo)
 OPENROUTER_API_KEY=sk-or-... ./daemon/run.sh --ocr --ocr-provider openrouter --verbose
+
+# With custom app blocklist
+./daemon/run.sh --ocr --ocr-provider openrouter --blocklist-file ~/blocklist.json --verbose
 ```
 
 | Provider | Pros | Cons |
 |---|---|---|
 | `apple-vision` (default) | Free, offline, fast (~200ms) | Text-only, no layout understanding |
-| `openrouter` | Understands layout and context | Requires API key, small cost |
+| `openrouter` | Structured JSON output, understands layout | Requires API key, small cost |
 
-### OCR options
+### Screen analysis options
 
 | Flag | Default | Description |
 |---|---|---|
-| `--ocr` | off | Enable OCR screen text extraction |
-| `--ocr-provider` | `apple-vision` | `apple-vision` (local) or `openrouter` (cloud) |
-| `--ocr-interval` | `30` | OCR capture interval in seconds |
+| `--ocr` | off | Enable screenshot analysis on context switch |
+| `--ocr-provider` | `apple-vision` | `apple-vision` (local) or `openrouter` (cloud, structured) |
 | `--ocr-model` | `google/gemini-2.5-flash-lite` | Model for OpenRouter provider |
 | `--openrouter-api-key` | `$OPENROUTER_API_KEY` | API key for OpenRouter provider |
+| `--blocklist-file` | (none) | Path to JSON blocklist config (extends built-in defaults) |
 
 ### Screen Recording permission
 


### PR DESCRIPTION
## Summary

- Screenshot analysis now runs **on context switch** (not a timer), producing structured JSON observations (activity type, project, summary) persisted to a new `ScreenObservation` table with automatic duration backfill
- Sensitive apps (password managers, banking, crypto wallets) are **blocked** from screenshots via a configurable blocklist (`daemon/blocklist.py`)
- Three new scheduler jobs: **daily activity digest** (8 PM), **weekly activity review** (Sun 6 PM), and **retention cleanup** (3 AM, 90-day default)
- New API endpoint: `GET /api/observer/activity/today` for daily summary
- Daemon `ocr_loop` removed — merged into `poll_loop`; `--ocr-interval` deprecated

## Test plan

- [x] 535 tests passing (511 backend + 24 daemon)
- [ ] Start daemon with `./daemon/run.sh --ocr --ocr-provider openrouter --verbose`, switch between apps — verify observations stored in DB
- [ ] Open a blocked app (1Password) — verify `blocked: true` stored, no screenshot taken
- [ ] Hit `GET /api/observer/activity/today` — verify daily summary returned
- [ ] Verify legacy daemon POSTs (without `observation` field) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)