### PR TITLE
Expand local scheduler runtime profile routing

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -345,6 +345,42 @@ async def _eval_daily_briefing_fallback() -> dict[str, Any]:
     }
 
 
+async def _eval_scheduled_local_runtime_profile() -> dict[str, Any]:
+    ctx = _make_context(upcoming_events=[{"summary": "Ship local routing", "start": "09:30"}])
+    mock_context_manager = MagicMock()
+    mock_context_manager.refresh = AsyncMock(return_value=ctx)
+    mock_deliver = AsyncMock()
+    local_response = _make_litellm_response("Morning briefing via local profile.")
+
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "local_model", "ollama/llama3.2"),
+        patch.object(settings, "local_llm_api_key", ""),
+        patch.object(settings, "local_llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "local_runtime_paths", "daily_briefing,evening_review,activity_digest,weekly_activity_review"),
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", ""),
+        patch("src.observer.manager.context_manager", mock_context_manager),
+        patch("src.memory.soul.read_soul", return_value="# Soul\nName: Hero"),
+        patch("src.memory.vector_store.search_formatted", return_value="- [memory] Prefer local summaries"),
+        patch("litellm.completion", return_value=local_response) as mock_completion,
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+    ):
+        await run_daily_briefing()
+
+    assert mock_completion.call_count == 1
+    assert mock_completion.call_args.kwargs["model"] == "ollama/llama3.2"
+    assert mock_completion.call_args.kwargs["api_base"] == "http://localhost:11434/v1"
+    return {
+        "job_name": "daily_briefing",
+        "runtime_profile": "local",
+        "routed_model": mock_completion.call_args.kwargs["model"],
+        "delivered_excerpt": mock_deliver.call_args.args[0].content,
+    }
+
+
 def _eval_shell_tool_timeout_contract() -> dict[str, Any]:
     mock_client = MagicMock()
     mock_client.post.side_effect = httpx.TimeoutException("timeout")
@@ -585,6 +621,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="proactive",
         description="Daily briefing survives a primary provider failure and still delivers via fallback.",
         runner=_eval_daily_briefing_fallback,
+    ),
+    EvalScenario(
+        name="scheduled_local_runtime_profile",
+        category="runtime",
+        description="Scheduled completion-based jobs can route through the first-class local runtime profile.",
+        runner=_eval_scheduled_local_runtime_profile,
     ),
     EvalScenario(
         name="shell_tool_timeout_contract",

--- a/backend/src/scheduler/jobs/activity_digest.py
+++ b/backend/src/scheduler/jobs/activity_digest.py
@@ -96,6 +96,7 @@ async def run_activity_digest() -> None:
                 temperature=0.6,
                 max_tokens=768,
                 timeout=settings.agent_briefing_timeout,
+                runtime_path="activity_digest",
             )
         except asyncio.TimeoutError:
             logger.warning("activity_digest: LLM timed out after %ds", settings.agent_briefing_timeout)

--- a/backend/src/scheduler/jobs/daily_briefing.py
+++ b/backend/src/scheduler/jobs/daily_briefing.py
@@ -85,6 +85,7 @@ async def run_daily_briefing() -> None:
                 temperature=0.6,
                 max_tokens=512,
                 timeout=settings.agent_briefing_timeout,
+                runtime_path="daily_briefing",
             )
         except asyncio.TimeoutError:
             logger.warning("daily_briefing: LLM timed out after %ds", settings.agent_briefing_timeout)

--- a/backend/src/scheduler/jobs/evening_review.py
+++ b/backend/src/scheduler/jobs/evening_review.py
@@ -108,6 +108,7 @@ async def run_evening_review() -> None:
                 temperature=0.6,
                 max_tokens=512,
                 timeout=settings.agent_briefing_timeout,
+                runtime_path="evening_review",
             )
         except asyncio.TimeoutError:
             logger.warning("evening_review: LLM timed out after %ds", settings.agent_briefing_timeout)

--- a/backend/src/scheduler/jobs/weekly_activity_review.py
+++ b/backend/src/scheduler/jobs/weekly_activity_review.py
@@ -103,6 +103,7 @@ async def run_weekly_activity_review() -> None:
                 temperature=0.6,
                 max_tokens=1024,
                 timeout=settings.agent_briefing_timeout,
