### PR TITLE
Add observer daemon audit coverage

### DIFF
--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -7,6 +7,7 @@ from datetime import date, datetime, timezone
 from fastapi import APIRouter
 from pydantic import BaseModel
 
+from src.audit.runtime import log_integration_event
 from src.observer.manager import context_manager
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,17 @@ async def get_observer_state():
 async def post_screen_context(body: ScreenContextRequest):
     """Receive screen context from native daemon."""
     context_manager.update_screen_context(body.active_window, body.screen_context)
+    await log_integration_event(
+        integration_type="observer_daemon",
+        name="screen_context",
+        outcome="received",
+        details={
+            "has_active_window": body.active_window is not None,
+            "has_screen_context": body.screen_context is not None,
+            "has_observation": body.observation is not None,
+            "blocked": body.observation.blocked if body.observation is not None else None,
+        },
+    )
 
     # Persist structured observation if present
     if body.observation is not None:
@@ -64,7 +76,29 @@ async def post_screen_context(body: ScreenContextRequest):
                 blocked=obs_data.blocked,
                 timestamp=timestamp,
             )
-        except Exception:
+            await log_integration_event(
+                integration_type="observer_daemon",
+                name="screen_context",
+                outcome="persisted",
+                details={
+                    "app": obs_data.app or "",
+                    "activity_type": obs_data.activity or "other",
+                    "blocked": obs_data.blocked,
+                    "has_switch_timestamp": body.switch_timestamp is not None,
+                },
+            )
+        except Exception as exc:
+            await log_integration_event(
+                integration_type="observer_daemon",
+                name="screen_context",
+                outcome="persist_failed",
+                details={
+                    "app": body.observation.app or "",
+                    "activity_type": body.observation.activity or "other",
+                    "blocked": body.observation.blocked,
+                    "error": str(exc),
+                },
+            )
             logger.exception("Failed to persist screen observation")
 
     return {"status": "ok"}

--- a/backend/tests/test_observer_api.py
+++ b/backend/tests/test_observer_api.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, AsyncMock, MagicMock
 import pytest
 import pytest_asyncio
 
+from src.audit.repository import audit_repository
 from src.observer.context import CurrentContext
 from src.observer.manager import ContextManager
 from src.observer.screen_repository import ScreenObservationRepository
@@ -34,6 +35,27 @@ class TestObserverAPI:
         assert resp.status_code == 200
         assert mgr.get_context().active_window == "Terminal"
         assert mgr.get_context().screen_context == "Running tests"
+
+    @pytest.mark.asyncio
+    async def test_post_screen_context_logs_runtime_audit(self, async_db, client):
+        mgr = ContextManager()
+        with patch("src.api.observer.context_manager", mgr):
+            resp = await client.post("/api/observer/context", json={
+                "active_window": "Terminal",
+                "screen_context": "Running tests",
+            })
+
+        assert resp.status_code == 200
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_received"
+            and event["tool_name"] == "observer_daemon:screen_context"
+            and event["details"]["has_active_window"] is True
+            and event["details"]["has_screen_context"] is True
+            and event["details"]["has_observation"] is False
+            for event in events
+        )
 
     @pytest.mark.asyncio
     async def test_post_screen_context_null_preserves(self, client):
@@ -138,6 +160,16 @@ class TestObserverAPI:
         assert obs.activity_type == "coding"
         assert obs.project == "seraph"
 
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_persisted"
+            and event["tool_name"] == "observer_daemon:screen_context"
+            and event["details"]["app"] == "VS Code"
+            and event["details"]["activity_type"] == "coding"
+            and event["details"]["blocked"] is False
+            for event in events
+        )
+
     @pytest.mark.asyncio
     async def test_post_blocked_observation(self, async_db, client):
         """Blocked observations should be persisted with blocked=True."""
@@ -162,6 +194,35 @@ class TestObserverAPI:
         assert obs.app_name == "1Password"
         assert obs.blocked is True
         assert obs.activity_type == "other"
+
+    @pytest.mark.asyncio
+    async def test_post_structured_observation_logs_persist_failure_runtime_audit(self, async_db, client):
+        mgr = ContextManager()
+        mock_repo = MagicMock()
+        mock_repo.create = AsyncMock(side_effect=RuntimeError("db down"))
+        with (
+            patch("src.api.observer.context_manager", mgr),
+            patch("src.observer.screen_repository.screen_observation_repo", mock_repo),
+        ):
+            resp = await client.post("/api/observer/context", json={
+                "active_window": "VS Code — main.py",
+                "observation": {
+                    "app": "VS Code",
+                    "activity": "coding",
+                    "blocked": False,
+                },
+            })
+
+        assert resp.status_code == 200
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_persist_failed"
+            and event["tool_name"] == "observer_daemon:screen_context"
+            and event["details"]["app"] == "VS Code"
+            and event["details"]["error"] == "db down"
+            for event in events
+        )
 
     @pytest.mark.asyncio
     async def test_legacy_compat_no_observation(self, client):

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -23,6 +23,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] MCP server connection lifecycle emits runtime audit coverage for connect, disconnect, auth-required, and failure states
 - [x] observer context refresh and queued-bundle delivery emit background runtime audit coverage
 - [x] proactive delivery-gate decisions emit runtime audit coverage for delivered, queued, and failed paths
+- [x] observer daemon screen-context ingest emits runtime audit coverage for receive, persist success, and persist failure
 
 ## In Progress
 
@@ -32,7 +33,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 
 - [ ] broaden model and provider routing beyond the first shared fallback path
 - [ ] deepen local-model-capable execution paths beyond API-base swapping
-- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, proactive delivery gating, and current MCP lifecycle coverage
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, daemon ingest, proactive delivery gating, and current MCP lifecycle coverage
 - [ ] expand eval coverage beyond the current runtime seam checks
 
 ## Done Means


### PR DESCRIPTION
## Summary
- add fail-open runtime audit events for observer daemon screen-context receives and structured observation persistence results
- record persist success and persist failure details so daemon ingest is visible in the runtime audit trail
- extend observer API coverage and update the runtime reliability checklist

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/api/observer.py backend/tests/test_observer_api.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_observer_api.py tests/test_observer_manager.py tests/test_delivery.py
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build

## Risks
- daemon ingest is now visible, but there are still remaining runtime observability gaps in other edge integrations and helper paths
