### PR TITLE
feat: audit vault secret operations

### DIFF
--- a/backend/src/tools/vault_tools.py
+++ b/backend/src/tools/vault_tools.py
@@ -1,15 +1,44 @@
 import asyncio
 import concurrent.futures
+import logging
 
 from smolagents import tool
 
+from src.approval.runtime import get_current_session_id
+from src.audit.repository import audit_repository
+from src.tools.policy import get_current_tool_policy_mode, get_tool_risk_level
 from src.vault.repository import vault_repository
+
+logger = logging.getLogger(__name__)
 
 
 def _run(coro):
     """Run an async coroutine from sync context (for smolagents tools)."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
         return pool.submit(asyncio.run, coro).result()
+
+
+def _log_secret_event(
+    *,
+    event_type: str,
+    tool_name: str,
+    summary: str,
+    details: dict | None = None,
+) -> None:
+    """Best-effort audit logging for vault operations."""
+    try:
+        _run(audit_repository.log_event(
+            event_type=event_type,
+            summary=summary,
+            session_id=get_current_session_id(),
+            actor="agent",
+            tool_name=tool_name,
+            risk_level=get_tool_risk_level(tool_name),
+            policy_mode=get_current_tool_policy_mode(),
+            details=details,
+        ))
+    except Exception:
+        logger.warning("Failed to log vault audit event for %s", tool_name, exc_info=True)
 
 
 @tool
@@ -34,6 +63,12 @@ def store_secret(key: str, value: str, description: str = "") -> str:
         value=value,
         description=description or None,
     ))
+    _log_secret_event(
+        event_type="secret_store",
+        tool_name="store_secret",
+        summary=f"Stored secret key '{key}' in vault",
+        details={"key": key, "has_description": bool(description)},
+    )
     return f"Secret '{key}' stored securely in vault."
 
 
@@ -52,7 +87,19 @@ def get_secret(key: str) -> str:
     """
     result = _run(vault_repository.get(key))
     if result is None:
+        _log_secret_event(
+            event_type="secret_access",
+            tool_name="get_secret",
+            summary=f"Attempted to access missing secret key '{key}'",
+            details={"key": key, "found": False},
+        )
         return f"Secret '{key}' not found in vault."
+    _log_secret_event(
+        event_type="secret_access",
+        tool_name="get_secret",
+        summary=f"Accessed secret key '{key}'",
+        details={"key": key, "found": True},
+    )
     return result
 
 
@@ -66,6 +113,12 @@ def list_secrets() -> str:
         Formatted list of stored secret keys with descriptions.
     """
     keys = _run(vault_repository.list_keys())
+    _log_secret_event(
+        event_type="secret_list",
+        tool_name="list_secrets",
+        summary=f"Listed vault secret keys ({len(keys)} total)",
+        details={"count": len(keys)},
+    )
     if not keys:
         return "No secrets stored in vault."
     lines = []
@@ -87,5 +140,17 @@ def delete_secret(key: str) -> str:
     """
     success = _run(vault_repository.delete(key))
     if not success:
+        _log_secret_event(
+            event_type="secret_delete",
+            tool_name="delete_secret",
+            summary=f"Attempted to delete missing secret key '{key}'",
+            details={"key": key, "deleted": False},
+        )
         return f"Secret '{key}' not found in vault."
+    _log_secret_event(
+        event_type="secret_delete",
+        tool_name="delete_secret",
+        summary=f"Deleted secret key '{key}' from vault",
+        details={"key": key, "deleted": True},
+    )
     return f"Secret '{key}' deleted from vault."

--- a/backend/tests/test_vault_tools.py
+++ b/backend/tests/test_vault_tools.py
@@ -6,16 +6,21 @@ import pytest
 
 
 @pytest.fixture
-def mock_vault_repo():
-    """Mock the vault repository for tool tests."""
-    with patch("src.tools.vault_tools.vault_repository") as mock:
-        yield mock
+def mock_vault_deps():
+    """Mock vault and audit dependencies for tool tests."""
+    with patch("src.tools.vault_tools.vault_repository") as mock_repo, \
+         patch("src.tools.vault_tools.audit_repository") as mock_audit, \
+         patch("src.tools.vault_tools.get_current_session_id", return_value="s1"), \
+         patch("src.tools.vault_tools.get_current_tool_policy_mode", return_value="full"):
+        mock_audit.log_event = AsyncMock()
+        yield mock_repo, mock_audit
 
 
 class TestStoreSecret:
-    def test_stores_and_confirms(self, mock_vault_repo):
+    def test_stores_and_confirms(self, mock_vault_deps):
         from src.tools.vault_tools import store_secret
 
+        mock_vault_repo, mock_audit = mock_vault_deps
         mock_vault_repo.store = AsyncMock()
         result = store_secret.forward("my_token", "sk-123", "API token")
         assert "my_token" in result
@@ -23,35 +28,53 @@ class TestStoreSecret:
         # Value should never appear in confirmation
         assert "sk-123" not in result
         mock_vault_repo.store.assert_called_once()
