### PR TITLE
feat(llm): audit fallback runtime behavior

### DIFF
--- a/backend/src/llm_runtime.py
+++ b/backend/src/llm_runtime.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any
 
 from config.settings import settings
+from src.audit.repository import audit_repository
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +79,46 @@ def has_fallback_model() -> bool:
     return bool(settings.fallback_model.strip())
 
 
+def _safe_model_name(kwargs: dict[str, Any]) -> str:
+    return str(kwargs.get("model", "unknown"))
+
+
+async def _log_llm_runtime_event(
+    *,
+    event_type: str,
+    summary: str,
+    details: dict[str, Any],
+) -> None:
+    try:
+        await audit_repository.log_event(
+            event_type=event_type,
+            actor="system",
+            tool_name="llm_runtime",
+            risk_level="low",
+            policy_mode="full",
+            summary=summary,
+            details=details,
+        )
+    except Exception:
+        logger.debug("Failed to record LLM runtime audit event", exc_info=True)
+
+
+def _log_llm_runtime_event_sync(
+    *,
+    event_type: str,
+    summary: str,
+    details: dict[str, Any],
+) -> None:
+    try:
+        asyncio.run(_log_llm_runtime_event(
+            event_type=event_type,
+            summary=summary,
+            details=details,
+        ))
+    except Exception:
+        logger.debug("Failed to run LLM runtime audit logger", exc_info=True)
+
+
 def completion_with_fallback_sync(
     *,
     messages: list[dict[str, str]],
@@ -94,10 +135,26 @@ def completion_with_fallback_sync(
         max_tokens=max_tokens,
         model_id=model_id,
     )
+    primary_model = _safe_model_name(primary_kwargs)
     try:
-        return litellm.completion(**primary_kwargs)
-    except Exception:
+        response = litellm.completion(**primary_kwargs)
+        _log_llm_runtime_event_sync(
+            event_type="llm_primary_success",
+            summary=f"Primary LLM completion succeeded via {primary_model}",
+            details={"primary_model": primary_model, "used_fallback": False},
+        )
+        return response
+    except Exception as primary_error:
         if not has_fallback_model():
+            _log_llm_runtime_event_sync(
+                event_type="llm_primary_failure",
+                summary=f"Primary LLM completion failed via {primary_model}",
+                details={
+                    "primary_model": primary_model,
+                    "used_fallback": False,
+                    "error": str(primary_error),
+                },
+            )
             raise
         fallback_kwargs = build_completion_kwargs(
             messages=messages,
@@ -105,13 +162,39 @@ def completion_with_fallback_sync(
             max_tokens=max_tokens,
             use_fallback=True,
         )
+        fallback_model = _safe_model_name(fallback_kwargs)
         logger.warning(
             "Primary LLM completion failed for model %s, retrying with fallback %s",
-            primary_kwargs["model"],
-            fallback_kwargs["model"],
+            primary_model,
+            fallback_model,
             exc_info=True,
         )
-        return litellm.completion(**fallback_kwargs)
+        try:
+            response = litellm.completion(**fallback_kwargs)
+            _log_llm_runtime_event_sync(
+                event_type="llm_fallback_success",
+                summary=f"Fallback LLM completion succeeded via {fallback_model}",
+                details={
+                    "primary_model": primary_model,
+                    "fallback_model": fallback_model,
+                    "used_fallback": True,
+                    "primary_error": str(primary_error),
+                },
+            )
+            return response
+        except Exception as fallback_error:
+            _log_llm_runtime_event_sync(
+                event_type="llm_fallback_failure",
+                summary=f"Fallback LLM completion failed via {fallback_model}",
+                details={
+                    "primary_model": primary_model,
+                    "fallback_model": fallback_model,
+                    "used_fallback": True,
+                    "primary_error": str(primary_error),
+                    "fallback_error": str(fallback_error),
+                },
+            )
+            raise
 
 
 async def completion_with_fallback(

--- a/backend/tests/test_llm_runtime.py
+++ b/backend/tests/test_llm_runtime.py
@@ -1,8 +1,10 @@
 """Tests for shared LLM runtime configuration and fallback behavior."""
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 from config.settings import settings
+from src.audit.repository import audit_repository
 from src.llm_runtime import (
     build_completion_kwargs,
     build_model_kwargs,
@@ -66,3 +68,63 @@ def test_completion_with_fallback_sync_retries_with_fallback():
     assert mock_completion.call_args_list[0].kwargs["model"] == "openrouter/anthropic/claude-sonnet-4"
     assert mock_completion.call_args_list[1].kwargs["model"] == "ollama/llama3.2"
     assert mock_completion.call_args_list[1].kwargs["api_base"] == "http://localhost:11434/v1"
+
+
+def test_completion_with_fallback_sync_logs_primary_success(async_db):
+    success_response = MagicMock()
+
+    with (
+        patch.object(settings, "default_model", "openai/gpt-4o-mini"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "fallback_model", ""),
+        patch("litellm.completion", return_value=success_response),
+    ):
+        result = completion_with_fallback_sync(
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=0.3,
+            max_tokens=256,
+        )
+
+    assert result is success_response
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "llm_primary_success"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["details"]["used_fallback"] is False
+    assert events[0]["details"]["primary_model"] == "openai/gpt-4o-mini"
+
+
+def test_completion_with_fallback_sync_logs_fallback_success(async_db):
+    primary_error = RuntimeError("primary down")
+    fallback_response = MagicMock()
+
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "fallback_model", "ollama/llama3.2"),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", "http://localhost:11434/v1"),
+        patch("litellm.completion", side_effect=[primary_error, fallback_response]),
+    ):
+        result = completion_with_fallback_sync(
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=0.3,
+            max_tokens=256,
+        )
+
+    assert result is fallback_response
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "llm_fallback_success"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["details"]["used_fallback"] is True
+    assert events[0]["details"]["fallback_model"] == "ollama/llama3.2"
+    assert "primary down" in events[0]["details"]["primary_error"]

--- a/docs/docs/overview/next-steps.md
+++ b/docs/docs/overview/next-steps.md
@@ -34,7 +34,7 @@ This is the right priority because Seraph's biggest moat already exists at the p
 ### 3. Runtime Reliability
 
 - [S1-B3 Runtime Reliability](../roadmap/batches/s1-b3-runtime-reliability)
-- started with degraded-mode hardening for offline token counting in the context window path and shared provider-agnostic LLM runtime settings
+- started with degraded-mode hardening for offline token counting in the context window path, shared provider-agnostic LLM runtime settings, and audit visibility into primary-vs-fallback completion behavior
 - still open: broader model routing, stronger fallback coverage, deeper local-model paths, observability, and evaluation harness
 
 ## What Comes After

--- a/docs/docs/roadmap/batches/s1-b3-runtime-reliability.md
+++ b/docs/docs/roadmap/batches/s1-b3-runtime-reliability.md
@@ -24,12 +24,13 @@ Shipped in this batch so far:
 
 - degraded-mode fallback in the token-aware context window when `tiktoken` cannot load offline
 - centralized provider-agnostic LLM runtime settings with an optional fallback completion path for direct LiteLLM calls
+- audit events for primary-vs-fallback LLM completion behavior so degraded mode is visible after the fact
 
 Still open inside this batch:
 
 - broader model/provider routing beyond the first shared fallback path
 - deeper local-model-capable execution paths beyond a configurable API base/model swap
-- broader observability coverage beyond trust-boundary events
+- broader observability coverage beyond the first LLM runtime audit events
 - a repeatable evaluation harness for core guardian and tool flows
 
 ## Non-goals


### PR DESCRIPTION
## Summary
- add audit events for primary LLM success/failure and fallback success/failure inside the shared runtime helper
- extend the runtime helper tests to assert the new observability behavior
- update the Season 1 runtime-reliability docs so the roadmap reflects that fallback behavior is now visible after the fact

## Validation
- `python3 -m py_compile backend/src/llm_runtime.py backend/tests/test_llm_runtime.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_llm_runtime.py tests/test_audit_api.py tests/test_daily_briefing.py tests/test_timeouts.py tests/test_context_window.py`
- `cd docs && npm run build`
- `git diff --check`

## Risks
- these audit events currently cover the shared direct-completion helper path, not every smolagents-internal step yet, so observability is improved but not comprehensive.
