### PR TITLE
Add scheduler job observability coverage

### DIFF
--- a/backend/src/scheduler/jobs/calendar_scan.py
+++ b/backend/src/scheduler/jobs/calendar_scan.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import datetime, timedelta
+from time import perf_counter
 
+from src.audit.runtime import log_scheduler_job_event
 from src.models.schemas import WSResponse
 
 logger = logging.getLogger(__name__)
@@ -9,47 +11,81 @@ logger = logging.getLogger(__name__)
 async def run_calendar_scan() -> None:
     """Scan upcoming calendar events and alert user about imminent ones."""
     logger.info("calendar_scan started")
+    started_at = perf_counter()
 
     try:
         from src.observer.manager import context_manager
         ctx = await context_manager.refresh()
-    except Exception:
-        logger.exception("calendar_scan: context refresh failed")
-        return
 
-    if not ctx.upcoming_events:
-        logger.debug("calendar_scan: no upcoming events")
-        return
+        if not ctx.upcoming_events:
+            logger.debug("calendar_scan: no upcoming events")
+            await log_scheduler_job_event(
+                job_name="calendar_scan",
+                outcome="skipped",
+                details={
+                    "duration_ms": int((perf_counter() - started_at) * 1000),
+                    "reason": "no_upcoming_events",
+                },
+            )
+            return
 
-    now = datetime.now()
-    alerts = []
+        now = datetime.now()
+        alerts = []
 
-    for event in ctx.upcoming_events:
-        start_str = event.get("start", "")
-        try:
-            start = datetime.fromisoformat(start_str)
-        except (ValueError, TypeError):
-            continue
+        for event in ctx.upcoming_events:
+            start_str = event.get("start", "")
+            try:
+                start = datetime.fromisoformat(start_str)
+            except (ValueError, TypeError):
+                continue
 
-        delta = start - now
-        if timedelta(0) < delta <= timedelta(minutes=15):
-            alerts.append(event.get("summary", "Upcoming event"))
+            delta = start - now
+            if timedelta(0) < delta <= timedelta(minutes=15):
+                alerts.append(event.get("summary", "Upcoming event"))
 
-    if not alerts:
-        return
+        if not alerts:
+            await log_scheduler_job_event(
+                job_name="calendar_scan",
+                outcome="skipped",
+                details={
+                    "duration_ms": int((perf_counter() - started_at) * 1000),
+                    "reason": "no_imminent_events",
+                    "upcoming_event_count": len(ctx.upcoming_events),
+                },
+            )
+            return
 
-    from src.observer.delivery import deliver_or_queue
+        from src.observer.delivery import deliver_or_queue
 
-    event_list = ", ".join(alerts)
-    content = f"Heads up! Starting soon: {event_list}"
+        event_list = ", ".join(alerts)
+        content = f"Heads up! Starting soon: {event_list}"
 
-    await deliver_or_queue(
-        WSResponse(
-            type="proactive",
-            content=content,
-            intervention_type="alert",
-            urgency=4,
-            reasoning="Calendar event starting within 15 minutes",
+        result = await deliver_or_queue(
+            WSResponse(
+                type="proactive",
+                content=content,
+                intervention_type="alert",
+                urgency=4,
+                reasoning="Calendar event starting within 15 minutes",
+            )
         )
-    )
-    logger.info("calendar_scan: alerted for %d event(s)", len(alerts))
+        await log_scheduler_job_event(
+            job_name="calendar_scan",
+            outcome="succeeded",
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "alert_count": len(alerts),
+                "delivery": result.value,
+            },
+        )
+        logger.info("calendar_scan: alerted for %d event(s)", len(alerts))
+    except Exception as exc:
+        await log_scheduler_job_event(
+            job_name="calendar_scan",
+            outcome="failed",
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "error": str(exc),
+            },
+        )
+        logger.exception("calendar_scan failed")