+                runtime_path="weekly_activity_review",
             )
         except asyncio.TimeoutError:
             await log_scheduler_job_event(

--- a/backend/tests/test_activity_digest.py
+++ b/backend/tests/test_activity_digest.py
@@ -89,6 +89,40 @@ class TestActivityDigest:
         assert call_args[1]["is_scheduled"] is True
 
     @pytest.mark.asyncio
+    async def test_uses_named_runtime_path(self):
+        """Digest should use its explicit runtime path when calling the shared LLM runtime."""
+        mock_repo = MagicMock()
+        mock_repo.get_daily_summary = AsyncMock(return_value={
+            "date": date.today().isoformat(),
+            "total_observations": 15,
+            "total_tracked_minutes": 120,
+            "switch_count": 15,
+            "by_activity": {"coding": 5400, "browsing": 1800},
+            "by_project": {"seraph": 3600},
+            "longest_streaks": [
+                {"activity": "coding", "duration_minutes": 45, "started_at": "2025-01-01T09:00"},
+            ],
+        })
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Your daily digest text here."
+
+        with (
+            patch("src.observer.screen_repository.screen_observation_repo", mock_repo),
+            patch("src.memory.soul.read_soul", return_value="Test soul content"),
+            patch(
+                "src.scheduler.jobs.activity_digest.completion_with_fallback",
+                new=AsyncMock(return_value=mock_response),
+            ) as mock_completion,
+            patch("src.observer.delivery.deliver_or_queue", AsyncMock()),
+        ):
+            from src.scheduler.jobs.activity_digest import run_activity_digest
+            await run_activity_digest()
+
+        assert mock_completion.await_args.kwargs["runtime_path"] == "activity_digest"
+
+    @pytest.mark.asyncio
     async def test_llm_timeout(self):
         """Digest should handle LLM timeout gracefully."""
         mock_repo = MagicMock()

--- a/backend/tests/test_daily_briefing.py
+++ b/backend/tests/test_daily_briefing.py
@@ -80,6 +80,28 @@ async def test_daily_briefing_logs_success(async_db):
 
 
 @pytest.mark.asyncio
+async def test_daily_briefing_uses_named_runtime_path():
+    ctx = _make_context()
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=ctx)
+    mock_response = _mock_litellm_response("Good morning, Hero! Here's your briefing...")
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.memory.soul.read_soul", return_value="# Soul\nName: Hero"),
+        patch("src.memory.vector_store.search_formatted", return_value="- [fact] User likes mornings"),
+        patch(
+            "src.scheduler.jobs.daily_briefing.completion_with_fallback",
+            new=AsyncMock(return_value=mock_response),
+        ) as mock_completion,
+        patch("src.observer.delivery.deliver_or_queue", AsyncMock()),
+    ):
+        await run_daily_briefing()
+
+    assert mock_completion.await_args.kwargs["runtime_path"] == "daily_briefing"
+
+
+@pytest.mark.asyncio
 async def test_daily_briefing_context_refresh_failure():
     """Context refresh failure → early return (exception caught)."""
     mock_cm = MagicMock()

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -20,12 +20,12 @@ def test_run_runtime_evals_passes_all_scenarios():
 
 
 def test_run_runtime_evals_can_filter_specific_scenarios():
-    summary = asyncio.run(run_runtime_evals(["local_runtime_profile", "observer_delivery_gate_audit"]))
+    summary = asyncio.run(run_runtime_evals(["scheduled_local_runtime_profile", "observer_delivery_gate_audit"]))
 
     assert summary.total == 2
     assert summary.failed == 0
     assert [result.name for result in summary.results] == [
-        "local_runtime_profile",
+        "scheduled_local_runtime_profile",
         "observer_delivery_gate_audit",
     ]
 
@@ -43,6 +43,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "chat_model_wrapper" in captured.out
     assert "provider_fallback_chain" in captured.out
     assert "local_runtime_profile" in captured.out
