### PR TITLE
feat(llm): centralize runtime config and fallback

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -4,6 +4,11 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     openrouter_api_key: str = ""
     default_model: str = "openrouter/anthropic/claude-sonnet-4"
+    llm_api_key: str = ""
+    llm_api_base: str = "https://openrouter.ai/api/v1"
+    fallback_model: str = ""
+    fallback_llm_api_key: str = ""
+    fallback_llm_api_base: str = ""
     model_temperature: float = 0.7
     model_max_tokens: int = 4096
     agent_max_steps: int = 10

--- a/backend/src/agent/context_window.py
+++ b/backend/src/agent/context_window.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 import tiktoken
 
 from config.settings import settings
+from src.llm_runtime import completion_with_fallback_sync
 
 logger = logging.getLogger(__name__)
 
@@ -55,10 +56,7 @@ def _summarize_middle(messages: list[dict], session_id: str, range_key: str) -> 
 
     text = _format_messages(messages)
     try:
-        import litellm
-
-        response = litellm.completion(
-            model=settings.default_model,
+        response = completion_with_fallback_sync(
             messages=[{
                 "role": "user",
                 "content": (
@@ -67,8 +65,6 @@ def _summarize_middle(messages: list[dict], session_id: str, range_key: str) -> 
                     f"{text[:8000]}"
                 ),
             }],
-            api_key=settings.openrouter_api_key,
-            api_base="https://openrouter.ai/api/v1",
             temperature=0.3,
             max_tokens=200,
         )

--- a/backend/src/agent/factory.py
+++ b/backend/src/agent/factory.py
@@ -1,6 +1,7 @@
 from smolagents import LiteLLMModel, ToolCallingAgent
 
 from config.settings import settings
+from src.llm_runtime import build_model_kwargs
 from src.plugins.loader import discover_tools
 from src.skills.manager import skill_manager
 from src.tools.approval import wrap_tools_for_approval, wrap_tools_with_forced_approval
@@ -10,14 +11,11 @@ from src.tools.secret_ref_tools import wrap_tools_for_secret_refs
 
 
 def get_model() -> LiteLLMModel:
-    """Create a LiteLLMModel configured for OpenRouter."""
-    return LiteLLMModel(
-        model_id=settings.default_model,
-        api_key=settings.openrouter_api_key,
-        api_base="https://openrouter.ai/api/v1",
+    """Create a LiteLLMModel from the shared runtime configuration."""
+    return LiteLLMModel(**build_model_kwargs(
         temperature=settings.model_temperature,
         max_tokens=settings.model_max_tokens,
-    )
+    ))
 
 
 def get_tools() -> list:

--- a/backend/src/agent/onboarding.py
+++ b/backend/src/agent/onboarding.py
@@ -3,6 +3,7 @@
 from smolagents import LiteLLMModel, ToolCallingAgent
 
 from config.settings import settings
+from src.llm_runtime import build_model_kwargs
 from src.tools.soul_tool import view_soul, update_soul
 from src.tools.goal_tools import create_goal, get_goals
 
@@ -51,13 +52,10 @@ and ready when you need me."
 
 def create_onboarding_agent() -> ToolCallingAgent:
     """Create a specialized agent for the onboarding conversation."""
-    model = LiteLLMModel(
-        model_id=settings.default_model,
-        api_key=settings.openrouter_api_key,
-        api_base="https://openrouter.ai/api/v1",
+    model = LiteLLMModel(**build_model_kwargs(
         temperature=0.8,
         max_tokens=settings.model_max_tokens,
-    )
+    ))
 
     return ToolCallingAgent(
         tools=[view_soul, update_soul, create_goal, get_goals],

--- a/backend/src/agent/session.py
+++ b/backend/src/agent/session.py
@@ -209,17 +209,13 @@ class SessionManager:
         transcript = "\n".join(f"{m.role.capitalize()}: {m.content[:200]}" for m in messages)
 
         try:
-            import litellm
+            from src.llm_runtime import completion_with_fallback
 
-            response = await asyncio.to_thread(
-                litellm.completion,
-                model=settings.default_model,
+            response = await completion_with_fallback(
                 messages=[{
                     "role": "user",
                     "content": f"Generate a very short title (3-6 words, no quotes) for this conversation. Respond with ONLY the title.\n\n{transcript}",
                 }],
-                api_key=settings.openrouter_api_key,
-                api_base="https://openrouter.ai/api/v1",
                 temperature=0.3,
                 max_tokens=20,
             )

--- a/backend/src/agent/specialists.py
+++ b/backend/src/agent/specialists.py
@@ -13,6 +13,7 @@ import re
 from smolagents import LiteLLMModel, ToolCallingAgent
 
 from config.settings import settings
+from src.llm_runtime import build_model_kwargs
 from src.plugins.loader import discover_tools
 from src.tools.approval import wrap_tools_for_approval, wrap_tools_with_forced_approval
 from src.tools.mcp_manager import mcp_manager
@@ -102,13 +103,10 @@ def _sanitize_agent_name(name: str) -> str:
 
 def _create_model(temperature: float) -> LiteLLMModel:
     """Create a LiteLLMModel with specialist-specific temperature."""
-    return LiteLLMModel(
-        model_id=settings.default_model,
-        api_key=settings.openrouter_api_key,
-        api_base="https://openrouter.ai/api/v1",
+    return LiteLLMModel(**build_model_kwargs(
         temperature=temperature,
         max_tokens=settings.model_max_tokens,
-    )
+    ))
 
 
 def create_specialist(

--- a/backend/src/agent/strategist.py
+++ b/backend/src/agent/strategist.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from smolagents import LiteLLMModel, ToolCallingAgent
 
 from config.settings import settings
+from src.llm_runtime import build_model_kwargs
 from src.tools.soul_tool import view_soul
 from src.tools.goal_tools import get_goals, get_goal_progress
 
@@ -62,13 +63,10 @@ class StrategistDecision:
 
 def create_strategist_agent(context_block: str) -> ToolCallingAgent:
     """Create a restricted agent for strategic reasoning."""
-    model = LiteLLMModel(
-        model_id=settings.default_model,
-        api_key=settings.openrouter_api_key,
-        api_base="https://openrouter.ai/api/v1",
+    model = LiteLLMModel(**build_model_kwargs(
         temperature=0.4,
         max_tokens=settings.model_max_tokens,
-    )
+    ))
 
     instructions = STRATEGIST_INSTRUCTIONS.format(
         proactivity_level=settings.proactivity_level,

--- a/backend/src/llm_runtime.py
+++ b/backend/src/llm_runtime.py
@@ -1,0 +1,135 @@
+"""Shared LLM configuration and fallback helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _primary_api_key() -> str:
+    return settings.llm_api_key or settings.openrouter_api_key
+
+
+def build_model_kwargs(
+    *,
+    temperature: float,
+    max_tokens: int,
+    model_id: str | None = None,
+) -> dict[str, Any]:
+    """Build LiteLLMModel kwargs from the shared runtime settings."""
+    kwargs: dict[str, Any] = {
+        "model_id": model_id or settings.default_model,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    api_key = _primary_api_key()
+    if api_key:
+        kwargs["api_key"] = api_key
+    if settings.llm_api_base:
+        kwargs["api_base"] = settings.llm_api_base
+    return kwargs
+
+
+def build_completion_kwargs(
+    *,
+    messages: list[dict[str, str]],
+    temperature: float,
+    max_tokens: int,
+    model_id: str | None = None,
+    use_fallback: bool = False,
+) -> dict[str, Any]:
+    """Build litellm.completion kwargs for either the primary or fallback path."""
+    if use_fallback:
+        fallback_model = settings.fallback_model
+        if not fallback_model:
+            raise ValueError("Fallback model is not configured")
+        kwargs: dict[str, Any] = {
+            "model": model_id or fallback_model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        api_key = settings.fallback_llm_api_key or _primary_api_key()
+        api_base = settings.fallback_llm_api_base or settings.llm_api_base
+    else:
+        kwargs = {
+            "model": model_id or settings.default_model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        api_key = _primary_api_key()
+        api_base = settings.llm_api_base
+
+    if api_key:
+        kwargs["api_key"] = api_key
+    if api_base:
+        kwargs["api_base"] = api_base
+    return kwargs
+
+
+def has_fallback_model() -> bool:
+    """Return whether a fallback completion target is configured."""
+    return bool(settings.fallback_model.strip())
+
+
+def completion_with_fallback_sync(
+    *,
+    messages: list[dict[str, str]],
+    temperature: float,
+    max_tokens: int,
+    model_id: str | None = None,
+):
+    """Execute a litellm completion with an optional fallback target."""
+    import litellm
+
+    primary_kwargs = build_completion_kwargs(
+        messages=messages,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        model_id=model_id,
+    )
+    try:
+        return litellm.completion(**primary_kwargs)
+    except Exception:
+        if not has_fallback_model():
+            raise
+        fallback_kwargs = build_completion_kwargs(
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            use_fallback=True,
+        )
+        logger.warning(
+            "Primary LLM completion failed for model %s, retrying with fallback %s",
+            primary_kwargs["model"],
+            fallback_kwargs["model"],
+            exc_info=True,
+        )
+        return litellm.completion(**fallback_kwargs)
+
+
+async def completion_with_fallback(
+    *,
+    messages: list[dict[str, str]],
+    temperature: float,
+    max_tokens: int,
+    timeout: int | None = None,
+    model_id: str | None = None,
+):
+    """Async wrapper around the shared completion fallback flow."""
+    coro = asyncio.to_thread(
+        completion_with_fallback_sync,
+        messages=messages,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        model_id=model_id,
+    )
+    if timeout is None:
+        return await coro
+    return await asyncio.wait_for(coro, timeout=timeout)

--- a/backend/src/memory/consolidator.py
+++ b/backend/src/memory/consolidator.py
@@ -3,6 +3,7 @@ import logging
 
 from config.settings import settings
 from src.agent.session import session_manager
+from src.llm_runtime import completion_with_fallback
 from src.memory.soul import read_soul, update_soul_section
 from src.memory.vector_store import add_memory
 
@@ -42,20 +43,11 @@ async def consolidate_session(session_id: str) -> None:
         soul = read_soul()
         prompt = _CONSOLIDATION_PROMPT.format(conversation=history, soul=soul)
 
-        # Use LiteLLM directly for the consolidation call (lighter than full agent)
-        import litellm
-
         try:
-            response = await asyncio.wait_for(
-                asyncio.to_thread(
-                    litellm.completion,
-                    model=settings.default_model,
-                    messages=[{"role": "user", "content": prompt}],
-                    api_key=settings.openrouter_api_key,
-                    api_base="https://openrouter.ai/api/v1",
-                    temperature=0.3,
-                    max_tokens=1024,
-                ),
+            response = await completion_with_fallback(
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.3,
+                max_tokens=1024,
                 timeout=settings.consolidation_llm_timeout,
             )
         except asyncio.TimeoutError:

--- a/backend/src/scheduler/jobs/activity_digest.py
+++ b/backend/src/scheduler/jobs/activity_digest.py
@@ -5,6 +5,7 @@ import logging
 from datetime import date
 
 from config.settings import settings
+from src.llm_runtime import completion_with_fallback
 from src.models.schemas import WSResponse
 
 logger = logging.getLogger(__name__)
@@ -78,19 +79,11 @@ async def run_activity_digest() -> None:
             streaks=streaks,
         )
 
-        import litellm
-
         try:
-            response = await asyncio.wait_for(
-                asyncio.to_thread(
-                    litellm.completion,
-                    model=settings.default_model,
-                    messages=[{"role": "user", "content": prompt}],
-                    api_key=settings.openrouter_api_key,
-                    api_base="https://openrouter.ai/api/v1",
-                    temperature=0.6,
-                    max_tokens=768,
-                ),
+            response = await completion_with_fallback(
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.6,
+                max_tokens=768,
                 timeout=settings.agent_briefing_timeout,
             )
         except asyncio.TimeoutError:

--- a/backend/src/scheduler/jobs/daily_briefing.py
+++ b/backend/src/scheduler/jobs/daily_briefing.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 
 from config.settings import settings
+from src.llm_runtime import completion_with_fallback
 from src.models.schemas import WSResponse
 
 logger = logging.getLogger(__name__)
@@ -75,19 +76,11 @@ async def run_daily_briefing() -> None:
             memories=memories_text,
         )
 
-        import litellm
-
         try:
-            response = await asyncio.wait_for(
-                asyncio.to_thread(
-                    litellm.completion,
-                    model=settings.default_model,
-                    messages=[{"role": "user", "content": prompt}],
-                    api_key=settings.openrouter_api_key,
-                    api_base="https://openrouter.ai/api/v1",
-                    temperature=0.6,
-                    max_tokens=512,
-                ),
+            response = await completion_with_fallback(
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.6,
+                max_tokens=512,
                 timeout=settings.agent_briefing_timeout,
             )
         except asyncio.TimeoutError:

--- a/backend/src/scheduler/jobs/evening_review.py
+++ b/backend/src/scheduler/jobs/evening_review.py
@@ -5,6 +5,7 @@ import logging
 from datetime import date
 
 from config.settings import settings
+from src.llm_runtime import completion_with_fallback
 from src.models.schemas import WSResponse
 
 logger = logging.getLogger(__name__)
@@ -98,19 +99,11 @@ async def run_evening_review() -> None:
             active_goals=goals_text,
         )
 
-        import litellm
-
         try:
-            response = await asyncio.wait_for(
-                asyncio.to_thread(
-                    litellm.completion,
-                    model=settings.default_model,
-                    messages=[{"role": "user", "content": prompt}],
-                    api_key=settings.openrouter_api_key,
-                    api_base="https://openrouter.ai/api/v1",
-                    temperature=0.6,
-                    max_tokens=512,
-                ),
+            response = await completion_with_fallback(
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.6,
+                max_tokens=512,
                 timeout=settings.agent_briefing_timeout,
             )
         except asyncio.TimeoutError:

--- a/backend/src/scheduler/jobs/weekly_activity_review.py
+++ b/backend/src/scheduler/jobs/weekly_activity_review.py
@@ -5,6 +5,7 @@ import logging
 from datetime import date, timedelta
 
 from config.settings import settings
+from src.llm_runtime import completion_with_fallback
 from src.models.schemas import WSResponse
 
 logger = logging.getLogger(__name__)
@@ -85,19 +86,11 @@ async def run_weekly_activity_review() -> None:
             daily_breakdown=daily_breakdown,
         )
 
-        import litellm
-
         try:
-            response = await asyncio.wait_for(
-                asyncio.to_thread(
-                    litellm.completion,
-                    model=settings.default_model,
-                    messages=[{"role": "user", "content": prompt}],
-                    api_key=settings.openrouter_api_key,
-                    api_base="https://openrouter.ai/api/v1",
-                    temperature=0.6,
-                    max_tokens=1024,
-                ),
+            response = await completion_with_fallback(
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.6,
+                max_tokens=1024,
                 timeout=settings.agent_briefing_timeout,
             )
         except asyncio.TimeoutError:

--- a/backend/tests/test_llm_runtime.py
+++ b/backend/tests/test_llm_runtime.py
@@ -1,0 +1,68 @@
+"""Tests for shared LLM runtime configuration and fallback behavior."""
+
+from unittest.mock import MagicMock, patch
+
+from config.settings import settings
+from src.llm_runtime import (
+    build_completion_kwargs,
+    build_model_kwargs,
+    completion_with_fallback_sync,
+)
+
+
+def test_build_model_kwargs_uses_provider_agnostic_settings():
+    with (
+        patch.object(settings, "default_model", "openai/gpt-4o-mini"),
+        patch.object(settings, "llm_api_key", "test-key"),
+        patch.object(settings, "llm_api_base", "http://localhost:11434/v1"),
+    ):
+        kwargs = build_model_kwargs(temperature=0.4, max_tokens=512)
+
+    assert kwargs["model_id"] == "openai/gpt-4o-mini"
+    assert kwargs["api_key"] == "test-key"
+    assert kwargs["api_base"] == "http://localhost:11434/v1"
+    assert kwargs["temperature"] == 0.4
+    assert kwargs["max_tokens"] == 512
+
+
+def test_build_completion_kwargs_uses_fallback_settings():
+    with (
+        patch.object(settings, "fallback_model", "ollama/llama3.2"),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+    ):
+        kwargs = build_completion_kwargs(
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.2,
+            max_tokens=128,
+            use_fallback=True,
+        )
+
+    assert kwargs["model"] == "ollama/llama3.2"
+    assert kwargs["api_key"] == "primary-key"
+    assert kwargs["api_base"] == "http://localhost:11434/v1"
+
+
+def test_completion_with_fallback_sync_retries_with_fallback():
+    primary_error = RuntimeError("primary down")
+    fallback_response = MagicMock()
+
+    with patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"), \
+         patch.object(settings, "llm_api_key", "primary-key"), \
+         patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"), \
+         patch.object(settings, "fallback_model", "ollama/llama3.2"), \
+         patch.object(settings, "fallback_llm_api_key", ""), \
+         patch.object(settings, "fallback_llm_api_base", "http://localhost:11434/v1"), \
+         patch("litellm.completion", side_effect=[primary_error, fallback_response]) as mock_completion:
+        result = completion_with_fallback_sync(
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=0.3,
+            max_tokens=256,
+        )
+
+    assert result is fallback_response
+    assert mock_completion.call_args_list[0].kwargs["model"] == "openrouter/anthropic/claude-sonnet-4"
+    assert mock_completion.call_args_list[1].kwargs["model"] == "ollama/llama3.2"
+    assert mock_completion.call_args_list[1].kwargs["api_base"] == "http://localhost:11434/v1"

--- a/docs/docs/overview/next-steps.md
+++ b/docs/docs/overview/next-steps.md
@@ -34,8 +34,8 @@ This is the right priority because Seraph's biggest moat already exists at the p
 ### 3. Runtime Reliability
 
 - [S1-B3 Runtime Reliability](../roadmap/batches/s1-b3-runtime-reliability)
-- started with degraded-mode hardening for offline token counting in the context window path
-- still open: model routing, provider fallback, local model option, broader observability, and evaluation harness
+- started with degraded-mode hardening for offline token counting in the context window path and shared provider-agnostic LLM runtime settings
+- still open: broader model routing, stronger fallback coverage, deeper local-model paths, observability, and evaluation harness
 
 ## What Comes After
 

--- a/docs/docs/roadmap/batches/s1-b3-runtime-reliability.md
+++ b/docs/docs/roadmap/batches/s1-b3-runtime-reliability.md
@@ -23,11 +23,12 @@ This batch is just starting, but reliability hardening has begun.
 Shipped in this batch so far:
 
 - degraded-mode fallback in the token-aware context window when `tiktoken` cannot load offline
+- centralized provider-agnostic LLM runtime settings with an optional fallback completion path for direct LiteLLM calls
 
 Still open inside this batch:
 
-- model/provider routing and fallback beyond the single primary path
-- clearer local-model-capable execution paths
+- broader model/provider routing beyond the first shared fallback path
+- deeper local-model-capable execution paths beyond a configurable API base/model swap
 - broader observability coverage beyond trust-boundary events
 - a repeatable evaluation harness for core guardian and tool flows
 


### PR DESCRIPTION
## Summary
- add shared provider-agnostic LLM runtime helpers for model construction and direct completion calls
- migrate the core direct LiteLLM callsites and agent model creation paths onto the shared config layer
- update the Season 1 runtime-reliability docs to reflect the new configurable provider and fallback foundation

## Validation
- `python3 -m py_compile backend/config/settings.py backend/src/llm_runtime.py backend/src/agent/factory.py backend/src/agent/specialists.py backend/src/agent/strategist.py backend/src/agent/onboarding.py backend/src/agent/context_window.py backend/src/agent/session.py backend/src/memory/consolidator.py backend/src/scheduler/jobs/daily_briefing.py backend/src/scheduler/jobs/evening_review.py backend/src/scheduler/jobs/activity_digest.py backend/src/scheduler/jobs/weekly_activity_review.py backend/tests/test_llm_runtime.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_llm_runtime.py tests/test_agent.py tests/test_specialists.py tests/test_strategist.py tests/test_daily_briefing.py tests/test_timeouts.py tests/test_context_window.py tests/test_delegation.py`
- `cd docs && npm run build`
- `git diff --check`

## Risks
- fallback behavior is currently implemented for the direct LiteLLM completion paths, not the full smolagents chat loop yet, so this is foundation work rather than complete provider failover.
