### PR TITLE
docs(roadmap): add long-term planning system

### DIFF
--- a/docs/docs/overview/next-steps.md
+++ b/docs/docs/overview/next-steps.md
@@ -2,55 +2,53 @@
 sidebar_position: 4
 ---
 
-# Seraph — Next Steps Analysis
-**Date: 2026-02-13**
+# Seraph Next Steps
 
----
+This page is the short-horizon companion to the [long-term roadmap](./roadmap). It should summarize what we are actively optimizing for now, not compete with the master plan.
 
-## Current State
+## Current Focus
 
-Phases 0-3 are complete and functional. 624 automated tests (500 backend, 124 frontend). Clean codebase with no TODOs/FIXMEs. The project's unique advantages — proactive intelligence, RPG village metaphor, five-pillar life model, screen awareness — are implemented but not fully leveraged in the UI.
+Seraph is now in **Season 1: Trust + Capability**.
 
----
+That means the next execution wave is focused on making the guardian thesis more credible by improving:
 
-## Completed (Tier 1)
+- trust boundaries
+- execution breadth
+- runtime reliability
 
-1. ~~**Fix the docs sidebar**~~ — Done. All docs wired into `docs/sidebars.ts`.
+This is the right priority because Seraph's biggest moat already exists at the product level, while its biggest gaps are operational.
 
-2. ~~**Interruption Mode UI**~~ (3.5.2) — Done. 3-state toggle (Focus/Balanced/Active) in SettingsPanel via `InterruptionModeToggle.tsx`.
+## Current Batches
 
-3. ~~**Goal Management UI**~~ (3.5.1) — Done. Create/edit modal (`GoalForm.tsx`), inline actions (complete/edit/delete) on GoalTree nodes, and search/filter (text search + level/domain dropdowns) in QuestPanel.
+### 1. Trust Boundaries
 
-4. ~~**Frontend Accessibility**~~ (3.5.9) — Done. Font sizes bumped to 9px minimum across all panels. Keyboard shortcuts: Shift+C (chat), Shift+Q (quests), Shift+S (settings), Escape (close). Shift modifier prevents WASD avatar movement conflict.
+- [S1-B1 Trust Boundaries](../roadmap/batches/s1-b1-trust-boundaries)
+- approvals, policy profiles, auditability, secret scoping, stronger isolation
 
-7. ~~**SKILL.md Plugin Ecosystem**~~ (4.1) — Done. Zero-code markdown plugins in `data/skills/`. YAML frontmatter, tool gating, runtime enable/disable via API + Settings UI. 8 bundled skills.
+### 2. Execution Plane
 
-5. ~~**Agent Execution Timeout**~~ (3.5.6) — Done. `asyncio.wait_for` timeouts on REST chat (504), daily briefing, evening review, memory consolidation LLM + add_memory calls. DDGS web search timeout via constructor. 3 new settings: `agent_briefing_timeout` (60s), `consolidation_llm_timeout` (30s), `web_search_timeout` (15s). 5 new tests.
+- [S1-B2 Execution Plane](../roadmap/batches/s1-b2-execution-plane)
+- real shell/process execution, stronger browser automation, workflow engine direction
 
-6. ~~**Token-Aware Context Window**~~ (3.5.5) — Done. Token-aware context window with configurable budget. Keeps first N + last M messages, summarizes middle via LLM. 3 new settings: `context_window_token_budget` (12000), `context_window_keep_first` (2), `context_window_keep_recent` (20). Info logging on both return paths. 3 new settings integration tests.
+### 3. Runtime Reliability
 
-## Tier 3: The growth engine (Phase 4)
+- [S1-B3 Runtime Reliability](../roadmap/batches/s1-b3-runtime-reliability)
+- model routing, fallback paths, local model option, observability, evaluation harness
 
-8. **Telegram Bot** (4.2, first channel) — Makes proactive system (briefings, reviews, nudges) actually useful. Users won't keep a browser tab open, but they always have their phone.
+## What Comes After
 
-## Tier 4: Bigger bets (quarter-scale)
+If Season 1 lands well, the next major execution arc is:
 
-9. **Tauri Desktop App** (3.5.7) — Eliminates Docker barrier. Single `.dmg` with bundled backend + daemon. System tray. Biggest adoption unlock but biggest effort.
+- [Season 2: Reach + Presence](../roadmap/seasons/season-2-reach-presence)
 
-10. **Avatar Ambient State Reflection** (3.5.3) — Ambient WebSocket messages already flow; Phaser doesn't react visually. Making Seraph meditate/pace/glow based on state brings the RPG metaphor to life.
+That season moves Seraph from a strong local product into something users can actually keep with them throughout the day via native presence, channel reach, and better ambient delivery.
 
-## What to skip for now
+## Guardrails
 
-- **Calendar scan** (3.5.4) — Already more complete than REPORT.md claimed. Works when credentials are configured.
-- ~~**Multi-agent architecture** (4.4) — Premature until single-agent is polished.~~ → Implemented as recursive delegation behind feature flag (`USE_DELEGATION=true`).
-- **Voice** (4.8) — Not a differentiator yet.
-- **Workflow engine** (4.3) — Wait for SKILL.md; workflows build on skills.
+For the next phase of work, avoid prioritizing:
 
-## Strategic take
+- cosmetic UX upgrades ahead of trust boundaries
+- new channels before the execution plane is safer
+- broad ecosystem work before the runtime is more reliable
 
-Seraph's biggest advantages are **proactive intelligence** and **the RPG village**. Neither is fully leveraged:
-- Proactive messages only reach a browser tab → Telegram fixes this
-- Village avatar doesn't reflect agent state → ambient states fix this
-- ~~Users can't control interruptions → interruption mode UI fixes this~~ ✓
-
-**Next priorities**: ~~Agent execution timeout (prevents user frustration)~~ ✓, ~~token-aware context (prevents quality degradation)~~ ✓, then Telegram bot (makes proactive intelligence useful in daily life).
+Those ideas still matter. They just land better after the current season closes its credibility gap.

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -2,450 +2,139 @@
 sidebar_position: 2
 ---
 
-# Seraph — Product Roadmap
-
-> Each phase builds on the previous. The trajectory moves from **reactive tool** → **persistent partner** → **proactive observer** → **strategic guardian** → **life operating system**.
+# Seraph Long-Term Roadmap
 
----
+Seraph wins if it becomes the agent that combines four traits better than anyone else:
 
-## Phase 0 — Foundation
+- **guardian intelligence**: proactive, interruption-aware, and long-horizon
+- **trust boundaries**: safer, more governable, and more credible than typical agent shells
+- **execution breadth**: able to act across real tools, workflows, and surfaces
+- **embodied UX**: a product people want to live with, not just run
 
-**Status**: Complete
-
-What was built:
-- Chat interface with WebSocket streaming
-- 4 tools (web search, file read/write, template fill)
-- Animated RPG avatar in Phaser 3 village scene
-- Day/night cycle, idle wandering, speech bubbles
-- In-memory sessions (no persistence)
-- Single model via OpenRouter
-
----
-
-## Phase 1 — Persistent Identity
-
-**Theme**: Seraph remembers. Conversations have continuity. The human exists between sessions.
-
-### 1.1 Persistent Sessions & Chat History
-- SQLite (or Postgres) backed session storage
-- Full conversation history survives restarts
-- Session list UI (switch between conversations)
-- Conversation search
-
-### 1.2 Soul System (Long-Term Memory)
-- `soul.md` — Core identity file: user's name, values, goals, personality notes
-- Seraph reads and references soul on every interaction
-- User can view and edit their soul file through the UI
-- Seraph proposes soul updates after meaningful conversations ("I learned something about you — should I remember this?")
-
-### 1.3 Goal Hierarchy (The Quest Log)
-- Data model for hierarchical goals:
-  ```
-  Life Vision → Annual Objectives → Quarterly Key Results
-  → Monthly Milestones → Weekly Plans → Daily Tasks
-  ```
-- Quest Log UI panel in the RPG interface
-- Seraph can create, update, and decompose goals through conversation
-- Progress tracking with completion percentages at every level
-- Goal conflict detection ("These two objectives compete for the same time")
-
-### 1.4 User Onboarding Flow
-- First-run experience where Seraph asks about:
-  - Who the user is (name, role, context)
-  - What they're trying to achieve (top 3 life goals)
-  - What a great day/week/month looks like
-  - What their biggest obstacles are
-  - How proactive they want Seraph to be (dial from passive to aggressive)
-- Populates soul.md and initial goal hierarchy from this conversation
-- RPG-style: "A new hero enters the village..."
+That is the path that differentiates Seraph from OpenClaw, IronClaw, Hermes Agent, and the broader field. The planning system below turns that thesis into a single canonical structure for long-term execution.
 
