### PR TITLE
Trace observer source runtime boundaries

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -23,6 +23,8 @@ from src.agent.strategist import create_strategist_agent
 from src.api.observer import ScreenContextRequest, ScreenObservationData, post_screen_context
 from src.audit.repository import audit_repository
 from src.llm_runtime import FallbackLiteLLMModel, _reset_target_health, completion_with_fallback_sync
+from src.observer.sources.calendar_source import gather_calendar
+from src.observer.sources.git_source import gather_git
 from src.memory.consolidator import consolidate_session
 from src.observer.context import CurrentContext
 from src.observer.delivery import deliver_or_queue
@@ -576,6 +578,53 @@ async def _eval_web_search_empty_result_audit() -> dict[str, Any]:
     }
 
 
+async def _eval_observer_calendar_source_audit() -> dict[str, Any]:
+    mock_path = MagicMock()
+    mock_path.exists.return_value = True
+
+    with (
+        patch("src.observer.sources.calendar_source._CREDENTIALS_PATH", mock_path),
+        patch(
+            "src.observer.sources.calendar_source._fetch_events",
+            return_value={
+                "upcoming_events": [{"summary": "Standup", "start": "09:00", "end": "09:15"}],
+                "current_event": None,
+            },
+        ),
+        patch.object(audit_repository, "log_event", AsyncMock()) as mock_log_event,
+    ):
+        result = await gather_calendar()
+
+    success = _find_audit_call(
+        mock_log_event,
+        event_type="integration_succeeded",
+        tool_name="observer_source:calendar",
+    )
+    return {
+        "upcoming_event_count": len(result["upcoming_events"]),
+        "audit_event_count": success["details"]["upcoming_event_count"],
+    }
+
+
+async def _eval_observer_git_source_audit() -> dict[str, Any]:
+    with patch.object(audit_repository, "log_event", AsyncMock()) as mock_log_event:
+        with patch("src.observer.sources.git_source.settings") as mock_settings:
+            mock_settings.observer_git_repo_path = "/tmp/missing"
+            mock_settings.workspace_dir = "/tmp/missing"
+            result = gather_git()
+        await asyncio.sleep(0)
+
+    unavailable = _find_audit_call(
+        mock_log_event,
+        event_type="integration_unavailable",
+        tool_name="observer_source:git",
+    )
+    return {
+        "result": result,
+        "reason": unavailable["details"]["reason"],
+    }
+
+
 async def _eval_strategist_tick_tool_audit() -> dict[str, Any]:
     mock_context_manager = MagicMock()
     mock_context_manager.refresh = AsyncMock(return_value=_make_context())
@@ -845,6 +894,18 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="observability",
         description="Web search no-hit responses record a distinct empty-result audit outcome.",
         runner=_eval_web_search_empty_result_audit,