--- a/backend/src/scheduler/jobs/goal_check.py
+++ b/backend/src/scheduler/jobs/goal_check.py
@@ -1,5 +1,7 @@
 import logging
+from time import perf_counter
 
+from src.audit.runtime import log_scheduler_job_event
 from src.models.schemas import WSResponse
 
 logger = logging.getLogger(__name__)
@@ -8,45 +10,66 @@ logger = logging.getLogger(__name__)
 async def run_goal_check() -> None:
     """Check goal progress and broadcast ambient state."""
     logger.info("goal_check started")
+    started_at = perf_counter()
 
     try:
         from src.observer.manager import context_manager
         await context_manager.refresh()
-    except Exception:
-        logger.exception("goal_check: context refresh failed")
-        return
-
-    try:
         from src.goals.repository import goal_repository
         dashboard = await goal_repository.get_dashboard()
-    except Exception:
-        logger.exception("goal_check: dashboard query failed")
-        return
 
-    total = dashboard.get("total_count", 0)
-    if total == 0:
-        logger.debug("goal_check: no goals to check")
-        return
+        total = dashboard.get("total_count", 0)
+        if total == 0:
+            logger.debug("goal_check: no goals to check")
+            await log_scheduler_job_event(
+                job_name="goal_check",
+                outcome="skipped",
+                details={
+                    "duration_ms": int((perf_counter() - started_at) * 1000),
+                    "reason": "no_goals",
+                },
+            )
+            return
 
-    completed = dashboard.get("completed_count", 0)
-    completion_rate = completed / total if total else 0
+        completed = dashboard.get("completed_count", 0)
+        completion_rate = completed / total if total else 0
 
-    from src.observer.delivery import deliver_or_queue
+        from src.observer.delivery import deliver_or_queue
 
-    if completion_rate < 0.3:
-        state = "goal_behind"
-        tooltip = "Some goals need attention — you're behind on progress."
-    else:
-        state = "on_track"
-        tooltip = f"Goals are {int(completion_rate * 100)}% complete. Keep it up!"
+        if completion_rate < 0.3:
+            state = "goal_behind"
+            tooltip = "Some goals need attention — you're behind on progress."
+        else:
+            state = "on_track"
+            tooltip = f"Goals are {int(completion_rate * 100)}% complete. Keep it up!"
 
-    await deliver_or_queue(
-        WSResponse(
-            type="ambient",
-            content="",
-            intervention_type="ambient",
-            state=state,
-            tooltip=tooltip,
+        result = await deliver_or_queue(
+            WSResponse(
+                type="ambient",
+                content="",
+                intervention_type="ambient",
+                state=state,
+                tooltip=tooltip,
+            )
         )
-    )
-    logger.info("goal_check: broadcast state=%s (%.0f%% complete)", state, completion_rate * 100)
+        await log_scheduler_job_event(
+            job_name="goal_check",
+            outcome="succeeded",
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "state": state,
+                "completion_rate": completion_rate,
+                "delivery": result.value,
+            },
+        )
+        logger.info("goal_check: broadcast state=%s (%.0f%% complete)", state, completion_rate * 100)
+    except Exception as exc:
+        await log_scheduler_job_event(
+            job_name="goal_check",
+            outcome="failed",
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "error": str(exc),
+            },
+        )
+        logger.exception("goal_check failed")

--- a/backend/src/scheduler/jobs/memory_consolidation.py
+++ b/backend/src/scheduler/jobs/memory_consolidation.py
@@ -1,8 +1,10 @@
 import logging
 from datetime import datetime, timedelta, timezone
+from time import perf_counter
 
 from sqlmodel import select, col
 
+from src.audit.runtime import log_scheduler_job_event
 from src.db.engine import get_session
 from src.db.models import Session, Message
 from src.memory.consolidator import consolidate_session