+    assert "scheduled_local_runtime_profile" in captured.out
     assert "observer_daemon_ingest_audit" in captured.out
 
 
@@ -63,6 +64,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
             [
                 "provider_fallback_chain",
                 "local_runtime_profile",
+                "scheduled_local_runtime_profile",
                 "observer_delivery_gate_audit",
                 "observer_daemon_ingest_audit",
             ]
@@ -80,6 +82,8 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["provider_fallback_chain"]["final_model"] == "openai/gpt-4.1-mini"
     assert details_by_name["local_runtime_profile"]["runtime_profile"] == "local"
     assert details_by_name["local_runtime_profile"]["routed_model"] == "ollama/llama3.2"
+    assert details_by_name["scheduled_local_runtime_profile"]["job_name"] == "daily_briefing"
+    assert details_by_name["scheduled_local_runtime_profile"]["routed_model"] == "ollama/llama3.2"
     assert details_by_name["observer_delivery_gate_audit"]["delivered_user_state"] == "available"
     assert details_by_name["observer_delivery_gate_audit"]["queued_user_state"] == "deep_work"
     assert details_by_name["observer_daemon_ingest_audit"]["persisted_app"] == "VS Code"

--- a/backend/tests/test_evening_review.py
+++ b/backend/tests/test_evening_review.py
@@ -61,6 +61,29 @@ async def test_evening_review_happy_path():
 
 
 @pytest.mark.asyncio
+async def test_evening_review_uses_named_runtime_path():
+    ctx = _make_context(recent_git_activity=[{"msg": "fix bug"}])
+    mock_cm = MagicMock()
+    mock_cm.refresh = AsyncMock(return_value=ctx)
+    mock_response = _mock_litellm_response("Great day, Hero! You completed Exercise.")
+
+    with (
+        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.memory.soul.read_soul", return_value="# Soul\nName: Hero"),
+        patch("src.scheduler.jobs.evening_review._count_messages_today", AsyncMock(return_value=15)),
+        patch("src.scheduler.jobs.evening_review._get_completed_goals_today", AsyncMock(return_value=["Exercise"])),
+        patch(
+            "src.scheduler.jobs.evening_review.completion_with_fallback",
+            new=AsyncMock(return_value=mock_response),
+        ) as mock_completion,
+        patch("src.observer.delivery.deliver_or_queue", AsyncMock()),
+    ):
+        await run_evening_review()
+
+    assert mock_completion.await_args.kwargs["runtime_path"] == "evening_review"
+
+
+@pytest.mark.asyncio
 async def test_evening_review_no_completed_goals():
     ctx = _make_context()
     mock_cm = MagicMock()

--- a/backend/tests/test_scheduler_job_audit.py
+++ b/backend/tests/test_scheduler_job_audit.py
@@ -229,6 +229,39 @@ async def test_weekly_activity_review_logs_success(async_db):
 
 
 @pytest.mark.asyncio