+    ),
+    EvalScenario(
+        name="observer_calendar_source_audit",
+        category="observability",
+        description="Observer calendar source records runtime integration coverage for successful fetches.",
+        runner=_eval_observer_calendar_source_audit,
+    ),
+    EvalScenario(
+        name="observer_git_source_audit",
+        category="observability",
+        description="Observer git source records runtime integration coverage when the workspace has no git context.",
+        runner=_eval_observer_git_source_audit,
     ),
     EvalScenario(
         name="strategist_tick_tool_audit",

--- a/backend/src/observer/sources/calendar_source.py
+++ b/backend/src/observer/sources/calendar_source.py
@@ -10,6 +10,8 @@ import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from src.audit.runtime import log_integration_event
+
 logger = logging.getLogger(__name__)
 
 # Default credential paths (match Docker mount layout)
@@ -57,10 +59,45 @@ def _fetch_events() -> dict:
 async def gather_calendar() -> dict:
     """Async wrapper — returns empty dict if credentials missing or error."""
     if not _CREDENTIALS_PATH.exists():
+        await log_integration_event(
+            integration_type="observer_source",
+            name="calendar",
+            outcome="unavailable",
+            details={"reason": "missing_credentials"},
+        )
         return {"upcoming_events": [], "current_event": None}
 
     try:
-        return await asyncio.to_thread(_fetch_events)
-    except Exception:
+        result = await asyncio.to_thread(_fetch_events)
+        upcoming_events = result.get("upcoming_events", [])
+        current_event = result.get("current_event")
+        if not upcoming_events and not current_event:
+            await log_integration_event(
+                integration_type="observer_source",
+                name="calendar",
+                outcome="empty_result",
+                details={
+                    "upcoming_event_count": 0,
+                    "has_current_event": False,
+                },
+            )
+        else:
+            await log_integration_event(
+                integration_type="observer_source",
+                name="calendar",
+                outcome="succeeded",
+                details={
+                    "upcoming_event_count": len(upcoming_events),
+                    "has_current_event": bool(current_event),
+                },
+            )
+        return result
+    except Exception as exc:
+        await log_integration_event(
+            integration_type="observer_source",
+            name="calendar",
+            outcome="failed",
+            details={"error": str(exc)},
+        )
         logger.exception("Calendar source failed")
         return {"upcoming_events": [], "current_event": None}

--- a/backend/src/observer/sources/git_source.py
+++ b/backend/src/observer/sources/git_source.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from config.settings import settings
+from src.audit.runtime import log_integration_event_sync
 
 logger = logging.getLogger(__name__)
 
@@ -21,15 +22,33 @@ def gather_git() -> dict | None:
     git_dir = Path(repo_path) / ".git"
 
     if not git_dir.is_dir():
+        log_integration_event_sync(
+            integration_type="observer_source",
+            name="git",
+            outcome="unavailable",
+            details={"reason": "missing_git_dir"},
+        )
         return None
 
     reflog_path = git_dir / "logs" / "HEAD"
     if not reflog_path.exists():
+        log_integration_event_sync(
+            integration_type="observer_source",
+            name="git",
+            outcome="unavailable",
+            details={"reason": "missing_reflog"},
+        )
         return None
 
     try:
         lines = reflog_path.read_text().strip().splitlines()
-    except OSError:
+    except OSError as exc:
+        log_integration_event_sync(
+            integration_type="observer_source",
+            name="git",
+            outcome="failed",
+            details={"error": str(exc)},
+        )
         logger.exception("Failed to read git reflog")
         return None
 
@@ -52,4 +71,19 @@ def gather_git() -> dict | None:
         if len(recent) >= 3:
             break
 
-    return {"recent_git_activity": recent if recent else None}
+    if not recent:
+        log_integration_event_sync(
+            integration_type="observer_source",
+            name="git",
+            outcome="empty_result",
+            details={"recent_activity_count": 0},
+        )
+        return {"recent_git_activity": None}
+
+    log_integration_event_sync(
+        integration_type="observer_source",
+        name="git",
+        outcome="succeeded",
+        details={"recent_activity_count": len(recent)},
+    )
+    return {"recent_git_activity": recent}

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -49,6 +49,8 @@ def test_main_lists_available_scenarios(capsys):
     assert "shell_tool_runtime_audit" in captured.out
     assert "web_search_runtime_audit" in captured.out
     assert "web_search_empty_result_audit" in captured.out
+    assert "observer_calendar_source_audit" in captured.out
+    assert "observer_git_source_audit" in captured.out
     assert "observer_daemon_ingest_audit" in captured.out
 
 
@@ -75,6 +77,8 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "shell_tool_runtime_audit",
                 "web_search_runtime_audit",
                 "web_search_empty_result_audit",
+                "observer_calendar_source_audit",
+                "observer_git_source_audit",
                 "observer_delivery_gate_audit",
                 "observer_daemon_ingest_audit",
             ]
@@ -107,6 +111,8 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["web_search_runtime_audit"]["query_length"] == len("slow search")
     assert details_by_name["web_search_empty_result_audit"]["query_length"] == len("empty query")
     assert details_by_name["web_search_empty_result_audit"]["result_count"] == 0
