### PR TITLE
Add health-aware provider rerouting

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     local_llm_api_key: str = ""
     local_llm_api_base: str = ""
     local_runtime_paths: str = ""  # comma-separated runtime paths that should prefer local profile
+    llm_target_cooldown_seconds: int = 300  # temporarily deprioritize failed LLM targets across requests
     model_temperature: float = 0.7
     model_max_tokens: int = 4096
     agent_max_steps: int = 10

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -22,7 +22,7 @@ from src.agent.specialists import create_specialist
 from src.agent.strategist import create_strategist_agent
 from src.api.observer import ScreenContextRequest, ScreenObservationData, post_screen_context
 from src.audit.repository import audit_repository
-from src.llm_runtime import FallbackLiteLLMModel, completion_with_fallback_sync
+from src.llm_runtime import FallbackLiteLLMModel, _reset_target_health, completion_with_fallback_sync
 from src.memory.consolidator import consolidate_session
 from src.observer.context import CurrentContext
 from src.observer.delivery import deliver_or_queue
@@ -228,6 +228,55 @@ def _eval_provider_fallback_chain() -> dict[str, Any]:
     return {
         "attempted_models": attempted_models,
         "final_model": attempted_models[-1],
+        "response_excerpt": response.choices[0].message.content,
+    }
+
+
+def _eval_provider_health_reroute() -> dict[str, Any]:
+    first_fallback_response = _make_litellm_response("Recovered through the fallback chain.")
+    rerouted_response = _make_litellm_response("Rerouted straight to the healthy fallback.")
+
+    _reset_target_health()
+    try:
+        with (
+            patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+            patch.object(settings, "fallback_model", ""),
+            patch.object(settings, "fallback_models", "openai/gpt-4o-mini"),
+            patch.object(settings, "llm_api_key", "primary-key"),
+            patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+            patch.object(settings, "llm_target_cooldown_seconds", 300),
+            patch(
+                "litellm.completion",
+                side_effect=[
+                    RuntimeError("primary down"),
+                    first_fallback_response,
+                    rerouted_response,
+                ],
+            ) as mock_completion,
+        ):
+            completion_with_fallback_sync(
+                messages=[{"role": "user", "content": "recover once"}],
+                temperature=0.2,
+                max_tokens=128,
+            )
+            response = completion_with_fallback_sync(
+                messages=[{"role": "user", "content": "recover again"}],
+                temperature=0.2,
+                max_tokens=128,
+            )
+    finally:
+        _reset_target_health()
+
+    attempted_models = [call.kwargs["model"] for call in mock_completion.call_args_list]
+    assert attempted_models == [
+        "openrouter/anthropic/claude-sonnet-4",
+        "openai/gpt-4o-mini",
+        "openai/gpt-4o-mini",
+    ]
+    return {
+        "cooldown_seconds": 300,
+        "rerouted_model": attempted_models[-1],
+        "attempted_models": attempted_models,
         "response_excerpt": response.choices[0].message.content,
     }
 
@@ -636,6 +685,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="runtime",
         description="Direct completion retries across an ordered fallback chain instead of a single backup target.",
         runner=_eval_provider_fallback_chain,
