### PR TITLE
Add observer delivery audit coverage

### DIFF
--- a/backend/src/audit/runtime.py
+++ b/backend/src/audit/runtime.py
@@ -115,6 +115,38 @@ async def log_integration_event(
         logger.debug("Failed to record integration runtime audit event", exc_info=True)
 
 
+async def log_observer_delivery_event(
+    *,
+    decision: str,
+    message_type: str,
+    intervention_type: str | None,
+    urgency: int | None,
+    is_scheduled: bool,
+    details: dict[str, Any] | None = None,
+) -> None:
+    """Record proactive delivery-gate decisions without breaking callers."""
+    target = intervention_type or message_type
+    summary = f"Observer delivery {decision} for {target}"
+    try:
+        await audit_repository.log_event(
+            actor="system",
+            event_type=f"observer_delivery_{decision}",
+            tool_name="observer_delivery_gate",
+            risk_level="low",
+            policy_mode="full",
+            summary=summary,
+            details={
+                "message_type": message_type,
+                "intervention_type": intervention_type,
+                "urgency": urgency,
+                "is_scheduled": is_scheduled,
+                **(details or {}),
+            },
+        )
+    except Exception:
+        logger.debug("Failed to record observer delivery audit event", exc_info=True)
+
+
 def log_integration_event_sync(
     *,
     integration_type: str,

--- a/backend/src/observer/delivery.py
+++ b/backend/src/observer/delivery.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from src.audit.runtime import log_observer_delivery_event
 from src.models.schemas import WSResponse
 from src.observer.user_state import DeliveryDecision, user_state_machine
 
@@ -22,40 +23,90 @@ async def deliver_or_queue(
     from src.scheduler.connection_manager import ws_manager
 
     ctx = context_manager.get_context()
+    intervention_type = message.intervention_type or message.type
+    urgency = message.urgency or 0
+    decision: DeliveryDecision | None = None
 
-    decision = user_state_machine.should_deliver(
-        user_state=ctx.user_state,
-        interruption_mode=ctx.interruption_mode,
-        attention_budget_remaining=ctx.attention_budget_remaining,
-        urgency=message.urgency or 0,
-        intervention_type=message.intervention_type or message.type,
-        is_scheduled=is_scheduled,
-    )
-
-    if decision == DeliveryDecision.deliver:
-        await ws_manager.broadcast(message)
-        # Decrement budget if this delivery costs budget
-        if user_state_machine.should_cost_budget(
-            intervention_type=message.intervention_type or message.type,
+    try:
+        decision = user_state_machine.should_deliver(
+            user_state=ctx.user_state,
+            interruption_mode=ctx.interruption_mode,
+            attention_budget_remaining=ctx.attention_budget_remaining,
+            urgency=urgency,
+            intervention_type=intervention_type,
             is_scheduled=is_scheduled,
-            urgency=message.urgency or 0,
-        ):
-            context_manager.decrement_attention_budget()
-        logger.info("Delivered proactive message (type=%s)", message.type)
-
-    elif decision == DeliveryDecision.queue:
-        await insight_queue.enqueue(
-            content=message.content,
-            intervention_type=message.intervention_type or message.type,
-            urgency=message.urgency or 0,
-            reasoning=message.reasoning or "",
         )
-        logger.info("Queued proactive message (state=%s, mode=%s)", ctx.user_state, ctx.interruption_mode)
 
-    else:
-        logger.info("Dropped proactive message (type=%s)", message.type)
+        event_details = {
+            "user_state": ctx.user_state,
+            "interruption_mode": ctx.interruption_mode,
+            "attention_budget_remaining": ctx.attention_budget_remaining,
+        }
 
-    return decision
+        if decision == DeliveryDecision.deliver:
+            await ws_manager.broadcast(message)
+            # Decrement budget if this delivery costs budget
+            if user_state_machine.should_cost_budget(
+                intervention_type=intervention_type,
+                is_scheduled=is_scheduled,
+                urgency=urgency,
+            ):
+                context_manager.decrement_attention_budget()
+            logger.info("Delivered proactive message (type=%s)", message.type)
+            await log_observer_delivery_event(
+                decision="delivered",
+                message_type=message.type,
+                intervention_type=intervention_type,
+                urgency=urgency,
+                is_scheduled=is_scheduled,
+                details=event_details,
+            )
+
+        elif decision == DeliveryDecision.queue:
+            await insight_queue.enqueue(
+                content=message.content,
+                intervention_type=intervention_type,
+                urgency=urgency,
+                reasoning=message.reasoning or "",
+            )
+            logger.info("Queued proactive message (state=%s, mode=%s)", ctx.user_state, ctx.interruption_mode)
+            await log_observer_delivery_event(
+                decision="queued",
+                message_type=message.type,
+                intervention_type=intervention_type,
+                urgency=urgency,
+                is_scheduled=is_scheduled,
+                details=event_details,
+            )
+
+        else:
+            logger.info("Dropped proactive message (type=%s)", message.type)
+            await log_observer_delivery_event(
+                decision="dropped",
+                message_type=message.type,
+                intervention_type=intervention_type,
+                urgency=urgency,
+                is_scheduled=is_scheduled,
+                details=event_details,
+            )
+
+        return decision
+    except Exception as exc:
+        await log_observer_delivery_event(
+            decision="failed",
+            message_type=message.type,
+            intervention_type=intervention_type,
+            urgency=urgency,
+            is_scheduled=is_scheduled,
+            details={
+                "user_state": ctx.user_state,
+                "interruption_mode": ctx.interruption_mode,
+                "attention_budget_remaining": ctx.attention_budget_remaining,
+                "delivery_decision": decision.value if decision is not None else None,
+                "error": str(exc),
+            },
+        )
+        raise
 
 
 async def deliver_queued_bundle() -> int:

--- a/backend/tests/test_delivery.py
+++ b/backend/tests/test_delivery.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
+from src.audit.repository import audit_repository
 from src.models.schemas import WSResponse
 from src.observer.context import CurrentContext
 from src.observer.delivery import deliver_or_queue, deliver_queued_bundle
@@ -51,6 +52,29 @@ async def test_deliver_broadcasts():
         assert decision == DeliveryDecision.deliver
         mock_ws.broadcast.assert_called_once_with(msg)
         mock_iq.enqueue.assert_not_called()
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_deliver_logs_runtime_audit(async_db):
+    ctx = _make_context()
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    for p in patches:
+        p.start()
+    try:
+        msg = WSResponse(type="proactive", content="Test", intervention_type="advisory", urgency=3)
+        await deliver_or_queue(msg)
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "observer_delivery_delivered"
+            and event["tool_name"] == "observer_delivery_gate"
+            and event["details"]["intervention_type"] == "advisory"
+            and event["details"]["user_state"] == "available"
+            for event in events
+        )
     finally:
         for p in patches:
             p.stop()
@@ -112,6 +136,29 @@ async def test_queue_when_blocked():
 
 
 @pytest.mark.asyncio
+async def test_queue_logs_runtime_audit(async_db):
+    ctx = _make_context(user_state="deep_work")
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    for p in patches:
+        p.start()
+    try:
+        msg = WSResponse(type="proactive", content="Queued msg", intervention_type="advisory", urgency=3)
+        await deliver_or_queue(msg)
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "observer_delivery_queued"
+            and event["tool_name"] == "observer_delivery_gate"
+            and event["details"]["user_state"] == "deep_work"
+            and event["details"]["interruption_mode"] == "balanced"
+            for event in events
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
 async def test_queue_when_no_budget():
     ctx = _make_context(attention_budget_remaining=0)
     patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
@@ -140,6 +187,49 @@ async def test_urgent_delivers_through_blocked():
 
         assert decision == DeliveryDecision.deliver
         mock_ws.broadcast.assert_called_once()
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_logs_runtime_audit(async_db):
+    ctx = _make_context()
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    mock_ws.broadcast.side_effect = RuntimeError("socket down")
+    for p in patches:
+        p.start()
+    try:
+        msg = WSResponse(type="proactive", content="Test", intervention_type="advisory", urgency=3)
+        with pytest.raises(RuntimeError, match="socket down"):
+            await deliver_or_queue(msg)
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "observer_delivery_failed"
+            and event["tool_name"] == "observer_delivery_gate"
+            and event["details"]["delivery_decision"] == "deliver"
+            and event["details"]["error"] == "socket down"
+            for event in events
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_delivery_audit_fails_open():
+    ctx = _make_context()
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    for p in patches:
+        p.start()
+    try:
+        msg = WSResponse(type="proactive", content="Test", intervention_type="advisory", urgency=3)
+        with patch("src.audit.runtime.audit_repository.log_event", new_callable=AsyncMock, side_effect=RuntimeError("audit down")):
+            decision = await deliver_or_queue(msg)
+
+        assert decision == DeliveryDecision.deliver
+        mock_ws.broadcast.assert_called_once_with(msg)
     finally:
         for p in patches:
             p.stop()

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -22,6 +22,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] strategist tool calls and background helper flows now emit runtime audit coverage
 - [x] MCP server connection lifecycle emits runtime audit coverage for connect, disconnect, auth-required, and failure states
 - [x] observer context refresh and queued-bundle delivery emit background runtime audit coverage
+- [x] proactive delivery-gate decisions emit runtime audit coverage for delivered, queued, and failed paths
 
 ## In Progress
 
@@ -31,7 +32,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 
 - [ ] broaden model and provider routing beyond the first shared fallback path
 - [ ] deepen local-model-capable execution paths beyond API-base swapping
-- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh and current MCP lifecycle coverage
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, proactive delivery gating, and current MCP lifecycle coverage
 - [ ] expand eval coverage beyond the current runtime seam checks
 
 ## Done Means


### PR DESCRIPTION
## Summary
- add fail-open runtime audit events for proactive delivery-gate decisions and delivery-path failures
- record delivered and queued outcomes with observer context details so proactive routing is visible end to end
- extend delivery coverage and update the runtime reliability checklist

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/audit/runtime.py backend/src/observer/delivery.py backend/tests/test_delivery.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_delivery.py tests/test_daily_briefing.py tests/test_evening_review.py tests/test_activity_digest.py tests/test_scheduler_job_audit.py tests/test_strategist_tick.py
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build

## Risks
- this adds delivery decision visibility, but daemon ingest and remaining observer edge cases still have room for deeper dedicated audit coverage
