### PR TITLE
Add observer runtime audit coverage

### DIFF
--- a/backend/src/observer/manager.py
+++ b/backend/src/observer/manager.py
@@ -5,6 +5,7 @@ import logging
 import time
 from datetime import datetime, timezone
 
+from src.audit.runtime import log_background_task_event
 from src.observer.context import CurrentContext
 from src.observer.user_state import UserState, user_state_machine
 
@@ -32,113 +33,137 @@ class ContextManager:
         Each source is wrapped in try/except so one failure doesn't block others.
         After gathering sources, derives user state and checks for transitions.
         """
-        async with self._lock:
-            old = self._context
+        try:
+            async with self._lock:
+                old = self._context
 
-            # Track source success for data quality
-            sources_ok = 0
-            sources_total = 4
+                # Track source success for data quality
+                sources_ok = 0
+                sources_total = 4
 
-            # Time source (sync, pure computation)
-            time_data: dict = {}
-            try:
-                from src.observer.sources.time_source import gather_time
-                time_data = gather_time()
-                sources_ok += 1
-            except Exception:
-                logger.exception("Time source failed")
+                # Time source (sync, pure computation)
+                time_data: dict = {}
+                try:
+                    from src.observer.sources.time_source import gather_time
+                    time_data = gather_time()
+                    sources_ok += 1
+                except Exception:
+                    logger.exception("Time source failed")
 
-            # Calendar source (async, I/O)
-            calendar_data: dict = {}
-            try:
-                from src.observer.sources.calendar_source import gather_calendar
-                calendar_data = await gather_calendar()
-                sources_ok += 1
-            except Exception:
-                logger.exception("Calendar source failed during refresh")
+                # Calendar source (async, I/O)
+                calendar_data: dict = {}
+                try:
+                    from src.observer.sources.calendar_source import gather_calendar
+                    calendar_data = await gather_calendar()
+                    sources_ok += 1
+                except Exception:
+                    logger.exception("Calendar source failed during refresh")
 
-            # Git source (sync, filesystem)
-            git_data: dict = {}
-            try:
-                from src.observer.sources.git_source import gather_git
-                result = gather_git()
-                if result:
-                    git_data = result
-                sources_ok += 1
-            except Exception:
-                logger.exception("Git source failed")
+                # Git source (sync, filesystem)
+                git_data: dict = {}
+                try:
+                    from src.observer.sources.git_source import gather_git
+                    result = gather_git()
+                    if result:
+                        git_data = result
+                    sources_ok += 1
+                except Exception:
+                    logger.exception("Git source failed")
 
-            # Goal source (async, DB)
-            goal_data: dict = {}
-            try:
-                from src.observer.sources.goal_source import gather_goals
-                goal_data = await gather_goals()
-                sources_ok += 1
-            except Exception:
-                logger.exception("Goal source failed")
+                # Goal source (async, DB)
+                goal_data: dict = {}
+                try:
+                    from src.observer.sources.goal_source import gather_goals
+                    goal_data = await gather_goals()
+                    sources_ok += 1
+                except Exception:
+                    logger.exception("Goal source failed")
 
-            # Derive data quality
-            if sources_ok == sources_total:
-                data_quality = "good"
-            elif sources_ok == 0:
-                data_quality = "stale"
-            else:
-                data_quality = "degraded"
+                # Derive data quality
+                if sources_ok == sources_total:
+                    data_quality = "good"
+                elif sources_ok == 0:
+                    data_quality = "stale"
+                else:
+                    data_quality = "degraded"
 
-            # Derive user state from gathered sources
-            new_user_state = user_state_machine.derive_state(
-                current_event=calendar_data.get("current_event"),
-                previous_state=old.user_state,
-                time_of_day=time_data.get("time_of_day", "unknown"),
-                is_working_hours=time_data.get("is_working_hours", False),
-                last_interaction=old.last_interaction,
-                active_window=old.active_window,
-            )
-
-            # Check for daily budget reset
-            budget = old.attention_budget_remaining
-            last_reset = old.attention_budget_last_reset
-            budget, last_reset = self._maybe_reset_budget(
-                old.interruption_mode, budget, last_reset,
-            )
-
-            self._context = CurrentContext(
-                time_of_day=time_data.get("time_of_day", "unknown"),
-                day_of_week=time_data.get("day_of_week", "unknown"),
-                is_working_hours=time_data.get("is_working_hours", False),
-                upcoming_events=calendar_data.get("upcoming_events", []),
-                current_event=calendar_data.get("current_event"),
-                recent_git_activity=git_data.get("recent_git_activity"),
-                active_goals_summary=goal_data.get("active_goals_summary", ""),
-                # Preserve externally-managed fields from old context
-                last_interaction=old.last_interaction,
-                user_state=new_user_state,
-                interruption_mode=old.interruption_mode,
-                attention_budget_remaining=budget,
-                active_window=old.active_window,
-                screen_context=old.screen_context,
-                last_daemon_post=old.last_daemon_post,
-                capture_mode=old.capture_mode,
-                tool_policy_mode=old.tool_policy_mode,
-                mcp_policy_mode=old.mcp_policy_mode,
-                approval_mode=old.approval_mode,
-                # Phase 3.3 tracking
-                previous_user_state=old.user_state,
-                attention_budget_last_reset=last_reset,
-                data_quality=data_quality,
-            )
-
-            # Detect blocked → unblocked transition and deliver queued bundle
-            if old.user_state in _BLOCKED_STATES and new_user_state in _UNBLOCKED_STATES:
-                self._transition_epoch += 1
-                epoch = self._transition_epoch
-                logger.info(
-                    "State transition %s → %s (epoch=%d) — delivering queued bundle",
-                    old.user_state, new_user_state, epoch,
+                # Derive user state from gathered sources
+                new_user_state = user_state_machine.derive_state(
+                    current_event=calendar_data.get("current_event"),
+                    previous_state=old.user_state,
+                    time_of_day=time_data.get("time_of_day", "unknown"),
+                    is_working_hours=time_data.get("is_working_hours", False),
+                    last_interaction=old.last_interaction,
+                    active_window=old.active_window,
                 )
-                asyncio.create_task(self._deliver_bundle(epoch))
 
-            return self._context
+                # Check for daily budget reset
+                budget = old.attention_budget_remaining
+                last_reset = old.attention_budget_last_reset
+                budget, last_reset = self._maybe_reset_budget(
+                    old.interruption_mode, budget, last_reset,
+                )
+
+                self._context = CurrentContext(
+                    time_of_day=time_data.get("time_of_day", "unknown"),
+                    day_of_week=time_data.get("day_of_week", "unknown"),
+                    is_working_hours=time_data.get("is_working_hours", False),
+                    upcoming_events=calendar_data.get("upcoming_events", []),
+                    current_event=calendar_data.get("current_event"),
+                    recent_git_activity=git_data.get("recent_git_activity"),
+                    active_goals_summary=goal_data.get("active_goals_summary", ""),
+                    # Preserve externally-managed fields from old context
+                    last_interaction=old.last_interaction,
+                    user_state=new_user_state,
+                    interruption_mode=old.interruption_mode,
+                    attention_budget_remaining=budget,
+                    active_window=old.active_window,
+                    screen_context=old.screen_context,
+                    last_daemon_post=old.last_daemon_post,
+                    capture_mode=old.capture_mode,
+                    tool_policy_mode=old.tool_policy_mode,
+                    mcp_policy_mode=old.mcp_policy_mode,
+                    approval_mode=old.approval_mode,
+                    # Phase 3.3 tracking
+                    previous_user_state=old.user_state,
+                    attention_budget_last_reset=last_reset,
+                    data_quality=data_quality,
+                )
+
+                triggered_bundle_delivery = False
+
+                # Detect blocked → unblocked transition and deliver queued bundle
+                if old.user_state in _BLOCKED_STATES and new_user_state in _UNBLOCKED_STATES:
+                    self._transition_epoch += 1
+                    epoch = self._transition_epoch
+                    triggered_bundle_delivery = True
+                    logger.info(
+                        "State transition %s → %s (epoch=%d) — delivering queued bundle",
+                        old.user_state, new_user_state, epoch,
+                    )
+                    asyncio.create_task(self._deliver_bundle(epoch))
+
+                await log_background_task_event(
+                    task_name="observer_context_refresh",
+                    outcome="succeeded",
+                    details={
+                        "sources_ok": sources_ok,
+                        "sources_total": sources_total,
+                        "data_quality": data_quality,
+                        "previous_user_state": old.user_state,
+                        "new_user_state": new_user_state,
+                        "triggered_bundle_delivery": triggered_bundle_delivery,
+                    },
+                )
+
+                return self._context
+        except Exception as exc:
+            await log_background_task_event(
+                task_name="observer_context_refresh",
+                outcome="failed",
+                details={"error": str(exc)},
+            )
+            raise
 
     async def _deliver_bundle(self, epoch: int) -> None:
         """Background task to deliver queued bundle after state transition.
