### PR TITLE
Expand runtime evals for observer flows

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -19,14 +19,17 @@ from src.agent.session import SessionManager, session_manager
 from src.agent.factory import get_model
 from src.agent.onboarding import create_onboarding_agent
 from src.agent.strategist import create_strategist_agent
+from src.api.observer import ScreenContextRequest, ScreenObservationData, post_screen_context
 from src.audit.repository import audit_repository
 from src.llm_runtime import FallbackLiteLLMModel
 from src.memory.consolidator import consolidate_session
 from src.observer.context import CurrentContext
+from src.observer.delivery import deliver_or_queue
 from src.scheduler.jobs.daily_briefing import run_daily_briefing
 from src.scheduler.jobs.strategist_tick import run_strategist_tick
 from src.tools.audit import wrap_tools_for_audit
 from src.tools.shell_tool import shell_execute
+from src.models.schemas import WSResponse
 
 
 Runner = Callable[[], dict[str, Any] | Awaitable[dict[str, Any]]]
@@ -368,6 +371,106 @@ async def _eval_session_title_generation_background_audit() -> dict[str, Any]:
     }
 
 
+async def _eval_observer_delivery_gate_audit() -> dict[str, Any]:
+    delivered_ctx = _make_context(user_state="available", interruption_mode="balanced", attention_budget_remaining=3)
+    queued_ctx = _make_context(user_state="deep_work", interruption_mode="balanced", attention_budget_remaining=3)
+    mock_context_manager = MagicMock()
+    mock_context_manager.get_context.side_effect = [delivered_ctx, queued_ctx]
+    mock_context_manager.decrement_attention_budget = MagicMock()
+    mock_ws_manager = MagicMock()
+    mock_ws_manager.broadcast = AsyncMock()
+    mock_insight_queue = MagicMock()
+    mock_insight_queue.enqueue = AsyncMock()
+    mock_log_event = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_context_manager),
+        patch("src.scheduler.connection_manager.ws_manager", mock_ws_manager),
+        patch("src.observer.insight_queue.insight_queue", mock_insight_queue),
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        await deliver_or_queue(
+            WSResponse(type="proactive", content="Ship it", intervention_type="advisory", urgency=3)
+        )
+        await deliver_or_queue(
+            WSResponse(type="proactive", content="Queue it", intervention_type="advisory", urgency=3)
+        )
+
+    delivered = _find_audit_call(
+        mock_log_event,
+        event_type="observer_delivery_delivered",
+        tool_name="observer_delivery_gate",
+    )
+    queued = _find_audit_call(
+        mock_log_event,
+        event_type="observer_delivery_queued",
+        tool_name="observer_delivery_gate",
+    )
+    return {
+        "delivered_user_state": delivered["details"]["user_state"],
+        "queued_user_state": queued["details"]["user_state"],
+        "broadcast_calls": mock_ws_manager.broadcast.await_count,
+        "enqueue_calls": mock_insight_queue.enqueue.await_count,
+    }
+
+
+async def _eval_observer_daemon_ingest_audit() -> dict[str, Any]:
+    mock_context_manager = MagicMock()
+    mock_context_manager.update_screen_context = MagicMock()
+    mock_log_event = AsyncMock()
+    mock_repo = MagicMock()
+    mock_repo.create = AsyncMock(side_effect=[None, RuntimeError("db down")])
+
+    with (
+        patch("src.api.observer.context_manager", mock_context_manager),
+        patch("src.observer.screen_repository.screen_observation_repo", mock_repo),
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        await post_screen_context(
+            ScreenContextRequest(
+                active_window="VS Code",
+                screen_context="Editing eval harness",
+                observation=ScreenObservationData(
+                    app="VS Code",
+                    activity="coding",
+                    blocked=False,
+                ),
+            )
+        )
+        await post_screen_context(
+            ScreenContextRequest(
+                active_window="Cursor",
+                observation=ScreenObservationData(
+                    app="Cursor",
+                    activity="coding",
+                    blocked=False,
+                ),
+            )
+        )
+
+    received = _find_audit_call(
+        mock_log_event,
+        event_type="integration_received",
+        tool_name="observer_daemon:screen_context",
+    )
+    persisted = _find_audit_call(
+        mock_log_event,
+        event_type="integration_persisted",
+        tool_name="observer_daemon:screen_context",
+    )
+    persist_failed = _find_audit_call(
+        mock_log_event,
+        event_type="integration_persist_failed",
+        tool_name="observer_daemon:screen_context",
+    )
+    return {
+        "received_has_observation": received["details"]["has_observation"],
+        "persisted_app": persisted["details"]["app"],
+        "persist_failed_error": persist_failed["details"]["error"],
+        "update_calls": mock_context_manager.update_screen_context.call_count,
+    }
+
+
 _SCENARIOS: tuple[EvalScenario, ...] = (
     EvalScenario(
         name="chat_model_wrapper",
@@ -416,6 +519,18 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="observability",
         description="Session title generation records background-task audit success without live providers.",
         runner=_eval_session_title_generation_background_audit,
+    ),
+    EvalScenario(
+        name="observer_delivery_gate_audit",
+        category="observability",
+        description="Proactive delivery gate records delivered and queued audit outcomes with observer context details.",
+        runner=_eval_observer_delivery_gate_audit,
+    ),
+    EvalScenario(
+        name="observer_daemon_ingest_audit",
+        category="observability",
+        description="Observer daemon screen-context ingest records receive, persist success, and persist failure audit events.",
+        runner=_eval_observer_daemon_ingest_audit,
     ),
 )
 

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -20,13 +20,13 @@ def test_run_runtime_evals_passes_all_scenarios():
 
 
 def test_run_runtime_evals_can_filter_specific_scenarios():
-    summary = asyncio.run(run_runtime_evals(["daily_briefing_fallback", "strategist_tick_tool_audit"]))
+    summary = asyncio.run(run_runtime_evals(["daily_briefing_fallback", "observer_delivery_gate_audit"]))
 
     assert summary.total == 2
     assert summary.failed == 0
     assert [result.name for result in summary.results] == [
         "daily_briefing_fallback",
-        "strategist_tick_tool_audit",
+        "observer_delivery_gate_audit",
     ]
 
 
@@ -41,7 +41,7 @@ def test_main_lists_available_scenarios(capsys):
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "chat_model_wrapper" in captured.out
-    assert "session_title_generation_background_audit" in captured.out
+    assert "observer_daemon_ingest_audit" in captured.out
 
 
 def test_main_emits_json_summary(capsys):
@@ -53,3 +53,15 @@ def test_main_emits_json_summary(capsys):
     assert exit_code == 0
     assert payload["failed"] == 0
     assert payload["results"][0]["name"] == "shell_tool_timeout_contract"
+
+
+def test_observer_eval_scenarios_expose_expected_details():
+    summary = asyncio.run(run_runtime_evals(["observer_delivery_gate_audit", "observer_daemon_ingest_audit"]))
+
+    assert summary.failed == 0
+    details_by_name = {result.name: result.details for result in summary.results}
+
+    assert details_by_name["observer_delivery_gate_audit"]["delivered_user_state"] == "available"
+    assert details_by_name["observer_delivery_gate_audit"]["queued_user_state"] == "deep_work"
+    assert details_by_name["observer_daemon_ingest_audit"]["persisted_app"] == "VS Code"
+    assert details_by_name["observer_daemon_ingest_audit"]["persist_failed_error"] == "db down"

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -36,10 +36,11 @@ cd backend
 uv run python -m src.evals.harness --list
 uv run python -m src.evals.harness
 uv run python -m src.evals.harness --scenario daily_briefing_fallback
-uv run python -m src.evals.harness --scenario strategist_tick_tool_audit
+uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
+uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so fallback wiring, proactive delivery, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so fallback wiring, proactive delivery, daemon ingest, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -16,7 +16,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] direct LiteLLM fallback path
 - [x] timeout-safe audit visibility into primary-vs-fallback LLM completion and agent-model behavior
 - [x] fallback-capable `smolagents` model wrappers for chat, onboarding, strategist, and specialists