@@ -16,6 +18,7 @@ async def run_memory_consolidation() -> None:
     This is a periodic catch-all — the ad-hoc trigger in ws.py handles
     immediate post-conversation consolidation.
     """
+    started_at = perf_counter()
     try:
         cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
 
@@ -28,16 +31,60 @@ async def run_memory_consolidation() -> None:
             )
             sessions = result.scalars().all()
 
+        if not sessions:
+            await log_scheduler_job_event(
+                job_name="memory_consolidation",
+                outcome="skipped",
+                details={
+                    "duration_ms": int((perf_counter() - started_at) * 1000),
+                    "reason": "no_recent_sessions",
+                },
+            )
+            return
+
         consolidated = 0
+        failed = 0
         for session in sessions:
             try:
                 await consolidate_session(session.id)
                 consolidated += 1
             except Exception:
+                failed += 1
                 logger.exception("Consolidation failed for session %s", session.id[:8])
 
+        if consolidated == 0 and failed > 0:
+            await log_scheduler_job_event(
+                job_name="memory_consolidation",
+                outcome="failed",
+                details={
+                    "duration_ms": int((perf_counter() - started_at) * 1000),
+                    "recent_session_count": len(sessions),
+                    "consolidated_count": consolidated,
+                    "failed_session_count": failed,
+                },
+            )
+            return
+
+        await log_scheduler_job_event(
+            job_name="memory_consolidation",
+            outcome="succeeded",
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "recent_session_count": len(sessions),
+                "consolidated_count": consolidated,
+                "failed_session_count": failed,
+            },
+        )
         if consolidated:
             logger.info("Scheduled memory consolidation: %d sessions processed", consolidated)
 
-    except Exception:
+    except Exception as exc:
+        await log_scheduler_job_event(
+            job_name="memory_consolidation",
+            outcome="failed",
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "error": str(exc),
+            },
+        )
         logger.exception("Scheduled memory consolidation job failed")

--- a/backend/src/scheduler/jobs/screen_cleanup.py
+++ b/backend/src/scheduler/jobs/screen_cleanup.py
@@ -1,25 +1,57 @@
 """Screen observation cleanup — deletes observations older than retention period."""
 
 import logging
+from time import perf_counter
 
 from config.settings import settings
+from src.audit.runtime import log_scheduler_job_event
 
 logger = logging.getLogger(__name__)
 
 
 async def run_screen_cleanup() -> None:
     """Delete screen observations older than the configured retention period."""
+    started_at = perf_counter()
     try:
         from src.observer.screen_repository import screen_observation_repo
 
         deleted = await screen_observation_repo.cleanup_old(
             settings.screen_observation_retention_days
         )
-        if deleted > 0:
-            logger.info(
-                "screen_cleanup: removed %d observations older than %d days",
-                deleted,
-                settings.screen_observation_retention_days,
+        if deleted == 0:
+            await log_scheduler_job_event(
+                job_name="screen_cleanup",
+                outcome="skipped",
+                details={
+                    "duration_ms": int((perf_counter() - started_at) * 1000),
+                    "reason": "no_expired_observations",
+                    "retention_days": settings.screen_observation_retention_days,
+                },
             )
-    except Exception:
+            return
+
+        await log_scheduler_job_event(
+            job_name="screen_cleanup",
+            outcome="succeeded",
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "deleted_count": deleted,
+                "retention_days": settings.screen_observation_retention_days,
+            },
+        )
+        logger.info(
+            "screen_cleanup: removed %d observations older than %d days",
+            deleted,
+            settings.screen_observation_retention_days,
+        )
+    except Exception as exc:
+        await log_scheduler_job_event(
+            job_name="screen_cleanup",
+            outcome="failed",
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "error": str(exc),
+                "retention_days": settings.screen_observation_retention_days,
+            },
+        )
         logger.exception("screen_cleanup failed")

--- a/backend/src/scheduler/jobs/weekly_activity_review.py
+++ b/backend/src/scheduler/jobs/weekly_activity_review.py
@@ -3,8 +3,10 @@
 import asyncio
 import logging
 from datetime import date, timedelta
+from time import perf_counter
 
 from config.settings import settings
+from src.audit.runtime import log_scheduler_job_event
 from src.llm_runtime import completion_with_fallback
 from src.models.schemas import WSResponse
 
@@ -43,6 +45,7 @@ Be concise. No preamble. Just the review text."""
 
 async def run_weekly_activity_review() -> None:
     """Generate and send the weekly activity review to connected clients."""