+    assert details_by_name["observer_calendar_source_audit"]["upcoming_event_count"] == 1
+    assert details_by_name["observer_git_source_audit"]["reason"] == "missing_git_dir"
     assert details_by_name["observer_delivery_gate_audit"]["delivered_user_state"] == "available"
     assert details_by_name["observer_delivery_gate_audit"]["queued_user_state"] == "deep_work"
     assert details_by_name["observer_daemon_ingest_audit"]["persisted_app"] == "VS Code"

--- a/backend/tests/test_observer_calendar.py
+++ b/backend/tests/test_observer_calendar.py
@@ -2,12 +2,13 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+from src.audit.repository import audit_repository
 from src.observer.sources.calendar_source import gather_calendar
 
 
 class TestCalendarSource:
     @pytest.mark.asyncio
-    async def test_no_credentials_returns_empty(self):
+    async def test_no_credentials_returns_empty(self, async_db):
         mock_path = MagicMock()
         mock_path.exists.return_value = False
         with patch("src.observer.sources.calendar_source._CREDENTIALS_PATH", mock_path):
@@ -15,9 +16,16 @@ class TestCalendarSource:
 
         assert result["upcoming_events"] == []
         assert result["current_event"] is None
+        events = await audit_repository.list_events(limit=5)
+        assert any(
+            event["event_type"] == "integration_unavailable"
+            and event["tool_name"] == "observer_source:calendar"
+            and event["details"]["reason"] == "missing_credentials"
+            for event in events
+        )
 
     @pytest.mark.asyncio
-    async def test_with_events(self):
+    async def test_with_events(self, async_db):
         mock_path = MagicMock()
         mock_path.exists.return_value = True
 
@@ -33,9 +41,16 @@ class TestCalendarSource:
 
         assert len(result["upcoming_events"]) == 1
         assert result["upcoming_events"][0]["summary"] == "Team Standup"
+        events = await audit_repository.list_events(limit=5)
+        assert any(
+            event["event_type"] == "integration_succeeded"
+            and event["tool_name"] == "observer_source:calendar"
+            and event["details"]["upcoming_event_count"] == 1
+            for event in events
+        )
 
     @pytest.mark.asyncio
-    async def test_exception_returns_empty(self):
+    async def test_exception_returns_empty(self, async_db):
         mock_path = MagicMock()
         mock_path.exists.return_value = True
 
@@ -45,3 +60,32 @@ class TestCalendarSource:
 
         assert result["upcoming_events"] == []
         assert result["current_event"] is None
