### PR TITLE
Trace browser and sandbox runtime boundaries

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -482,6 +482,31 @@ def _eval_shell_tool_timeout_contract() -> dict[str, Any]:
     return {"result": result}
 
 
+async def _eval_shell_tool_runtime_audit() -> dict[str, Any]:
+    mock_client = MagicMock()
+    mock_client.post.side_effect = httpx.TimeoutException("timeout")
+
+    with (
+        patch("src.tools.shell_tool.httpx.Client") as client_cls,
+        patch.object(audit_repository, "log_event", AsyncMock()) as mock_log_event,
+    ):
+        client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        result = shell_execute("import time; time.sleep(999)")
+        await asyncio.sleep(0)
+
+    assert "timed out" in result.lower()
+    timed_out = _find_audit_call(
+        mock_log_event,
+        event_type="integration_timed_out",
+        tool_name="sandbox:snekbox",
+    )
+    return {
+        "result": result,
+        "timeout_seconds": timed_out["details"]["timeout_seconds"],
+    }
+
+
 async def _eval_strategist_tick_tool_audit() -> dict[str, Any]:
     mock_context_manager = MagicMock()
     mock_context_manager.refresh = AsyncMock(return_value=_make_context())
@@ -733,6 +758,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="tool",
         description="Shell tool returns a clear timeout contract when sandbox execution stalls.",
         runner=_eval_shell_tool_timeout_contract,