+    started_at = perf_counter()
     try:
         from src.observer.screen_repository import screen_observation_repo
         from src.memory.soul import read_soul
@@ -55,6 +58,14 @@ async def run_weekly_activity_review() -> None:
 
         if summary.get("total_observations", 0) == 0:
             logger.info("weekly_activity_review: no observations this week — skipping")
+            await log_scheduler_job_event(
+                job_name="weekly_activity_review",
+                outcome="skipped",
+                details={
+                    "duration_ms": int((perf_counter() - started_at) * 1000),
+                    "reason": "no_observations",
+                },
+            )
             return
 
         soul = read_soul()
@@ -94,6 +105,14 @@ async def run_weekly_activity_review() -> None:
                 timeout=settings.agent_briefing_timeout,
             )
         except asyncio.TimeoutError:
+            await log_scheduler_job_event(
+                job_name="weekly_activity_review",
+                outcome="timed_out",
+                details={
+                    "duration_ms": int((perf_counter() - started_at) * 1000),
+                    "timeout_seconds": settings.agent_briefing_timeout,
+                },
+            )
             logger.warning("weekly_activity_review: LLM timed out after %ds", settings.agent_briefing_timeout)
             return
 
@@ -108,8 +127,26 @@ async def run_weekly_activity_review() -> None:
             urgency=2,
             reasoning="Scheduled weekly activity review",
         )
-        await deliver_or_queue(message, is_scheduled=True)
+        result = await deliver_or_queue(message, is_scheduled=True)
+        await log_scheduler_job_event(
+            job_name="weekly_activity_review",
+            outcome="succeeded",
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "delivery": result.value,
+                "total_observations": summary.get("total_observations", 0),
+                "total_tracked_minutes": summary.get("total_tracked_minutes", 0),
+            },
+        )
         logger.info("weekly_activity_review: delivered weekly review")
 
-    except Exception:
+    except Exception as exc:
+        await log_scheduler_job_event(
+            job_name="weekly_activity_review",
+            outcome="failed",
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "error": str(exc),
+            },
+        )
         logger.exception("weekly_activity_review failed")