+async def test_weekly_activity_review_uses_named_runtime_path():
+    mock_repo = MagicMock()
+    mock_repo.get_weekly_summary = AsyncMock(
+        return_value={
+            "week_start": "2026-03-09",
+            "week_end": "2026-03-15",
+            "total_observations": 12,
+            "total_tracked_minutes": 180,
+            "by_activity": {"coding": 7200},
+            "by_project": {"seraph": 5400},
+            "daily_breakdown": [
+                {"date": date.today().isoformat(), "tracked_minutes": 90, "observations": 6}
+            ],
+        }
+    )
+
+    with (
+        patch("src.observer.screen_repository.screen_observation_repo", mock_repo),
+        patch("src.memory.soul.read_soul", return_value="# Soul"),
+        patch(
+            "src.scheduler.jobs.weekly_activity_review.completion_with_fallback",
+            new=AsyncMock(return_value=_mock_llm_response("Solid week. Keep momentum.")),
+        ) as mock_completion,
+        patch("src.observer.delivery.deliver_or_queue", AsyncMock(return_value=DeliveryDecision.deliver)),
+    ):
+        from src.scheduler.jobs.weekly_activity_review import run_weekly_activity_review
+
+        await run_weekly_activity_review()
+
+    assert mock_completion.await_args.kwargs["runtime_path"] == "weekly_activity_review"
+
+
+@pytest.mark.asyncio
 async def test_weekly_activity_review_logs_timeout(async_db):
     mock_repo = MagicMock()
     mock_repo.get_weekly_summary = AsyncMock(

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -37,12 +37,13 @@ uv run python -m src.evals.harness --list
 uv run python -m src.evals.harness
 uv run python -m src.evals.harness --scenario provider_fallback_chain
 uv run python -m src.evals.harness --scenario local_runtime_profile
+uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
 uv run python -m src.evals.harness --scenario daily_briefing_fallback
 uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, local helper-profile routing, proactive delivery, daemon ingest, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, local helper/scheduler profile routing, proactive delivery, daemon ingest, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -43,8 +43,8 @@ If you want the current truth, use this page plus the workstream files linked be
 
 ### 03. [Runtime Reliability](../plan/runtime-reliability)
 
-- [x] ordered fallbacks, local helper-profile routing, observability, and eval foundations are shipped
-- [ ] smarter provider selection, broader local routing, and remaining edge coverage are still left
+- [x] ordered fallbacks, local helper/scheduler-profile routing, observability, and eval foundations are shipped
+- [ ] smarter provider selection, broader agent-path local routing, and remaining edge coverage are still left
 - focus: routing, fallbacks, observability, evals, and degraded-mode behavior
 
 ### 04. [Presence And Reach](../plan/presence-and-reach)

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -15,7 +15,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] centralized provider-agnostic LLM runtime settings
 - [x] direct LiteLLM fallback path
 - [x] ordered fallback-chain routing across shared completion and agent-model paths
-- [x] first-class local runtime profile for bounded helper flows like context summarization, title generation, and consolidation
+- [x] first-class local runtime profile for bounded helper flows and scheduled completion-based jobs
 - [x] timeout-safe audit visibility into primary-vs-fallback LLM completion and agent-model behavior
 - [x] fallback-capable `smolagents` model wrappers for chat, onboarding, strategist, and specialists
 - [x] repeatable runtime eval harness for core guardian, tool, and observer/audit-runtime reliability contracts
@@ -34,13 +34,13 @@ Make Seraph more resilient, observable, and predictable under real usage.
 ## Left To Do
 
 - [ ] deepen provider routing beyond the ordered fallback chain with smarter health- or policy-aware selection
-- [ ] broaden local-model routing beyond helper completions into more agent and runtime paths where it makes sense
+- [ ] broaden local-model routing beyond helper and scheduled completion paths into more agent and runtime paths where it makes sense
 - [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, daemon ingest, proactive delivery gating, and current MCP lifecycle coverage
 - [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing, local-profile behavior, and remaining edge-path contracts
 
 ## Done Means
 
 - [ ] provider failure does not collapse the entire chat path
-- [ ] a local or non-OpenRouter path is demonstrably possible across more than the current bounded helper flows
+- [ ] a local or non-OpenRouter path is demonstrably possible across more than the current helper and scheduled completion flows
 - [ ] key flows are observable and easier to debug
 - [ ] the project has repeatable eval coverage for core behavior


### PR DESCRIPTION
## Summary
- route scheduled completion-based jobs through explicit named runtime paths so they can use the first-class local runtime profile
- add regression tests and a deterministic eval scenario for scheduled local runtime routing
- update runtime reliability and roadmap docs so shipped versus remaining work stays current

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/scheduler/jobs/daily_briefing.py backend/src/scheduler/jobs/evening_review.py backend/src/scheduler/jobs/activity_digest.py backend/src/scheduler/jobs/weekly_activity_review.py backend/src/evals/harness.py backend/tests/test_daily_briefing.py backend/tests/test_evening_review.py backend/tests/test_activity_digest.py backend/tests/test_scheduler_job_audit.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_daily_briefing.py tests/test_evening_review.py tests/test_activity_digest.py tests/test_scheduler_job_audit.py tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build

## Risks
- local routing still covers helper and scheduled completion flows; broader agent-path local routing remains separate work