+    ),
+    EvalScenario(
+        name="shell_tool_runtime_audit",
+        category="observability",
+        description="Shell tool timeout records sandbox runtime audit coverage.",
+        runner=_eval_shell_tool_runtime_audit,
     ),
     EvalScenario(
         name="strategist_tick_tool_audit",

--- a/backend/src/tools/browser_tool.py
+++ b/backend/src/tools/browser_tool.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from smolagents import tool
 
 from config.settings import settings
+from src.audit.runtime import log_integration_event_sync
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,15 @@ def _is_internal_url(url: str) -> bool:
         return True
 
     return False
+
+
+def _browser_details(url: str, action: str) -> dict[str, str]:
+    parsed = urlparse(url)
+    return {
+        "hostname": parsed.hostname or "",
+        "scheme": parsed.scheme or "",
+        "action": action,
+    }
 
 
 async def _browse(url: str, action: str) -> str:
@@ -110,6 +120,12 @@ def browse_webpage(url: str, action: str = "extract") -> str:
         return "Error: URL must start with http:// or https://"
 
     if _is_internal_url(url):
+        log_integration_event_sync(
+            integration_type="browser",
+            name="playwright",
+            outcome="blocked",
+            details=_browser_details(url, action),
+        )
         return "Error: Access to internal/private network addresses is not allowed."
 
     if action not in ("extract", "html", "screenshot"):
@@ -119,7 +135,22 @@ def browse_webpage(url: str, action: str = "extract") -> str:
         import concurrent.futures
         with concurrent.futures.ThreadPoolExecutor() as pool:
             result = pool.submit(asyncio.run, _browse(url, action)).result()
+        log_integration_event_sync(
+            integration_type="browser",
+            name="playwright",
+            outcome="succeeded",
+            details=_browser_details(url, action),
+        )
         return result
     except Exception as e:
+        log_integration_event_sync(
+            integration_type="browser",
+            name="playwright",
+            outcome="failed",
+            details={
+                **_browser_details(url, action),
+                "error": str(e),
+            },
+        )
         logger.exception("Browser automation failed")
         return f"Error browsing {url}: {e}"

--- a/backend/src/tools/shell_tool.py
+++ b/backend/src/tools/shell_tool.py
@@ -6,6 +6,7 @@ import httpx
 from smolagents import tool
 
 from config.settings import settings
+from src.audit.runtime import log_integration_event_sync
 
 logger = logging.getLogger(__name__)
 
@@ -48,17 +49,54 @@ def shell_execute(code: str, language: str = "python") -> str:
         returncode = result.get("returncode", -1)
 
         if returncode != 0:
+            log_integration_event_sync(
+                integration_type="sandbox",
+                name="snekbox",
+                outcome="returned_nonzero",
+                details={
+                    "returncode": returncode,
+                    "stdout_length": len(stdout),
+                    "stderr_present": bool(result.get("stderr", "")),
+                },
+            )
             stderr = result.get("stderr", "")
             if stderr:
                 return f"Exit code {returncode}:\n{stdout}\n--- stderr ---\n{stderr}"
             return f"Exit code {returncode}:\n{stdout}" if stdout else f"Execution failed with exit code {returncode}."
 
+        log_integration_event_sync(
+            integration_type="sandbox",
+            name="snekbox",
+            outcome="succeeded",
+            details={
+                "returncode": returncode,
+                "stdout_length": len(stdout),
+            },
+        )
         return stdout if stdout else "(no output)"
 
     except httpx.TimeoutException:
+        log_integration_event_sync(
+            integration_type="sandbox",
+            name="snekbox",
+            outcome="timed_out",
+            details={"timeout_seconds": settings.sandbox_timeout},
+        )
         return f"Error: Code execution timed out after {settings.sandbox_timeout}s."
     except httpx.ConnectError:
+        log_integration_event_sync(
+            integration_type="sandbox",
+            name="snekbox",
+            outcome="unavailable",
+            details={"sandbox_url": sandbox_url},
+        )
         return "Error: Sandbox service is not available. The snekbox container may not be running."
     except Exception as e:
+        log_integration_event_sync(
+            integration_type="sandbox",
+            name="snekbox",
+            outcome="failed",
+            details={"error": str(e)},
+        )
         logger.exception("Shell execution failed")
         return f"Error: {e}"

--- a/backend/tests/test_browser_tool.py
+++ b/backend/tests/test_browser_tool.py
@@ -1,0 +1,61 @@
+"""Tests for browse_webpage tool runtime integration coverage."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from src.audit.repository import audit_repository
+from src.tools.browser_tool import browse_webpage
+
+
+class _ImmediateFuture:
+    def __init__(self, value):
+        self._value = value
+
+    def result(self):
+        return self._value
+
+
+class _ImmediateExecutor:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def submit(self, fn, *args, **kwargs):
+        return _ImmediateFuture(fn(*args, **kwargs))
+
+
+def test_browse_webpage_logs_blocked_runtime_audit(async_db):
+    result = browse_webpage("http://localhost:3000/secret")
+
+    assert "internal/private" in result.lower()
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "integration_blocked"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["tool_name"] == "browser:playwright"
+    assert events[0]["details"]["hostname"] == "localhost"
+
+
+def test_browse_webpage_logs_success_runtime_audit(async_db):
+    with (
+        patch("src.tools.browser_tool._browse", new=AsyncMock(return_value="hello from page")),
+        patch("concurrent.futures.ThreadPoolExecutor", return_value=_ImmediateExecutor()),
+    ):
+        result = browse_webpage("https://example.com/docs")
+
+    assert result == "hello from page"
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "integration_succeeded"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["tool_name"] == "browser:playwright"
+    assert events[0]["details"]["hostname"] == "example.com"
+    assert events[0]["details"]["action"] == "extract"

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -46,6 +46,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "local_runtime_profile" in captured.out
     assert "agent_local_runtime_profile" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
+    assert "shell_tool_runtime_audit" in captured.out
     assert "observer_daemon_ingest_audit" in captured.out
 
 
@@ -69,6 +70,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "local_runtime_profile",
                 "agent_local_runtime_profile",
                 "scheduled_local_runtime_profile",
+                "shell_tool_runtime_audit",
                 "observer_delivery_gate_audit",
                 "observer_daemon_ingest_audit",
             ]
@@ -96,6 +98,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["agent_local_runtime_profile"]["routed_models"]["memory_keeper"] == "ollama/llama3.2"
     assert details_by_name["scheduled_local_runtime_profile"]["job_name"] == "daily_briefing"
     assert details_by_name["scheduled_local_runtime_profile"]["routed_model"] == "ollama/llama3.2"
+    assert details_by_name["shell_tool_runtime_audit"]["timeout_seconds"] == 35
     assert details_by_name["observer_delivery_gate_audit"]["delivered_user_state"] == "available"
     assert details_by_name["observer_delivery_gate_audit"]["queued_user_state"] == "deep_work"
     assert details_by_name["observer_daemon_ingest_audit"]["persisted_app"] == "VS Code"

--- a/backend/tests/test_shell_tool.py
+++ b/backend/tests/test_shell_tool.py
@@ -1,10 +1,12 @@
 """Tests for shell_execute tool (src/tools/shell_tool.py)."""
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
+from src.audit.repository import audit_repository
 from src.tools.shell_tool import shell_execute
 
 
@@ -73,3 +75,42 @@ class TestShellExecute:
 
         result = shell_execute("print(1)")
         assert "not available" in result.lower()
+
+    @patch("src.tools.shell_tool.httpx.Client")
+    def test_success_logs_runtime_audit(self, MockClient, async_db):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"stdout": "hello\n", "returncode": 0}
+        mock_resp.raise_for_status = MagicMock()
+        MockClient.return_value.__enter__ = MagicMock(return_value=MagicMock(post=MagicMock(return_value=mock_resp)))
+        MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = shell_execute('print("hello")')
+        assert "hello" in result
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_succeeded"]
+
+        events = asyncio.run(_fetch())
+        assert events
+        assert events[0]["tool_name"] == "sandbox:snekbox"
+        assert events[0]["details"]["returncode"] == 0
+
+    @patch("src.tools.shell_tool.httpx.Client")
+    def test_timeout_logs_runtime_audit(self, MockClient, async_db):
+        MockClient.return_value.__enter__ = MagicMock(
+            return_value=MagicMock(post=MagicMock(side_effect=httpx.TimeoutException("timeout")))
+        )
+        MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = shell_execute("import time; time.sleep(999)")
+        assert "timed out" in result.lower()
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_timed_out"]
+
+        events = asyncio.run(_fetch())
+        assert events
+        assert events[0]["tool_name"] == "sandbox:snekbox"
+        assert events[0]["details"]["timeout_seconds"] == 35

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -41,11 +41,12 @@ uv run python -m src.evals.harness --scenario local_runtime_profile
 uv run python -m src.evals.harness --scenario agent_local_runtime_profile
 uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
 uv run python -m src.evals.harness --scenario daily_briefing_fallback
+uv run python -m src.evals.harness --scenario shell_tool_runtime_audit
 uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, sandbox timeout auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -67,6 +68,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 |---|---|---|
 | `test_agent.py` | 8 | Agent factory — tool count, model creation, context injection |
 | `test_catalog_api.py` | 9 | Catalog API — browse catalog, install skills/MCP servers |
+| `test_browser_tool.py` | 2 | Browser tool — blocked internal URLs and successful runtime audit logging |
 | `test_chat_api.py` | 5 | REST chat endpoint — success, session continuity, errors |
 | `test_consolidation_reliability.py` | 6 | Memory consolidation reliability — edge cases, retry behavior |
 | `test_consolidator.py` | 5 | Memory consolidation — extract facts, soul updates, markdown fences, LLM failure |
@@ -98,7 +100,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_session.py` | 23 | SessionManager — async DB-backed CRUD, history, pagination, title generation |
 | `test_sessions_api.py` | 8 | Session HTTP endpoints — list, messages, update title, delete |
 | `test_settings_api.py` | 6 | Settings API — interruption mode get/set |
-| `test_shell_tool.py` | 7 | Shell execution — success, errors, size limits, timeout, connection errors |
+| `test_shell_tool.py` | 9 | Shell execution — success, errors, size limits, timeout, connection errors, runtime audit logging |
 | `test_skills.py` | 27 | Skills system — loading, gating, enable/disable, frontmatter parsing, API |
 | `test_soul.py` | 9 | Soul file persistence — read/write, section update, ensure exists |
 | `test_specialists.py` | 28 | Specialist agents — factory, tool domains, MCP specialist generation |
@@ -174,7 +176,6 @@ These areas are intentionally excluded from the test suite:
 
 - **Phaser game objects** (VillageScene, AgentSprite, UserSprite, SpeechBubble) — require WebGL context, fragile mocking
 - **EventBus.ts** — single-line Phaser EventEmitter wrapper
-- **Browser tool** — thin wrapper around Playwright
 - **LanceDB vector_store.py** — requires real embeddings model loaded
 - **Full WS message streaming** — complex sync/async interaction with agent streaming; basic WS tests cover ping, error handling, and skip_onboarding
 

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -43,7 +43,7 @@ If you want the current truth, use this page plus the workstream files linked be
 
 ### 03. [Runtime Reliability](../plan/runtime-reliability)
 
-- [x] ordered fallbacks, health-aware provider rerouting, local helper/agent/scheduler-profile routing, observability, and eval foundations are shipped
+- [x] ordered fallbacks, health-aware provider rerouting, local helper/agent/scheduler-profile routing, tool/integration observability, and eval foundations are shipped
 - [ ] deeper policy-aware provider selection and remaining edge coverage are still left
 - focus: routing, fallbacks, observability, evals, and degraded-mode behavior
 

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -24,6 +24,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] real tool execution audit events for call, result, and failure across agent transports
 - [x] strategist tool calls and background helper flows now emit runtime audit coverage
 - [x] MCP server connection lifecycle emits runtime audit coverage for connect, disconnect, auth-required, and failure states
+- [x] sandbox and browser tool boundaries emit runtime integration coverage for success, blocked, timeout, and failure paths
 - [x] observer context refresh and queued-bundle delivery emit background runtime audit coverage
 - [x] proactive delivery-gate decisions emit runtime audit coverage for delivered, queued, and failed paths
 - [x] observer daemon screen-context ingest emits runtime audit coverage for receive, persist success, and persist failure
@@ -36,7 +37,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 
 - [ ] deepen provider routing beyond the current ordered fallback and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduled completion, and core agent-model paths into any remaining runtime paths where it makes sense
-- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, daemon ingest, proactive delivery gating, and current MCP lifecycle coverage
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, and the browser/sandbox tool boundaries
 - [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing, local-profile behavior, and remaining edge-path contracts
 
 ## Done Means


### PR DESCRIPTION
## Summary
- add runtime integration audit coverage for the sandbox shell and browser tool boundaries
- add deterministic and regression coverage for shell timeout auditing plus browser blocked/success paths
- update the runtime reliability and testing docs so shipped vs remaining coverage stays current

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/tools/shell_tool.py backend/src/tools/browser_tool.py backend/src/evals/harness.py backend/tests/test_shell_tool.py backend/tests/test_browser_tool.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_shell_tool.py tests/test_browser_tool.py tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario shell_tool_runtime_audit --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build

## Risks
- browser runtime coverage currently verifies blocked and successful paths with mocked Playwright execution rather than a live browser timeout/failure matrix
