### PR TITLE
feat: capture mode setting for screenshot frequency control

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -50,6 +50,9 @@ class Settings(BaseSettings):
     observer_git_repo_path: str = ""
     deep_work_apps: str = ""  # comma-separated extra app keywords for deep work detection
 
+    # Capture mode
+    default_capture_mode: str = "on_switch"  # on_switch | balanced | detailed
+
     # Screen Activity Tracking
     activity_digest_hour: int = 20                    # 8 PM daily digest
     weekly_review_hour: int = 18                      # 6 PM Sunday weekly review

--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -1,4 +1,4 @@
-"""Settings API — interruption mode management."""
+"""Settings API — interruption mode and capture mode management."""
 
 import logging
 from datetime import datetime, timezone
@@ -18,6 +18,13 @@ router = APIRouter()
 
 class InterruptionModeRequest(BaseModel):
     mode: str
+
+
+class CaptureModeRequest(BaseModel):
+    mode: str
+
+
+_VALID_CAPTURE_MODES = {"on_switch", "balanced", "detailed"}
 
 
 @router.get("/settings/interruption-mode")
@@ -62,3 +69,36 @@ async def set_interruption_mode(body: InterruptionModeRequest):
         "attention_budget_remaining": ctx.attention_budget_remaining,
         "user_state": ctx.user_state,
     }
+
+
+@router.get("/settings/capture-mode")
+async def get_capture_mode():
+    """Get current capture mode setting."""
+    ctx = context_manager.get_context()
+    return {"mode": ctx.capture_mode}
+
+
+@router.put("/settings/capture-mode")
+async def set_capture_mode(body: CaptureModeRequest):
+    """Update capture mode (on_switch | balanced | detailed)."""
+    if body.mode not in _VALID_CAPTURE_MODES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid mode '{body.mode}'. Must be one of: {', '.join(sorted(_VALID_CAPTURE_MODES))}",
+        )
+
+    # Update in-memory context
+    context_manager.update_capture_mode(body.mode)
+
+    # Persist to DB
+    async with get_db() as db:
+        result = await db.execute(
+            select(UserProfile).where(UserProfile.id == "singleton")
+        )
+        profile = result.scalars().first()
+        if profile:
+            profile.capture_mode = body.mode
+            profile.updated_at = datetime.now(timezone.utc)
+            db.add(profile)
+
+    return {"mode": body.mode}

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -37,16 +37,18 @@ async def lifespan(app: FastAPI):
     await init_db()
     ensure_soul_exists()
     init_llm_logging()
-    # Load persisted interruption mode before scheduler starts
+    # Load persisted settings before scheduler starts
     try:
         from src.api.profile import get_or_create_profile
         from src.observer.manager import context_manager
         profile = await get_or_create_profile()
         if profile.interruption_mode:
             context_manager.update_interruption_mode(profile.interruption_mode)
+        if profile.capture_mode:
+            context_manager.update_capture_mode(profile.capture_mode)
     except Exception:
         import logging
-        logging.getLogger(__name__).warning("Failed to load persisted interruption mode", exc_info=True)
+        logging.getLogger(__name__).warning("Failed to load persisted settings", exc_info=True)
     init_scheduler()
     try:
         from src.observer.manager import context_manager

--- a/backend/src/db/models.py
+++ b/backend/src/db/models.py
@@ -124,6 +124,7 @@ class UserProfile(SQLModel, table=True):
     preferences_json: Optional[str] = Field(default=None)
     onboarding_completed: bool = Field(default=False)
     interruption_mode: str = Field(default="balanced")
+    capture_mode: str = Field(default="on_switch")  # on_switch | balanced | detailed
     created_at: datetime = Field(default_factory=_now)
     updated_at: datetime = Field(default_factory=_now)
 

--- a/backend/src/observer/context.py
+++ b/backend/src/observer/context.py
@@ -37,6 +37,9 @@ class CurrentContext:
     # Daemon heartbeat — Unix timestamp of last POST from daemon
     last_daemon_post: Optional[float] = None
 
+    # Capture mode — controls screenshot frequency (on_switch | balanced | detailed)
+    capture_mode: str = "on_switch"
+
     # Phase 3.3 — State machine tracking
     previous_user_state: str = "available"
     attention_budget_last_reset: Optional[datetime] = None

