### PR TITLE
Add tool policy mode to Seraph settings

### DIFF
--- a/backend/src/agent/factory.py
+++ b/backend/src/agent/factory.py
@@ -3,6 +3,7 @@ from smolagents import LiteLLMModel, ToolCallingAgent
 from config.settings import settings
 from src.plugins.loader import discover_tools
 from src.skills.manager import skill_manager
+from src.tools.policy import filter_tools, get_current_tool_policy_mode
 from src.tools.mcp_manager import mcp_manager
 
 
@@ -19,7 +20,10 @@ def get_model() -> LiteLLMModel:
 
 def get_tools() -> list:
     """Return all auto-discovered tools + MCP tools."""
-    return discover_tools() + mcp_manager.get_tools()
+    mode = get_current_tool_policy_mode()
+    native_tools = filter_tools(discover_tools(), mode)
+    mcp_tools = filter_tools(mcp_manager.get_tools(), mode, is_mcp=True)
+    return native_tools + mcp_tools
 
 
 def create_agent(

--- a/backend/src/agent/specialists.py
+++ b/backend/src/agent/specialists.py
@@ -14,6 +14,7 @@ from smolagents import LiteLLMModel, ToolCallingAgent
 
 from config.settings import settings
 from src.plugins.loader import discover_tools
+from src.tools.policy import filter_tools, get_current_tool_policy_mode
 from src.tools.mcp_manager import mcp_manager
 
 # --- Tool → domain mapping ---
@@ -179,7 +180,8 @@ def create_mcp_specialist(
 def build_all_specialists() -> list[ToolCallingAgent]:
     """Assemble the full list of specialist agents (built-in + MCP)."""
     # Build tools_by_name from discovered tools
-    all_tools = discover_tools()
+    mode = get_current_tool_policy_mode()
+    all_tools = filter_tools(discover_tools(), mode)
     tools_by_name = {t.name: t for t in all_tools}
 
     specialists: list[ToolCallingAgent] = []
@@ -196,7 +198,7 @@ def build_all_specialists() -> list[ToolCallingAgent]:
         name = server_info["name"]
         if not mcp_manager.is_connected(name):
             continue
-        server_tools = mcp_manager.get_server_tools(name)
+        server_tools = filter_tools(mcp_manager.get_server_tools(name), mode, is_mcp=True)
         if not server_tools:
             continue
         desc = server_info.get("description", "")

--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -1,4 +1,4 @@
-"""Settings API — interruption mode and capture mode management."""
+"""Settings API — runtime mode management."""
 
 import logging
 from datetime import datetime, timezone
@@ -11,6 +11,7 @@ from src.db.engine import get_session as get_db
 from src.db.models import UserProfile
 from src.observer.manager import context_manager
 from src.observer.user_state import InterruptionMode
+from src.tools.policy import TOOL_POLICY_MODES
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -24,7 +25,12 @@ class CaptureModeRequest(BaseModel):
     mode: str
 
 
+class ToolPolicyModeRequest(BaseModel):
+    mode: str
+
+
 _VALID_CAPTURE_MODES = {"on_switch", "balanced", "detailed"}
+_VALID_TOOL_POLICY_MODES = set(TOOL_POLICY_MODES)
 
 
 @router.get("/settings/interruption-mode")
@@ -98,6 +104,40 @@ async def set_capture_mode(body: CaptureModeRequest):
         profile = result.scalars().first()
         if profile:
             profile.capture_mode = body.mode
+            profile.updated_at = datetime.now(timezone.utc)
+            db.add(profile)
+
+    return {"mode": body.mode}
+
+
+@router.get("/settings/tool-policy-mode")
+async def get_tool_policy_mode():
+    """Get current tool policy mode."""
+    ctx = context_manager.get_context()
+    return {"mode": ctx.tool_policy_mode}
+
+
+@router.put("/settings/tool-policy-mode")
+async def set_tool_policy_mode(body: ToolPolicyModeRequest):
+    """Update tool policy mode (safe | balanced | full)."""
+    if body.mode not in _VALID_TOOL_POLICY_MODES:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Invalid mode '{body.mode}'. Must be one of: "
+                f"{', '.join(sorted(_VALID_TOOL_POLICY_MODES))}"
+            ),
+        )
+
+    context_manager.update_tool_policy_mode(body.mode)
+
+    async with get_db() as db:
+        result = await db.execute(
+            select(UserProfile).where(UserProfile.id == "singleton")
+        )
+        profile = result.scalars().first()
+        if profile:
+            profile.tool_policy_mode = body.mode
             profile.updated_at = datetime.now(timezone.utc)
             db.add(profile)
 

