### PR TITLE
docs: add OpenClaw feature parity analysis

### DIFF
--- a/docs/docs/development/openclaw-feature-parity.md
+++ b/docs/docs/development/openclaw-feature-parity.md
@@ -1,0 +1,151 @@
+---
+sidebar_position: 4
+---
+
+# OpenClaw Feature Parity Analysis
+
+Competitive analysis comparing Seraph with OpenClaw (formerly Clawdbot/Moltbot), identifying feature gaps and prioritized recommendations.
+
+*Last updated: 2026-02-18*
+
+## What is OpenClaw?
+
+OpenClaw is a MIT-licensed AI agent by Peter Steinberger with 200k+ GitHub stars. Its core idea: your **existing chat apps** (WhatsApp, Telegram, Slack, iMessage, Discord, etc.) ARE the interface. It runs locally, supports 15+ LLM providers, and has a massive community (3,500+ skills in ClawHub).
+
+## Where Seraph is AHEAD
+
+| Area | Seraph Advantage |
+|------|-----------------|
+| **Visual UI** | Phaser 3 RPG village with animated sprites, magic effects, tile-based map — nothing like this in OpenClaw (text-only chat) |
+| **Screen Awareness** | Continuous daemon with structured OCR analysis, activity digests, capture modes — OpenClaw only has on-demand screen recording via device nodes |
+| **Goal System** | Full hierarchical 6-level goal tree with domains, materialized paths, dashboard, scheduled checks — OpenClaw tracks goals in plain markdown |
+| **Attention Guardian** | Sophisticated delivery gate with 6 user states, 3 interruption modes, attention budget, queued bundles — OpenClaw has no equivalent |
+| **Map Editor** | Standalone Tiled-compatible editor with 33 tilesets, building interiors, NPC browser — unique |
+| **Activity Digests** | Daily + weekly LLM-generated analysis of screen activity patterns — unique |
+
+## Where OpenClaw is AHEAD (Feature Gaps)
+
+### 1. Multi-Channel Messaging (HIGH IMPACT)
+
+OpenClaw connects to WhatsApp, Telegram, Slack, Discord, Signal, iMessage, Teams, Matrix, and more simultaneously. One brain, many surfaces. Seraph only has its built-in WebSocket chat.
+
+**Gap**: Users can't interact with Seraph from where they already communicate.
+
+**Effort**: Large — requires channel adapter abstraction, per-platform SDKs, message normalization.
+
+### 2. Multi-Provider LLM Support (HIGH IMPACT)
+
+OpenClaw supports 10+ providers natively: Anthropic, OpenAI, Google, xAI, Groq, Cerebras, Mistral, Ollama (local), LM Studio (local), GitHub Copilot — with automatic fallback chains.
+
+**Gap**: Seraph only uses LiteLLM via OpenRouter. No local model support, no direct provider integrations, no fallback chains.
+
+**Effort**: Medium — LiteLLM already abstracts providers; adding Ollama/local model support and provider priority/fallback would be the main work.
+
+### 3. Voice Interaction (HIGH IMPACT)
+
+OpenClaw has wake word detection ("Hey OpenClaw"), continuous talk mode with ElevenLabs TTS/STT, and interrupt-on-speech.
+
+**Gap**: Seraph has no voice interface at all.
+
+**Effort**: Large — requires wake word detection, STT pipeline, TTS integration, voice activity detection.
+
+### 4. Browser Automation (MEDIUM-HIGH IMPACT)
+
+OpenClaw has full Chrome automation via CDP with 3 modes: Extension Relay (control your logged-in browser), managed Chromium (isolated), and remote CDP. Includes Browser Relay Chrome extension.
+
+**Gap**: Seraph has Playwright-based `browse_webpage` but it's limited (extract/html/screenshot modes). No ability to control the user's actual browser with logged-in sessions. No interactive automation (clicking, filling forms, navigating flows).
+
+**Effort**: Medium — could adopt CDP approach or extend Playwright. Browser Relay extension is a bigger project.
+
+### 5. Device Node Mesh (MEDIUM IMPACT)
+
+OpenClaw's companion apps (macOS/iOS/Android) expose device capabilities: camera, GPS, notifications, SMS, system commands — all orchestrated by the AI.
+
+**Gap**: Seraph's daemon only observes screen context. No camera, GPS, notifications, or cross-device orchestration.
+
+**Effort**: Large — requires companion app development for each platform.
+
+### 6. Community Skill Ecosystem (MEDIUM IMPACT)
+
+OpenClaw has ClawHub with 3,500+ community-contributed skills, hot-loading, file watchers, and per-skill env vars.
+
+**Gap**: Seraph has 8 bundled skills and a small catalog. No community registry, no hot-loading (requires reload API call), no per-skill env vars.
+
+**Effort**: Medium — skill system already exists; needs a registry/hub, file watching, and env var support.
+
+### 7. Shell/Code Execution (MEDIUM IMPACT)
+
+OpenClaw has `exec` (shell commands with approval gates + safe binary allowlists), `bash` (interactive), and `process` (background sessions). Multi-language support.
+
+**Gap**: Seraph's `shell_execute` only runs Python in snekbox sandbox. No shell access, no background processes, no approval-gated arbitrary commands.
+
+**Effort**: Medium — could add a proper shell tool with approval gates while keeping sandbox for untrusted code.
+
+### 8. Sub-Agent / Session Spawning (MEDIUM IMPACT)
+
+OpenClaw has `sessions_spawn` for creating sub-agents with their own workspaces, models, and tool access. True multi-agent orchestration.
+
+**Gap**: Seraph has delegation mode but it's feature-flagged off and experimental. No session spawning or per-agent workspaces.
+
+**Effort**: Medium — delegation infrastructure exists; needs maturation and enabling.
+
+### 9. Cron Jobs (User-Defined) (MEDIUM IMPACT)
+
+OpenClaw lets users create arbitrary cron jobs via natural language. Jobs run in isolated sessions with announce/webhook delivery.
+
+**Gap**: Seraph has hardcoded scheduler jobs only. Users cannot create their own scheduled tasks.
+
+**Effort**: Medium — APScheduler is already in place; needs user-facing job creation API + agent tool.
+
+### 10. Canvas / A2UI (LOWER IMPACT for Seraph)
+
+OpenClaw's A2UI protocol lets agents render declarative UI. Seraph has Phaser (arguably richer) but can't dynamically generate new UI surfaces.
+
+**Gap**: Agent can't create custom visual outputs beyond chat text.
+
+**Effort**: Medium — could render agent-generated HTML/markdown in panels.
+
+### 11. DM Pairing / Access Control (LOWER IMPACT)
+
+OpenClaw has approval-code pairing for unknown senders, group policies, and per-channel routing.
+
+**Gap**: Seraph is single-user, no access control needed currently.
+
+**Effort**: Low — only matters if multi-channel is added.
+
+## Prioritized Recommendations
+
+### Tier 1 — Highest Impact, Plays to Seraph's Strengths
+
+1. **User-Defined Cron Jobs** — Let users say "remind me every morning to check X" and have the agent create persistent scheduled tasks. Infrastructure (APScheduler) already exists. Add a `create_cron_job` tool + UI in QuestPanel.
+
+2. **Multi-Provider + Local Model Support** — Add Ollama/LM Studio support for local models. LiteLLM already handles this; mainly a config/UI task. Huge for privacy-conscious users.
+
+3. **Enhanced Shell/Code Execution** — Expand beyond Python-only snekbox. Add a proper shell tool with approval gates for safe commands (git, npm, pip, etc.) while keeping sandbox for untrusted code.
+
+### Tier 2 — Medium Impact, Moderate Effort
+
+4. **Richer Browser Automation** — Upgrade `browse_webpage` to support interactive flows (click, fill, navigate). Consider CDP integration for controlling the user's actual browser.
+
+5. **Community Skill Registry** — Build a simple ClawHub equivalent where users can share and discover skills. Add file watching for hot-reload.
+
+6. **Mature Delegation Mode** — Enable and stabilize the existing orchestrator/specialist architecture. This unlocks complex multi-step workflows.
+
+7. **Messaging Channel Adapter** — Start with one channel (Telegram or Discord) as a proof-of-concept for multi-channel interaction. Design the adapter abstraction first.
+
+### Tier 3 — Longer Term
+
+8. **Voice Interface** — Wake word + TTS/STT. Could start with a simple push-to-talk in the web UI before doing full wake word detection.
+
+9. **Device Capabilities** — Extend the daemon to expose more than screen context (notifications, quick actions).
+
+10. **Agent-Generated UI** — Let the agent render dynamic content in a panel (charts, tables, interactive widgets) beyond plain text.
+
+## Key Insight
+
+Seraph and OpenClaw have **fundamentally different philosophies**:
+
+- **OpenClaw**: "Meet users where they are" (messaging apps) — breadth across platforms
+- **Seraph**: "Create a compelling new home" (RPG village) — depth in a unique experience
+
+Seraph's biggest moat is the **visual experience + screen awareness + proactive intelligence** combination. No one else has that. The gaps to close are primarily in **agent capability breadth** (more tools, more providers, user-defined automation) rather than in the core architecture, which is already sophisticated.


### PR DESCRIPTION
## Summary
- Add competitive analysis comparing Seraph with OpenClaw
- Identifies 11 feature gaps with impact and effort ratings
- Prioritized recommendations in 3 tiers
- Saved to `docs/docs/development/openclaw-feature-parity.md`

## Test plan
- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)