### PR TITLE
Add runtime reliability eval harness

### DIFF
--- a/backend/src/evals/__init__.py
+++ b/backend/src/evals/__init__.py
@@ -1,0 +1,1 @@
+"""Repeatable evaluation helpers for core guardian reliability flows."""

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -1,0 +1,349 @@
+"""Deterministic runtime evaluation harness for core guardian flows."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Awaitable, Callable, Sequence
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from config.settings import settings
+from src.agent.factory import get_model
+from src.agent.onboarding import create_onboarding_agent
+from src.agent.strategist import create_strategist_agent
+from src.llm_runtime import FallbackLiteLLMModel
+from src.observer.context import CurrentContext
+from src.scheduler.jobs.daily_briefing import run_daily_briefing
+from src.tools.shell_tool import shell_execute
+
+
+Runner = Callable[[], dict[str, Any] | Awaitable[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class EvalScenario:
+    name: str
+    category: str
+    description: str
+    runner: Runner
+
+
+@dataclass
+class EvalResult:
+    name: str
+    category: str
+    description: str
+    passed: bool
+    duration_ms: int
+    details: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class EvalSummary:
+    results: list[EvalResult]
+    duration_ms: int
+
+    @property
+    def total(self) -> int:
+        return len(self.results)
+
+    @property
+    def passed(self) -> int:
+        return sum(1 for result in self.results if result.passed)
+
+    @property
+    def failed(self) -> int:
+        return self.total - self.passed
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total": self.total,
+            "passed": self.passed,
+            "failed": self.failed,
+            "duration_ms": self.duration_ms,
+            "results": [result.to_dict() for result in self.results],
+        }
+
+
+def _make_litellm_response(text: str) -> MagicMock:
+    choice = MagicMock()
+    choice.message.content = text
+    response = MagicMock()
+    response.choices = [choice]
+    return response
+
+
+def _make_context(**overrides: Any) -> CurrentContext:
+    defaults = dict(
+        time_of_day="morning",
+        day_of_week="Monday",
+        is_working_hours=True,
+        active_goals_summary="Ship the next reliability batch",
+    )
+    defaults.update(overrides)
+    return CurrentContext(**defaults)
+
+
+def _tool_names(agent: Any) -> list[str]:
+    tools = agent.tools
+    if isinstance(tools, dict):
+        return sorted(str(name) for name in tools)
+    names = []
+    for tool in tools:
+        names.append(tool if isinstance(tool, str) else tool.name)
+    return sorted(names)
+
+
+def _eval_chat_model_wrapper() -> dict[str, Any]:
+    with (
+        patch.object(settings, "default_model", "openai/gpt-4o-mini"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "fallback_model", "ollama/llama3.2"),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", "http://localhost:11434/v1"),
+    ):
+        model = get_model()
+
+    assert isinstance(model, FallbackLiteLLMModel)
+    assert model.model_id == "openai/gpt-4o-mini"
+    assert model._fallback_model is not None
+    assert model._fallback_model.model_id == "ollama/llama3.2"
+    return {
+        "primary_model": model.model_id,
+        "fallback_model": model._fallback_model.model_id,
+    }
+
+
+def _eval_onboarding_model_wrapper() -> dict[str, Any]:
+    with (
+        patch.object(settings, "fallback_model", "ollama/llama3.2"),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+    ):
+        agent = create_onboarding_agent()
+
+    tool_names = _tool_names(agent)
+    assert isinstance(agent.model, FallbackLiteLLMModel)
+    assert agent.model._fallback_model is not None
+    assert {"create_goal", "get_goals", "update_soul", "view_soul"} <= set(tool_names)
+    return {
+        "tool_names": tool_names,
+        "fallback_model": agent.model._fallback_model.model_id,
+    }
+
+
+def _eval_strategist_model_wrapper() -> dict[str, Any]:
+    with (
+        patch.object(settings, "fallback_model", "ollama/llama3.2"),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+    ):
+        agent = create_strategist_agent("Time: morning\nGoals: 2 active")
+
+    tool_names = _tool_names(agent)
+    assert isinstance(agent.model, FallbackLiteLLMModel)
+    assert agent.model._fallback_model is not None
+    assert {"get_goal_progress", "get_goals", "view_soul"} <= set(tool_names)
+    return {
+        "tool_names": tool_names,
+        "fallback_model": agent.model._fallback_model.model_id,
+        "max_steps": agent.max_steps,
+    }
+
+
+async def _eval_daily_briefing_fallback() -> dict[str, Any]:
+    ctx = _make_context(upcoming_events=[{"summary": "Ship eval harness", "start": "09:30"}])
+    mock_context_manager = MagicMock()
+    mock_context_manager.refresh = AsyncMock(return_value=ctx)
+    mock_deliver = AsyncMock()
+    fallback_response = _make_litellm_response("Morning briefing via fallback.")
+    primary_error = RuntimeError("primary down")
+
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "fallback_model", "ollama/llama3.2"),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", "http://localhost:11434/v1"),
+        patch("src.observer.manager.context_manager", mock_context_manager),
+        patch("src.memory.soul.read_soul", return_value="# Soul\nName: Hero"),
+        patch("src.memory.vector_store.search_formatted", return_value="- [memory] Prioritize reliability"),
+        patch("src.llm_runtime.logger.warning"),
+        patch("litellm.completion", side_effect=[primary_error, fallback_response]) as mock_completion,
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        await run_daily_briefing()
+
+    assert mock_completion.call_count == 2
+    assert mock_completion.call_args_list[0].kwargs["model"] == "openrouter/anthropic/claude-sonnet-4"
+    assert mock_completion.call_args_list[1].kwargs["model"] == "ollama/llama3.2"
+    mock_deliver.assert_called_once()
+    delivered_message = mock_deliver.call_args.args[0]
+    return {
+        "primary_model": mock_completion.call_args_list[0].kwargs["model"],
+        "fallback_model": mock_completion.call_args_list[1].kwargs["model"],
+        "delivered_excerpt": delivered_message.content,
+    }
+
+
+def _eval_shell_tool_timeout_contract() -> dict[str, Any]:
+    mock_client = MagicMock()
+    mock_client.post.side_effect = httpx.TimeoutException("timeout")
+
+    with patch("src.tools.shell_tool.httpx.Client") as client_cls:
+        client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        result = shell_execute("import time; time.sleep(999)")
+
+    assert "timed out" in result.lower()
+    return {"result": result}
+
+
+_SCENARIOS: tuple[EvalScenario, ...] = (
+    EvalScenario(
+        name="chat_model_wrapper",
+        category="runtime",
+        description="Main agent model wiring exposes the shared fallback wrapper.",
+        runner=_eval_chat_model_wrapper,
+    ),
+    EvalScenario(
+        name="onboarding_model_wrapper",
+        category="guardian",
+        description="Onboarding agent keeps its core tools while using fallback-capable model wiring.",
+        runner=_eval_onboarding_model_wrapper,
+    ),
+    EvalScenario(
+        name="strategist_model_wrapper",
+        category="guardian",
+        description="Strategist agent uses fallback-capable model wiring with its restricted tool set.",
+        runner=_eval_strategist_model_wrapper,
+    ),
+    EvalScenario(
+        name="daily_briefing_fallback",
+        category="proactive",
+        description="Daily briefing survives a primary provider failure and still delivers via fallback.",
+        runner=_eval_daily_briefing_fallback,
+    ),
+    EvalScenario(
+        name="shell_tool_timeout_contract",
+        category="tool",
+        description="Shell tool returns a clear timeout contract when sandbox execution stalls.",
+        runner=_eval_shell_tool_timeout_contract,
+    ),
+)
+
+
+def available_scenarios() -> tuple[EvalScenario, ...]:
+    return _SCENARIOS
+
+
+def _select_scenarios(selected_names: Sequence[str] | None) -> list[EvalScenario]:
+    scenarios = list(_SCENARIOS)
+    if not selected_names:
+        return scenarios
+
+    scenario_map = {scenario.name: scenario for scenario in scenarios}
+    missing = sorted({name for name in selected_names if name not in scenario_map})
+    if missing:
+        available = ", ".join(sorted(scenario_map))
+        missing_str = ", ".join(missing)
+        raise ValueError(f"Unknown eval scenario(s): {missing_str}. Available: {available}")
+
+    return [scenario_map[name] for name in selected_names]
+
+
+async def _run_scenario(scenario: EvalScenario) -> EvalResult:
+    started = time.perf_counter()
+    try:
+        output = scenario.runner()
+        if asyncio.iscoroutine(output):
+            details = await output
+        else:
+            details = output
+        return EvalResult(
+            name=scenario.name,
+            category=scenario.category,
+            description=scenario.description,
+            passed=True,
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            details=details,
+        )
+    except Exception as exc:
+        return EvalResult(
+            name=scenario.name,
+            category=scenario.category,
+            description=scenario.description,
+            passed=False,
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            error=str(exc),
+        )
+
+
+async def run_runtime_evals(selected_names: Sequence[str] | None = None) -> EvalSummary:
+    scenarios = _select_scenarios(selected_names)
+    started = time.perf_counter()
+    results = []
+    for scenario in scenarios:
+        results.append(await _run_scenario(scenario))
+    return EvalSummary(results=results, duration_ms=int((time.perf_counter() - started) * 1000))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        dest="scenarios",
+        help="Specific scenario to run. Repeat to run more than one.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available scenarios and exit.",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indentation for output.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.list:
+        for scenario in available_scenarios():
+            print(f"{scenario.name}: [{scenario.category}] {scenario.description}")
+        return 0
+
+    try:
+        summary = asyncio.run(run_runtime_evals(args.scenarios))
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    print(json.dumps(summary.to_dict(), indent=args.indent))
+    return 0 if summary.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -1,0 +1,55 @@
+"""Tests for the repeatable runtime evaluation harness."""
+
+import asyncio
+import json
+
+import pytest
+
+from src.evals.harness import available_scenarios, main, run_runtime_evals
+
+
+def test_run_runtime_evals_passes_all_scenarios():
+    summary = asyncio.run(run_runtime_evals())
+
+    scenario_names = {scenario.name for scenario in available_scenarios()}
+    result_names = {result.name for result in summary.results}
+
+    assert summary.total == len(scenario_names)
+    assert summary.failed == 0
+    assert result_names == scenario_names
+
+
+def test_run_runtime_evals_can_filter_specific_scenarios():
+    summary = asyncio.run(run_runtime_evals(["daily_briefing_fallback", "shell_tool_timeout_contract"]))
+
+    assert summary.total == 2
+    assert summary.failed == 0
+    assert [result.name for result in summary.results] == [
+        "daily_briefing_fallback",
+        "shell_tool_timeout_contract",
+    ]
+
+
+def test_run_runtime_evals_rejects_unknown_scenarios():
+    with pytest.raises(ValueError, match="Unknown eval scenario"):
+        asyncio.run(run_runtime_evals(["missing-scenario"]))
+
+
+def test_main_lists_available_scenarios(capsys):
+    exit_code = main(["--list"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "chat_model_wrapper" in captured.out
+    assert "shell_tool_timeout_contract" in captured.out
+
+
+def test_main_emits_json_summary(capsys):
+    exit_code = main(["--scenario", "shell_tool_timeout_contract", "--indent", "0"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["failed"] == 0
+    assert payload["results"][0]["name"] == "shell_tool_timeout_contract"

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -27,6 +27,19 @@ asyncio_mode = "auto"
 addopts = "--cov=src --cov-report=term-missing"
 ```
 
+### Runtime Evals
+
+For `S1-B3` reliability work, there is also a deterministic eval harness for core guardian/runtime contracts:
+
+```bash
+cd backend
+uv run python -m src.evals.harness --list
+uv run python -m src.evals.harness
+uv run python -m src.evals.harness --scenario daily_briefing_fallback
+```
+
+This runner does not call external providers. It exercises core seams with controlled mocks so fallback wiring, proactive delivery, and tool degradation behavior stay easy to verify after reliability changes.
+
 ### Frontend
 
 ```bash

--- a/docs/docs/overview/next-steps.md
+++ b/docs/docs/overview/next-steps.md
@@ -34,8 +34,8 @@ This is the right priority because Seraph's biggest moat already exists at the p
 ### 3. Runtime Reliability
 
 - [S1-B3 Runtime Reliability](../roadmap/batches/s1-b3-runtime-reliability)
-- started with degraded-mode hardening for offline token counting in the context window path, shared provider-agnostic LLM runtime settings, timeout-safe audit visibility into primary-vs-fallback completion behavior, and fallback-capable agent models for the main smolagents runtime
-- still open: broader model routing, stronger fallback coverage, deeper local-model paths, observability, and evaluation harness
+- started with degraded-mode hardening for offline token counting in the context window path, shared provider-agnostic LLM runtime settings, timeout-safe audit visibility into primary-vs-fallback completion behavior, fallback-capable agent models for the main smolagents runtime, and a repeatable runtime eval harness for core guardian/tool reliability contracts
+- still open: broader model routing, deeper local-model paths, broader observability coverage, and richer eval coverage beyond the first core scenarios
 
 ## What Comes After
 

--- a/docs/docs/roadmap/batches/s1-b3-runtime-reliability.md
+++ b/docs/docs/roadmap/batches/s1-b3-runtime-reliability.md
@@ -26,13 +26,14 @@ Shipped in this batch so far:
 - centralized provider-agnostic LLM runtime settings with an optional fallback completion path for direct LiteLLM calls
 - timeout-safe audit events for primary-vs-fallback direct LLM completion behavior so degraded mode is visible after the fact
 - fallback-capable `smolagents` model wrappers for the main agent, onboarding agent, strategist, and specialists so provider failure is less likely to collapse the interactive runtime
+- a repeatable runtime eval harness for core guardian/tool reliability contracts so fallback wiring and degraded behavior can be checked without live providers
 
 Still open inside this batch:
 
 - broader model/provider routing beyond the first shared fallback path
 - deeper local-model-capable execution paths beyond a configurable API base/model swap
 - broader observability coverage beyond the first direct LLM runtime audit events
-- a repeatable evaluation harness for core guardian and tool flows
+- richer evaluation coverage beyond the first core guardian and tool scenarios
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary
- add a deterministic runtime eval harness for core guardian and tool reliability contracts
- cover the new eval runner with backend tests and document how to run it locally
- update the Season 1 runtime reliability roadmap docs to reflect the shipped harness and remaining gaps

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/evals/__init__.py backend/src/evals/harness.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_eval_harness.py tests/test_daily_briefing.py tests/test_agent.py tests/test_strategist.py tests/test_shell_tool.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario daily_briefing_fallback --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build

## Risks
- the first harness focuses on deterministic seam checks rather than full live-provider or end-to-end behavioral evaluation
