### PR TITLE
Add fallback model coverage for smolagents runtime

### DIFF
--- a/backend/src/agent/factory.py
+++ b/backend/src/agent/factory.py
@@ -1,7 +1,7 @@
-from smolagents import LiteLLMModel, ToolCallingAgent
+from smolagents import ToolCallingAgent
 
 from config.settings import settings
-from src.llm_runtime import build_model_kwargs
+from src.llm_runtime import FallbackLiteLLMModel as LiteLLMModel, build_model_kwargs
 from src.plugins.loader import discover_tools
 from src.skills.manager import skill_manager
 from src.tools.approval import wrap_tools_for_approval, wrap_tools_with_forced_approval

--- a/backend/src/agent/onboarding.py
+++ b/backend/src/agent/onboarding.py
@@ -1,9 +1,9 @@
 """Onboarding agent — guides first-time users through identity & goal setup."""
 
-from smolagents import LiteLLMModel, ToolCallingAgent
+from smolagents import ToolCallingAgent
 
 from config.settings import settings
-from src.llm_runtime import build_model_kwargs
+from src.llm_runtime import FallbackLiteLLMModel as LiteLLMModel, build_model_kwargs
 from src.tools.soul_tool import view_soul, update_soul
 from src.tools.goal_tools import create_goal, get_goals
 

--- a/backend/src/agent/specialists.py
+++ b/backend/src/agent/specialists.py
@@ -10,10 +10,10 @@ Tier 2 (dynamic): one specialist per connected MCP server
 
 import re
 
-from smolagents import LiteLLMModel, ToolCallingAgent
+from smolagents import ToolCallingAgent
 
 from config.settings import settings
-from src.llm_runtime import build_model_kwargs
+from src.llm_runtime import FallbackLiteLLMModel as LiteLLMModel, build_model_kwargs
 from src.plugins.loader import discover_tools
 from src.tools.approval import wrap_tools_for_approval, wrap_tools_with_forced_approval
 from src.tools.mcp_manager import mcp_manager

--- a/backend/src/agent/strategist.py
+++ b/backend/src/agent/strategist.py
@@ -4,10 +4,10 @@ import json
 import logging
 from dataclasses import dataclass
 
-from smolagents import LiteLLMModel, ToolCallingAgent
+from smolagents import ToolCallingAgent
 
 from config.settings import settings
-from src.llm_runtime import build_model_kwargs
+from src.llm_runtime import FallbackLiteLLMModel as LiteLLMModel, build_model_kwargs
 from src.tools.soul_tool import view_soul
 from src.tools.goal_tools import get_goals, get_goal_progress
 

--- a/backend/src/llm_runtime.py
+++ b/backend/src/llm_runtime.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from threading import Lock
 from typing import Any
+from uuid import uuid4
+
+from smolagents import LiteLLMModel as BaseLiteLLMModel
 
 from config.settings import settings
 from src.audit.repository import audit_repository
 
 logger = logging.getLogger(__name__)
+_runtime_request_lock = Lock()
+_runtime_requests: dict[str, bool] = {}
 
 
 def _primary_api_key() -> str:
@@ -79,8 +85,42 @@ def has_fallback_model() -> bool:
     return bool(settings.fallback_model.strip())
 
 
+def _fallback_api_key(primary_api_key: str | None) -> str:
+    return settings.fallback_llm_api_key or primary_api_key or _primary_api_key()
+
+
+def _fallback_api_base(primary_api_base: str | None) -> str:
+    return settings.fallback_llm_api_base or primary_api_base or settings.llm_api_base
+
+
 def _safe_model_name(kwargs: dict[str, Any]) -> str:
     return str(kwargs.get("model", "unknown"))
