### PR TITLE
Add ordered LLM fallback chains

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     llm_api_key: str = ""
     llm_api_base: str = "https://openrouter.ai/api/v1"
     fallback_model: str = ""
+    fallback_models: str = ""  # comma-separated ordered fallback chain
     fallback_llm_api_key: str = ""
     fallback_llm_api_base: str = ""
     model_temperature: float = 0.7

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -21,7 +21,7 @@ from src.agent.onboarding import create_onboarding_agent
 from src.agent.strategist import create_strategist_agent
 from src.api.observer import ScreenContextRequest, ScreenObservationData, post_screen_context
 from src.audit.repository import audit_repository
-from src.llm_runtime import FallbackLiteLLMModel
+from src.llm_runtime import FallbackLiteLLMModel, completion_with_fallback_sync
 from src.memory.consolidator import consolidate_session
 from src.observer.context import CurrentContext
 from src.observer.delivery import deliver_or_queue
@@ -187,6 +187,47 @@ def _eval_chat_model_wrapper() -> dict[str, Any]:
     return {
         "primary_model": model.model_id,
         "fallback_model": model._fallback_model.model_id,
+    }
+
+
+def _eval_provider_fallback_chain() -> dict[str, Any]:
+    completion_response = _make_litellm_response("Resolved after ordered fallback chain.")
+
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "fallback_model", ""),
+        patch.object(
+            settings,
+            "fallback_models",
+            "openai/gpt-4o-mini,openai/gpt-4.1-mini",
+        ),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch(
+            "litellm.completion",
+            side_effect=[
+                RuntimeError("primary down"),
+                RuntimeError("first fallback down"),
+                completion_response,
+            ],
+        ) as mock_completion,
+    ):
+        response = completion_with_fallback_sync(
+            messages=[{"role": "user", "content": "route around provider issues"}],
+            temperature=0.2,
+            max_tokens=128,
+        )
+
+    attempted_models = [call.kwargs["model"] for call in mock_completion.call_args_list]
+    assert attempted_models == [
+        "openrouter/anthropic/claude-sonnet-4",
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-mini",
+    ]
+    return {
+        "attempted_models": attempted_models,
+        "final_model": attempted_models[-1],
+        "response_excerpt": response.choices[0].message.content,
     }
 
 
@@ -477,6 +518,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="runtime",
         description="Main agent model wiring exposes the shared fallback wrapper.",
         runner=_eval_chat_model_wrapper,