--- a/backend/src/observer/manager.py
+++ b/backend/src/observer/manager.py
@@ -118,6 +118,7 @@ class ContextManager:
                 active_window=old.active_window,
                 screen_context=old.screen_context,
                 last_daemon_post=old.last_daemon_post,
+                capture_mode=old.capture_mode,
                 # Phase 3.3 tracking
                 previous_user_state=old.user_state,
                 attention_budget_last_reset=last_reset,
@@ -206,6 +207,11 @@ class ContextManager:
         self._context.attention_budget_remaining = max(
             0, self._context.attention_budget_remaining - 1
         )
+
+    def update_capture_mode(self, mode: str) -> None:
+        """Change capture mode setting."""
+        self._context.capture_mode = mode
+        logger.info("Capture mode set to %s", mode)
 
     def update_interruption_mode(self, mode: str) -> None:
         """Change interruption mode and reset budget to mode default."""

--- a/backend/tests/test_settings_capture_mode.py
+++ b/backend/tests/test_settings_capture_mode.py
@@ -1,0 +1,80 @@
+"""Tests for settings API — GET/PUT capture mode."""
+
+import pytest
+from unittest.mock import patch
+
+from src.db.models import UserProfile
+from src.observer.context import CurrentContext
+
+
+@pytest.mark.asyncio
+async def test_get_capture_mode_default(client):
+    """GET returns default on_switch."""
+    fresh = CurrentContext()
+    with patch("src.api.settings.context_manager.get_context", return_value=fresh):
+        resp = await client.get("/api/settings/capture-mode")
+    assert resp.status_code == 200
+    assert resp.json()["mode"] == "on_switch"
+
+
+@pytest.mark.asyncio
+async def test_put_capture_mode_balanced(client, async_db):
+    """PUT balanced persists to DB and updates context."""
+    async with async_db() as db:
+        db.add(UserProfile(id="singleton"))
+
+    resp = await client.put(
+        "/api/settings/capture-mode",
+        json={"mode": "balanced"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["mode"] == "balanced"
+
+
+@pytest.mark.asyncio
+async def test_put_capture_mode_detailed(client, async_db):
+    async with async_db() as db:
+        db.add(UserProfile(id="singleton"))
+
+    resp = await client.put(
+        "/api/settings/capture-mode",
+        json={"mode": "detailed"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["mode"] == "detailed"
+
+
+@pytest.mark.asyncio
+async def test_put_invalid_capture_mode_422(client):
+    """PUT with invalid mode returns 422."""
+    resp = await client.put(
+        "/api/settings/capture-mode",
+        json={"mode": "invalid"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_capture_mode_round_trip(client, async_db):
+    """PUT then GET returns the new value."""
+    async with async_db() as db:
+        db.add(UserProfile(id="singleton"))
+
+    await client.put(
+        "/api/settings/capture-mode",
+        json={"mode": "detailed"},
+    )
+
+    resp = await client.get("/api/settings/capture-mode")
+    assert resp.json()["mode"] == "detailed"
+
+
+@pytest.mark.asyncio
+async def test_put_on_switch_resets(client, async_db):
+    """Can switch back to on_switch."""
+    async with async_db() as db:
+        db.add(UserProfile(id="singleton"))
+
+    await client.put("/api/settings/capture-mode", json={"mode": "balanced"})
+    resp = await client.put("/api/settings/capture-mode", json={"mode": "on_switch"})
+    assert resp.json()["mode"] == "on_switch"

--- a/daemon/seraph_daemon.py
+++ b/daemon/seraph_daemon.py
@@ -98,6 +98,20 @@ def format_active_window(app_name: str | None, window_title: str | None) -> str 
     return app_name
 
 
+# ─── Capture mode helper ─────────────────────────────────
+
+
+async def fetch_capture_mode(client: httpx.AsyncClient, url: str) -> str:
+    """Fetch capture mode setting from backend. Returns 'on_switch' on error."""
+    try:
+        r = await client.get(f"{url}/api/settings/capture-mode")
+        if r.status_code == 200:
+            return r.json().get("mode", "on_switch")
+    except Exception:
+        pass
+    return "on_switch"
+
+
 # ─── Main loop ────────────────────────────────────────────
 
 
@@ -209,6 +223,114 @@ async def poll_loop(
                 logger.exception("Unexpected error in poll loop")
 
             await asyncio.sleep(interval)
+
+
+async def periodic_capture_loop(
+    url: str,
+    idle_timeout: float,
+    verbose: bool,
+    ocr_provider: "ocr.base.OCRProvider | None" = None,
+    blocklist: set[str] | None = None,
+) -> None:
+    """Periodic capture loop — takes screenshots at intervals within the same app.
+
+    Runs alongside poll_loop. Polls backend for capture_mode every 60s.
+    When mode is 'balanced' (300s) or 'detailed' (60s), captures periodic
+    screenshots of the current app if it hasn't changed (poll_loop handles switches).
+    """
+    from blocklist import is_blocked
+
+    _blocklist = blocklist or set()
+    capture_mode = "on_switch"
+    last_periodic = 0.0
+    mode_poll_interval = 60  # poll setting every 60s
+    check_interval = 10  # check timer every 10s
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        last_mode_poll = 0.0
+        while True:
+            try:
+                now = time.time()
+
+                # Poll capture mode from backend every 60s
+                if now - last_mode_poll >= mode_poll_interval:
+                    capture_mode = await fetch_capture_mode(client, url)
+                    last_mode_poll = now
+
+                # Nothing to do in on_switch mode
+                if capture_mode == "on_switch":
+                    await asyncio.sleep(check_interval)
+                    continue
+
+                period = 300 if capture_mode == "balanced" else 60
+                if now - last_periodic < period:
+                    await asyncio.sleep(check_interval)
+                    continue
+
+                # Skip if user is idle
+                idle_secs = get_idle_seconds()
+                if idle_secs > idle_timeout:
+                    await asyncio.sleep(check_interval)
+                    continue
+
+                # Get current app
+                app_name = get_frontmost_app_name()
+                if not app_name or is_blocked(app_name, _blocklist):
+                    last_periodic = now
+                    await asyncio.sleep(check_interval)
+                    continue
+
+                # Take periodic screenshot
+                observation = {
+                    "app": app_name,
+                    "window_title": get_window_title() or "",
+                }
+
+                if ocr_provider is not None:
+                    try:
+                        from ocr.screenshot import capture_screen_png
+
+                        png_bytes = await asyncio.to_thread(capture_screen_png)
+                        if png_bytes:
+                            result = await ocr_provider.analyze_screen(png_bytes, app_name)
+                            if result.success:
+                                observation.update(result.data)
+                                if verbose:
+                                    ts = time.strftime("%H:%M:%S")
+                                    logger.info(
+                                        "[%s] periodic (%s, %ds): %s",
+                                        ts,
+                                        capture_mode,
+                                        period,
+                                        result.data.get("summary", "")[:80],
+                                    )
+                            else:
+                                logger.debug("Periodic analysis failed: %s", result.error)
+                    except Exception:
+                        logger.debug("Periodic screenshot/analysis error", exc_info=True)
+
+                # Post to backend
+                try:
+                    payload: dict = {
+                        "active_window": format_active_window(app_name, observation.get("window_title")),
+                        "observation": observation,
+                        "switch_timestamp": now,
+                    }
+                    await client.post(f"{url}/api/observer/context", json=payload)
+                    if verbose:
+                        ts = time.strftime("%H:%M:%S")
+                        logger.info("[%s] periodic capture → %s", ts, app_name)
+                except httpx.ConnectError:
+                    logger.warning("Backend not reachable at %s — will retry", url)
+                except httpx.HTTPError as exc:
+                    logger.warning("HTTP error posting periodic capture: %s", exc)
+
+                last_periodic = now
+
+            except Exception:
+                logger.exception("Unexpected error in periodic capture loop")
+
+            await asyncio.sleep(check_interval)
 
 
 async def main() -> None:
@@ -350,13 +472,27 @@ async def main() -> None:
             blocklist=blocklist,
         )
     )
+    periodic_task = asyncio.create_task(
+        periodic_capture_loop(
+            args.url,
+            args.idle_timeout,
+            args.verbose,
+            ocr_provider=ocr_provider,
+            blocklist=blocklist,
+        )
+    ) if ocr_provider is not None else None
 
     await stop_event.wait()
 
     heartbeat_task.cancel()
     poll_task.cancel()
+    if periodic_task is not None:
+        periodic_task.cancel()
 
-    for t in (heartbeat_task, poll_task):
+    tasks = [heartbeat_task, poll_task]
+    if periodic_task is not None:
+        tasks.append(periodic_task)
+    for t in tasks:
         try:
             await t
         except asyncio.CancelledError:

--- a/daemon/tests/test_periodic_capture.py
+++ b/daemon/tests/test_periodic_capture.py
@@ -1,0 +1,154 @@
+"""Tests for periodic capture loop and fetch_capture_mode helper.
+
+These tests depend on macOS-specific packages (PyObjC, Quartz) via seraph_daemon.
+They are automatically skipped on non-macOS platforms.
+"""
+
+import asyncio
+import platform
+import sys
+import os
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Darwin",
+    reason="Daemon tests require macOS (PyObjC, Quartz)",
+)
+
+httpx = pytest.importorskip("httpx")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from seraph_daemon import fetch_capture_mode, periodic_capture_loop
+
+
+class TestFetchCaptureMode:
+    @pytest.mark.asyncio
+    async def test_returns_default_on_error(self):
+        """Returns 'on_switch' when backend is unreachable."""
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        result = await fetch_capture_mode(mock_client, "http://localhost:9999")
+        assert result == "on_switch"
+
+    @pytest.mark.asyncio
+    async def test_returns_default_on_non_200(self):
+        """Returns 'on_switch' on non-200 response."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        result = await fetch_capture_mode(mock_client, "http://localhost:9999")
+        assert result == "on_switch"
+
+    @pytest.mark.asyncio
+    async def test_parses_valid_response(self):
+        """Parses mode from valid JSON response."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mode": "balanced"}
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        result = await fetch_capture_mode(mock_client, "http://localhost:8004")
+        assert result == "balanced"
+
+    @pytest.mark.asyncio
+    async def test_parses_detailed_mode(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mode": "detailed"}
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        result = await fetch_capture_mode(mock_client, "http://localhost:8004")
+        assert result == "detailed"
+
+
+class TestPeriodicCaptureLoop:
+    @pytest.mark.asyncio
+    async def test_skips_when_on_switch(self):
+        """No captures should happen when mode is on_switch."""
+        posts = []
+
+        async def mock_get(url, **kwargs):
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {"mode": "on_switch"}
+            return resp
+
+        async def mock_post(url, **kwargs):
+            posts.append(kwargs.get("json", {}))
+            return MagicMock(status_code=200)
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = mock_post
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("seraph_daemon.get_frontmost_app_name", return_value="VS Code"), \
+             patch("seraph_daemon.get_window_title", return_value="main.py"), \
+             patch("seraph_daemon.get_idle_seconds", return_value=0.0), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+
+            task = asyncio.create_task(
+                periodic_capture_loop(
+                    "http://localhost:8004",
+                    idle_timeout=300,
+                    verbose=False,
+                    ocr_provider=None,
+                )
+            )
+            await asyncio.sleep(0.3)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # No posts should have been made
+        assert len(posts) == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_when_idle(self):
+        """No captures when user is idle even in detailed mode."""
+        posts = []
+
+        async def mock_get(url, **kwargs):
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {"mode": "detailed"}
+            return resp
+
+        async def mock_post(url, **kwargs):
+            posts.append(kwargs.get("json", {}))
+            return MagicMock(status_code=200)
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = mock_post
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("seraph_daemon.get_frontmost_app_name", return_value="VS Code"), \
+             patch("seraph_daemon.get_window_title", return_value="main.py"), \
+             patch("seraph_daemon.get_idle_seconds", return_value=600.0), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+
+            task = asyncio.create_task(
+                periodic_capture_loop(
+                    "http://localhost:8004",
+                    idle_timeout=300,
+                    verbose=False,
+                    ocr_provider=None,
+                )
+            )
+            await asyncio.sleep(0.3)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert len(posts) == 0

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -63,6 +63,7 @@ These control the observer system and proactive behavior:
 | `PROACTIVITY_LEVEL` | `3` | Proactivity scale (1–5, higher = more proactive) |
 | `OBSERVER_GIT_REPO_PATH` | (empty) | Path to a git repo for commit-aware context |
 | `DEEP_WORK_APPS` | (empty) | Comma-separated extra app keywords that trigger deep work state |
+| `DEFAULT_CAPTURE_MODE` | `on_switch` | Screenshot frequency: `on_switch` (app changes only), `balanced` (+ every 5 min), `detailed` (+ every 1 min) |
 
 ### Optional timeout settings
 
@@ -163,6 +164,16 @@ This is a one-time grant. The daemon will then report the frontmost app and wind
 ## Optional: Screen Activity Tracking
 
 Screen analysis captures and analyzes screenshots **on context switch** (when you change apps), producing structured activity data: activity type, project, summary. Observations are persisted to the database and power daily/weekly activity digests.
+
+**Capture Mode** controls screenshot frequency. Configure via the Settings UI:
+
+| Mode | Behavior |
+|---|---|
+| **On Switch** (default) | Screenshot only when the active app changes |
+| **Balanced** | On switch + periodic every 5 minutes within the same app |
+| **Detailed** | On switch + periodic every 1 minute within the same app |
+
+Blocked apps are never screenshotted in any mode. The daemon polls the backend for capture mode changes every 60 seconds — no restart needed.
 
 Sensitive apps (password managers, banking, crypto wallets) are automatically blocked from screenshots.
 

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import { EventBus } from "../game/EventBus";
 import { DialogFrame } from "./chat/DialogFrame";
 import { InterruptionModeToggle } from "./settings/InterruptionModeToggle";
 import { DaemonStatus } from "./settings/DaemonStatus";
+import { CaptureModeToggle } from "./settings/CaptureModeToggle";
 
 interface SkillInfo {
   name: string;
@@ -575,6 +576,8 @@ export function SettingsPanel() {
           <InterruptionModeToggle />
 
           <DaemonStatus />
+
+          <CaptureModeToggle />
 
           <div className="px-1">
             <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-1">

--- a/frontend/src/components/settings/CaptureModeToggle.tsx
+++ b/frontend/src/components/settings/CaptureModeToggle.tsx
@@ -1,0 +1,69 @@
+import { useState, useEffect } from "react";
+import { API_URL } from "../../config/constants";
+
+type CaptureMode = "on_switch" | "balanced" | "detailed";
+
+const MODES: { value: CaptureMode; label: string; desc: string }[] = [
+  { value: "on_switch", label: "On Switch", desc: "App changes only" },
+  { value: "balanced", label: "Balanced", desc: "Switch + every 5 min" },
+  { value: "detailed", label: "Detailed", desc: "Switch + every 1 min" },
+];
+
+export function CaptureModeToggle() {
+  const [mode, setMode] = useState<CaptureMode>("on_switch");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/settings/capture-mode`)
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => {
+        if (data?.mode) setMode(data.mode);
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleSelect = async (m: CaptureMode) => {
+    if (m === mode || loading) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_URL}/api/settings/capture-mode`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: m }),
+      });
+      if (res.ok) setMode(m);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="px-1">
+      <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-2">
+        Capture Mode
+      </div>
+      <div className="flex gap-1">
+        {MODES.map((m) => {
+          const selected = mode === m.value;
+          return (
+            <button
+              key={m.value}
+              onClick={() => handleSelect(m.value)}
+              disabled={loading}
+              className={`flex-1 px-1 py-1 border rounded-sm text-center transition-colors ${
+                selected
+                  ? "text-retro-highlight border-retro-highlight"
+                  : "text-retro-text/40 border-retro-text/20 hover:text-retro-text/60 hover:border-retro-text/40"
+              }`}
+            >
+              <div className="text-[10px] font-bold uppercase tracking-wider">{m.label}</div>
+              <div className="text-[9px] mt-0.5 opacity-70">{m.desc}</div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add capture mode setting (on_switch/balanced/detailed) controlling daemon screenshot frequency
- New API endpoints: `GET/PUT /api/settings/capture-mode`
- Settings UI toggle (CaptureModeToggle component)
- Daemon periodic capture loop polls setting every 60s, takes screenshots at configured interval
- Persisted to UserProfile DB, loaded on startup

## Test plan
- [x] Backend tests: 6 new tests for capture-mode API (GET default, PUT balanced/detailed, invalid 422, round-trip, reset)
- [x] Daemon tests: 6 new tests for fetch_capture_mode + periodic_capture_loop
- [x] Full backend suite: 517 passed, 0 failed
- [x] No regressions in existing settings API tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)