+
+
+def _register_request(request_id: str) -> None:
+    with _runtime_request_lock:
+        _runtime_requests[request_id] = False
+
+
+def _mark_request_timed_out(request_id: str) -> None:
+    with _runtime_request_lock:
+        if request_id in _runtime_requests:
+            _runtime_requests[request_id] = True
+
+
+def _finish_request(request_id: str) -> None:
+    with _runtime_request_lock:
+        _runtime_requests.pop(request_id, None)
+
+
+def _can_log_request(request_id: str | None) -> bool:
+    if request_id is None:
+        return True
+    with _runtime_request_lock:
+        timed_out = _runtime_requests.get(request_id)
+    if timed_out is None:
+        return True
+    return not timed_out
 
 
 async def _log_llm_runtime_event(
@@ -119,82 +159,172 @@ def _log_llm_runtime_event_sync(
         logger.debug("Failed to run LLM runtime audit logger", exc_info=True)
 
 
+class FallbackLiteLLMModel(BaseLiteLLMModel):
+    """LiteLLM model wrapper that retries via the configured fallback model."""
+
+    def __init__(
+        self,
+        model_id: str | None = None,
+        api_base: str | None = None,
+        api_key: str | None = None,
+        custom_role_conversions: dict[str, str] | None = None,
+        flatten_messages_as_text: bool | None = None,
+        **kwargs,
+    ):
+        super().__init__(
+            model_id=model_id,
+            api_base=api_base,
+            api_key=api_key,
+            custom_role_conversions=custom_role_conversions,
+            flatten_messages_as_text=flatten_messages_as_text,
+            **kwargs,
+        )
+        self._fallback_model: BaseLiteLLMModel | None = None
+
+        fallback_model_id = settings.fallback_model.strip()
+        if not fallback_model_id:
+            return
+
+        fallback_api_key = _fallback_api_key(api_key)
+        fallback_api_base = _fallback_api_base(api_base)
+        fallback_target_differs = (
+            fallback_model_id != self.model_id
+            or (fallback_api_base or None) != self.api_base
+            or (fallback_api_key or None) != self.api_key
+        )
+        if not fallback_target_differs:
+            return
+
+        fallback_kwargs = dict(kwargs)
+        if flatten_messages_as_text is not None:
+            fallback_kwargs["flatten_messages_as_text"] = flatten_messages_as_text
+        self._fallback_model = BaseLiteLLMModel(
+            model_id=fallback_model_id,
+            api_base=fallback_api_base or None,
+            api_key=fallback_api_key or None,
+            custom_role_conversions=custom_role_conversions,
+            **fallback_kwargs,
+        )
+
+    def generate(
+        self,
+        messages,
+        stop_sequences=None,
+        response_format=None,
+        tools_to_call_from=None,
+        **kwargs,
+    ):
+        try:
+            return super().generate(
+                messages,
+                stop_sequences=stop_sequences,
+                response_format=response_format,
+                tools_to_call_from=tools_to_call_from,
+                **kwargs,
+            )
+        except Exception:
+            if self._fallback_model is None:
+                raise
+            logger.warning(
+                "Primary agent model %s failed, retrying with fallback %s",
+                self.model_id,
+                self._fallback_model.model_id,
+                exc_info=True,
+            )
+            return self._fallback_model.generate(
+                messages,
+                stop_sequences=stop_sequences,
+                response_format=response_format,
+                tools_to_call_from=tools_to_call_from,
+                **kwargs,
+            )
+
+
 def completion_with_fallback_sync(
     *,
     messages: list[dict[str, str]],
     temperature: float,
     max_tokens: int,
     model_id: str | None = None,
+    request_id: str | None = None,
 ):
     """Execute a litellm completion with an optional fallback target."""
     import litellm
 
-    primary_kwargs = build_completion_kwargs(
-        messages=messages,
-        temperature=temperature,
-        max_tokens=max_tokens,
-        model_id=model_id,
-    )
-    primary_model = _safe_model_name(primary_kwargs)
     try:
-        response = litellm.completion(**primary_kwargs)
-        _log_llm_runtime_event_sync(
-            event_type="llm_primary_success",
-            summary=f"Primary LLM completion succeeded via {primary_model}",
-            details={"primary_model": primary_model, "used_fallback": False},
-        )
-        return response
-    except Exception as primary_error:
-        if not has_fallback_model():
-            _log_llm_runtime_event_sync(
-                event_type="llm_primary_failure",
-                summary=f"Primary LLM completion failed via {primary_model}",
-                details={
-                    "primary_model": primary_model,
-                    "used_fallback": False,
-                    "error": str(primary_error),
-                },
-            )
-            raise
-        fallback_kwargs = build_completion_kwargs(
+        primary_kwargs = build_completion_kwargs(
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
-            use_fallback=True,
+            model_id=model_id,
         )
-        fallback_model = _safe_model_name(fallback_kwargs)
-        logger.warning(
-            "Primary LLM completion failed for model %s, retrying with fallback %s",
-            primary_model,
-            fallback_model,
-            exc_info=True,
-        )
+        primary_model = _safe_model_name(primary_kwargs)
         try:
-            response = litellm.completion(**fallback_kwargs)
-            _log_llm_runtime_event_sync(
-                event_type="llm_fallback_success",
-                summary=f"Fallback LLM completion succeeded via {fallback_model}",
-                details={
-                    "primary_model": primary_model,
-                    "fallback_model": fallback_model,
-                    "used_fallback": True,
-                    "primary_error": str(primary_error),
-                },
-            )
+            response = litellm.completion(**primary_kwargs)
+            if _can_log_request(request_id):
+                _log_llm_runtime_event_sync(
+                    event_type="llm_primary_success",
+                    summary=f"Primary LLM completion succeeded via {primary_model}",
+                    details={"primary_model": primary_model, "used_fallback": False},
+                )
             return response
-        except Exception as fallback_error:
-            _log_llm_runtime_event_sync(
-                event_type="llm_fallback_failure",
-                summary=f"Fallback LLM completion failed via {fallback_model}",
-                details={
-                    "primary_model": primary_model,
-                    "fallback_model": fallback_model,
-                    "used_fallback": True,
-                    "primary_error": str(primary_error),
-                    "fallback_error": str(fallback_error),
-                },
+        except Exception as primary_error:
+            if not has_fallback_model():
+                if _can_log_request(request_id):
+                    _log_llm_runtime_event_sync(
+                        event_type="llm_primary_failure",
+                        summary=f"Primary LLM completion failed via {primary_model}",
+                        details={
+                            "primary_model": primary_model,
+                            "used_fallback": False,
+                            "error": str(primary_error),
+                        },
+                    )
+                raise
+            fallback_kwargs = build_completion_kwargs(
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                use_fallback=True,
             )
-            raise
+            fallback_model = _safe_model_name(fallback_kwargs)
+            logger.warning(
+                "Primary LLM completion failed for model %s, retrying with fallback %s",
+                primary_model,
+                fallback_model,
+                exc_info=True,
+            )
+            try:
+                response = litellm.completion(**fallback_kwargs)
+                if _can_log_request(request_id):
+                    _log_llm_runtime_event_sync(
+                        event_type="llm_fallback_success",
+                        summary=f"Fallback LLM completion succeeded via {fallback_model}",
+                        details={
+                            "primary_model": primary_model,
+                            "fallback_model": fallback_model,
+                            "used_fallback": True,
+                            "primary_error": str(primary_error),
+                        },
+                    )
+                return response
+            except Exception as fallback_error:
+                if _can_log_request(request_id):
+                    _log_llm_runtime_event_sync(
+                        event_type="llm_fallback_failure",
+                        summary=f"Fallback LLM completion failed via {fallback_model}",
+                        details={
+                            "primary_model": primary_model,
+                            "fallback_model": fallback_model,
+                            "used_fallback": True,
+                            "primary_error": str(primary_error),
+                            "fallback_error": str(fallback_error),
+                        },
+                    )
+                raise
+    finally:
+        if request_id is not None:
+            _finish_request(request_id)
 
 
 async def completion_with_fallback(
@@ -206,13 +336,23 @@ async def completion_with_fallback(
     model_id: str | None = None,
 ):
     """Async wrapper around the shared completion fallback flow."""
+    request_id = uuid4().hex
+    _register_request(request_id)
     coro = asyncio.to_thread(
         completion_with_fallback_sync,
         messages=messages,
         temperature=temperature,
         max_tokens=max_tokens,
         model_id=model_id,
+        request_id=request_id,
     )
-    if timeout is None:
-        return await coro
-    return await asyncio.wait_for(coro, timeout=timeout)
+    try:
+        if timeout is None:
+            return await coro
+        return await asyncio.wait_for(coro, timeout=timeout)
+    except asyncio.TimeoutError:
+        _mark_request_timed_out(request_id)
+        raise
+    finally:
+        if timeout is None:
+            _finish_request(request_id)

--- a/backend/tests/test_llm_runtime.py
+++ b/backend/tests/test_llm_runtime.py
@@ -1,13 +1,18 @@
 """Tests for shared LLM runtime configuration and fallback behavior."""
 
 import asyncio
+import time
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from config.settings import settings
 from src.audit.repository import audit_repository
 from src.llm_runtime import (
+    FallbackLiteLLMModel,
     build_completion_kwargs,
     build_model_kwargs,
+    completion_with_fallback,
     completion_with_fallback_sync,
 )
 
@@ -128,3 +133,78 @@ def test_completion_with_fallback_sync_logs_fallback_success(async_db):
     assert events[0]["details"]["used_fallback"] is True
     assert events[0]["details"]["fallback_model"] == "ollama/llama3.2"
     assert "primary down" in events[0]["details"]["primary_error"]
+
+
+def test_fallback_litellm_model_retries_generate_with_fallback():
+    primary_error = RuntimeError("primary down")
+    fallback_response = MagicMock()
+
+    with (
+        patch.object(settings, "fallback_model", "ollama/llama3.2"),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", "http://localhost:11434/v1"),
+    ):
+        with patch(
+            "src.llm_runtime.BaseLiteLLMModel.generate",
+            autospec=True,
+            side_effect=[primary_error, fallback_response],
+        ) as mock_generate:
+            model = FallbackLiteLLMModel(
+                model_id="openrouter/anthropic/claude-sonnet-4",
+                api_key="primary-key",
+                api_base="https://openrouter.ai/api/v1",
+                temperature=0.3,
+                max_tokens=256,
+            )
+            result = model.generate([{"role": "user", "content": "hello"}])
+
+    assert result is fallback_response
+    assert mock_generate.call_count == 2
+    assert mock_generate.call_args_list[0].args[0].model_id == "openrouter/anthropic/claude-sonnet-4"
+    assert mock_generate.call_args_list[1].args[0].model_id == "ollama/llama3.2"
+
+
+def test_fallback_litellm_model_skips_duplicate_fallback_target():
+    with (
+        patch.object(settings, "fallback_model", "openai/gpt-4o-mini"),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", "http://localhost:11434/v1"),
+    ):
+        model = FallbackLiteLLMModel(
+            model_id="openai/gpt-4o-mini",
+            api_key="primary-key",
+            api_base="http://localhost:11434/v1",
+            temperature=0.3,
+            max_tokens=256,
+        )
+
+    assert model._fallback_model is None
+
+
+@pytest.mark.asyncio
+async def test_completion_with_fallback_timeout_does_not_log_late_success(async_db):
+    success_response = MagicMock()
+
+    def _slow_success(**_kwargs):
+        time.sleep(0.1)
+        return success_response
+
+    with (
+        patch.object(settings, "default_model", "openai/gpt-4o-mini"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "fallback_model", ""),
+        patch("litellm.completion", side_effect=_slow_success),
+    ):
+        with pytest.raises(asyncio.TimeoutError):
+            await completion_with_fallback(
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0.3,
+                max_tokens=256,
+                timeout=0.01,
+            )
+        await asyncio.sleep(0.15)
+
+    events = await audit_repository.list_events(limit=10)
+    success_events = [e for e in events if e["event_type"] == "llm_primary_success"]
+    assert success_events == []

--- a/docs/docs/overview/next-steps.md
+++ b/docs/docs/overview/next-steps.md
@@ -34,7 +34,7 @@ This is the right priority because Seraph's biggest moat already exists at the p
 ### 3. Runtime Reliability
 
 - [S1-B3 Runtime Reliability](../roadmap/batches/s1-b3-runtime-reliability)
-- started with degraded-mode hardening for offline token counting in the context window path, shared provider-agnostic LLM runtime settings, and audit visibility into primary-vs-fallback completion behavior
+- started with degraded-mode hardening for offline token counting in the context window path, shared provider-agnostic LLM runtime settings, timeout-safe audit visibility into primary-vs-fallback completion behavior, and fallback-capable agent models for the main smolagents runtime
 - still open: broader model routing, stronger fallback coverage, deeper local-model paths, observability, and evaluation harness
 
 ## What Comes After

--- a/docs/docs/roadmap/batches/s1-b3-runtime-reliability.md
+++ b/docs/docs/roadmap/batches/s1-b3-runtime-reliability.md
@@ -24,13 +24,14 @@ Shipped in this batch so far:
 
 - degraded-mode fallback in the token-aware context window when `tiktoken` cannot load offline
 - centralized provider-agnostic LLM runtime settings with an optional fallback completion path for direct LiteLLM calls
-- audit events for primary-vs-fallback LLM completion behavior so degraded mode is visible after the fact
+- timeout-safe audit events for primary-vs-fallback direct LLM completion behavior so degraded mode is visible after the fact
+- fallback-capable `smolagents` model wrappers for the main agent, onboarding agent, strategist, and specialists so provider failure is less likely to collapse the interactive runtime
 
 Still open inside this batch:
 
 - broader model/provider routing beyond the first shared fallback path
 - deeper local-model-capable execution paths beyond a configurable API base/model swap
-- broader observability coverage beyond the first LLM runtime audit events
+- broader observability coverage beyond the first direct LLM runtime audit events
 - a repeatable evaluation harness for core guardian and tool flows
 
 ## Non-goals


### PR DESCRIPTION
## Summary
- add a fallback-capable LiteLLM model wrapper so the main smolagents agent path, onboarding agent, strategist, and specialists retry via the configured fallback model
- restore timeout-safe audit tracking for direct completion fallback calls so late successes are not logged after a caller times out
- update the Season 1 runtime reliability docs to reflect the broader fallback coverage now in place

## Validation
- python3 -m py_compile backend/src/llm_runtime.py backend/src/agent/factory.py backend/src/agent/specialists.py backend/src/agent/strategist.py backend/src/agent/onboarding.py backend/tests/test_llm_runtime.py backend/tests/test_agent.py backend/tests/test_specialists.py backend/tests/test_delegation.py backend/tests/test_strategist.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_llm_runtime.py tests/test_agent.py tests/test_specialists.py tests/test_delegation.py tests/test_strategist.py tests/test_daily_briefing.py tests/test_timeouts.py tests/test_context_window.py
- cd docs && npm run build
- git diff --check

## Risks
- fallback is still single-hop and still depends on explicit fallback configuration rather than broader provider routing