--- a/backend/src/api/tools.py
+++ b/backend/src/api/tools.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from config.settings import settings
 from src.agent.factory import get_tools
 from src.plugins.registry import get_tool_metadata
+from src.tools.policy import get_current_tool_policy_mode
 
 router = APIRouter()
 
@@ -11,6 +12,7 @@ router = APIRouter()
 async def list_tools():
     """List all available tools with their metadata (including dynamic MCP tools)."""
     tools = get_tools()
+    mode = get_current_tool_policy_mode()
 
     result = []
     for tool in tools:
@@ -18,22 +20,19 @@ async def list_tools():
         result.append({
             "name": tool.name,
             "description": meta.get("description") if meta else getattr(tool, "description", ""),
+            "policy_modes": meta.get("policy_modes") if meta else [mode],
         })
 
     # When delegation is active, also include specialist names so the frontend
     # toolRegistry recognizes them for animation triggers.
     if settings.use_delegation:
-        from src.agent.specialists import SPECIALIST_CONFIGS, _sanitize_agent_name
-        from src.tools.mcp_manager import mcp_manager
+        from src.agent.specialists import build_all_specialists
 
-        for name, cfg in SPECIALIST_CONFIGS.items():
-            result.append({"name": name, "description": cfg["description"]})
-
-        for server_info in mcp_manager.get_config():
-            if mcp_manager.is_connected(server_info["name"]):
-                result.append({
-                    "name": _sanitize_agent_name(f"mcp_{server_info['name']}"),
-                    "description": server_info.get("description", ""),
-                })
+        for specialist in build_all_specialists():
+            result.append({
+                "name": specialist.name,
+                "description": specialist.description,
+                "policy_modes": [mode],
+            })
 
     return result

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -46,6 +46,8 @@ async def lifespan(app: FastAPI):
             context_manager.update_interruption_mode(profile.interruption_mode)
         if profile.capture_mode:
             context_manager.update_capture_mode(profile.capture_mode)
+        if profile.tool_policy_mode:
+            context_manager.update_tool_policy_mode(profile.tool_policy_mode)
     except Exception:
         import logging
         logging.getLogger(__name__).warning("Failed to load persisted settings", exc_info=True)

--- a/backend/src/db/engine.py
+++ b/backend/src/db/engine.py
@@ -22,11 +22,22 @@ async_session_factory = sessionmaker(
 )
 
 
+async def _ensure_legacy_columns(conn) -> None:
+    """Backfill columns for older local SQLite databases."""
+    result = await conn.exec_driver_sql("PRAGMA table_info(user_profiles)")
+    columns = {row[1] for row in result.fetchall()}
+    if "tool_policy_mode" not in columns:
+        await conn.exec_driver_sql(
+            "ALTER TABLE user_profiles ADD COLUMN tool_policy_mode VARCHAR DEFAULT 'full'"
+        )
+
+
 async def init_db() -> None:
     """Create all tables on startup."""
     os.makedirs(os.path.dirname(_db_path), exist_ok=True)
     async with engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
+        await _ensure_legacy_columns(conn)
 
 
 async def close_db() -> None:

--- a/backend/src/db/models.py
+++ b/backend/src/db/models.py
@@ -125,6 +125,7 @@ class UserProfile(SQLModel, table=True):
     onboarding_completed: bool = Field(default=False)
     interruption_mode: str = Field(default="balanced")
     capture_mode: str = Field(default="on_switch")  # on_switch | balanced | detailed
+    tool_policy_mode: str = Field(default="full")  # safe | balanced | full
     created_at: datetime = Field(default_factory=_now)
     updated_at: datetime = Field(default_factory=_now)
 

--- a/backend/src/observer/context.py
+++ b/backend/src/observer/context.py
@@ -39,6 +39,7 @@ class CurrentContext:
 
     # Capture mode — controls screenshot frequency (on_switch | balanced | detailed)
     capture_mode: str = "on_switch"