+    ),
+    EvalScenario(
+        name="provider_fallback_chain",
+        category="runtime",
+        description="Direct completion retries across an ordered fallback chain instead of a single backup target.",
+        runner=_eval_provider_fallback_chain,
     ),
     EvalScenario(
         name="onboarding_model_wrapper",

--- a/backend/src/llm_runtime.py
+++ b/backend/src/llm_runtime.py
@@ -27,6 +27,17 @@ def _primary_api_key() -> str:
     return settings.llm_api_key or settings.openrouter_api_key
 
 
+def fallback_model_ids() -> list[str]:
+    """Return the ordered list of configured fallback model ids."""
+    fallback_ids: list[str] = []
+    for raw_value in (settings.fallback_model, settings.fallback_models):
+        for model_id in raw_value.split(","):
+            normalized = model_id.strip()
+            if normalized and normalized not in fallback_ids:
+                fallback_ids.append(normalized)
+    return fallback_ids
+
+
 def build_model_kwargs(
     *,
     temperature: float,
@@ -54,10 +65,13 @@ def build_completion_kwargs(
     max_tokens: int,
     model_id: str | None = None,
     use_fallback: bool = False,
+    fallback_model_id: str | None = None,
+    fallback_api_key: str | None = None,
+    fallback_api_base: str | None = None,
 ) -> dict[str, Any]:
     """Build litellm.completion kwargs for either the primary or fallback path."""
     if use_fallback:
-        fallback_model = settings.fallback_model
+        fallback_model = fallback_model_id or next(iter(fallback_model_ids()), "")
         if not fallback_model:
             raise ValueError("Fallback model is not configured")
         kwargs: dict[str, Any] = {
@@ -66,8 +80,8 @@ def build_completion_kwargs(
             "temperature": temperature,
             "max_tokens": max_tokens,
         }
-        api_key = settings.fallback_llm_api_key or _primary_api_key()
-        api_base = settings.fallback_llm_api_base or settings.llm_api_base
+        api_key = fallback_api_key or settings.fallback_llm_api_key or _primary_api_key()
+        api_base = fallback_api_base or settings.fallback_llm_api_base or settings.llm_api_base
     else:
         kwargs = {
             "model": model_id or settings.default_model,
@@ -87,7 +101,7 @@ def build_completion_kwargs(
 
 def has_fallback_model() -> bool:
     """Return whether a fallback completion target is configured."""
-    return bool(settings.fallback_model.strip())
+    return bool(fallback_model_ids())
 
 
 def _fallback_api_key(primary_api_key: str | None) -> str:
@@ -100,6 +114,45 @@ def _fallback_api_base(primary_api_base: str | None) -> str:
 
 def _safe_model_name(kwargs: dict[str, Any]) -> str:
     return str(kwargs.get("model", "unknown"))
+
+
+def _target_key(*, model_id: str, api_base: str | None, api_key: str | None) -> tuple[str, str | None, str | None]:
+    return (model_id, api_base or None, api_key or None)
+
+
+def _fallback_targets(
+    *,
+    primary_model_id: str,
+    primary_api_base: str | None,
+    primary_api_key: str | None,
+) -> list[dict[str, str | None]]:
+    fallback_api_key = _fallback_api_key(primary_api_key)
+    fallback_api_base = _fallback_api_base(primary_api_base)
+    seen_targets = {
+        _target_key(
+            model_id=primary_model_id,
+            api_base=primary_api_base,
+            api_key=primary_api_key,
+        ),
+    }
+    targets: list[dict[str, str | None]] = []
+    for fallback_model_id in fallback_model_ids():
+        target_key = _target_key(
+            model_id=fallback_model_id,
+            api_base=fallback_api_base,
+            api_key=fallback_api_key,
+        )
+        if target_key in seen_targets:
+            continue
+        seen_targets.add(target_key)
+        targets.append(
+            {
+                "model_id": fallback_model_id,
+                "api_base": fallback_api_base,
+                "api_key": fallback_api_key,
+            }
+        )
+    return targets
 
 
 def _register_request(request_id: str) -> None:
@@ -169,7 +222,17 @@ def _log_llm_runtime_event_sync(
     details: dict[str, Any],
 ) -> None:
     try:
-        asyncio.run(_log_llm_runtime_event(
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(_log_llm_runtime_event(
+                event_type=event_type,
+                summary=summary,
+                details=details,
+            ))
+            return
+
+        loop.create_task(_log_llm_runtime_event(
             event_type=event_type,
             summary=summary,
             details=details,
@@ -198,32 +261,30 @@ class FallbackLiteLLMModel(BaseLiteLLMModel):
             flatten_messages_as_text=flatten_messages_as_text,
             **kwargs,
         )
+        self._fallback_models: tuple[BaseLiteLLMModel, ...] = ()
         self._fallback_model: BaseLiteLLMModel | None = None
-
-        fallback_model_id = settings.fallback_model.strip()
-        if not fallback_model_id:
-            return
-
-        fallback_api_key = _fallback_api_key(api_key)
-        fallback_api_base = _fallback_api_base(api_base)
-        fallback_target_differs = (
-            fallback_model_id != self.model_id
-            or (fallback_api_base or None) != self.api_base
-            or (fallback_api_key or None) != self.api_key
-        )
-        if not fallback_target_differs:
-            return
-
         fallback_kwargs = dict(kwargs)
         if flatten_messages_as_text is not None:
             fallback_kwargs["flatten_messages_as_text"] = flatten_messages_as_text
-        self._fallback_model = BaseLiteLLMModel(
-            model_id=fallback_model_id,
-            api_base=fallback_api_base or None,
-            api_key=fallback_api_key or None,
-            custom_role_conversions=custom_role_conversions,
-            **fallback_kwargs,
-        )
+
+        fallback_models: list[BaseLiteLLMModel] = []
+        for target in _fallback_targets(
+            primary_model_id=self.model_id,
+            primary_api_base=self.api_base,
+            primary_api_key=self.api_key,
+        ):
+            fallback_models.append(
+                BaseLiteLLMModel(
+                    model_id=str(target["model_id"]),
+                    api_base=target["api_base"] or None,
+                    api_key=target["api_key"] or None,
+                    custom_role_conversions=custom_role_conversions,
+                    **fallback_kwargs,
+                )
+            )
+
+        self._fallback_models = tuple(fallback_models)
+        self._fallback_model = self._fallback_models[0] if self._fallback_models else None
 
     def generate(
         self,
@@ -255,7 +316,7 @@ class FallbackLiteLLMModel(BaseLiteLLMModel):
                 )
             return response
         except Exception as primary_error:
-            if self._fallback_model is None:
+            if not self._fallback_models:
                 if _can_log_request(request_id):
                     _log_llm_runtime_event_sync(
                         event_type="llm_primary_failure",
@@ -268,52 +329,78 @@ class FallbackLiteLLMModel(BaseLiteLLMModel):
                         },
                     )
                 raise
-            logger.warning(
-                "Primary agent model %s failed, retrying with fallback %s",
-                self.model_id,
-                self._fallback_model.model_id,
-                exc_info=True,
-            )
-            try:
-                response = self._fallback_model.generate(
-                    messages,
-                    stop_sequences=stop_sequences,
-                    response_format=response_format,
-                    tools_to_call_from=tools_to_call_from,
-                    **kwargs,
+            attempted_fallback_models: list[str] = []
+            fallback_errors: list[dict[str, str]] = []
+            last_error: Exception = primary_error
+
+            for index, fallback_model in enumerate(self._fallback_models):
+                attempted_fallback_models.append(fallback_model.model_id)
+                if index == 0:
+                    logger.warning(
+                        "LLM generate failed for %s, retrying with fallback %s",
+                        primary_model,
+                        fallback_model.model_id,
+                        exc_info=True,
+                    )
+                try:
+                    response = fallback_model.generate(
+                        messages,
+                        stop_sequences=stop_sequences,
+                        response_format=response_format,
+                        tools_to_call_from=tools_to_call_from,
+                        **kwargs,
+                    )
+                    if _can_log_request(request_id):
+                        _log_llm_runtime_event_sync(
+                            event_type="llm_fallback_success",
+                            summary=(
+                                f"Fallback agent model generate succeeded via {fallback_model.model_id}"
+                            ),
+                            details={
+                                "runtime_path": "agent_generate",
+                                "primary_model": primary_model,
+                                "fallback_model": fallback_model.model_id,
+                                "attempted_fallback_models": attempted_fallback_models,
+                                "fallback_attempts": len(attempted_fallback_models),
+                                "used_fallback": True,
+                                "primary_error": str(primary_error),
+                            },
+                        )
+                    return response
+                except Exception as fallback_error:
+                    last_error = fallback_error
+                    fallback_errors.append(
+                        {
+                            "model": fallback_model.model_id,
+                            "error": str(fallback_error),
+                        }
+                    )
+                    if index + 1 < len(self._fallback_models):
+                        logger.warning(
+                            "Fallback model %s failed, retrying with next fallback %s",
+                            fallback_model.model_id,
+                            self._fallback_models[index + 1].model_id,
+                            exc_info=True,
+                        )
+
+            if _can_log_request(request_id):
+                final_fallback_model = attempted_fallback_models[-1]
+                _log_llm_runtime_event_sync(
+                    event_type="llm_fallback_failure",
+                    summary=f"Fallback agent model generate failed via {final_fallback_model}",
+                    details={
+                        "runtime_path": "agent_generate",
+                        "primary_model": primary_model,
+                        "fallback_model": final_fallback_model,
+                        "attempted_fallback_models": attempted_fallback_models,
+                        "fallback_attempts": len(attempted_fallback_models),
+                        "used_fallback": True,
+                        "primary_error": str(primary_error),
+                        "fallback_error": str(last_error),
+                        "fallback_errors": fallback_errors,
+                    },
                 )
-                if _can_log_request(request_id):
-                    _log_llm_runtime_event_sync(
-                        event_type="llm_fallback_success",
-                        summary=(
-                            f"Fallback agent model generate succeeded via {self._fallback_model.model_id}"
-                        ),
-                        details={
-                            "runtime_path": "agent_generate",
-                            "primary_model": primary_model,
-                            "fallback_model": self._fallback_model.model_id,
-                            "used_fallback": True,
-                            "primary_error": str(primary_error),
-                        },
-                    )
-                return response
-            except Exception as fallback_error:
-                if _can_log_request(request_id):
-                    _log_llm_runtime_event_sync(
-                        event_type="llm_fallback_failure",
-                        summary=(
-                            f"Fallback agent model generate failed via {self._fallback_model.model_id}"
-                        ),
-                        details={
-                            "runtime_path": "agent_generate",
-                            "primary_model": primary_model,
-                            "fallback_model": self._fallback_model.model_id,
-                            "used_fallback": True,
-                            "primary_error": str(primary_error),
-                            "fallback_error": str(fallback_error),
-                        },
-                    )
-                raise
+            raise last_error
 
 
 def completion_with_fallback_sync(
@@ -349,7 +436,12 @@ def completion_with_fallback_sync(
                 )
             return response
         except Exception as primary_error:
-            if not has_fallback_model():
+            fallback_targets = _fallback_targets(
+                primary_model_id=primary_model,
+                primary_api_base=primary_kwargs.get("api_base"),
+                primary_api_key=primary_kwargs.get("api_key"),
+            )
+            if not fallback_targets:
                 if _can_log_request(request_id):
                     _log_llm_runtime_event_sync(
                         event_type="llm_primary_failure",
@@ -362,49 +454,80 @@ def completion_with_fallback_sync(
                         },
                     )
                 raise
-            fallback_kwargs = build_completion_kwargs(
-                messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                use_fallback=True,
-            )
-            fallback_model = _safe_model_name(fallback_kwargs)
-            logger.warning(
-                "Primary LLM completion failed for model %s, retrying with fallback %s",
-                primary_model,
-                fallback_model,
-                exc_info=True,
-            )
-            try:
-                response = litellm.completion(**fallback_kwargs)
-                if _can_log_request(request_id):
-                    _log_llm_runtime_event_sync(
-                        event_type="llm_fallback_success",
-                        summary=f"Fallback LLM completion succeeded via {fallback_model}",
-                        details={
-                            "runtime_path": "completion",
-                            "primary_model": primary_model,
-                            "fallback_model": fallback_model,
-                            "used_fallback": True,
-                            "primary_error": str(primary_error),
-                        },
+            attempted_fallback_models: list[str] = []
+            fallback_errors: list[dict[str, str]] = []
+            last_error: Exception = primary_error
+
+            for index, target in enumerate(fallback_targets):
+                fallback_kwargs = build_completion_kwargs(
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    use_fallback=True,
+                    fallback_model_id=str(target["model_id"]),
+                    fallback_api_key=target["api_key"],
+                    fallback_api_base=target["api_base"],
+                )
+                fallback_model = _safe_model_name(fallback_kwargs)
+                attempted_fallback_models.append(fallback_model)
+                if index == 0:
+                    logger.warning(
+                        "LLM completion failed for model %s, retrying with fallback %s",
+                        primary_model,
+                        fallback_model,
+                        exc_info=True,
                     )
-                return response
-            except Exception as fallback_error:
-                if _can_log_request(request_id):
-                    _log_llm_runtime_event_sync(
-                        event_type="llm_fallback_failure",
-                        summary=f"Fallback LLM completion failed via {fallback_model}",
-                        details={
-                            "runtime_path": "completion",
-                            "primary_model": primary_model,
-                            "fallback_model": fallback_model,
-                            "used_fallback": True,
-                            "primary_error": str(primary_error),
-                            "fallback_error": str(fallback_error),
-                        },
+                try:
+                    response = litellm.completion(**fallback_kwargs)
+                    if _can_log_request(request_id):
+                        _log_llm_runtime_event_sync(
+                            event_type="llm_fallback_success",
+                            summary=f"Fallback LLM completion succeeded via {fallback_model}",
+                            details={
+                                "runtime_path": "completion",
+                                "primary_model": primary_model,
+                                "fallback_model": fallback_model,
+                                "attempted_fallback_models": attempted_fallback_models,
+                                "fallback_attempts": len(attempted_fallback_models),
+                                "used_fallback": True,
+                                "primary_error": str(primary_error),
+                            },
+                        )
+                    return response
+                except Exception as fallback_error:
+                    last_error = fallback_error
+                    fallback_errors.append(
+                        {
+                            "model": fallback_model,
+                            "error": str(fallback_error),
+                        }
                     )
-                raise
+                    if index + 1 < len(fallback_targets):
+                        logger.warning(
+                            "Fallback model %s failed, retrying with next fallback %s",
+                            fallback_model,
+                            fallback_targets[index + 1]["model_id"],
+                            exc_info=True,
+                        )
+
+            final_fallback_model = attempted_fallback_models[-1]
+            if _can_log_request(request_id):
+                _log_llm_runtime_event_sync(
+                    event_type="llm_fallback_failure",
+                    summary=f"Fallback LLM completion failed via {final_fallback_model}",
+                    details={
+                        "runtime_path": "completion",
+                        "primary_model": primary_model,
+                        "fallback_model": final_fallback_model,
+                        "attempted_fallback_models": attempted_fallback_models,
+                        "fallback_attempts": len(attempted_fallback_models),
+                        "used_fallback": True,
+                        "primary_error": str(primary_error),
+                        "fallback_error": str(last_error),
+                        "fallback_errors": fallback_errors,
+                    },
+                )
+            raise last_error
     finally:
         if request_id is not None:
             _finish_request(request_id)

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -20,12 +20,12 @@ def test_run_runtime_evals_passes_all_scenarios():
 
 
 def test_run_runtime_evals_can_filter_specific_scenarios():
-    summary = asyncio.run(run_runtime_evals(["daily_briefing_fallback", "observer_delivery_gate_audit"]))
+    summary = asyncio.run(run_runtime_evals(["provider_fallback_chain", "observer_delivery_gate_audit"]))
 
     assert summary.total == 2
     assert summary.failed == 0
     assert [result.name for result in summary.results] == [
-        "daily_briefing_fallback",
+        "provider_fallback_chain",
         "observer_delivery_gate_audit",
     ]
 
@@ -41,6 +41,7 @@ def test_main_lists_available_scenarios(capsys):
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "chat_model_wrapper" in captured.out
+    assert "provider_fallback_chain" in captured.out
     assert "observer_daemon_ingest_audit" in captured.out
 
 
@@ -55,12 +56,26 @@ def test_main_emits_json_summary(capsys):
     assert payload["results"][0]["name"] == "shell_tool_timeout_contract"
 
 
-def test_observer_eval_scenarios_expose_expected_details():
-    summary = asyncio.run(run_runtime_evals(["observer_delivery_gate_audit", "observer_daemon_ingest_audit"]))
+def test_runtime_eval_scenarios_expose_expected_details():
+    summary = asyncio.run(
+        run_runtime_evals(
+            [
+                "provider_fallback_chain",
+                "observer_delivery_gate_audit",
+                "observer_daemon_ingest_audit",
+            ]
+        )
+    )
 
     assert summary.failed == 0
     details_by_name = {result.name: result.details for result in summary.results}
 
+    assert details_by_name["provider_fallback_chain"]["attempted_models"] == [
+        "openrouter/anthropic/claude-sonnet-4",
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-mini",
+    ]
+    assert details_by_name["provider_fallback_chain"]["final_model"] == "openai/gpt-4.1-mini"
     assert details_by_name["observer_delivery_gate_audit"]["delivered_user_state"] == "available"
     assert details_by_name["observer_delivery_gate_audit"]["queued_user_state"] == "deep_work"
     assert details_by_name["observer_daemon_ingest_audit"]["persisted_app"] == "VS Code"

--- a/backend/tests/test_llm_runtime.py
+++ b/backend/tests/test_llm_runtime.py
@@ -57,6 +57,27 @@ def test_build_completion_kwargs_uses_fallback_settings():
     assert kwargs["api_base"] == "http://localhost:11434/v1"
 
 
+def test_build_completion_kwargs_uses_first_model_from_fallback_chain():
+    with (
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", "openai/gpt-4o-mini,openai/gpt-4.1-mini"),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", ""),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+    ):
+        kwargs = build_completion_kwargs(
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.2,
+            max_tokens=128,
+            use_fallback=True,
+        )
+
+    assert kwargs["model"] == "openai/gpt-4o-mini"
+    assert kwargs["api_key"] == "primary-key"
+    assert kwargs["api_base"] == "https://openrouter.ai/api/v1"
+
+
 def test_completion_with_fallback_sync_retries_with_fallback():
     primary_error = RuntimeError("primary down")
     fallback_response = MagicMock()
@@ -78,6 +99,55 @@ def test_completion_with_fallback_sync_retries_with_fallback():
     assert mock_completion.call_args_list[0].kwargs["model"] == "openrouter/anthropic/claude-sonnet-4"
     assert mock_completion.call_args_list[1].kwargs["model"] == "ollama/llama3.2"
     assert mock_completion.call_args_list[1].kwargs["api_base"] == "http://localhost:11434/v1"
+
+
+def test_completion_with_fallback_sync_walks_fallback_chain(async_db):
+    completion_response = MagicMock()
+
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "fallback_model", ""),
+        patch.object(
+            settings,
+            "fallback_models",
+            "openai/gpt-4o-mini,openai/gpt-4.1-mini",
+        ),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch(
+            "litellm.completion",
+            side_effect=[
+                RuntimeError("primary down"),
+                RuntimeError("first fallback down"),
+                completion_response,
+            ],
+        ) as mock_completion,
+    ):
+        result = completion_with_fallback_sync(
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=0.3,
+            max_tokens=256,
+        )
+
+    assert result is completion_response
+    assert [call.kwargs["model"] for call in mock_completion.call_args_list] == [
+        "openrouter/anthropic/claude-sonnet-4",
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-mini",
+    ]
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "llm_fallback_success"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["details"]["fallback_model"] == "openai/gpt-4.1-mini"
+    assert events[0]["details"]["attempted_fallback_models"] == [
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-mini",
+    ]
+    assert events[0]["details"]["fallback_attempts"] == 2
 
 
 def test_completion_with_fallback_sync_logs_primary_success(async_db):
@@ -107,6 +177,32 @@ def test_completion_with_fallback_sync_logs_primary_success(async_db):
     assert events[0]["details"]["runtime_path"] == "completion"
     assert events[0]["details"]["used_fallback"] is False
     assert events[0]["details"]["primary_model"] == "openai/gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_completion_with_fallback_sync_logs_inside_running_loop(async_db):
+    success_response = MagicMock()
+
+    with (
+        patch.object(settings, "default_model", "openai/gpt-4o-mini"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", ""),
+        patch("litellm.completion", return_value=success_response),
+    ):
+        result = completion_with_fallback_sync(
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=0.3,
+            max_tokens=256,
+        )
+        await asyncio.sleep(0)
+
+    assert result is success_response
+    events = await audit_repository.list_events(limit=5)
+    success_events = [e for e in events if e["event_type"] == "llm_primary_success"]
+    assert success_events
+    assert success_events[0]["details"]["primary_model"] == "openai/gpt-4o-mini"
 
 
 def test_completion_with_fallback_sync_logs_fallback_success(async_db):
@@ -140,6 +236,50 @@ def test_completion_with_fallback_sync_logs_fallback_success(async_db):
     assert events[0]["details"]["used_fallback"] is True
     assert events[0]["details"]["fallback_model"] == "ollama/llama3.2"
     assert "primary down" in events[0]["details"]["primary_error"]
+
+
+def test_completion_with_fallback_sync_logs_final_chain_failure(async_db):
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "fallback_model", ""),
+        patch.object(
+            settings,
+            "fallback_models",
+            "openai/gpt-4o-mini,openai/gpt-4.1-mini",
+        ),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch(
+            "litellm.completion",
+            side_effect=[
+                RuntimeError("primary down"),
+                RuntimeError("first fallback down"),
+                RuntimeError("final fallback down"),
+            ],
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="final fallback down"):
+            completion_with_fallback_sync(
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0.3,
+                max_tokens=256,
+            )
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "llm_fallback_failure"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["details"]["fallback_model"] == "openai/gpt-4.1-mini"
+    assert events[0]["details"]["attempted_fallback_models"] == [
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-mini",
+    ]
+    assert events[0]["details"]["fallback_errors"] == [
+        {"model": "openai/gpt-4o-mini", "error": "first fallback down"},
+        {"model": "openai/gpt-4.1-mini", "error": "final fallback down"},
+    ]
 
 
 def test_fallback_litellm_model_retries_generate_with_fallback(async_db):
@@ -181,6 +321,55 @@ def test_fallback_litellm_model_retries_generate_with_fallback(async_db):
     assert "primary down" in events[0]["details"]["primary_error"]
 
 
+def test_fallback_litellm_model_walks_fallback_chain(async_db):
+    fallback_response = MagicMock()
+
+    with (
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", "openai/gpt-4o-mini,openai/gpt-4.1-mini"),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", ""),
+        patch(
+            "src.llm_runtime.BaseLiteLLMModel.generate",
+            autospec=True,
+            side_effect=[
+                RuntimeError("primary down"),
+                RuntimeError("first fallback down"),
+                fallback_response,
+            ],
+        ) as mock_generate,
+    ):
+        model = FallbackLiteLLMModel(
+            model_id="openrouter/anthropic/claude-sonnet-4",
+            api_key="primary-key",
+            api_base="https://openrouter.ai/api/v1",
+            temperature=0.3,
+            max_tokens=256,
+        )
+        result = model.generate([{"role": "user", "content": "hello"}])
+
+    assert result is fallback_response
+    assert len(model._fallback_models) == 2
+    assert [call.args[0].model_id for call in mock_generate.call_args_list] == [
+        "openrouter/anthropic/claude-sonnet-4",
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-mini",
+    ]
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "llm_fallback_success"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["details"]["fallback_model"] == "openai/gpt-4.1-mini"
+    assert events[0]["details"]["attempted_fallback_models"] == [
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-mini",
+    ]
+    assert events[0]["details"]["fallback_attempts"] == 2
+
+
 def test_fallback_litellm_model_skips_duplicate_fallback_target():
     with (
         patch.object(settings, "fallback_model", "openai/gpt-4o-mini"),
@@ -196,6 +385,31 @@ def test_fallback_litellm_model_skips_duplicate_fallback_target():
         )
 
     assert model._fallback_model is None
+
+
+def test_fallback_litellm_model_deduplicates_chain_targets():
+    with (
+        patch.object(settings, "fallback_model", "openai/gpt-4o-mini"),
+        patch.object(
+            settings,
+            "fallback_models",
+            "openai/gpt-4o-mini,openai/gpt-4o-mini,openai/gpt-4.1-mini",
+        ),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", ""),
+    ):
+        model = FallbackLiteLLMModel(
+            model_id="openrouter/anthropic/claude-sonnet-4",
+            api_key="primary-key",
+            api_base="https://openrouter.ai/api/v1",
+            temperature=0.3,
+            max_tokens=256,
+        )
+
+    assert [candidate.model_id for candidate in model._fallback_models] == [
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-mini",
+    ]
 
 
 @pytest.mark.asyncio
@@ -327,6 +541,49 @@ def test_fallback_litellm_model_logs_fallback_failure(async_db):
     assert events[0]["details"]["runtime_path"] == "agent_generate"
     assert events[0]["details"]["fallback_model"] == "ollama/llama3.2"
     assert events[0]["details"]["fallback_error"] == "fallback down"
+
+
+def test_fallback_litellm_model_logs_final_chain_failure(async_db):
+    with (
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", "openai/gpt-4o-mini,openai/gpt-4.1-mini"),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", ""),
+        patch(
+            "src.llm_runtime.BaseLiteLLMModel.generate",
+            autospec=True,
+            side_effect=[
+                RuntimeError("primary down"),
+                RuntimeError("first fallback down"),
+                RuntimeError("final fallback down"),
+            ],
+        ),
+    ):
+        model = FallbackLiteLLMModel(
+            model_id="openrouter/anthropic/claude-sonnet-4",
+            api_key="primary-key",
+            api_base="https://openrouter.ai/api/v1",
+            temperature=0.3,
+            max_tokens=256,
+        )
+        with pytest.raises(RuntimeError, match="final fallback down"):
+            model.generate([{"role": "user", "content": "hello"}])
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "llm_fallback_failure"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["details"]["fallback_model"] == "openai/gpt-4.1-mini"
+    assert events[0]["details"]["attempted_fallback_models"] == [
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-mini",
+    ]
+    assert events[0]["details"]["fallback_errors"] == [
+        {"model": "openai/gpt-4o-mini", "error": "first fallback down"},
+        {"model": "openai/gpt-4.1-mini", "error": "final fallback down"},
+    ]
 
 
 def test_fallback_litellm_model_skips_late_success_after_timeout(async_db):

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -35,12 +35,13 @@ For `S1-B3` reliability work, there is also a deterministic eval harness for cor
 cd backend
 uv run python -m src.evals.harness --list
 uv run python -m src.evals.harness
+uv run python -m src.evals.harness --scenario provider_fallback_chain
 uv run python -m src.evals.harness --scenario daily_briefing_fallback
 uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so fallback wiring, proactive delivery, daemon ingest, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, proactive delivery, daemon ingest, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -14,6 +14,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] degraded-mode fallback in the token-aware context window when `tiktoken` cannot load offline
 - [x] centralized provider-agnostic LLM runtime settings
 - [x] direct LiteLLM fallback path
+- [x] ordered fallback-chain routing across shared completion and agent-model paths
 - [x] timeout-safe audit visibility into primary-vs-fallback LLM completion and agent-model behavior
 - [x] fallback-capable `smolagents` model wrappers for chat, onboarding, strategist, and specialists
 - [x] repeatable runtime eval harness for core guardian, tool, and observer/audit-runtime reliability contracts
@@ -31,7 +32,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 
 ## Left To Do
 
-- [ ] broaden model and provider routing beyond the first shared fallback path
+- [ ] deepen provider routing beyond the ordered fallback chain with smarter health- or policy-aware selection
 - [ ] deepen local-model-capable execution paths beyond API-base swapping
 - [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, daemon ingest, proactive delivery gating, and current MCP lifecycle coverage
 - [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing and remaining edge-path contracts


### PR DESCRIPTION
## Summary
- add ordered fallback-chain routing to the shared LLM runtime for both direct completions and agent-model generation
- keep the legacy `fallback_model` setting working while adding ordered `fallback_models` support, deduped targets, and richer fallback audit details
- extend the runtime eval harness, regression tests, and workstream docs for the new provider-chain contract

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/config/settings.py backend/src/llm_runtime.py backend/src/evals/harness.py backend/tests/test_llm_runtime.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_llm_runtime.py tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_agent.py tests/test_specialists.py tests/test_strategist.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario provider_fallback_chain --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build

## Risks
- fallback chains are still ordered and static; health-aware or policy-aware provider selection remains a follow-up