+        events = await audit_repository.list_events(limit=5)
+        assert any(
+            event["event_type"] == "integration_failed"
+            and event["tool_name"] == "observer_source:calendar"
+            and event["details"]["error"] == "fail"
+            for event in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_calendar_logs_empty_result(self, async_db):
+        mock_path = MagicMock()
+        mock_path.exists.return_value = True
+
+        with patch("src.observer.sources.calendar_source._CREDENTIALS_PATH", mock_path), \
+             patch("src.observer.sources.calendar_source._fetch_events", return_value={
+                 "upcoming_events": [],
+                 "current_event": None,
+             }):
+            result = await gather_calendar()
+
+        assert result["upcoming_events"] == []
+        assert result["current_event"] is None
+        events = await audit_repository.list_events(limit=5)
+        assert any(
+            event["event_type"] == "integration_empty_result"
+            and event["tool_name"] == "observer_source:calendar"
+            and event["details"]["upcoming_event_count"] == 0
+            for event in events
+        )

--- a/backend/tests/test_observer_git.py
+++ b/backend/tests/test_observer_git.py
@@ -1,6 +1,8 @@
 import time
+import asyncio
 from unittest.mock import patch, MagicMock
 
+from src.audit.repository import audit_repository
 from src.observer.sources.git_source import gather_git
 
 
@@ -10,15 +12,24 @@ def _reflog_line(message: str, seconds_ago: int = 0) -> str:
 
 
 class TestGitSource:
-    def test_no_git_dir_returns_none(self, tmp_path):
+    def test_no_git_dir_returns_none(self, tmp_path, async_db):
         with patch("src.observer.sources.git_source.settings") as mock_s:
             mock_s.observer_git_repo_path = str(tmp_path)
             mock_s.workspace_dir = str(tmp_path)
             result = gather_git()
 
         assert result is None
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_unavailable"]
+        events = asyncio.run(_fetch())
+        assert any(
+            event["tool_name"] == "observer_source:git"
+            and event["details"]["reason"] == "missing_git_dir"
+            for event in events
+        )
 
-    def test_recent_reflog_entries(self, tmp_path):
+    def test_recent_reflog_entries(self, tmp_path, async_db):
         git_dir = tmp_path / ".git" / "logs"
         git_dir.mkdir(parents=True)
         reflog = git_dir / "HEAD"
@@ -37,8 +48,17 @@ class TestGitSource:
         assert len(result["recent_git_activity"]) == 2
         # Most recent first
         assert "add feature" in result["recent_git_activity"][0]["message"]
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_succeeded"]
+        events = asyncio.run(_fetch())
+        assert any(
+            event["tool_name"] == "observer_source:git"
+            and event["details"]["recent_activity_count"] == 2
+            for event in events
+        )
 
-    def test_old_entries_ignored(self, tmp_path):
+    def test_old_entries_ignored(self, tmp_path, async_db):
         git_dir = tmp_path / ".git" / "logs"
         git_dir.mkdir(parents=True)
         reflog = git_dir / "HEAD"
@@ -52,6 +72,15 @@ class TestGitSource:
 
         assert result is not None
         assert result["recent_git_activity"] is None
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_empty_result"]
+        events = asyncio.run(_fetch())
+        assert any(
+            event["tool_name"] == "observer_source:git"
+            and event["details"]["recent_activity_count"] == 0
+            for event in events
+        )
 
     def test_max_three_entries(self, tmp_path):
         git_dir = tmp_path / ".git" / "logs"
@@ -81,7 +110,7 @@ class TestGitSource:
         assert result is not None
         assert result["recent_git_activity"] is not None
 
-    def test_no_reflog_file_returns_none(self, tmp_path):
+    def test_no_reflog_file_returns_none(self, tmp_path, async_db):
         (tmp_path / ".git").mkdir()
 
         with patch("src.observer.sources.git_source.settings") as mock_s:
@@ -90,3 +119,35 @@ class TestGitSource:
             result = gather_git()
 
         assert result is None
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_unavailable"]
+        events = asyncio.run(_fetch())
+        assert any(
+            event["tool_name"] == "observer_source:git"
+            and event["details"]["reason"] == "missing_reflog"
+            for event in events
+        )
+
+    def test_read_error_logs_failure(self, tmp_path, async_db):
+        git_dir = tmp_path / ".git" / "logs"
+        git_dir.mkdir(parents=True)
+        reflog = git_dir / "HEAD"
+        reflog.write_text(_reflog_line("commit: test", seconds_ago=30) + "\n")
+
+        with patch("src.observer.sources.git_source.settings") as mock_s, \
+             patch("pathlib.Path.read_text", side_effect=OSError("nope")):
+            mock_s.observer_git_repo_path = str(tmp_path)
+            mock_s.workspace_dir = str(tmp_path)
+            result = gather_git()
+
+        assert result is None
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_failed"]
+        events = asyncio.run(_fetch())
+        assert any(
+            event["tool_name"] == "observer_source:git"
+            and event["details"]["error"] == "nope"
+            for event in events
+        )

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -44,11 +44,13 @@ uv run python -m src.evals.harness --scenario daily_briefing_fallback
 uv run python -m src.evals.harness --scenario shell_tool_runtime_audit
 uv run python -m src.evals.harness --scenario web_search_runtime_audit
 uv run python -m src.evals.harness --scenario web_search_empty_result_audit
+uv run python -m src.evals.harness --scenario observer_calendar_source_audit
+uv run python -m src.evals.harness --scenario observer_git_source_audit
 uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, sandbox and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, observer source availability, sandbox and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -89,8 +91,8 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_mcp_api.py` | 3 | MCP HTTP API endpoints — list, add, remove servers |
 | `test_mcp_manager.py` | 31 | MCP server integration — connect, disconnect, failure handling, token auth, env var resolution |
 | `test_observer_api.py` | 7 | Observer API endpoints — state, context POST, daemon status |
-| `test_observer_calendar.py` | 3 | Calendar observer source — event parsing, caching |
-| `test_observer_git.py` | 6 | Git observer source — commit parsing, branch detection |
+| `test_observer_calendar.py` | 4 | Calendar observer source — event parsing, empty/failure handling, runtime audit logging |
+| `test_observer_git.py` | 7 | Git observer source — commit parsing, missing repo/reflog handling, runtime audit logging |
 | `test_observer_goals.py` | 4 | Goals observer source — active goals summary |
 | `test_observer_manager.py` | 20 | ContextManager — refresh, state transitions, budget reset |
 | `test_observer_time.py` | 12 | Time observer source — time-of-day, working hours, timezone |

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -43,7 +43,7 @@ If you want the current truth, use this page plus the workstream files linked be
 
 ### 03. [Runtime Reliability](../plan/runtime-reliability)
 
-- [x] ordered fallbacks, health-aware provider rerouting, local helper/agent/scheduler-profile routing, tool/integration observability across MCP, browser, sandbox, and web search, and eval foundations are shipped
+- [x] ordered fallbacks, health-aware provider rerouting, local helper/agent/scheduler-profile routing, tool/integration observability across MCP, browser, sandbox, web search, and observer-source boundaries, and eval foundations are shipped
 - [ ] deeper policy-aware provider selection and remaining edge coverage are still left
 - focus: routing, fallbacks, observability, evals, and degraded-mode behavior
 

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -25,6 +25,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] strategist tool calls and background helper flows now emit runtime audit coverage
 - [x] MCP server connection lifecycle emits runtime audit coverage for connect, disconnect, auth-required, and failure states
 - [x] sandbox, browser, and web-search tool boundaries emit runtime integration coverage for success, blocked, timeout, empty-result, and failure paths
+- [x] observer calendar and git source boundaries emit runtime integration coverage for unavailable, empty-result, success, and failure paths
 - [x] observer context refresh and queued-bundle delivery emit background runtime audit coverage
 - [x] proactive delivery-gate decisions emit runtime audit coverage for delivered, queued, and failed paths
 - [x] observer daemon screen-context ingest emits runtime audit coverage for receive, persist success, and persist failure
@@ -37,7 +38,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 
 - [ ] deepen provider routing beyond the current ordered fallback and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduled completion, and core agent-model paths into any remaining runtime paths where it makes sense
-- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, and the browser/sandbox/web-search tool boundaries
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, and the browser/sandbox/web-search tool boundaries
 - [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing, local-profile behavior, and remaining edge-path contracts
 
 ## Done Means


### PR DESCRIPTION
## Summary
- add runtime integration audit coverage for observer calendar and git source boundaries
- add deterministic eval and regression coverage for observer source availability, empty-result, success, and failure paths
- update the runtime reliability and testing docs so shipped observability coverage stays aligned with the repo

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/observer/sources/calendar_source.py backend/src/observer/sources/git_source.py backend/src/evals/harness.py backend/tests/test_observer_calendar.py backend/tests/test_observer_git.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_observer_calendar.py tests/test_observer_git.py tests/test_eval_harness.py tests/test_observer_manager.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario observer_calendar_source_audit --scenario observer_git_source_audit --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build

## Risks
- observer source coverage still focuses on calendar and git; other remaining edge paths are still explicitly left open in the workstream doc