+    tool_policy_mode: str = "full"
 
     # Phase 3.3 — State machine tracking
     previous_user_state: str = "available"
@@ -90,6 +91,10 @@ class CurrentContext:
             minutes_ago = int(delta.total_seconds() / 60)
             lines.append(f"Last interaction: {minutes_ago}m ago")
 
-        lines.append(f"User state: {self.user_state} | Mode: {self.interruption_mode} | Budget: {self.attention_budget_remaining}")
+        lines.append(
+            "User state: "
+            f"{self.user_state} | Mode: {self.interruption_mode} | "
+            f"Budget: {self.attention_budget_remaining} | Tools: {self.tool_policy_mode}"
+        )
 
         return "\n".join(lines)

--- a/backend/src/observer/manager.py
+++ b/backend/src/observer/manager.py
@@ -119,6 +119,7 @@ class ContextManager:
                 screen_context=old.screen_context,
                 last_daemon_post=old.last_daemon_post,
                 capture_mode=old.capture_mode,
+                tool_policy_mode=old.tool_policy_mode,
                 # Phase 3.3 tracking
                 previous_user_state=old.user_state,
                 attention_budget_last_reset=last_reset,
@@ -212,6 +213,11 @@ class ContextManager:
         """Change capture mode setting."""
         self._context.capture_mode = mode
         logger.info("Capture mode set to %s", mode)
+
+    def update_tool_policy_mode(self, mode: str) -> None:
+        """Change the tool policy mode."""
+        self._context.tool_policy_mode = mode
+        logger.info("Tool policy mode set to %s", mode)
 
     def update_interruption_mode(self, mode: str) -> None:
         """Change interruption mode and reset budget to mode default."""

--- a/backend/src/plugins/registry.py
+++ b/backend/src/plugins/registry.py
@@ -1,4 +1,4 @@
-"""Tool metadata registry — maps tool names to descriptions.
+"""Tool metadata registry — maps tool names to descriptions and policy tiers.
 
 Native tools have static entries in TOOL_METADATA. MCP tools get their
 description dynamically from their tool object.
@@ -8,53 +8,69 @@ TOOL_METADATA: dict[str, dict] = {
     # Phase 1 tools
     "web_search": {
         "description": "Search the web for information",
+        "policy_modes": ["safe", "balanced", "full"],
     },
     "read_file": {
         "description": "Read a file from the workspace",
+        "policy_modes": ["safe", "balanced", "full"],
     },
     "write_file": {
         "description": "Write content to a file",
+        "policy_modes": ["balanced", "full"],
     },
     "fill_template": {
         "description": "Fill a text template with values",
+        "policy_modes": ["safe", "balanced", "full"],
     },
     "view_soul": {
         "description": "View the soul file",
+        "policy_modes": ["safe", "balanced", "full"],
     },
     "update_soul": {
         "description": "Update a section of the soul file",
+        "policy_modes": ["balanced", "full"],
     },
     "create_goal": {
         "description": "Create a new goal",
+        "policy_modes": ["balanced", "full"],
     },
     "update_goal": {
         "description": "Update an existing goal",
+        "policy_modes": ["balanced", "full"],
     },
     "get_goals": {
         "description": "List goals",
+        "policy_modes": ["safe", "balanced", "full"],
     },
     "get_goal_progress": {
         "description": "Get goal progress dashboard",
+        "policy_modes": ["safe", "balanced", "full"],
     },
     # Phase 2 tools
     "shell_execute": {
         "description": "Execute code in a sandboxed environment",
+        "policy_modes": ["full"],
     },
     "browse_webpage": {
         "description": "Browse and extract content from a webpage",
+        "policy_modes": ["safe", "balanced", "full"],
     },
     # Vault tools
     "store_secret": {
         "description": "Store an encrypted secret in the vault",
+        "policy_modes": ["balanced", "full"],
     },
     "get_secret": {
         "description": "Retrieve a secret from the vault",
+        "policy_modes": ["full"],
     },
     "list_secrets": {
         "description": "List secret keys stored in the vault",
+        "policy_modes": ["safe", "balanced", "full"],
     },
     "delete_secret": {
         "description": "Delete a secret from the vault",
+        "policy_modes": ["full"],
     },
 }
 