--- a/backend/tests/test_scheduler_job_audit.py
+++ b/backend/tests/test_scheduler_job_audit.py
@@ -1,0 +1,263 @@
+"""Tests for runtime audit coverage across the remaining scheduler jobs."""
+
+from datetime import date, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.audit.repository import audit_repository
+from src.observer.context import CurrentContext
+from src.observer.user_state import DeliveryDecision
+
+
+def _make_context(**overrides) -> CurrentContext:
+    defaults = dict(
+        time_of_day="morning",
+        day_of_week="Monday",
+        is_working_hours=True,
+        active_goals_summary="3 active goals",
+    )
+    defaults.update(overrides)
+    return CurrentContext(**defaults)
+
+
+def _mock_llm_response(text: str):
+    mock_choice = MagicMock()
+    mock_choice.message.content = text
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    return mock_response
+
+
+@pytest.mark.asyncio
+async def test_calendar_scan_logs_skip_without_upcoming_events(async_db):
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=_make_context(upcoming_events=[]))
+
+    with patch("src.observer.manager.context_manager", mock_cm):
+        from src.scheduler.jobs.calendar_scan import run_calendar_scan
+
+        await run_calendar_scan()
+
+    events = await audit_repository.list_events(limit=10)
+    assert any(
+        event["event_type"] == "scheduler_job_skipped"
+        and event["tool_name"] == "calendar_scan"
+        and event["details"]["reason"] == "no_upcoming_events"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_calendar_scan_logs_success(async_db):
+    soon = (datetime.now() + timedelta(minutes=10)).isoformat()
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(
+        return_value=_make_context(upcoming_events=[{"summary": "Standup", "start": soon}])
+    )
+    mock_deliver = AsyncMock(return_value=DeliveryDecision.deliver)
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        from src.scheduler.jobs.calendar_scan import run_calendar_scan
+
+        await run_calendar_scan()
+
+    events = await audit_repository.list_events(limit=10)
+    assert any(
+        event["event_type"] == "scheduler_job_succeeded"
+        and event["tool_name"] == "calendar_scan"
+        and event["details"]["alert_count"] == 1
+        and event["details"]["delivery"] == "deliver"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_goal_check_logs_skip_without_goals(async_db):
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=_make_context())
+    mock_goals = MagicMock()
+    mock_goals.get_dashboard = AsyncMock(return_value={"total_count": 0, "completed_count": 0})
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.goals.repository.goal_repository", mock_goals),
+    ):
+        from src.scheduler.jobs.goal_check import run_goal_check
+
+        await run_goal_check()
+
+    events = await audit_repository.list_events(limit=10)
+    assert any(
+        event["event_type"] == "scheduler_job_skipped"
+        and event["tool_name"] == "goal_check"
+        and event["details"]["reason"] == "no_goals"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_goal_check_logs_success(async_db):
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=_make_context())
+    mock_goals = MagicMock()
+    mock_goals.get_dashboard = AsyncMock(return_value={"total_count": 5, "completed_count": 1})
+    mock_deliver = AsyncMock(return_value=DeliveryDecision.deliver)
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.goals.repository.goal_repository", mock_goals),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        from src.scheduler.jobs.goal_check import run_goal_check
+
+        await run_goal_check()
+
+    events = await audit_repository.list_events(limit=10)
+    assert any(
+        event["event_type"] == "scheduler_job_succeeded"
+        and event["tool_name"] == "goal_check"
+        and event["details"]["state"] == "goal_behind"
+        and event["details"]["delivery"] == "deliver"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_memory_consolidation_logs_skip_without_recent_sessions(async_db):
+    from src.scheduler.jobs.memory_consolidation import run_memory_consolidation
+
+    await run_memory_consolidation()
+
+    events = await audit_repository.list_events(limit=10)
+    assert any(
+        event["event_type"] == "scheduler_job_skipped"
+        and event["tool_name"] == "memory_consolidation"
+        and event["details"]["reason"] == "no_recent_sessions"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_memory_consolidation_logs_failure_when_all_sessions_fail(async_db):
+    from src.db.models import Message, Session
+    from src.scheduler.jobs.memory_consolidation import run_memory_consolidation
+
+    async with async_db() as db:
+        session = Session(id="session-a", title="Test")
+        db.add(session)
+        db.add(Message(session_id="session-a", role="user", content="hello"))
+
+    with patch(
+        "src.scheduler.jobs.memory_consolidation.consolidate_session",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("boom"),
+    ):
+        await run_memory_consolidation()
+
+    events = await audit_repository.list_events(limit=10)
+    assert any(
+        event["event_type"] == "scheduler_job_failed"
+        and event["tool_name"] == "memory_consolidation"
+        and event["details"]["failed_session_count"] == 1
+        and event["details"]["consolidated_count"] == 0
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_screen_cleanup_logs_skip_when_nothing_deleted(async_db):
+    mock_repo = MagicMock()
+    mock_repo.cleanup_old = AsyncMock(return_value=0)
+
+    with patch("src.observer.screen_repository.screen_observation_repo", mock_repo):
+        from src.scheduler.jobs.screen_cleanup import run_screen_cleanup
+
+        await run_screen_cleanup()
+
+    events = await audit_repository.list_events(limit=10)
+    assert any(
+        event["event_type"] == "scheduler_job_skipped"
+        and event["tool_name"] == "screen_cleanup"
+        and event["details"]["reason"] == "no_expired_observations"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_weekly_activity_review_logs_success(async_db):
+    mock_repo = MagicMock()
+    mock_repo.get_weekly_summary = AsyncMock(
+        return_value={
+            "week_start": "2026-03-09",
+            "week_end": "2026-03-15",
+            "total_observations": 12,
+            "total_tracked_minutes": 180,
+            "by_activity": {"coding": 7200},
+            "by_project": {"seraph": 5400},
+            "daily_breakdown": [
+                {"date": date.today().isoformat(), "tracked_minutes": 90, "observations": 6}
+            ],
+        }
+    )
+    mock_deliver = AsyncMock(return_value=DeliveryDecision.deliver)
+
+    with (
+        patch("src.observer.screen_repository.screen_observation_repo", mock_repo),
+        patch("src.memory.soul.read_soul", return_value="# Soul"),
+        patch(
+            "src.scheduler.jobs.weekly_activity_review.completion_with_fallback",
+            new=AsyncMock(return_value=_mock_llm_response("Solid week. Keep momentum.")),
+        ),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        from src.scheduler.jobs.weekly_activity_review import run_weekly_activity_review
+
+        await run_weekly_activity_review()
+
+    events = await audit_repository.list_events(limit=10)
+    assert any(
+        event["event_type"] == "scheduler_job_succeeded"
+        and event["tool_name"] == "weekly_activity_review"
+        and event["details"]["delivery"] == "deliver"
+        and event["details"]["total_observations"] == 12
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_weekly_activity_review_logs_timeout(async_db):
+    mock_repo = MagicMock()
+    mock_repo.get_weekly_summary = AsyncMock(
+        return_value={
+            "week_start": "2026-03-09",
+            "week_end": "2026-03-15",
+            "total_observations": 4,
+            "total_tracked_minutes": 60,
+            "by_activity": {},
+            "by_project": {},
+            "daily_breakdown": [],
+        }
+    )
+
+    with (
+        patch("src.observer.screen_repository.screen_observation_repo", mock_repo),
+        patch("src.memory.soul.read_soul", return_value="# Soul"),
+        patch(
+            "src.scheduler.jobs.weekly_activity_review.completion_with_fallback",
+            new=AsyncMock(side_effect=TimeoutError),
+        ),
+    ):
+        from src.scheduler.jobs.weekly_activity_review import run_weekly_activity_review
+
+        await run_weekly_activity_review()
+
+    events = await audit_repository.list_events(limit=10)
+    assert any(
+        event["event_type"] == "scheduler_job_timed_out"
+        and event["tool_name"] == "weekly_activity_review"
+        for event in events
+    )

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -17,11 +17,11 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] timeout-safe audit visibility into primary-vs-fallback LLM completion behavior
 - [x] fallback-capable `smolagents` model wrappers for chat, onboarding, strategist, and specialists
 - [x] repeatable runtime eval harness for core guardian and tool reliability contracts
-- [x] lifecycle audit events for REST chat, WebSocket chat, and scheduled proactive jobs
+- [x] lifecycle audit events for REST chat, WebSocket chat, and the full scheduler job surface
 
 ## In Progress
 
-- [ ] broaden observability beyond the first direct LLM events and first chat/proactive-job lifecycle coverage
+- [ ] broaden observability beyond chat and scheduler coverage into more tool and provider edge paths
 
 ## Left To Do
 


### PR DESCRIPTION
## Summary
- add fail-open lifecycle audit events for the remaining scheduler jobs: calendar scan, goal check, memory consolidation, screen cleanup, and weekly activity review
- cover the new scheduler observability paths with regression tests for success, skipped, timed_out, and failure outcomes where relevant
- update the Runtime Reliability workstream checklist to mark the full scheduler job surface as covered

## Validation
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build

## Risks
- runtime observability is broader now, but provider-level and tool-level edge paths still need more audit coverage outside the scheduler surface