+    ),
+    EvalScenario(
+        name="provider_health_reroute",
+        category="runtime",
+        description="A recently failed primary provider target is temporarily rerouted to a healthy fallback target.",
+        runner=_eval_provider_health_reroute,
     ),
     EvalScenario(
         name="local_runtime_profile",

--- a/backend/src/llm_runtime.py
+++ b/backend/src/llm_runtime.py
@@ -6,6 +6,7 @@ import asyncio
 import contextvars
 import logging
 from threading import Lock
+from time import monotonic
 from typing import Any
 from uuid import uuid4
 
@@ -17,6 +18,8 @@ from src.audit.repository import audit_repository
 logger = logging.getLogger(__name__)
 _runtime_request_lock = Lock()
 _runtime_requests: dict[str, bool] = {}
+_target_health_lock = Lock()
+_unhealthy_targets: dict[tuple[str, str | None, str | None], float] = {}
 _runtime_request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "llm_runtime_request_id",
     default=None,
@@ -217,6 +220,77 @@ def _fallback_targets(
     return targets
 
 
+def _target_cooldown_seconds() -> int:
+    return max(0, settings.llm_target_cooldown_seconds)
+
+
+def _reset_target_health() -> None:
+    with _target_health_lock:
+        _unhealthy_targets.clear()
+
+
+def _mark_target_failed(
+    *,
+    model_id: str,
+    api_base: str | None,
+    api_key: str | None,
+) -> None:
+    cooldown_seconds = _target_cooldown_seconds()
+    if cooldown_seconds <= 0:
+        return
+    with _target_health_lock:
+        _unhealthy_targets[_target_key(model_id=model_id, api_base=api_base, api_key=api_key)] = (
+            monotonic() + cooldown_seconds
+        )
+
+
+def _mark_target_succeeded(
+    *,
+    model_id: str,
+    api_base: str | None,
+    api_key: str | None,
+) -> None:
+    with _target_health_lock:
+        _unhealthy_targets.pop(
+            _target_key(model_id=model_id, api_base=api_base, api_key=api_key),
+            None,
+        )
+
+
+def _is_target_healthy(
+    *,
+    model_id: str,
+    api_base: str | None,
+    api_key: str | None,
+) -> bool:
+    target_key = _target_key(model_id=model_id, api_base=api_base, api_key=api_key)
+    with _target_health_lock:
+        unhealthy_until = _unhealthy_targets.get(target_key)
+        if unhealthy_until is None:
+            return True
+        if unhealthy_until <= monotonic():
+            _unhealthy_targets.pop(target_key, None)
+            return True
+        return False
+
+
+def _partition_targets_by_health(
+    targets: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    healthy_targets: list[dict[str, Any]] = []
+    unhealthy_targets: list[dict[str, Any]] = []
+    for target in targets:
+        if _is_target_healthy(
+            model_id=str(target["model_id"]),
+            api_base=target.get("api_base"),
+            api_key=target.get("api_key"),
+        ):
+            healthy_targets.append(target)
+        else:
+            unhealthy_targets.append(target)
+    return healthy_targets, unhealthy_targets
+
+
 def _register_request(request_id: str) -> None:
     with _runtime_request_lock:
         _runtime_requests[request_id] = False
@@ -361,111 +435,179 @@ class FallbackLiteLLMModel(BaseLiteLLMModel):
     ):
         primary_model = self.model_id
         request_id = _current_llm_request_id()
-        try:
-            response = super().generate(
-                messages,
-                stop_sequences=stop_sequences,
-                response_format=response_format,
-                tools_to_call_from=tools_to_call_from,
-                **kwargs,
+        fallback_targets = [
+            {
+                "model_id": fallback_model.model_id,
+                "api_base": fallback_model.api_base,
+                "api_key": fallback_model.api_key,
+                "model": fallback_model,
+            }
+            for fallback_model in self._fallback_models
+        ]
+        healthy_fallbacks, unhealthy_fallbacks = _partition_targets_by_health(fallback_targets)
+        primary_unhealthy = not _is_target_healthy(
+            model_id=primary_model,
+            api_base=self.api_base,
+            api_key=self.api_key,
+        )
+        rerouted = primary_unhealthy and bool(healthy_fallbacks)
+
+        if rerouted and _can_log_request(request_id):
+            _log_llm_runtime_event_sync(
+                event_type="llm_target_rerouted",
+                summary=(
+                    f"Agent model generate rerouted from unhealthy {primary_model} "
+                    f"to {healthy_fallbacks[0]['model_id']}"
+                ),
+                details={
+                    "runtime_path": "agent_generate",
+                    "primary_model": primary_model,
+                    "rerouted_model": healthy_fallbacks[0]["model_id"],
+                    "unhealthy_models": [primary_model],
+                    "cooldown_seconds": _target_cooldown_seconds(),
+                },
             )
-            if _can_log_request(request_id):
-                _log_llm_runtime_event_sync(
-                    event_type="llm_primary_success",
-                    summary=f"Primary agent model generate succeeded via {primary_model}",
-                    details={
-                        "runtime_path": "agent_generate",
-                        "primary_model": primary_model,
-                        "used_fallback": False,
-                    },
+
+        ordered_fallbacks = healthy_fallbacks + unhealthy_fallbacks
+        primary_attempted = False
+        primary_error: Exception | None = None
+        attempted_fallback_models: list[str] = []
+        fallback_errors: list[dict[str, str]] = []
+
+        if not rerouted:
+            try:
+                response = super().generate(
+                    messages,
+                    stop_sequences=stop_sequences,
+                    response_format=response_format,
+                    tools_to_call_from=tools_to_call_from,
+                    **kwargs,
                 )
-            return response
-        except Exception as primary_error:
-            if not self._fallback_models:
+                _mark_target_succeeded(
+                    model_id=primary_model,
+                    api_base=self.api_base,
+                    api_key=self.api_key,
+                )
                 if _can_log_request(request_id):
                     _log_llm_runtime_event_sync(
-                        event_type="llm_primary_failure",
-                        summary=f"Primary agent model generate failed via {primary_model}",
+                        event_type="llm_primary_success",
+                        summary=f"Primary agent model generate succeeded via {primary_model}",
                         details={
                             "runtime_path": "agent_generate",
                             "primary_model": primary_model,
                             "used_fallback": False,
-                            "error": str(primary_error),
                         },
                     )
-                raise
-            attempted_fallback_models: list[str] = []
-            fallback_errors: list[dict[str, str]] = []
-            last_error: Exception = primary_error
-
-            for index, fallback_model in enumerate(self._fallback_models):
-                attempted_fallback_models.append(fallback_model.model_id)
-                if index == 0:
-                    logger.warning(
-                        "LLM generate failed for %s, retrying with fallback %s",
-                        primary_model,
-                        fallback_model.model_id,
-                        exc_info=True,
-                    )
-                try:
-                    response = fallback_model.generate(
-                        messages,
-                        stop_sequences=stop_sequences,
-                        response_format=response_format,
-                        tools_to_call_from=tools_to_call_from,
-                        **kwargs,
-                    )
+                return response
+            except Exception as error:
+                primary_attempted = True
+                primary_error = error
+                _mark_target_failed(
+                    model_id=primary_model,
+                    api_base=self.api_base,
+                    api_key=self.api_key,
+                )
+                if not ordered_fallbacks:
                     if _can_log_request(request_id):
                         _log_llm_runtime_event_sync(
-                            event_type="llm_fallback_success",
-                            summary=(
-                                f"Fallback agent model generate succeeded via {fallback_model.model_id}"
-                            ),
+                            event_type="llm_primary_failure",
+                            summary=f"Primary agent model generate failed via {primary_model}",
                             details={
                                 "runtime_path": "agent_generate",
                                 "primary_model": primary_model,
-                                "fallback_model": fallback_model.model_id,
-                                "attempted_fallback_models": attempted_fallback_models,
-                                "fallback_attempts": len(attempted_fallback_models),
-                                "used_fallback": True,
-                                "primary_error": str(primary_error),
+                                "used_fallback": False,
+                                "error": str(error),
                             },
                         )
-                    return response
-                except Exception as fallback_error:
-                    last_error = fallback_error
-                    fallback_errors.append(
-                        {
-                            "model": fallback_model.model_id,
-                            "error": str(fallback_error),
-                        }
-                    )
-                    if index + 1 < len(self._fallback_models):
-                        logger.warning(
-                            "Fallback model %s failed, retrying with next fallback %s",
-                            fallback_model.model_id,
-                            self._fallback_models[index + 1].model_id,
-                            exc_info=True,
-                        )
+                    raise
+                logger.warning(
+                    "LLM generate failed for %s, retrying with fallback %s",
+                    primary_model,
+                    ordered_fallbacks[0]["model_id"],
+                    exc_info=True,
+                )
 
-            if _can_log_request(request_id):
-                final_fallback_model = attempted_fallback_models[-1]
-                _log_llm_runtime_event_sync(
-                    event_type="llm_fallback_failure",
-                    summary=f"Fallback agent model generate failed via {final_fallback_model}",
-                    details={
+        last_error: Exception = primary_error or RuntimeError("No fallback targets available")
+
+        for index, target in enumerate(ordered_fallbacks):
+            fallback_model = target["model"]
+            attempted_fallback_models.append(fallback_model.model_id)
+            try:
+                response = fallback_model.generate(
+                    messages,
+                    stop_sequences=stop_sequences,
+                    response_format=response_format,
+                    tools_to_call_from=tools_to_call_from,
+                    **kwargs,
+                )
+                _mark_target_succeeded(
+                    model_id=fallback_model.model_id,
+                    api_base=fallback_model.api_base,
+                    api_key=fallback_model.api_key,
+                )
+                if _can_log_request(request_id):
+                    details = {
                         "runtime_path": "agent_generate",
                         "primary_model": primary_model,
-                        "fallback_model": final_fallback_model,
+                        "fallback_model": fallback_model.model_id,
                         "attempted_fallback_models": attempted_fallback_models,
                         "fallback_attempts": len(attempted_fallback_models),
                         "used_fallback": True,
-                        "primary_error": str(primary_error),
-                        "fallback_error": str(last_error),
-                        "fallback_errors": fallback_errors,
-                    },
+                        "primary_attempted": primary_attempted,
+                    }
+                    if primary_error is not None:
+                        details["primary_error"] = str(primary_error)
+                    if rerouted:
+                        details["rerouted_from_unhealthy_primary"] = True
+                    _log_llm_runtime_event_sync(
+                        event_type="llm_fallback_success",
+                        summary=f"Fallback agent model generate succeeded via {fallback_model.model_id}",
+                        details=details,
+                    )
+                return response
+            except Exception as fallback_error:
+                last_error = fallback_error
+                _mark_target_failed(
+                    model_id=fallback_model.model_id,
+                    api_base=fallback_model.api_base,
+                    api_key=fallback_model.api_key,
                 )
-            raise last_error
+                fallback_errors.append(
+                    {
+                        "model": fallback_model.model_id,
+                        "error": str(fallback_error),
+                    }
+                )
+                if index + 1 < len(ordered_fallbacks):
+                    logger.warning(
+                        "Fallback model %s failed, retrying with next fallback %s",
+                        fallback_model.model_id,
+                        ordered_fallbacks[index + 1]["model_id"],
+                        exc_info=True,
+                    )
+
+        if attempted_fallback_models and _can_log_request(request_id):
+            details = {
+                "runtime_path": "agent_generate",
+                "primary_model": primary_model,
+                "fallback_model": attempted_fallback_models[-1],
+                "attempted_fallback_models": attempted_fallback_models,
+                "fallback_attempts": len(attempted_fallback_models),
+                "used_fallback": True,
+                "fallback_error": str(last_error),
+                "fallback_errors": fallback_errors,
+                "primary_attempted": primary_attempted,
+            }
+            if primary_error is not None:
+                details["primary_error"] = str(primary_error)
+            if rerouted:
+                details["rerouted_from_unhealthy_primary"] = True
+            _log_llm_runtime_event_sync(
+                event_type="llm_fallback_failure",
+                summary=f"Fallback agent model generate failed via {attempted_fallback_models[-1]}",
+                details=details,
+            )
+        raise last_error
 
 
 def completion_with_fallback_sync(
@@ -492,117 +634,178 @@ def completion_with_fallback_sync(
             profile=resolved_profile,
         )
         primary_model = _safe_model_name(primary_kwargs)
-        try:
-            response = litellm.completion(**primary_kwargs)
-            if _can_log_request(request_id):
-                _log_llm_runtime_event_sync(
-                    event_type="llm_primary_success",
-                    summary=f"Primary LLM completion succeeded via {primary_model}",
-                    details={
-                        "runtime_path": runtime_path,
-                        "runtime_profile": resolved_profile,
-                        "primary_model": primary_model,
-                        "used_fallback": False,
-                    },
-                )
-            return response
-        except Exception as primary_error:
-            fallback_targets = _fallback_targets(
-                primary_model_id=primary_model,
-                primary_api_base=primary_kwargs.get("api_base"),
-                primary_api_key=primary_kwargs.get("api_key"),
-                primary_profile=resolved_profile,
+        fallback_targets = _fallback_targets(
+            primary_model_id=primary_model,
+            primary_api_base=primary_kwargs.get("api_base"),
+            primary_api_key=primary_kwargs.get("api_key"),
+            primary_profile=resolved_profile,
+        )
+        healthy_fallbacks, unhealthy_fallbacks = _partition_targets_by_health(fallback_targets)
+        primary_unhealthy = not _is_target_healthy(
+            model_id=primary_model,
+            api_base=primary_kwargs.get("api_base"),
+            api_key=primary_kwargs.get("api_key"),
+        )
+        rerouted = primary_unhealthy and bool(healthy_fallbacks)
+
+        if rerouted and _can_log_request(request_id):
+            _log_llm_runtime_event_sync(
+                event_type="llm_target_rerouted",
+                summary=(
+                    f"LLM completion rerouted from unhealthy {primary_model} "
+                    f"to {healthy_fallbacks[0]['model_id']}"
+                ),
+                details={
+                    "runtime_path": runtime_path,
+                    "runtime_profile": resolved_profile,
+                    "primary_model": primary_model,
+                    "rerouted_model": healthy_fallbacks[0]["model_id"],
+                    "unhealthy_models": [primary_model],
+                    "cooldown_seconds": _target_cooldown_seconds(),
+                },
             )
-            if not fallback_targets:
+
+        ordered_fallbacks = healthy_fallbacks + unhealthy_fallbacks
+        primary_attempted = False
+        primary_error: Exception | None = None
+        attempted_fallback_models: list[str] = []
+        fallback_errors: list[dict[str, str]] = []
+
+        if not rerouted:
+            try:
+                response = litellm.completion(**primary_kwargs)
+                _mark_target_succeeded(
+                    model_id=primary_model,
+                    api_base=primary_kwargs.get("api_base"),
+                    api_key=primary_kwargs.get("api_key"),
+                )
                 if _can_log_request(request_id):
                     _log_llm_runtime_event_sync(
-                        event_type="llm_primary_failure",
-                        summary=f"Primary LLM completion failed via {primary_model}",
+                        event_type="llm_primary_success",
+                        summary=f"Primary LLM completion succeeded via {primary_model}",
                         details={
                             "runtime_path": runtime_path,
                             "runtime_profile": resolved_profile,
                             "primary_model": primary_model,
                             "used_fallback": False,
-                            "error": str(primary_error),
                         },
                     )
-                raise
-            attempted_fallback_models: list[str] = []
-            fallback_errors: list[dict[str, str]] = []
-            last_error: Exception = primary_error
-
-            for index, target in enumerate(fallback_targets):
-                fallback_kwargs = build_completion_kwargs(
-                    messages=messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    use_fallback=True,
-                    fallback_model_id=str(target["model_id"]),
-                    fallback_api_key=target["api_key"],
-                    fallback_api_base=target["api_base"],
+                return response
+            except Exception as error:
+                primary_attempted = True
+                primary_error = error
+                _mark_target_failed(
+                    model_id=primary_model,
+                    api_base=primary_kwargs.get("api_base"),
+                    api_key=primary_kwargs.get("api_key"),
                 )
-                fallback_model = _safe_model_name(fallback_kwargs)
-                attempted_fallback_models.append(fallback_model)
-                if index == 0:
-                    logger.warning(
-                        "LLM completion failed for model %s, retrying with fallback %s",
-                        primary_model,
-                        fallback_model,
-                        exc_info=True,
-                    )
-                try:
-                    response = litellm.completion(**fallback_kwargs)
+                if not ordered_fallbacks:
                     if _can_log_request(request_id):
                         _log_llm_runtime_event_sync(
-                            event_type="llm_fallback_success",
-                            summary=f"Fallback LLM completion succeeded via {fallback_model}",
+                            event_type="llm_primary_failure",
+                            summary=f"Primary LLM completion failed via {primary_model}",
                             details={
                                 "runtime_path": runtime_path,
                                 "runtime_profile": resolved_profile,
                                 "primary_model": primary_model,
-                                "fallback_model": fallback_model,
-                                "attempted_fallback_models": attempted_fallback_models,
-                                "fallback_attempts": len(attempted_fallback_models),
-                                "used_fallback": True,
-                                "primary_error": str(primary_error),
+                                "used_fallback": False,
+                                "error": str(error),
                             },
                         )
-                    return response
-                except Exception as fallback_error:
-                    last_error = fallback_error
-                    fallback_errors.append(
-                        {
-                            "model": fallback_model,
-                            "error": str(fallback_error),
-                        }
-                    )
-                    if index + 1 < len(fallback_targets):
-                        logger.warning(
-                            "Fallback model %s failed, retrying with next fallback %s",
-                            fallback_model,
-                            fallback_targets[index + 1]["model_id"],
-                            exc_info=True,
-                        )
+                    raise
+                logger.warning(
+                    "LLM completion failed for model %s, retrying with fallback %s",
+                    primary_model,
+                    ordered_fallbacks[0]["model_id"],
+                    exc_info=True,
+                )
 
-            final_fallback_model = attempted_fallback_models[-1]
-            if _can_log_request(request_id):
-                _log_llm_runtime_event_sync(
-                    event_type="llm_fallback_failure",
-                    summary=f"Fallback LLM completion failed via {final_fallback_model}",
-                    details={
+        last_error: Exception = primary_error or RuntimeError("No fallback targets available")
+
+        for index, target in enumerate(ordered_fallbacks):
+            fallback_kwargs = build_completion_kwargs(
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                use_fallback=True,
+                fallback_model_id=str(target["model_id"]),
+                fallback_api_key=target["api_key"],
+                fallback_api_base=target["api_base"],
+            )
+            fallback_model = _safe_model_name(fallback_kwargs)
+            attempted_fallback_models.append(fallback_model)
+            try:
+                response = litellm.completion(**fallback_kwargs)
+                _mark_target_succeeded(
+                    model_id=fallback_model,
+                    api_base=target["api_base"],
+                    api_key=target["api_key"],
+                )
+                if _can_log_request(request_id):
+                    details = {
                         "runtime_path": runtime_path,
                         "runtime_profile": resolved_profile,
                         "primary_model": primary_model,
-                        "fallback_model": final_fallback_model,
+                        "fallback_model": fallback_model,
                         "attempted_fallback_models": attempted_fallback_models,
                         "fallback_attempts": len(attempted_fallback_models),
                         "used_fallback": True,
-                        "primary_error": str(primary_error),
-                        "fallback_error": str(last_error),
-                        "fallback_errors": fallback_errors,
-                    },
+                        "primary_attempted": primary_attempted,
+                    }
+                    if primary_error is not None:
+                        details["primary_error"] = str(primary_error)
+                    if rerouted:
+                        details["rerouted_from_unhealthy_primary"] = True
+                    _log_llm_runtime_event_sync(
+                        event_type="llm_fallback_success",
+                        summary=f"Fallback LLM completion succeeded via {fallback_model}",
+                        details=details,
+                    )
+                return response
+            except Exception as fallback_error:
+                last_error = fallback_error
+                _mark_target_failed(
+                    model_id=fallback_model,
+                    api_base=target["api_base"],
+                    api_key=target["api_key"],
                 )
-            raise last_error
+                fallback_errors.append(
+                    {
+                        "model": fallback_model,
+                        "error": str(fallback_error),
+                    }
+                )
+                if index + 1 < len(ordered_fallbacks):
+                    logger.warning(
+                        "Fallback model %s failed, retrying with next fallback %s",
+                        fallback_model,
+                        ordered_fallbacks[index + 1]["model_id"],
+                        exc_info=True,
+                    )
+
+        if attempted_fallback_models and _can_log_request(request_id):
+            details = {
+                "runtime_path": runtime_path,
+                "runtime_profile": resolved_profile,
+                "primary_model": primary_model,
+                "fallback_model": attempted_fallback_models[-1],
+                "attempted_fallback_models": attempted_fallback_models,
+                "fallback_attempts": len(attempted_fallback_models),
+                "used_fallback": True,
+                "fallback_error": str(last_error),
+                "fallback_errors": fallback_errors,
+                "primary_attempted": primary_attempted,
+            }
+            if primary_error is not None:
+                details["primary_error"] = str(primary_error)
+            if rerouted:
+                details["rerouted_from_unhealthy_primary"] = True
+            _log_llm_runtime_event_sync(
+                event_type="llm_fallback_failure",
+                summary=f"Fallback LLM completion failed via {attempted_fallback_models[-1]}",
+                details=details,
+            )
+        raise last_error
     finally:
         if request_id is not None:
             _finish_request(request_id)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,6 +14,7 @@ os.environ.setdefault("OPENROUTER_API_KEY", "test-key")
 os.environ.setdefault("WORKSPACE_DIR", "/tmp/seraph-test")
 
 from src.app import create_app
+from src.llm_runtime import _reset_target_health
 
 # Every place get_session is imported — use the local attribute name.
 _PATCH_TARGETS = [
@@ -93,3 +94,10 @@ def mock_agent():
     agent = MagicMock()
     agent.run.return_value = "Mocked agent response"
     return agent
+
+
+@pytest.fixture(autouse=True)
+def reset_llm_target_health():
+    _reset_target_health()
+    yield
+    _reset_target_health()

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -42,6 +42,7 @@ def test_main_lists_available_scenarios(capsys):
     assert exit_code == 0
     assert "chat_model_wrapper" in captured.out
     assert "provider_fallback_chain" in captured.out
+    assert "provider_health_reroute" in captured.out
     assert "local_runtime_profile" in captured.out
     assert "agent_local_runtime_profile" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
@@ -64,6 +65,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
         run_runtime_evals(
             [
                 "provider_fallback_chain",
+                "provider_health_reroute",
                 "local_runtime_profile",
                 "agent_local_runtime_profile",
                 "scheduled_local_runtime_profile",
@@ -82,6 +84,12 @@ def test_runtime_eval_scenarios_expose_expected_details():
         "openai/gpt-4.1-mini",
     ]
     assert details_by_name["provider_fallback_chain"]["final_model"] == "openai/gpt-4.1-mini"
+    assert details_by_name["provider_health_reroute"]["attempted_models"] == [
+        "openrouter/anthropic/claude-sonnet-4",
+        "openai/gpt-4o-mini",
+        "openai/gpt-4o-mini",
+    ]
+    assert details_by_name["provider_health_reroute"]["rerouted_model"] == "openai/gpt-4o-mini"
     assert details_by_name["local_runtime_profile"]["runtime_profile"] == "local"
     assert details_by_name["local_runtime_profile"]["routed_model"] == "ollama/llama3.2"
     assert details_by_name["agent_local_runtime_profile"]["routed_models"]["chat_agent"] == "ollama/llama3.2"

--- a/backend/tests/test_llm_runtime.py
+++ b/backend/tests/test_llm_runtime.py
@@ -10,6 +10,7 @@ from config.settings import settings
 from src.audit.repository import audit_repository
 from src.llm_runtime import (
     FallbackLiteLLMModel,
+    _reset_target_health,
     build_completion_kwargs,
     build_model_kwargs,
     completion_with_fallback,
@@ -315,6 +316,56 @@ def test_completion_with_fallback_sync_walks_fallback_chain(async_db):
     assert events[0]["details"]["fallback_attempts"] == 2
 
 
+def test_completion_with_fallback_sync_reroutes_away_from_unhealthy_primary(async_db):
+    first_fallback_response = MagicMock()
+    rerouted_response = MagicMock()
+
+    _reset_target_health()
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", "openai/gpt-4o-mini"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "llm_target_cooldown_seconds", 300),
+        patch(
+            "litellm.completion",
+            side_effect=[
+                RuntimeError("primary down"),
+                first_fallback_response,
+                rerouted_response,
+            ],
+        ) as mock_completion,
+    ):
+        first_result = completion_with_fallback_sync(
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=0.3,
+            max_tokens=256,
+        )
+        second_result = completion_with_fallback_sync(
+            messages=[{"role": "user", "content": "hello again"}],
+            temperature=0.3,
+            max_tokens=256,
+        )
+
+    assert first_result is first_fallback_response
+    assert second_result is rerouted_response
+    assert [call.kwargs["model"] for call in mock_completion.call_args_list] == [
+        "openrouter/anthropic/claude-sonnet-4",
+        "openai/gpt-4o-mini",
+        "openai/gpt-4o-mini",
+    ]
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=10)
+        return [e for e in events if e["event_type"] == "llm_target_rerouted"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["details"]["primary_model"] == "openrouter/anthropic/claude-sonnet-4"
+    assert events[0]["details"]["rerouted_model"] == "openai/gpt-4o-mini"
+
+
 def test_completion_with_fallback_sync_logs_primary_success(async_db):
     success_response = MagicMock()
 
@@ -533,6 +584,62 @@ def test_fallback_litellm_model_walks_fallback_chain(async_db):
         "openai/gpt-4.1-mini",
     ]
     assert events[0]["details"]["fallback_attempts"] == 2
+
+
+def test_fallback_litellm_model_reroutes_away_from_unhealthy_primary(async_db):
+    first_fallback_response = MagicMock()
+    rerouted_response = MagicMock()
+
+    _reset_target_health()
+    with (
+        patch.object(settings, "fallback_model", "ollama/llama3.2"),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "llm_target_cooldown_seconds", 300),
+        patch(
+            "src.llm_runtime.BaseLiteLLMModel.generate",
+            autospec=True,
+            side_effect=[
+                RuntimeError("primary down"),
+                first_fallback_response,
+                rerouted_response,
+            ],
+        ) as mock_generate,
+    ):
+        model = FallbackLiteLLMModel(
+            model_id="openrouter/anthropic/claude-sonnet-4",
+            api_key="primary-key",
+            api_base="https://openrouter.ai/api/v1",
+            temperature=0.3,
+            max_tokens=256,
+        )
+        first_result = model.generate([{"role": "user", "content": "hello"}])
+
+        rerouted_model = FallbackLiteLLMModel(
+            model_id="openrouter/anthropic/claude-sonnet-4",
+            api_key="primary-key",
+            api_base="https://openrouter.ai/api/v1",
+            temperature=0.3,
+            max_tokens=256,
+        )
+        second_result = rerouted_model.generate([{"role": "user", "content": "hello again"}])
+
+    assert first_result is first_fallback_response
+    assert second_result is rerouted_response
+    assert [call.args[0].model_id for call in mock_generate.call_args_list] == [
+        "openrouter/anthropic/claude-sonnet-4",
+        "ollama/llama3.2",
+        "ollama/llama3.2",
+    ]
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=10)
+        return [e for e in events if e["event_type"] == "llm_target_rerouted"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["details"]["primary_model"] == "openrouter/anthropic/claude-sonnet-4"
+    assert events[0]["details"]["rerouted_model"] == "ollama/llama3.2"
 
 
 def test_fallback_litellm_model_skips_duplicate_fallback_target():

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -36,6 +36,7 @@ cd backend
 uv run python -m src.evals.harness --list
 uv run python -m src.evals.harness
 uv run python -m src.evals.harness --scenario provider_fallback_chain
+uv run python -m src.evals.harness --scenario provider_health_reroute
 uv run python -m src.evals.harness --scenario local_runtime_profile
 uv run python -m src.evals.harness --scenario agent_local_runtime_profile
 uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
@@ -44,7 +45,7 @@ uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -43,8 +43,8 @@ If you want the current truth, use this page plus the workstream files linked be
 
 ### 03. [Runtime Reliability](../plan/runtime-reliability)
 
-- [x] ordered fallbacks, local helper/agent/scheduler-profile routing, observability, and eval foundations are shipped
-- [ ] smarter provider selection and remaining edge coverage are still left
+- [x] ordered fallbacks, health-aware provider rerouting, local helper/agent/scheduler-profile routing, observability, and eval foundations are shipped
+- [ ] deeper policy-aware provider selection and remaining edge coverage are still left
 - focus: routing, fallbacks, observability, evals, and degraded-mode behavior
 
 ### 04. [Presence And Reach](../plan/presence-and-reach)

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -15,6 +15,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] centralized provider-agnostic LLM runtime settings
 - [x] direct LiteLLM fallback path
 - [x] ordered fallback-chain routing across shared completion and agent-model paths
+- [x] health-aware cooldown rerouting across shared completion and agent-model paths
 - [x] first-class local runtime profile for bounded helper flows, scheduled completion-based jobs, and core agent model factories
 - [x] timeout-safe audit visibility into primary-vs-fallback LLM completion and agent-model behavior
 - [x] fallback-capable `smolagents` model wrappers for chat, onboarding, strategist, and specialists
@@ -33,14 +34,14 @@ Make Seraph more resilient, observable, and predictable under real usage.
 
 ## Left To Do
 
-- [ ] deepen provider routing beyond the ordered fallback chain with smarter health- or policy-aware selection
+- [ ] deepen provider routing beyond the current ordered fallback and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduled completion, and core agent-model paths into any remaining runtime paths where it makes sense
 - [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, daemon ingest, proactive delivery gating, and current MCP lifecycle coverage
 - [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing, local-profile behavior, and remaining edge-path contracts
 
 ## Done Means
 
-- [ ] provider failure does not collapse the entire chat path
+- [x] provider failure with configured fallbacks does not collapse the entire chat path
 - [x] a local or non-OpenRouter path is demonstrably possible across more than the current helper and scheduled completion flows
 - [ ] key flows are observable and easier to debug
 - [ ] the project has repeatable eval coverage for core behavior


### PR DESCRIPTION
## Summary
- add health-aware cooldown rerouting so recently failed LLM targets are temporarily deprioritized across completion and agent-model paths
- add deterministic regression coverage and a runtime eval scenario for repeated primary-provider failure rerouting
- update the Runtime Reliability plan and roadmap docs so shipped versus remaining provider-routing work is current

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/config/settings.py backend/src/llm_runtime.py backend/src/evals/harness.py backend/tests/conftest.py backend/tests/test_llm_runtime.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_llm_runtime.py tests/test_eval_harness.py tests/test_agent.py tests/test_specialists.py tests/test_strategist.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario provider_health_reroute --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build

## Risks
- routing is now health-aware via cooldowns, but it is still not a full policy-aware or cost-aware provider selector