--- a/backend/src/tools/policy.py
+++ b/backend/src/tools/policy.py
@@ -1,0 +1,47 @@
+"""Tool policy helpers for filtering available agent tools."""
+
+from collections.abc import Iterable
+
+from src.observer.manager import context_manager
+from src.plugins.registry import get_tool_metadata
+
+TOOL_POLICY_MODES = ("safe", "balanced", "full")
+DEFAULT_TOOL_POLICY_MODE = "full"
+
+
+def normalize_tool_policy_mode(mode: str | None) -> str:
+    """Coerce missing or invalid modes to the default."""
+    if mode in TOOL_POLICY_MODES:
+        return mode
+    return DEFAULT_TOOL_POLICY_MODE
+
+
+def is_tool_allowed(tool_name: str, mode: str, *, is_mcp: bool = False) -> bool:
+    """Return whether a tool is allowed under the selected policy mode."""
+    normalized = normalize_tool_policy_mode(mode)
+    if normalized == "full":
+        return True
+    if is_mcp:
+        return False
+
+    metadata = get_tool_metadata(tool_name)
+    if metadata is None:
+        return normalized == "full"
+
+    return normalized in metadata.get("policy_modes", [])
+
+
+def filter_tools(tools: Iterable, mode: str, *, is_mcp: bool = False) -> list:
+    """Filter a tool collection to only those allowed by policy."""
+    return [
+        tool for tool in tools
+        if is_tool_allowed(getattr(tool, "name", ""), mode, is_mcp=is_mcp)
+    ]
+
+
+def get_current_tool_policy_mode() -> str:
+    """Read the current tool policy mode from the shared observer context."""
+    try:
+        return normalize_tool_policy_mode(context_manager.get_context().tool_policy_mode)
+    except Exception:
+        return DEFAULT_TOOL_POLICY_MODE