@@ -147,11 +172,35 @@ class ContextManager:
         """
         if epoch != self._transition_epoch:
             logger.info("Skipping bundle delivery — epoch %d superseded by %d", epoch, self._transition_epoch)
+            await log_background_task_event(
+                task_name="observer_queued_bundle_delivery",
+                outcome="skipped",
+                details={
+                    "requested_epoch": epoch,
+                    "current_epoch": self._transition_epoch,
+                },
+            )
             return
         try:
             from src.observer.delivery import deliver_queued_bundle
-            await deliver_queued_bundle()
-        except Exception:
+            delivered_count = await deliver_queued_bundle()
+            await log_background_task_event(
+                task_name="observer_queued_bundle_delivery",
+                outcome="succeeded",
+                details={
+                    "requested_epoch": epoch,
+                    "delivered_count": delivered_count,
+                },
+            )
+        except Exception as exc:
+            await log_background_task_event(
+                task_name="observer_queued_bundle_delivery",
+                outcome="failed",
+                details={
+                    "requested_epoch": epoch,
+                    "error": str(exc),
+                },
+            )
             logger.exception("Failed to deliver queued bundle")
 
     def _maybe_reset_budget(

--- a/backend/tests/test_observer_manager.py
+++ b/backend/tests/test_observer_manager.py
@@ -1,9 +1,11 @@
+import asyncio
 import time
 from datetime import datetime, timezone
 from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 
+from src.audit.repository import audit_repository
 from src.observer.context import CurrentContext
 from src.observer.manager import ContextManager
 
@@ -109,6 +111,116 @@ class TestContextManagerRefresh:
         assert ctx.time_of_day == "unknown"
         assert ctx.upcoming_events == []
 
+    @pytest.mark.asyncio
+    async def test_refresh_logs_runtime_audit_event(self, async_db):
+        mgr = ContextManager()
+
+        with patch("src.observer.sources.time_source.gather_time", return_value={
+            "time_of_day": "morning",
+            "day_of_week": "Monday",
+            "is_working_hours": True,
+        }), \
+             patch("src.observer.sources.calendar_source.gather_calendar", new_callable=AsyncMock, return_value={
+                 "upcoming_events": [], "current_event": None
+             }), \
+             patch("src.observer.sources.git_source.gather_git", return_value=None), \
+             patch("src.observer.sources.goal_source.gather_goals", new_callable=AsyncMock, return_value={
+                 "active_goals_summary": ""
+             }):
+            await mgr.refresh()
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "background_task_succeeded"
+            and event["tool_name"] == "observer_context_refresh"
+            and event["details"]["data_quality"] == "good"
+            and event["details"]["sources_ok"] == 4
+            and event["details"]["triggered_bundle_delivery"] is False
+            for event in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_logs_degraded_runtime_audit_details(self, async_db):
+        mgr = ContextManager()
+
+        with patch("src.observer.sources.time_source.gather_time", side_effect=RuntimeError("boom")), \
+             patch("src.observer.sources.calendar_source.gather_calendar", new_callable=AsyncMock, return_value={
+                 "upcoming_events": [], "current_event": None
+             }), \
+             patch("src.observer.sources.git_source.gather_git", return_value=None), \
+             patch("src.observer.sources.goal_source.gather_goals", new_callable=AsyncMock, return_value={
+                 "active_goals_summary": ""
+             }):
+            await mgr.refresh()
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "background_task_succeeded"
+            and event["tool_name"] == "observer_context_refresh"
+            and event["details"]["data_quality"] == "degraded"
+            and event["details"]["sources_ok"] == 3
+            for event in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_logs_failure_runtime_audit_event(self, async_db):
+        mgr = ContextManager()
+
+        with patch("src.observer.sources.time_source.gather_time", return_value={
+            "time_of_day": "morning",
+            "day_of_week": "Monday",
+            "is_working_hours": True,
+        }), \
+             patch("src.observer.sources.calendar_source.gather_calendar", new_callable=AsyncMock, return_value={
+                 "upcoming_events": [], "current_event": None
+             }), \
+             patch("src.observer.sources.git_source.gather_git", return_value=None), \
+             patch("src.observer.sources.goal_source.gather_goals", new_callable=AsyncMock, return_value={
+                 "active_goals_summary": ""
+             }), \
+             patch("src.observer.manager.user_state_machine.derive_state", side_effect=RuntimeError("derive failed")):
+            with pytest.raises(RuntimeError, match="derive failed"):
+                await mgr.refresh()
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "background_task_failed"
+            and event["tool_name"] == "observer_context_refresh"
+            and event["details"]["error"] == "derive failed"
+            for event in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_transition_logs_bundle_trigger(self, async_db):
+        mgr = ContextManager()
+        mgr._context.user_state = "deep_work"
+
+        with patch("src.observer.sources.time_source.gather_time", return_value={
+            "time_of_day": "morning",
+            "day_of_week": "Monday",
+            "is_working_hours": True,
+        }), \
+             patch("src.observer.sources.calendar_source.gather_calendar", new_callable=AsyncMock, return_value={
+                 "upcoming_events": [], "current_event": None
+             }), \
+             patch("src.observer.sources.git_source.gather_git", return_value=None), \
+             patch("src.observer.sources.goal_source.gather_goals", new_callable=AsyncMock, return_value={
+                 "active_goals_summary": ""
+             }), \
+             patch.object(mgr, "_deliver_bundle", new_callable=AsyncMock):
+            await mgr.refresh()
+            await asyncio.sleep(0)
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "background_task_succeeded"
+            and event["tool_name"] == "observer_context_refresh"
+            and event["details"]["triggered_bundle_delivery"] is True
+            and event["details"]["previous_user_state"] == "deep_work"
+            and event["details"]["new_user_state"] == "transitioning"
+            for event in events
+        )
+
 
 class TestContextManagerUpdates:
     def test_update_last_interaction(self):
@@ -170,6 +282,55 @@ class TestContextManagerUpdates:
         mgr.update_screen_context(None, None)
         ts2 = mgr.get_context().last_daemon_post
         assert ts2 >= ts1
+
+
+class TestQueuedBundleAudit:
+    @pytest.mark.asyncio
+    async def test_deliver_bundle_logs_success_runtime_audit(self, async_db):
+        mgr = ContextManager()
+
+        with patch("src.observer.delivery.deliver_queued_bundle", new_callable=AsyncMock, return_value=2):
+            await mgr._deliver_bundle(0)
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "background_task_succeeded"
+            and event["tool_name"] == "observer_queued_bundle_delivery"
+            and event["details"]["requested_epoch"] == 0
+            and event["details"]["delivered_count"] == 2
+            for event in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_deliver_bundle_logs_skipped_runtime_audit(self, async_db):
+        mgr = ContextManager()
+        mgr._transition_epoch = 2
+
+        await mgr._deliver_bundle(1)
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "background_task_skipped"
+            and event["tool_name"] == "observer_queued_bundle_delivery"
+            and event["details"]["requested_epoch"] == 1
+            and event["details"]["current_epoch"] == 2
+            for event in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_deliver_bundle_logs_failure_runtime_audit(self, async_db):
+        mgr = ContextManager()
+
+        with patch("src.observer.delivery.deliver_queued_bundle", new_callable=AsyncMock, side_effect=RuntimeError("ws down")):
+            await mgr._deliver_bundle(0)
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "background_task_failed"
+            and event["tool_name"] == "observer_queued_bundle_delivery"
+            and event["details"]["error"] == "ws down"
+            for event in events
+        )
 
 
 class TestCurrentContextSerialization:

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -21,6 +21,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] real tool execution audit events for call, result, and failure across agent transports
 - [x] strategist tool calls and background helper flows now emit runtime audit coverage
 - [x] MCP server connection lifecycle emits runtime audit coverage for connect, disconnect, auth-required, and failure states
+- [x] observer context refresh and queued-bundle delivery emit background runtime audit coverage
 
 ## In Progress
 
@@ -30,7 +31,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 
 - [ ] broaden model and provider routing beyond the first shared fallback path
 - [ ] deepen local-model-capable execution paths beyond API-base swapping
-- [ ] add observability coverage across any remaining edge helpers and external integration paths
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh and current MCP lifecycle coverage
 - [ ] expand eval coverage beyond the current runtime seam checks
 
 ## Done Means


### PR DESCRIPTION
## Summary
- add fail-open runtime audit coverage for observer context refresh, including source counts, data quality, and bundle-trigger details
- log queued-bundle delivery outcomes for succeeded, skipped, and failed observer background runs
- extend observer manager coverage and update the runtime reliability checklist to reflect the new observer audit surface

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/observer/manager.py backend/tests/test_observer_manager.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_observer_manager.py tests/test_observer_api.py tests/test_delivery.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_scheduler.py tests/test_scheduler_job_audit.py
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build

## Risks
- this expands audit visibility for observer flows but does not yet add dedicated audit events for every proactive delivery decision or daemon ingest edge case