-### Milestone
-Seraph knows who you are, what you want, and remembers everything.
+## Planning Model
 
----
+Seraph now uses a hybrid roadmap model:
 
-## Phase 2 — Capable Executor
+- **Sections** explain why the work exists
+- **Seasons** explain when major work lands
+- **Batches** explain what gets built next
 
-**Theme**: Seraph can actually do things in the world, not just talk about them.
+Read the external framing first:
 
-### 2.1 Shell Execution Tool
-- Sandboxed shell command execution (Docker-based)
-- Configurable permissions (read-only, workspace-scoped, full)
-- Output streaming to chat
-- New village location: **Forge** (visual element in village)
+- [Competitive Research: Seraph vs OpenClaw, IronClaw, and Hermes Agent](../architecture/competitive-agent-research)
 
-### 2.2 Browser Automation Tool
-- Playwright-based browser control
-- Navigate, extract, fill forms, screenshot
-- Sandboxed browser instance (no access to user's real browser)
-- New village location: **Observatory/Tower** (visual element in village)
+Then use the roadmap layers below.
 
-### 2.3 Calendar & Email Integration
-- Google Calendar / Outlook read/write
-- Gmail / Outlook email read, compose, send (with user approval)
-- New village locations: **Mailbox** (email), **Town Clock** (calendar)
+## Section Map
 
-### 2.4 Note-Taking & Knowledge Base
-- Integration with Obsidian / local markdown vault
-- Seraph can read, search, create, and link notes
-- New village location: **Library** (avatar browses shelves)
+1. [Trust + Capability](../roadmap/sections/section-1-trust-capability)
+2. [Presence + Distribution](../roadmap/sections/section-2-presence-distribution)
+3. [Memory + Guardian Intelligence](../roadmap/sections/section-3-memory-guardian-intelligence)
+4. [Embodiment + Life OS](../roadmap/sections/section-4-embodiment-life-os)
+5. [Ecosystem + Leverage](../roadmap/sections/section-5-ecosystem-leverage)
 
-### 2.5 Plugin/Skill Architecture
-- Tool registration API (define new tools without modifying core)
-- Tool metadata (name, description, required permissions, village location, avatar animation)
-- Community skill directory (future)
-- Each new tool automatically gets a village building and avatar animation
+These sections are durable. They should survive individual implementation waves and help explain why a batch matters even when the code changes.
 
-### Milestone
-Seraph can search the web, run code, manage your calendar, handle email, take notes, and learn new skills.
+## Season Map
 
----
+1. [Season 1: Trust + Capability](../roadmap/seasons/season-1-trust-capability)
+2. [Season 2: Reach + Presence](../roadmap/seasons/season-2-reach-presence)
+3. [Season 3: Memory + Guardian](../roadmap/seasons/season-3-memory-guardian)
+4. [Season 4: Embodied Life OS](../roadmap/seasons/season-4-embodied-life-os)
 
-## Phase 3 — The Observer
+The seasons are chronological. They intentionally prioritize credibility before ubiquity and trust before delight.
 
-**Theme**: Seraph watches (with consent) and understands what the human is doing.
+## Season-to-Section Matrix
 
-**Status**: Complete (Phases 3.1–3.5). Background scheduler, context awareness, user state machine, strategist agent, daily briefing, evening review, frontend ambient/nudge feedback, and native macOS screen daemon are all operational. Pattern detection, behavioral state inference, and avatar state reflection remain planned for future iterations.
+| Season | Primary sections | What this season changes |
+|---|---|---|
+| Season 1 | Trust + Capability, Ecosystem + Leverage | Makes Seraph safe enough and capable enough to justify the guardian promise |
+| Season 2 | Presence + Distribution, Embodiment + Life OS | Makes Seraph reachable outside localhost and more present in daily life |
+| Season 3 | Memory + Guardian Intelligence, Trust + Capability | Turns Seraph from stateful assistant into long-horizon guardian |
+| Season 4 | Embodiment + Life OS, Presence + Distribution, Ecosystem + Leverage | Fully cashes in Seraph's unique product and motivation moat |
 
-### 3.1 Context Awareness Layer ✅
-- **Active application detection** — What app/site is the user on? *(API contract documented, daemon deferred)*
-- **Calendar awareness** — What's coming up? What just ended?
-- **Git activity monitoring** — Commits, branches, build status
-- **Idle/active detection** — Is the user at their machine? *(basic: last interaction tracking)*
-- All observation is opt-in, configurable per source, locally processed
+## Now / Next / Later
 
-### 3.2 Screen Context (Optional, Opt-In)
-- Periodic screen capture → local vision model extraction → discard image
-- Extracts: active document name, key content, current task context
-- Never stores raw screenshots — only extracted semantic context
-- User controls frequency (never / every 5 min / every minute)
+### Now
 
-*Status: Planned. Backend endpoint and `ContextManager.update_screen_context()` are ready. Native daemon deferred.*
+**Season 1: Trust + Capability**
 
-### 3.3 Working Memory System
-- Real-time context buffer: what the user is doing *right now*
-- Combines: active task, recent messages, calendar, observations
-- Pruned aggressively — only the relevant survives
-- Fed to Strategist as "current situation" context
+This is the highest-priority season because Seraph's biggest weakness is not product positioning. It is the gap between the guardian thesis and the runtime's current operational credibility.
 
-*Status: Partially implemented via `CurrentContext.to_prompt_block()` — aggregates time, calendar, git, goals, screen context, and user state into a text block for agent injection.*
+Immediate batches:
 
-### 3.4 Pattern Detection Engine
-- Tracks over time: work hours, break patterns, productivity cycles
-- Detects: energy peaks/valleys, procrastination triggers, context-switch frequency
-- Identifies: recurring behaviors, habit formation/decay, stress signals
-- Stores patterns in long-term memory, not raw data
+- [S1-B1 Trust Boundaries](../roadmap/batches/s1-b1-trust-boundaries)
+- [S1-B2 Execution Plane](../roadmap/batches/s1-b2-execution-plane)
+- [S1-B3 Runtime Reliability](../roadmap/batches/s1-b3-runtime-reliability)
 
-*Status: Planned.*
+### Next
 
-### 3.5 State Inference
-- Estimates current human state: focused / distracted / stressed / energized / idle
-- Uses: typing speed, app switching frequency, time of day, calendar density
-- Feeds into Advisor's interruption intelligence
+**Season 2: Reach + Presence**
 
-*Status: Partially implemented. User state machine derives state from calendar + time + activity, but not from behavioral signals like typing speed or app switching.*
+Once Seraph is safer and more credible, it needs to become available in real life rather than trapped in a dev stack. The second season focuses on native presence, channels, and ambient delivery.
 
-### 3.6 Avatar Reflects Human State
-- Avatar's idle behavior changes based on inferred state:
-  - **Focused**: Avatar meditates peacefully, glowing aura
-  - **Stressed**: Avatar paces, darker lighting
-  - **Energized**: Avatar practices sword forms, bright scene
-  - **Idle/resting**: Avatar sleeps, fireflies in scene
-  - **Distracted**: Avatar looks around nervously
+Upcoming batches:
 
-*Status: Planned. Frontend ambient indicator dot and nudge speech bubble are implemented (Phase 3.4), but Phaser-level avatar animation changes are not yet wired.*
+- [S2-B1 Native Presence](../roadmap/batches/s2-b1-native-presence)
+- [S2-B2 Channel Reach](../roadmap/batches/s2-b2-channel-reach)
+- [S2-B3 Ambient Guardian](../roadmap/batches/s2-b3-ambient-guardian)
 
-### Milestone
-Seraph sees what you're doing, understands your patterns, and its avatar mirrors your state.
+### Later
 
----
+**Season 3 and Season 4**
 
-## Phase 3.5 — Polish & Production Readiness
+These seasons deepen the parts of Seraph that make it more than a secure task runner:
 
-**Theme**: Make what exists production-quality. Complete unfinished UI, fix backend gaps, harden infrastructure, eliminate adoption barriers.
+- a richer model of the human
+- adaptive guardian behavior
+- a stronger embodied life operating system
 
-**Status**: Mostly complete. Goal UI, interruption mode, accessibility, timeouts, token-aware context, SKILL.md plugins, draggable panels, MCP auth UX, and stdio proxy are done. Avatar state reflection and Tauri desktop remain planned.
+Later-season batches are already defined so implementation can continue without rethinking the entire roadmap:
 
-### 3.5.1 Goal Management UI ✅
-- ~~Create/edit/delete goals via dedicated form (not just chat)~~ — `GoalForm.tsx` with create/edit modal
-- ~~Quest panel search, filter by domain/level/status, sort~~ — Text search + level/domain dropdowns, inline actions (complete/edit/delete) on GoalTree nodes
-- ~~Backend APIs already exist — this is frontend-only~~
+- [Season 3: Memory + Guardian](../roadmap/seasons/season-3-memory-guardian)
+- [Season 4: Embodied Life OS](../roadmap/seasons/season-4-embodied-life-os)
 
-### 3.5.2 Interruption Mode UI ✅
-- ~~Focus / Balanced / Active toggle in Settings panel~~ — `InterruptionModeToggle.tsx`, 3-state toggle
-- ~~Mode indicator in HUD area~~
-- ~~Backend API exists at `/api/settings/interruption-mode`~~
+## Detailed Planning Tree
 
-### 3.5.3 Avatar State Reflection
-- Avatar behavior changes based on ambient state (has_insight, goal_behind, on_track)
-- Click avatar in has_insight state → opens chat with queued insights
-- Ambient WebSocket messages already flow — Phaser visuals missing
+### Sections
 
-*Status: Planned.*
-
-### 3.5.4 Calendar Scan
-- ~~Complete the calendar_scan job with Google Calendar API integration~~ — Works when credentials are configured
-- Enable calendar-aware user state transitions
-
-*Status: Functional when credentials are configured.*
-
-### 3.5.5 Token-Aware Context Window ✅
-- ~~Replace fixed 50-message window with adaptive token counting~~ — Configurable budget (default 12,000 tokens)
-- ~~Summarize middle messages when budget exceeded~~ — Keeps first N + last M messages, LLM summarization for middle
-- ~~Prevent quality degradation in long conversations~~
-- 3 new settings: `context_window_token_budget`, `context_window_keep_first`, `context_window_keep_recent`
-
-### 3.5.6 Agent Execution Timeout ✅
-- ~~Timeout handling for agent runs (120s default)~~ — `asyncio.wait_for` on all agent paths (REST, WS, strategist, briefing)
-- ~~Per-tool timeouts (shell 30s, browser 60s, others 15s)~~ — 5 configurable timeout settings
-- ~~Graceful error messages on timeout~~ — 504 on REST, error message on WS
-
-### 3.5.7 Tauri Desktop App
-- Native macOS app (single `.dmg` installer)
-- Eliminates Docker + Python + Node.js requirements
-- System tray, native notifications, auto-updater
-- Bundles backend as sidecar, daemon as Rust plugin
-
-*Status: Planned. Analysis complete in `docs/architecture/tauri-analysis.md`.*
-
-### 3.5.8 Infrastructure Hardening
-- Production Docker Compose with health checks, restart policies, resource limits
-- CI/CD pipeline (GitHub Actions: lint, type-check, test on PR)
-- API key security (rotate exposed key, `.gitignore` protection)
-
-*Status: Planned.*
-
-### 3.5.9 Frontend Accessibility ✅
-- ~~Increase minimum font sizes (7-9px → 11-12px)~~ — 9px minimum across all panels (Press Start 2P pixel font)
-- ~~Keyboard shortcuts for panel toggling (C/Q/S/Esc)~~ — Shift+C (chat), Shift+Q (quests), Shift+S (settings), Escape (close). Shift modifier prevents WASD conflict.
-
-### 3.5.10 Draggable & Resizable Panels ✅
-- All panels (chat, quest, settings) draggable via title bar, resizable from 8 edges/corners
-- Layout (position/size) persisted in localStorage via `panelLayoutStore`
-- Z-ordering: clicking a panel brings it to front
-
-### 3.5.11 MCP Auth UX ✅
-- 4-state status indicator per server: gray (disabled), green (connected), yellow pulsing (auth needed), red (error)
-- Inline token config form with save-and-test flow
-- Clickable auth hints guide users through token setup
-
-### 3.5.12 Stdio-to-HTTP MCP Proxy ✅
-- Native macOS proxy (`mcp-servers/stdio-proxy/`) wraps stdio-only MCP servers as HTTP endpoints
-- `manage.sh` integration: `proxy start|stop|status|logs`
-- Backend connects to proxied servers as normal HTTP MCP servers — no backend changes needed
-
-### Milestone
-Everything that exists is robust, polished, and installable. Ready to expand.
-
----
-
-## Phase 4 — The Strategist
-
-**Theme**: Seraph doesn't just observe — it *thinks*. Continuously reasoning about how to elevate its human.
-
-**Status**: Core proactive reasoning is complete (4.1–4.4). SKILL.md plugin ecosystem and recursive delegation also shipped. Decision support, mistake prevention, and weekly strategy remain planned.
-
-### 4.1 Proactive Reasoning Engine ✅
-- ~~Background process that runs on a schedule (every 15 min) and on triggers~~ — `strategist_tick` job (APScheduler, every 15 min)
-- ~~Inputs: current context, user model, goal hierarchy, calendar, recent patterns~~ — `CurrentContext.to_prompt_block()` aggregates all sources
-- ~~Outputs: ranked list of potential interventions with urgency scores~~ — `StrategistDecision` dataclass with urgency scoring
-- ~~Uses chain-of-thought reasoning~~ — Restricted smolagents agent (`view_soul`, `get_goals`, `get_goal_progress`, temp=0.4, max_steps=5)
-
-### 4.2 Interruption Intelligence ✅
-- ~~Cost/benefit calculator for each potential intervention~~ — User state machine (6 states) + attention budget + delivery gating
-- ~~Factors: urgency, user receptivity state, time until window closes, intervention history~~ — `should_deliver()` considers all factors
-- ~~Urgency levels: Ambient → Nudge → Advisory → Alert → Autonomous~~ — Implemented as `ambient`, `nudge`, `advisory`, `alert` intervention types
-- ~~Respects user's proactivity dial (set during onboarding, adjustable anytime)~~ — Focus/Balanced/Active modes via API + UI
-- Learns from dismissal/engagement patterns — *Not yet implemented*
-
-### 4.3 Morning Briefing ✅
-- ~~Proactive daily briefing at user's configured time~~ — `daily_briefing` job (cron 8 AM)
-- ~~Contents: calendar, goal progress, priority recommendations~~ — Gathers soul + calendar + goals + memories, calls LiteLLM
-- ~~Delivered as RPG "quest briefing" in the village~~ — Delivered via WebSocket with `is_scheduled=True`
-
-### 4.4 Evening Review ✅
-- ~~End-of-day reflection prompt~~ — `evening_review` job (cron 9 PM)
-- ~~What was accomplished vs. planned~~ — Counts today's messages + completed goals
-- ~~Goal progress updates~~ — Delivered via LiteLLM with `is_scheduled=True`
-- RPG "campfire scene" — *Visual scene not yet implemented*
-
-### 4.5 Decision Support
-- When the user faces a decision, Seraph can:
-  - Run a pre-mortem ("Imagine this decision failed — why?")
-  - Analyze second/third-order consequences
-  - Reference similar past decisions and their outcomes
-  - Present a structured pros/cons with weighted scoring
-  - Play devil's advocate on request
-
-*Status: Planned.*
-
-### 4.6 Mistake Prevention
-- Pattern-based alerts:
-  - "You're about to commit credentials to a public repo"
-  - "This email tone is more aggressive than your usual style"
-  - "You've scheduled 6 hours of meetings tomorrow — when will you do deep work?"
-  - "You've been on social media for 45 minutes — your deadline is in 2 days"
-  - "Last time you made this type of decision under stress, the outcome was..."
-
-*Status: Planned.*
-
-### 4.7 Weekly Strategy Session
-- Weekly proactive conversation (user picks the day/time)
-- Review: goal progress, wins, setbacks, patterns
-- Plan: next week's priorities, time allocation, key decisions
-- Adjust: goal timelines, reprioritize if needed
-- RPG framing: "War room" scene in the village
-
-*Status: Planned.*
-
-### 4.8 SKILL.md Plugin Ecosystem ✅
-- Zero-code markdown plugins in `data/skills/` with YAML frontmatter (`name`, `description`, `requires.tools`, `user_invocable`, `enabled`)
-- Tool gating: skills only loaded when required tools are available
-- Runtime enable/disable via `GET/PUT /api/skills` + Settings UI
-- 8 bundled skills: `daily-standup`, `code-review`, `goal-reflection`, `weekly-planner`, `morning-intention`, `evening-journal`, `moltbook` (requires `http_request`), `web-briefing` (requires `http_request` + `web_search`)
-
-### 4.9 Recursive Delegation Architecture ✅
-- Orchestrator (no tools) delegates to domain specialists behind feature flag (`USE_DELEGATION=true`)
-- 4 built-in specialists: `memory_keeper`, `goal_planner`, `web_researcher`, `file_worker`
-- 1 MCP specialist auto-generated per enabled MCP server
-- Configurable: `delegation_max_depth` (default 1), `orchestrator_max_steps` (default 8)
-
-### Milestone
-Seraph thinks about your life constantly, intervenes at the right moments, and helps you strategize.
-
----
-
-## Phase 5 — The Guardian
-
-**Theme**: Seraph operates autonomously within boundaries. It doesn't just advise — it acts.
-
-### 5.1 Autonomous Actions (Pre-Authorized)
-- User defines action classes Seraph can take without asking:
-  - Block calendar conflicts with deep work
-  - Decline meetings that don't serve current priorities (with templated response)
-  - Send pre-approved check-in messages
-  - Create and assign tasks from conversations
-  - File and organize notes
-- Each autonomous action is logged and reviewable
-
-### 5.2 Scheduled/Heartbeat Tasks
-- Cron-like system for recurring autonomous work:
-  - Morning: check calendar, prepare briefing, scan email for urgent items
-  - Periodic: monitor goal-relevant metrics, check deadlines
-  - Evening: compile daily summary, prepare tomorrow's plan
-  - Weekly: generate progress report, detect stalled goals
-- User configures which heartbeats are active
-
-### 5.3 Multi-Channel Delivery
-- **Telegram bot** as first channel — simplest bot API, mobile push notifications, unlocks proactive system's full value. This is the next major priority.
-- Discord / Slack / WhatsApp as subsequent channels
-- Push notifications (PWA or mobile app)
-- Email digests for non-urgent items
-- The RPG web UI remains the primary deep-interaction interface
-- Channel selection based on urgency and user preferences
-
-### 5.4 Delegation Intelligence
-- Seraph identifies tasks it can handle autonomously vs. tasks that need the human
-- "I can research this for you in the background. Want me to?"
-- "This requires a decision only you can make. Here's what you need to know."
-- Background task execution with status updates in the quest log
-
-### 5.5 Accountability System
-- Tracks commitments the user makes (in conversation or during planning)
-- Gentle follow-ups: "You said you'd finish X by today. How's it going?"
-- Patterns: "You've rescheduled this commitment 3 times. Let's either do it or drop it."
-- Never nagging — strategic accountability based on the user's own stated priorities
-
-### Milestone
-Seraph acts on your behalf within defined boundaries, follows up on your commitments, and reaches you where you are.
-
----
-
-## Phase 6 — The Life Operating System
-
-**Theme**: The full vision realized. Seraph as the operating layer between the human and their life.
-
-### 6.1 RPG Life Dashboard
-- Full character sheet with real stats computed from real data:
-  - **Vitality** (health, energy, sleep, exercise)
-  - **Focus** (deep work hours, context switches, flow states)
-  - **Influence** (network activity, communication quality, reputation signals)
-  - **Wisdom** (learning velocity, reflection frequency, decision quality)
-  - **Execution** (goal completion rate, task velocity, commitment follow-through)
-- Leveling system based on sustained stat improvement
-- Historical graphs showing progression over months/years
-
-### 6.2 Village Evolution
-- Village visually evolves based on life progress:
-  - New buildings unlock as capabilities expand
-  - Buildings upgrade as related skills improve (library grows, forge gets better)
-  - Neglected domains show visible decay (motivational feedback)
-  - Seasonal events tied to quarterly goal cycles
-- The village becomes a mirror of the user's life investment
-
-### 6.3 Network Intelligence
-- Relationship mapping: key people, interaction frequency, relationship health
-- Proactive: "You haven't connected with [mentor] in 2 months — they're important to [goal]"
-- Meeting prep: "Here's context on everyone in your 3pm meeting"
-- Communication coaching: real-time tone and strategy suggestions
-
-### 6.4 Financial Awareness (Optional)
-- Spending pattern awareness (with explicit opt-in)
-- Alignment checking: "Your spending this month doesn't align with your savings goal"
-- Investment/opportunity flagging relevant to stated financial goals
-
-### 6.5 Health Integration (Optional)
-- Wearable data integration (Apple Health, WHOOP, Fitbit)
-- Correlate health data with productivity patterns
-- "Your deep work quality drops 40% on days you sleep under 6 hours"
-- Proactive health-productivity recommendations
-
-### 6.6 Multi-Agent Architecture
-- Partial implementation via recursive delegation (Phase 4.9): orchestrator + 4 domain specialists + auto-generated MCP specialists
-- Full vision with named sub-agents remains planned:
-  - **Sentinel** — Security, mistake prevention, risk monitoring
-  - **Strategist** — Goal planning, decision support, trajectory analysis
-  - **Executor** — Task execution, tool operation, background work
-  - **Chronicler** — Memory management, pattern detection, reflection
-  - **Herald** — Communication coaching, meeting prep, network management
-- Agents coordinate through shared memory, overseen by the Seraph core
-
-### 6.7 TTS / Voice
-- Seraph speaks in the RPG UI (avatar voice with retro effect)
-- Voice interaction option (speak to Seraph, hear responses)
-- Fits the guardian angel aesthetic — a voice in your ear
-
-### 6.8 Mobile Experience
-- PWA or native app for mobile access
-- Quick capture: "Seraph, remind me to..." / "Seraph, I just decided to..."
-- Notification-driven interaction on mobile (full UI on desktop)
-- Mobile as the "always with you" channel, desktop as the "deep work" channel
-
-### Milestone
-Seraph is a comprehensive life operating system — observing, thinking, acting, and evolving alongside its human toward their highest potential.
-
----
-
-## Technical Prerequisites by Phase
-
-| Phase | Key Technical Requirements |
-|-------|---------------------------|
-| **1** | Database (SQLite/Postgres), file-based memory (soul.md), goal data model, onboarding flow |
-| **2** | Docker sandboxing, Playwright, OAuth for Google/Microsoft, plugin API, tool registry |
-| **3** | OS-level context APIs, local vision model, pattern detection pipeline, state inference model |
-| **4** | Background scheduler, reasoning engine (LLM-in-a-loop), interruption cost model, briefing templates |
-| **5** | Telegram/Discord bot SDK, push notification service, delegation framework, action audit log |
-| **6** | Stat computation engine, Phaser village evolution system, wearable APIs, sub-agent orchestration |
-
----
-
-## Design Principles (Every Phase)
-
-1. **Proactive over reactive** — Default to initiating, not waiting
-2. **Strategic over tactical** — Ask "does this serve the highest goal?" not just "is this task done?"
-3. **Earn trust incrementally** — Start quiet, prove value, then increase agency
-4. **Transparent always** — Every observation, reasoning step, and action is visible and auditable
-5. **Human sovereignty** — The human is always in control. Seraph advises and acts within boundaries, never overrides
-6. **Privacy by architecture** — All data local by default. Raw observations discarded after processing. Nothing leaves the machine without explicit consent
-7. **The RPG metaphor serves the mission** — Every game element must map to real life value. No decoration without purpose
-8. **Optimize for the human, not for engagement** — Seraph should make itself less needed over time as the human grows. The goal is elevation, not dependency
+- [Section 1: Trust + Capability](../roadmap/sections/section-1-trust-capability)
+- [Section 2: Presence + Distribution](../roadmap/sections/section-2-presence-distribution)
+- [Section 3: Memory + Guardian Intelligence](../roadmap/sections/section-3-memory-guardian-intelligence)
+- [Section 4: Embodiment + Life OS](../roadmap/sections/section-4-embodiment-life-os)
+- [Section 5: Ecosystem + Leverage](../roadmap/sections/section-5-ecosystem-leverage)
+
+### Seasons
+
+- [Season 1: Trust + Capability](../roadmap/seasons/season-1-trust-capability)
+- [Season 2: Reach + Presence](../roadmap/seasons/season-2-reach-presence)
+- [Season 3: Memory + Guardian](../roadmap/seasons/season-3-memory-guardian)
+- [Season 4: Embodied Life OS](../roadmap/seasons/season-4-embodied-life-os)
+
+### Current Decision-Complete Batches
+
+- [S1-B1 Trust Boundaries](../roadmap/batches/s1-b1-trust-boundaries)
+- [S1-B2 Execution Plane](../roadmap/batches/s1-b2-execution-plane)
+- [S1-B3 Runtime Reliability](../roadmap/batches/s1-b3-runtime-reliability)
+- [S2-B1 Native Presence](../roadmap/batches/s2-b1-native-presence)
+- [S2-B2 Channel Reach](../roadmap/batches/s2-b2-channel-reach)
+- [S2-B3 Ambient Guardian](../roadmap/batches/s2-b3-ambient-guardian)
+
+### Later-Season Stubs
+
+- [S3-B1 Human World Model](../roadmap/batches/s3-b1-human-world-model)
+- [S3-B2 Observer Deepening](../roadmap/batches/s3-b2-observer-deepening)
+- [S3-B3 Learning Loop](../roadmap/batches/s3-b3-learning-loop)
+- [S4-B1 Avatar Reflection](../roadmap/batches/s4-b1-avatar-reflection)
+- [S4-B2 Life OS Surfaces](../roadmap/batches/s4-b2-life-os-surfaces)
+- [S4-B3 World + Motivation](../roadmap/batches/s4-b3-world-motivation)
+
+## How To Use This Roadmap
+
+- Use this page as the single long-term entry point.
+- Use section docs to explain strategic rationale.
+- Use season docs to coordinate cross-batch sequencing.
+- Use batch docs to drive implementation and issue breakdown.
+- Use [Next Steps](./next-steps) as the short horizon summary derived from this roadmap.

--- a/docs/docs/roadmap/batches/s1-b1-trust-boundaries.md
+++ b/docs/docs/roadmap/batches/s1-b1-trust-boundaries.md
@@ -1,0 +1,54 @@
+---
+title: S1-B1 Trust Boundaries
+---
+
+# S1-B1: Trust Boundaries
+
+## Intent
+
+Add the minimum serious trust and control layer Seraph needs before broader autonomy work.
+
+## Capabilities in scope
+
+- policy profiles for tool access
+- approval gates for sensitive actions
+- secret scoping and safer credential usage
+- audit log of meaningful actions and approvals
+- clearer isolation boundaries between planning, execution, and privileged operations
+
+## Non-goals
+
+- full enterprise multi-tenant security
+- hardware enclave or IronClaw-style Wasm rearchitecture
+- complete OAuth platform buildout
+
+## Required architectural changes
+
+- introduce policy-aware execution paths around tools
+- add an approval checkpoint model for high-risk actions
+- separate secret access from ordinary tool invocation
+- define a consistent audit event format for agent actions
+
+## Likely files/systems touched
+
+- backend agent and tool orchestration
+- settings and policy configuration
+- vault / secret handling
+- chat and WS flows where approvals surface to the user
+
+## Acceptance criteria
+
+- privileged tools cannot run without an explicit policy path
+- high-risk actions can be paused for approval
+- secret use becomes scoped and auditable
+- actions and approvals are logged in a structured way
+
+## Dependencies on earlier batches
+
+- none; this batch starts the season
+
+## Open risks
+
+- poor policy design can create user friction without meaningful safety
+- approval UX can become annoying if the risk model is too coarse
+- partial trust boundaries may create a false sense of safety if messaging is sloppy

--- a/docs/docs/roadmap/batches/s1-b2-execution-plane.md
+++ b/docs/docs/roadmap/batches/s1-b2-execution-plane.md
@@ -1,0 +1,53 @@
+---
+title: S1-B2 Execution Plane
+---
+
+# S1-B2: Execution Plane
+
+## Intent
+
+Expand Seraph's ability to actually do work so the guardian thesis is backed by a more serious action layer.
+
+## Capabilities in scope
+
+- real shell and process execution beyond Python-only snippets
+- stronger browser control and interactive web flows
+- background process/session handling
+- workflow engine direction for repeatable tool chains
+
+## Non-goals
+
+- full desktop computer control across every app
+- unlimited shell access without policy controls
+- large-scale workflow marketplace
+
+## Required architectural changes
+
+- split lightweight code execution from broader command/process execution
+- upgrade browser tooling from extract-only patterns toward interactive automation
+- define a process/session abstraction that can report status back to the UI
+- establish the first workflow representation and execution contract
+
+## Likely files/systems touched
+
+- backend tools and tool registry
+- sandbox / execution environment
+- browser automation layer
+- chat and step streaming for longer-running actions
+
+## Acceptance criteria
+
+- Seraph can run bounded shell/process tasks under policy control
+- browser automation supports richer interactive flows
+- longer-running tasks can surface intermediate state
+- at least one workflow path exists for repeatable multi-step execution
+
+## Dependencies on earlier batches
+
+- depends on [S1-B1 Trust Boundaries](./s1-b1-trust-boundaries) for safe execution expansion
+
+## Open risks
+
+- execution breadth can outpace safety
+- UX may degrade if longer tasks are not surfaced clearly
+- browser automation can become flaky without careful constraints

--- a/docs/docs/roadmap/batches/s1-b3-runtime-reliability.md
+++ b/docs/docs/roadmap/batches/s1-b3-runtime-reliability.md
@@ -1,0 +1,55 @@
+---
+title: S1-B3 Runtime Reliability
+---
+
+# S1-B3: Runtime Reliability
+
+## Intent
+
+Make Seraph more resilient, observable, and predictable under real usage.
+
+## Capabilities in scope
+
+- model/provider routing and fallback
+- at least one local-model-capable path
+- richer observability for agent behavior and tool execution
+- evaluation harness for core agent workflows
+- clearer degraded-mode behavior when dependencies fail
+
+## Non-goals
+
+- exhaustive benchmark program across every model
+- production-grade hosted observability platform
+- fully automated eval-driven deployment gating
+
+## Required architectural changes
+
+- centralize model selection and fallback strategy
+- standardize runtime event logging across critical paths
+- define test/eval scenarios for guardian, tool, and proactive flows
+- add explicit error-handling behavior for provider/tool outages
+
+## Likely files/systems touched
+
+- model configuration and agent factory paths
+- scheduler and proactive jobs
+- logging and evaluation utilities
+- tool failure and timeout handling
+
+## Acceptance criteria
+
+- provider failure does not collapse the entire chat path
+- a local or non-OpenRouter path is demonstrably possible
+- key flows are observable and easier to debug
+- the project has a repeatable evaluation harness for core behavior
+
+## Dependencies on earlier batches
+
+- can begin in parallel with [S1-B2 Execution Plane](./s1-b2-execution-plane)
+- benefits from [S1-B1 Trust Boundaries](./s1-b1-trust-boundaries) defining clearer execution paths
+
+## Open risks
+
+- fallback logic can become inconsistent if added ad hoc
+- observability can create noise if events are not scoped well
+- local model support may underperform unless task routing is explicit

--- a/docs/docs/roadmap/batches/s2-b1-native-presence.md
+++ b/docs/docs/roadmap/batches/s2-b1-native-presence.md
@@ -1,0 +1,54 @@
+---
+title: S2-B1 Native Presence
+---
+
+# S2-B1: Native Presence
+
+## Intent
+
+Give Seraph a native-feeling local presence so it no longer depends on a browser tab and manual startup habits.
+
+## Capabilities in scope
+
+- Tauri desktop shell or equivalent native wrapper
+- tray presence
+- system notifications
+- startup and background lifecycle handling
+- packaging that feels closer to an app than a dev environment
+
+## Non-goals
+
+- full cross-platform parity on day one
+- complete replacement of the Python backend
+- deep mobile support
+
+## Required architectural changes
+
+- define the desktop shell boundary and process model
+- unify lifecycle management for backend, daemon, and UI
+- add notification and tray interfaces
+- harden local packaging and startup paths
+
+## Likely files/systems touched
+
+- desktop packaging layer
+- manage/run lifecycle assumptions
+- notification and status surfaces
+- setup and docs for installation
+
+## Acceptance criteria
+
+- Seraph can be launched and kept present as a local app
+- notifications work without relying on an open browser tab
+- local lifecycle is simpler than the current Docker-first path
+- desktop presence does not break existing web development flow
+
+## Dependencies on earlier batches
+
+- depends on Season 1 making the runtime worth packaging
+
+## Open risks
+
+- packaging complexity can slow momentum
+- desktop shell work can distract from core product behavior if not tightly scoped
+- process orchestration may become brittle without good observability

--- a/docs/docs/roadmap/batches/s2-b2-channel-reach.md
+++ b/docs/docs/roadmap/batches/s2-b2-channel-reach.md
@@ -1,0 +1,54 @@
+---
+title: S2-B2 Channel Reach
+---
+
+# S2-B2: Channel Reach
+
+## Intent
+
+Add the first serious external communication channel so Seraph can reach the user where they already are.
+
+## Capabilities in scope
+
+- one initial channel, likely Telegram first
+- inbound and outbound session routing
+- proactive delivery to that channel
+- lightweight message normalization and user/session mapping
+
+## Non-goals
+
+- simultaneous launch across many channels
+- complex group chat policies beyond the minimum safe path
+- enterprise team routing
+
+## Required architectural changes
+
+- define a channel adapter abstraction
+- route messages into the existing session system
+- support outbound proactive delivery through channel preferences
+- add enough policy to prevent spammy or unsafe delivery behavior
+
+## Likely files/systems touched
+
+- backend channel integration layer
+- session identity and routing
+- proactive delivery paths
+- settings and configuration UX
+
+## Acceptance criteria
+
+- Seraph can receive and answer messages on one external channel
+- proactive messages can reach the user there
+- channel conversations map cleanly into Seraph sessions
+- the browser UI remains the canonical rich interface rather than being broken by channel work
+
+## Dependencies on earlier batches
+
+- depends on [S2-B1 Native Presence](./s2-b1-native-presence) or equivalent presence groundwork
+- depends on Season 1 reliability so channel delivery is credible
+
+## Open risks
+
+- multi-surface behavior can become confusing without clear session identity rules
+- notifications may become noisy if interruption logic is not respected across channels
+- channel-specific auth and rate limits can add operational drag

--- a/docs/docs/roadmap/batches/s2-b3-ambient-guardian.md
+++ b/docs/docs/roadmap/batches/s2-b3-ambient-guardian.md
@@ -1,0 +1,54 @@
+---
+title: S2-B3 Ambient Guardian
+---
+
+# S2-B3: Ambient Guardian
+
+## Intent
+
+Improve how Seraph shows up between major interactions so its presence feels intentional, calm, and useful.
+
+## Capabilities in scope
+
+- richer ambient summaries and nudges
+- better notification/report surfaces
+- stronger timing and delivery polish outside the core chat panel
+- clearer transitions between ambient, nudge, advisory, and alert moments
+
+## Non-goals
+
+- full Season 4 embodiment work
+- complicated gamification systems
+- every possible delivery surface
+
+## Required architectural changes
+
+- unify proactive delivery behavior across desktop and external channels
+- improve surface selection for different intervention types
+- tighten summary/report formatting for briefings, reviews, and queued bundles
+- expose more of the guardian state outside direct chat
+
+## Likely files/systems touched
+
+- observer and delivery logic
+- frontend ambient surfaces
+- desktop or channel notification formatting
+- daily briefing / review presentation paths
+
+## Acceptance criteria
+
+- proactive delivery feels more deliberate and less like raw chat output
+- users can distinguish ambient presence from urgent intervention
+- briefings, reviews, and queued insights read well on the active surfaces
+- this batch sets up Season 4 rather than duplicating it
+
+## Dependencies on earlier batches
+
+- depends on [S2-B1 Native Presence](./s2-b1-native-presence)
+- depends on [S2-B2 Channel Reach](./s2-b2-channel-reach) if external channels are part of the chosen delivery mix
+
+## Open risks
+
+- surface proliferation can fragment the experience
+- better delivery without better intelligence can make Seraph feel louder rather than better
+- batch boundaries can blur with Season 4 if embodiment work starts too early

--- a/docs/docs/roadmap/batches/s3-b1-human-world-model.md
+++ b/docs/docs/roadmap/batches/s3-b1-human-world-model.md
@@ -1,0 +1,42 @@
+---
+title: S3-B1 Human World Model
+---
+
+# S3-B1: Human World Model
+
+## Intent
+
+Define a richer memory model for people, commitments, projects, and ongoing life context.
+
+## Capabilities in scope
+
+- structured entities and relationships
+- commitment and project tracking
+- better linkage between soul, sessions, goals, and long-term memory
+
+## Non-goals
+
+- exhaustive personal knowledge graph design in one batch
+
+## Required architectural changes
+
+- introduce a richer memory schema beyond generic vector recall
+- connect memory objects to real guardian workflows
+
+## Likely files/systems touched
+
+- memory layer
+- goals and profile model
+- strategist context inputs
+
+## Acceptance criteria
+
+- Seraph can retain more structured human context than today
+
+## Dependencies on earlier batches
+
+- benefits from Season 1 reliability and observability
+
+## Open risks
+
+- schema complexity can outrun real use cases

--- a/docs/docs/roadmap/batches/s3-b2-observer-deepening.md
+++ b/docs/docs/roadmap/batches/s3-b2-observer-deepening.md
@@ -1,0 +1,42 @@
+---
+title: S3-B2 Observer Deepening
+---
+
+# S3-B2: Observer Deepening
+
+## Intent
+
+Increase the depth and usefulness of observer signals that feed guardian reasoning.
+
+## Capabilities in scope
+
+- stronger state inference
+- better pattern detection
+- richer contextual signals over time
+
+## Non-goals
+
+- invasive surveillance or unlimited signal collection
+
+## Required architectural changes
+
+- deepen observer signal processing and pattern extraction
+- improve the bridge from observation to strategist context
+
+## Likely files/systems touched
+
+- daemon inputs
+- observer manager and state machine
+- proactive reasoning inputs
+
+## Acceptance criteria
+
+- Seraph can reason over more meaningful behavioral context than today
+
+## Dependencies on earlier batches
+
+- depends on S3-B1 giving the observer somewhere richer to write into
+
+## Open risks
+
+- privacy and noise management become more important as signal depth increases

--- a/docs/docs/roadmap/batches/s3-b3-learning-loop.md
+++ b/docs/docs/roadmap/batches/s3-b3-learning-loop.md
@@ -1,0 +1,42 @@
+---
+title: S3-B3 Learning Loop
+---
+
+# S3-B3: Learning Loop
+
+## Intent
+
+Make Seraph adapt based on intervention outcomes instead of fixed heuristics alone.
+
+## Capabilities in scope
+
+- intervention outcome tracking
+- feedback-aware proactivity
+- stronger adaptation over time
+
+## Non-goals
+
+- opaque self-modifying behavior without guardrails
+
+## Required architectural changes
+
+- record intervention results and feed them back into strategy
+- define safe learning signals and adaptation rules
+
+## Likely files/systems touched
+
+- strategist
+- delivery system
+- memory and analytics paths
+
+## Acceptance criteria
+
+- Seraph can improve future interventions using prior outcomes
+
+## Dependencies on earlier batches
+
+- depends on S3-B1 and S3-B2
+
+## Open risks
+
+- poor feedback loops can amplify bad behavior rather than improve it

--- a/docs/docs/roadmap/batches/s4-b1-avatar-reflection.md
+++ b/docs/docs/roadmap/batches/s4-b1-avatar-reflection.md
@@ -1,0 +1,42 @@
+---
+title: S4-B1 Avatar Reflection
+---
+
+# S4-B1: Avatar Reflection
+
+## Intent
+
+Make the avatar visibly reflect real user and guardian state.
+
+## Capabilities in scope
+
+- state-driven ambient behavior
+- mood and focus reflection
+- stronger visual feedback loops
+
+## Non-goals
+
+- full village progression systems
+
+## Required architectural changes
+
+- connect ambient and observer state to Phaser behaviors
+- define a stable mapping from system state to avatar expression
+
+## Likely files/systems touched
+
+- frontend game scene
+- animation state machine
+- ambient/proactive state plumbing
+
+## Acceptance criteria
+
+- avatar behavior changes meaningfully with real state
+
+## Dependencies on earlier batches
+
+- depends on Season 3 making state richer
+
+## Open risks
+
+- can feel cosmetic if state mapping is shallow

--- a/docs/docs/roadmap/batches/s4-b2-life-os-surfaces.md
+++ b/docs/docs/roadmap/batches/s4-b2-life-os-surfaces.md
@@ -1,0 +1,42 @@
+---
+title: S4-B2 Life OS Surfaces
+---
+
+# S4-B2: Life OS Surfaces
+
+## Intent
+
+Expand Seraph's visible progress, ritual, and review surfaces into a true life operating system.
+
+## Capabilities in scope
+
+- richer dashboards and review flows
+- stats and progress surfaces
+- dynamic panels or canvas outputs
+
+## Non-goals
+
+- full ecosystem of user-generated widgets in this batch
+
+## Required architectural changes
+
+- add richer presentation surfaces driven by real guardian data
+- make periodic reviews and summaries more visually expressive
+
+## Likely files/systems touched
+
+- frontend panels
+- reporting surfaces
+- backend summary generation
+
+## Acceptance criteria
+
+- Seraph exposes more useful long-horizon progress than chat alone
+
+## Dependencies on earlier batches
+
+- depends on S4-B1 and Season 3 data quality
+
+## Open risks
+
+- visual surfaces can become shallow dashboards if not tied to real outcomes

--- a/docs/docs/roadmap/batches/s4-b3-world-motivation.md
+++ b/docs/docs/roadmap/batches/s4-b3-world-motivation.md
@@ -1,0 +1,42 @@
+---
+title: S4-B3 World + Motivation
+---
+
+# S4-B3: World + Motivation
+
+## Intent
+
+Tie long-term growth in the village world to real-life progress in a way that is motivating without becoming gimmicky.
+
+## Capabilities in scope
+
+- village growth and decay
+- meaningful unlocks
+- long-term motivation tied to real behavior
+
+## Non-goals
+
+- arbitrary gamification disconnected from life outcomes
+
+## Required architectural changes
+
+- map real user progress to world state
+- define progression rules that reinforce rather than distract
+
+## Likely files/systems touched
+
+- village data and rendering
+- goals/progress systems
+- ritual and review surfaces
+
+## Acceptance criteria
+
+- world changes reflect real progress in a way users can understand
+
+## Dependencies on earlier batches
+
+- depends on S4-B1 and S4-B2
+
+## Open risks
+
+- easy to make cheesy or manipulative if the progression model is not disciplined

--- a/docs/docs/roadmap/seasons/season-1-trust-capability.md
+++ b/docs/docs/roadmap/seasons/season-1-trust-capability.md
@@ -1,0 +1,54 @@
+---
+title: Season 1 - Trust + Capability
+---
+
+# Season 1: Trust + Capability
+
+## Theme
+
+Make Seraph's guardian promise operationally credible.
+
+## Why this season is first
+
+Seraph already has a differentiated thesis, but it still trails the best competitors on runtime credibility. This season fixes that before we invest further in reach or delight.
+
+## Win condition
+
+By the end of this season, Seraph should be safer, broader in execution, and more reliable under real use, with enough guardrails that future presence work is worth shipping.
+
+## Batches
+
+### [S1-B1 Trust Boundaries](../batches/s1-b1-trust-boundaries)
+
+- policy profiles
+- approvals for sensitive actions
+- secret scoping
+- auditable action flow
+- stronger isolation model
+
+### [S1-B2 Execution Plane](../batches/s1-b2-execution-plane)
+
+- real shell and process execution
+- stronger browser automation
+- workflow engine direction
+- a clearer path from “reasoning” to “doing”
+
+### [S1-B3 Runtime Reliability](../batches/s1-b3-runtime-reliability)
+
+- model routing and fallback
+- local model path
+- observability
+- evaluation harness
+- predictable degraded-mode behavior
+
+## Related sections
+
+- [Trust + Capability](../sections/section-1-trust-capability)
+- [Ecosystem + Leverage](../sections/section-5-ecosystem-leverage)
+
+## Exit criteria
+
+- security and trust boundaries are materially stronger than today
+- the execution plane no longer feels toy-sized next to the product thesis
+- the runtime can fail more gracefully and more observably
+- implementation work can proceed without constantly reopening core trust concerns

--- a/docs/docs/roadmap/seasons/season-2-reach-presence.md
+++ b/docs/docs/roadmap/seasons/season-2-reach-presence.md
@@ -1,0 +1,51 @@
+---
+title: Season 2 - Reach + Presence
+---
+
+# Season 2: Reach + Presence
+
+## Theme
+
+Move Seraph from a powerful local app to a daily companion with real-world presence.
+
+## Why this season follows Season 1
+
+Presence only matters if the underlying runtime is worth trusting. Once the execution and safety foundation is stronger, Seraph can expand outward into the user's daily environment.
+
+## Win condition
+
+By the end of this season, Seraph should have at least one native-feeling local surface, at least one external communication channel, and better ambient delivery behavior across the day.
+
+## Batches
+
+### [S2-B1 Native Presence](../batches/s2-b1-native-presence)
+
+- desktop shell
+- tray presence
+- notifications
+- startup/background polish
+
+### [S2-B2 Channel Reach](../batches/s2-b2-channel-reach)
+
+- first external channel
+- routing and continuity
+- notification and response flow outside the browser
+
+### [S2-B3 Ambient Guardian](../batches/s2-b3-ambient-guardian)
+
+- richer delivery surfaces
+- ambient visibility improvements
+- better summaries, reports, and nudges
+
+## Related sections
+
+- [Presence + Distribution](../sections/section-2-presence-distribution)
+- [Embodiment + Life OS](../sections/section-4-embodiment-life-os)
+- [Ecosystem + Leverage](../sections/section-5-ecosystem-leverage)
+
+## Exit criteria
+
+- Seraph is no longer browser-tab-bound
+- proactive behavior can reliably reach the user
+- delivery surfaces feel intentional rather than improvised
+- the groundwork is set for deeper memory and embodiment work

--- a/docs/docs/roadmap/seasons/season-3-memory-guardian.md
+++ b/docs/docs/roadmap/seasons/season-3-memory-guardian.md
@@ -1,0 +1,34 @@
+---
+title: Season 3 - Memory + Guardian
+---
+
+# Season 3: Memory + Guardian
+
+## Theme
+
+Upgrade Seraph from stateful assistant to long-horizon guardian.
+
+## Why this season matters
+
+This season turns Seraph's memory and observer systems into a richer human world model, which is what ultimately separates a guardian from a merely capable agent runtime.
+
+## Win condition
+
+By the end of this season, Seraph should understand more than messages and retrieval snippets. It should be reasoning over commitments, projects, patterns, and intervention outcomes with better timing and better personalization.
+
+## Batches
+
+- [S3-B1 Human World Model](../batches/s3-b1-human-world-model)
+- [S3-B2 Observer Deepening](../batches/s3-b2-observer-deepening)
+- [S3-B3 Learning Loop](../batches/s3-b3-learning-loop)
+
+## Related sections
+
+- [Memory + Guardian Intelligence](../sections/section-3-memory-guardian-intelligence)
+- [Trust + Capability](../sections/section-1-trust-capability)
+
+## Exit criteria
+
+- memory is more relational and less purely vector-based
+- observer signals carry more behavioral depth
+- proactivity adapts based on outcomes, not only heuristics

--- a/docs/docs/roadmap/seasons/season-4-embodied-life-os.md
+++ b/docs/docs/roadmap/seasons/season-4-embodied-life-os.md
@@ -1,0 +1,35 @@
+---
+title: Season 4 - Embodied Life OS
+---
+
+# Season 4: Embodied Life OS
+
+## Theme
+
+Fully realize Seraph as a living, motivating, embodied life operating system.
+
+## Why this season matters
+
+This is where Seraph fully turns its strongest product differentiator into a hard moat. The system should feel like a companion world with meaningful ambient presence, not just a themed agent shell.
+
+## Win condition
+
+By the end of this season, the avatar, village, rituals, stats, and progress surfaces should all reflect real user state and real life momentum in a way no competitor matches.
+
+## Batches
+
+- [S4-B1 Avatar Reflection](../batches/s4-b1-avatar-reflection)
+- [S4-B2 Life OS Surfaces](../batches/s4-b2-life-os-surfaces)
+- [S4-B3 World + Motivation](../batches/s4-b3-world-motivation)
+
+## Related sections
+
+- [Embodiment + Life OS](../sections/section-4-embodiment-life-os)
+- [Presence + Distribution](../sections/section-2-presence-distribution)
+- [Ecosystem + Leverage](../sections/section-5-ecosystem-leverage)
+
+## Exit criteria
+
+- ambient embodiment is tied to real signals and outcomes
+- the life-OS metaphor is visible in daily use, not just in vision docs
+- Seraph feels uniquely alive, not just uniquely themed

--- a/docs/docs/roadmap/sections/section-1-trust-capability.md
+++ b/docs/docs/roadmap/sections/section-1-trust-capability.md
@@ -1,0 +1,46 @@
+---
+title: Section 1 - Trust + Capability
+---
+
+# Section 1: Trust + Capability
+
+## Why this section matters competitively
+
+Seraph's biggest strategic gap versus OpenClaw, IronClaw, and Hermes is not vision. It is operational credibility. This section exists to close the gap between a compelling guardian product and a runtime people can trust with real work.
+
+## Current state in Seraph
+
+- strong product thesis and proactive architecture
+- limited execution plane
+- early sandboxing and timeout controls
+- weak approval and policy model
+- limited secret and trust-boundary handling
+- single primary model/provider path
+
+## Target end state
+
+Seraph can act with broader power while remaining auditable, governable, and meaningfully safer than a typical tool-calling shell.
+
+## Key capabilities
+
+- tool policy profiles and approvals
+- secret scoping and safer credential handling
+- stronger execution isolation
+- richer shell and browser execution
+- workflow orchestration
+- provider routing and fallbacks
+- evaluation and observability for agent behavior
+
+## Dependencies and risks
+
+- touches backend runtime, tools, settings, and security assumptions
+- can sprawl if execution breadth grows faster than guardrails
+- may tempt the project into platform work that weakens the guardian product identity
+
+## Advanced by
+
+- [Season 1: Trust + Capability](../seasons/season-1-trust-capability)
+- [S1-B1 Trust Boundaries](../batches/s1-b1-trust-boundaries)
+- [S1-B2 Execution Plane](../batches/s1-b2-execution-plane)
+- [S1-B3 Runtime Reliability](../batches/s1-b3-runtime-reliability)
+- later reinforcement in [Season 3: Memory + Guardian](../seasons/season-3-memory-guardian)

--- a/docs/docs/roadmap/sections/section-2-presence-distribution.md
+++ b/docs/docs/roadmap/sections/section-2-presence-distribution.md
@@ -1,0 +1,44 @@
+---
+title: Section 2 - Presence + Distribution
+---
+
+# Section 2: Presence + Distribution
+
+## Why this section matters competitively
+
+Seraph cannot become a real daily guardian if it only exists in a browser tab on localhost. This section translates the product from an impressive local app into something that is reachable, ambient, and present across the day.
+
+## Current state in Seraph
+
+- strong browser-based product experience
+- local Docker-centered setup
+- no real channel reach yet
+- no desktop shell or system tray
+- limited notification presence outside the active web UI
+
+## Target end state
+
+Seraph is available as a native-feeling local companion with at least one external channel and reliable delivery surfaces that make proactive behavior useful in ordinary life.
+
+## Key capabilities
+
+- native desktop packaging
+- tray presence and notifications
+- startup/background availability
+- external messaging channel integration
+- cross-surface session continuity
+- better delivery routing for briefings, alerts, and nudges
+
+## Dependencies and risks
+
+- depends on Season 1 establishing runtime credibility first
+- can create support and platform burden quickly
+- risks diluting the main UX if distribution precedes product discipline
+
+## Advanced by
+
+- [Season 2: Reach + Presence](../seasons/season-2-reach-presence)
+- [S2-B1 Native Presence](../batches/s2-b1-native-presence)
+- [S2-B2 Channel Reach](../batches/s2-b2-channel-reach)
+- [S2-B3 Ambient Guardian](../batches/s2-b3-ambient-guardian)
+- later amplification in [Season 4: Embodied Life OS](../seasons/season-4-embodied-life-os)

--- a/docs/docs/roadmap/sections/section-3-memory-guardian-intelligence.md
+++ b/docs/docs/roadmap/sections/section-3-memory-guardian-intelligence.md
@@ -1,0 +1,43 @@
+---
+title: Section 3 - Memory + Guardian Intelligence
+---
+
+# Section 3: Memory + Guardian Intelligence
+
+## Why this section matters competitively
+
+Seraph's moat is not merely that it remembers. It is that it can build a richer, evolving model of a human and use that model to intervene helpfully. This section turns memory from retrieval infrastructure into guardian intelligence.
+
+## Current state in Seraph
+
+- soul file and vector memory are already present
+- current context aggregation exists
+- proactive strategist exists
+- pattern and outcome learning are still limited
+- memory remains mostly summarize, embed, retrieve
+
+## Target end state
+
+Seraph maintains a richer model of people, projects, commitments, patterns, and intervention outcomes, then uses that model to adapt its timing, recommendations, and long-range guidance.
+
+## Key capabilities
+
+- entity and commitment modeling
+- project and relationship memory
+- pattern detection over time
+- intervention history and outcomes
+- adaptive proactivity and learning loops
+- stronger observer-driven reasoning inputs
+
+## Dependencies and risks
+
+- depends on reliable observability and runtime instrumentation
+- risks becoming complicated without clear schemas and evaluation
+- needs careful privacy boundaries as context gets richer
+
+## Advanced by
+
+- [Season 3: Memory + Guardian](../seasons/season-3-memory-guardian)
+- [S3-B1 Human World Model](../batches/s3-b1-human-world-model)
+- [S3-B2 Observer Deepening](../batches/s3-b2-observer-deepening)
+- [S3-B3 Learning Loop](../batches/s3-b3-learning-loop)

--- a/docs/docs/roadmap/sections/section-4-embodiment-life-os.md
+++ b/docs/docs/roadmap/sections/section-4-embodiment-life-os.md
@@ -1,0 +1,42 @@
+---
+title: Section 4 - Embodiment + Life OS
+---
+
+# Section 4: Embodiment + Life OS
+
+## Why this section matters competitively
+
+OpenClaw, IronClaw, and Hermes all compete more naturally on capability than on presence, motivation, or long-term emotional stickiness. This section protects the part of Seraph that could become uniquely beloved rather than merely useful.
+
+## Current state in Seraph
+
+- village, quest log, avatar, and ambient UX are already real
+- the RPG metaphor is compelling but under-leveraged
+- avatar state reflection and richer life surfaces remain mostly planned
+- the village is stronger as a shell than as a living long-term system
+
+## Target end state
+
+Seraph feels like a true life operating system with embodied ambient feedback, rich progress surfaces, and visible world-state changes tied to real growth.
+
+## Key capabilities
+
+- avatar reflection of user and agent state
+- ambient visual feedback loops
+- richer stats, rituals, dashboards, and review surfaces
+- dynamic panels and canvas outputs
+- village growth, decay, and meaningful progression systems
+
+## Dependencies and risks
+
+- depends on earlier seasons making the runtime worth embodying
+- risks becoming cosmetic if not tied to real behavioral outcomes
+- needs discipline to avoid gamification that cheapens the product
+
+## Advanced by
+
+- [Season 2: Reach + Presence](../seasons/season-2-reach-presence)
+- [Season 4: Embodied Life OS](../seasons/season-4-embodied-life-os)
+- [S4-B1 Avatar Reflection](../batches/s4-b1-avatar-reflection)
+- [S4-B2 Life OS Surfaces](../batches/s4-b2-life-os-surfaces)
+- [S4-B3 World + Motivation](../batches/s4-b3-world-motivation)

--- a/docs/docs/roadmap/sections/section-5-ecosystem-leverage.md
+++ b/docs/docs/roadmap/sections/section-5-ecosystem-leverage.md
@@ -1,0 +1,42 @@
+---
+title: Section 5 - Ecosystem + Leverage
+---
+
+# Section 5: Ecosystem + Leverage
+
+## Why this section matters competitively
+
+OpenClaw and Hermes become more valuable as their skills, integrations, and operating patterns compound. Seraph needs that leverage too, but in service of the guardian product rather than as a generic plugin farm.
+
+## Current state in Seraph
+
+- SKILL.md support exists
+- MCP integration exists
+- recursive delegation exists behind a flag
+- workflow composition is still immature
+- community and ecosystem leverage are still early
+
+## Target end state
+
+Seraph compounds through reusable skills, workflows, integrations, and structured leverage layers that extend the guardian without overwhelming the core experience.
+
+## Key capabilities
+
+- richer skills and workflow composition
+- reusable execution patterns
+- stronger MCP and integration ergonomics
+- evaluable multi-agent leverage
+- community-compatible extension points
+
+## Dependencies and risks
+
+- depends on trust and capability work landing first
+- easy to over-expand into an incoherent ecosystem
+- should not outrun product clarity or security posture
+
+## Advanced by
+
+- [Season 1: Trust + Capability](../seasons/season-1-trust-capability)
+- [Season 2: Reach + Presence](../seasons/season-2-reach-presence)
+- [Season 4: Embodied Life OS](../seasons/season-4-embodied-life-os)
+- all batch work that improves workflows, integrations, or extensibility

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -11,6 +11,51 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'Long-Term Plan',
+      items: [
+        {
+          type: 'category',
+          label: 'Sections',
+          items: [
+            'roadmap/sections/section-1-trust-capability',
+            'roadmap/sections/section-2-presence-distribution',
+            'roadmap/sections/section-3-memory-guardian-intelligence',
+            'roadmap/sections/section-4-embodiment-life-os',
+            'roadmap/sections/section-5-ecosystem-leverage',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Seasons',
+          items: [
+            'roadmap/seasons/season-1-trust-capability',
+            'roadmap/seasons/season-2-reach-presence',
+            'roadmap/seasons/season-3-memory-guardian',
+            'roadmap/seasons/season-4-embodied-life-os',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Batches',
+          items: [
+            'roadmap/batches/s1-b1-trust-boundaries',
+            'roadmap/batches/s1-b2-execution-plane',
+            'roadmap/batches/s1-b3-runtime-reliability',
+            'roadmap/batches/s2-b1-native-presence',
+            'roadmap/batches/s2-b2-channel-reach',
+            'roadmap/batches/s2-b3-ambient-guardian',
+            'roadmap/batches/s3-b1-human-world-model',
+            'roadmap/batches/s3-b2-observer-deepening',
+            'roadmap/batches/s3-b3-learning-loop',
+            'roadmap/batches/s4-b1-avatar-reflection',
+            'roadmap/batches/s4-b2-life-os-surfaces',
+            'roadmap/batches/s4-b3-world-motivation',
+          ],
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: 'Development Phases',
       items: [
         'development/phase-1-persistent-identity',
@@ -47,6 +92,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Architecture',
       items: [
+        'architecture/competitive-agent-research',
         'architecture/tauri-analysis',
         'architecture/feature-comparison',
         'architecture/recursive-delegation-research',


### PR DESCRIPTION
## Summary
- replace the old roadmap with a canonical long-term planning system
- add a new planning tree organized into sections, seasons, and batches
- align next-steps to the new roadmap and expose the plan in the docs sidebar
- add the competitive research doc to the Architecture section for roadmap context

## Validation
- git diff --check
- cd docs && npm run build