--- a/backend/tests/test_settings_tool_policy_mode.py
+++ b/backend/tests/test_settings_tool_policy_mode.py
@@ -1,0 +1,52 @@
+"""Tests for settings API — GET/PUT tool policy mode."""
+
+import pytest
+from unittest.mock import patch
+
+from src.db.models import UserProfile
+from src.observer.context import CurrentContext
+
+
+@pytest.mark.asyncio
+async def test_get_tool_policy_mode_default(client):
+    fresh = CurrentContext()
+    with patch("src.api.settings.context_manager.get_context", return_value=fresh):
+        resp = await client.get("/api/settings/tool-policy-mode")
+    assert resp.status_code == 200
+    assert resp.json()["mode"] == "full"
+
+
+@pytest.mark.asyncio
+async def test_put_tool_policy_mode_balanced(client, async_db):
+    async with async_db() as db:
+        db.add(UserProfile(id="singleton"))
+
+    resp = await client.put(
+        "/api/settings/tool-policy-mode",
+        json={"mode": "balanced"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["mode"] == "balanced"
+
+
+@pytest.mark.asyncio
+async def test_put_invalid_tool_policy_mode_422(client):
+    resp = await client.put(
+        "/api/settings/tool-policy-mode",
+        json={"mode": "risky"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_tool_policy_mode_round_trip(client, async_db):
+    async with async_db() as db:
+        db.add(UserProfile(id="singleton"))
+
+    await client.put(
+        "/api/settings/tool-policy-mode",
+        json={"mode": "safe"},
+    )
+
+    resp = await client.get("/api/settings/tool-policy-mode")
+    assert resp.json()["mode"] == "safe"

--- a/backend/tests/test_tool_registry.py
+++ b/backend/tests/test_tool_registry.py
@@ -14,7 +14,7 @@ class TestToolRegistry:
 
     def test_all_entries_have_required_fields(self):
         all_meta = get_all_metadata()
-        required = {"description"}
+        required = {"description", "policy_modes"}
         for name, meta in all_meta.items():
             missing = required - set(meta.keys())
             assert not missing, f"Tool '{name}' missing fields: {missing}"

--- a/backend/tests/test_tools_api.py
+++ b/backend/tests/test_tools_api.py
@@ -1,0 +1,28 @@
+"""Tests for tool list filtering by tool policy mode."""
+
+import pytest
+from unittest.mock import patch
+
+from src.observer.context import CurrentContext
+
+
+@pytest.mark.asyncio
+async def test_tools_api_full_mode_includes_shell_execute(client):
+    ctx = CurrentContext(tool_policy_mode="full")
+    with patch("src.tools.policy.context_manager.get_context", return_value=ctx):
+        resp = await client.get("/api/tools")
+    assert resp.status_code == 200
+    names = {tool["name"] for tool in resp.json()}
+    assert "shell_execute" in names
+
+
+@pytest.mark.asyncio
+async def test_tools_api_balanced_mode_hides_full_only_tools(client):
+    ctx = CurrentContext(tool_policy_mode="balanced")
+    with patch("src.tools.policy.context_manager.get_context", return_value=ctx):
+        resp = await client.get("/api/tools")
+    assert resp.status_code == 200
+    names = {tool["name"] for tool in resp.json()}
+    assert "write_file" in names
+    assert "shell_execute" not in names
+    assert "get_secret" not in names

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -8,6 +8,7 @@ import { DialogFrame } from "./chat/DialogFrame";
 import { InterruptionModeToggle } from "./settings/InterruptionModeToggle";
 import { DaemonStatus } from "./settings/DaemonStatus";
 import { CaptureModeToggle } from "./settings/CaptureModeToggle";
+import { ToolPolicyModeToggle } from "./settings/ToolPolicyModeToggle";
 
 interface SkillInfo {
   name: string;
@@ -578,6 +579,8 @@ export function SettingsPanel() {
           <DaemonStatus />
 
           <CaptureModeToggle />
+
+          <ToolPolicyModeToggle />
 
           <div className="px-1">
             <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-1">

--- a/frontend/src/components/settings/ToolPolicyModeToggle.tsx
+++ b/frontend/src/components/settings/ToolPolicyModeToggle.tsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from "react";
+import { API_URL } from "../../config/constants";
+import { useChatStore } from "../../stores/chatStore";
+
+type ToolPolicyMode = "safe" | "balanced" | "full";
+
+const MODES: { value: ToolPolicyMode; label: string; desc: string }[] = [
+  { value: "safe", label: "Safe", desc: "Read-focused tools only" },
+  { value: "balanced", label: "Balanced", desc: "Allow edits, block high-risk tools" },
+  { value: "full", label: "Full", desc: "Current behavior, including shell and vault access" },
+];
+
+export function ToolPolicyModeToggle() {
+  const [mode, setMode] = useState<ToolPolicyMode>("full");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/settings/tool-policy-mode`)
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => {
+        if (data?.mode) setMode(data.mode);
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleSelect = async (m: ToolPolicyMode) => {
+    if (m === mode || loading) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_URL}/api/settings/tool-policy-mode`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: m }),
+      });
+      if (res.ok) {
+        setMode(m);
+        await useChatStore.getState().fetchToolRegistry();
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="px-1">
+      <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-2">
+        Tool Policy
+      </div>
+      <div className="flex gap-1">
+        {MODES.map((m) => {
+          const selected = mode === m.value;
+          return (
+            <button
+              key={m.value}
+              onClick={() => handleSelect(m.value)}
+              disabled={loading}
+              className={`flex-1 px-1 py-1 border rounded-sm text-center transition-colors ${
+                selected
+                  ? "text-retro-highlight border-retro-highlight"
+                  : "text-retro-text/40 border-retro-text/20 hover:text-retro-text/60 hover:border-retro-text/40"
+              }`}
+            >
+              <div className="text-[10px] font-bold uppercase tracking-wider">{m.label}</div>
+              <div className="text-[9px] mt-0.5 opacity-70">{m.desc}</div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add persisted safe, balanced, and full tool policy modes with backend enforcement for native and delegated tools
- expose the current policy through settings and tools APIs, including a lightweight SQLite upgrade for existing local profiles
- add a settings panel toggle that refreshes the visible tool registry after a policy change

## Validation
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_settings_api.py tests/test_settings_capture_mode.py tests/test_settings_tool_policy_mode.py tests/test_tool_registry.py tests/test_tools_api.py`
- `cd frontend && npm test`
- `git diff --cached --check`

## Risks
- `safe` and `balanced` currently disable all MCP tools by design, which is conservative but may be stricter than some workflows want
- `npm run build` in `frontend/` still has pre-existing TypeScript issues outside this PR