-- [x] repeatable runtime eval harness for core guardian, tool, and audit-runtime reliability contracts
+- [x] repeatable runtime eval harness for core guardian, tool, and observer/audit-runtime reliability contracts
 - [x] lifecycle audit events for REST chat, WebSocket chat, and the full scheduler job surface
 - [x] real tool execution audit events for call, result, and failure across agent transports
 - [x] strategist tool calls and background helper flows now emit runtime audit coverage
@@ -34,7 +34,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [ ] broaden model and provider routing beyond the first shared fallback path
 - [ ] deepen local-model-capable execution paths beyond API-base swapping
 - [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, daemon ingest, proactive delivery gating, and current MCP lifecycle coverage
-- [ ] expand eval coverage beyond the current runtime seam checks
+- [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing and remaining edge-path contracts
 
 ## Done Means
 


### PR DESCRIPTION
## Summary
- expand the deterministic runtime eval harness with observer delivery-gate and daemon-ingest scenarios
- verify the new observer eval scenarios in harness tests and document how to run them from the testing guide
- update the runtime reliability checklist to reflect broader observer/runtime eval coverage

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/evals/harness.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_eval_harness.py tests/test_observer_api.py tests/test_delivery.py tests/test_observer_manager.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario observer_delivery_gate_audit --scenario observer_daemon_ingest_audit --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build

## Risks
- the harness now covers observer delivery and daemon seams, but it still does not replace broader live-provider or end-to-end behavioral evaluation