+        mock_audit.log_event.assert_awaited_once()
+        audit_call = mock_audit.log_event.await_args.kwargs
+        assert audit_call["event_type"] == "secret_store"
+        assert audit_call["details"] == {"key": "my_token", "has_description": True}
+        assert "sk-123" not in str(audit_call)
 
 
 class TestGetSecret:
-    def test_found(self, mock_vault_repo):
+    def test_found(self, mock_vault_deps):
         from src.tools.vault_tools import get_secret
 
+        mock_vault_repo, mock_audit = mock_vault_deps
         mock_vault_repo.get = AsyncMock(return_value="decrypted-value")
         result = get_secret.forward("my_token")
         assert result == "decrypted-value"
+        mock_audit.log_event.assert_awaited_once()
+        audit_call = mock_audit.log_event.await_args.kwargs
+        assert audit_call["event_type"] == "secret_access"
+        assert audit_call["details"] == {"key": "my_token", "found": True}
+        assert "decrypted-value" not in str(audit_call)
 
-    def test_not_found(self, mock_vault_repo):
+    def test_not_found(self, mock_vault_deps):
         from src.tools.vault_tools import get_secret
 
+        mock_vault_repo, mock_audit = mock_vault_deps
         mock_vault_repo.get = AsyncMock(return_value=None)
         result = get_secret.forward("nope")
         assert "not found" in result.lower()
+        mock_audit.log_event.assert_awaited_once()
+        assert mock_audit.log_event.await_args.kwargs["details"] == {"key": "nope", "found": False}
 
 
 class TestListSecrets:
-    def test_empty(self, mock_vault_repo):
+    def test_empty(self, mock_vault_deps):
         from src.tools.vault_tools import list_secrets
 
+        mock_vault_repo, mock_audit = mock_vault_deps
         mock_vault_repo.list_keys = AsyncMock(return_value=[])
         result = list_secrets.forward()
         assert "no secrets" in result.lower()
+        mock_audit.log_event.assert_awaited_once()
+        assert mock_audit.log_event.await_args.kwargs["details"] == {"count": 0}
 
-    def test_returns_keys_not_values(self, mock_vault_repo):
+    def test_returns_keys_not_values(self, mock_vault_deps):
         from src.tools.vault_tools import list_secrets
 
+        mock_vault_repo, mock_audit = mock_vault_deps
         mock_vault_repo.list_keys = AsyncMock(return_value=[
             {"key": "token_a", "description": "Token A", "created_at": "2025-01-01", "updated_at": "2025-01-01"},
             {"key": "token_b", "description": None, "created_at": "2025-01-01", "updated_at": "2025-01-01"},
@@ -60,19 +83,44 @@ class TestListSecrets:
         assert "token_a" in result
         assert "token_b" in result
         assert "Token A" in result
+        mock_audit.log_event.assert_awaited_once()
+        audit_call = mock_audit.log_event.await_args.kwargs
+        assert audit_call["event_type"] == "secret_list"
+        assert audit_call["details"] == {"count": 2}
+        assert "token_a" not in str(audit_call)
 
 
 class TestDeleteSecret:
-    def test_success(self, mock_vault_repo):
+    def test_success(self, mock_vault_deps):
         from src.tools.vault_tools import delete_secret
 
+        mock_vault_repo, mock_audit = mock_vault_deps
         mock_vault_repo.delete = AsyncMock(return_value=True)
         result = delete_secret.forward("old_token")
         assert "deleted" in result.lower()
+        mock_audit.log_event.assert_awaited_once()
+        assert mock_audit.log_event.await_args.kwargs["details"] == {"key": "old_token", "deleted": True}
 
-    def test_not_found(self, mock_vault_repo):
+    def test_not_found(self, mock_vault_deps):
         from src.tools.vault_tools import delete_secret
 
+        mock_vault_repo, mock_audit = mock_vault_deps
         mock_vault_repo.delete = AsyncMock(return_value=False)
         result = delete_secret.forward("nope")
         assert "not found" in result.lower()
+        mock_audit.log_event.assert_awaited_once()
+        assert mock_audit.log_event.await_args.kwargs["details"] == {"key": "nope", "deleted": False}
+
+
+class TestVaultAuditResilience:
+    def test_store_secret_succeeds_when_audit_logging_fails(self, mock_vault_deps):
+        from src.tools.vault_tools import store_secret
+
+        mock_vault_repo, mock_audit = mock_vault_deps
+        mock_vault_repo.store = AsyncMock()
+        mock_audit.log_event.side_effect = RuntimeError("audit down")
+
+        result = store_secret.forward("my_token", "sk-123", "API token")
+
+        assert "stored" in result.lower()
+        mock_vault_repo.store.assert_called_once()


### PR DESCRIPTION
## Summary
- add best-effort audit logging around vault store, get, list, and delete tools
- record key-level metadata and operation outcomes without persisting secret values
- extend vault tool tests to cover audit payloads and audit-path resilience

## Validation
- `cd backend && python3 -m py_compile src/tools/vault_tools.py tests/test_vault_tools.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_vault_tools.py tests/test_audit_api.py`

## Risks
- vault audit is still tool-level rather than a deeper secret-handle boundary
- key names are recorded for store/get/delete operations, which improves traceability but assumes key names are acceptable metadata
