### PR TITLE
Trace observer goal source runtime boundaries

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -24,6 +24,7 @@ from src.api.observer import ScreenContextRequest, ScreenObservationData, post_s
 from src.audit.repository import audit_repository
 from src.llm_runtime import FallbackLiteLLMModel, _reset_target_health, completion_with_fallback_sync
 from src.observer.sources.calendar_source import gather_calendar
+from src.observer.sources.goal_source import gather_goals
 from src.observer.sources.git_source import gather_git
 from src.memory.consolidator import consolidate_session
 from src.observer.context import CurrentContext
@@ -625,6 +626,30 @@ async def _eval_observer_git_source_audit() -> dict[str, Any]:
     }
 
 
+async def _eval_observer_goal_source_audit() -> dict[str, Any]:
+    goal1 = MagicMock(domain="productivity", title="Write docs")
+    goal2 = MagicMock(domain="health", title="Exercise")
+    mock_repo = AsyncMock()
+    mock_repo.list_goals.return_value = [goal1, goal2]
+
+    with (
+        patch("src.goals.repository.goal_repository", mock_repo),
+        patch.object(audit_repository, "log_event", AsyncMock()) as mock_log_event,
+    ):
+        result = await gather_goals()
+
+    success = _find_audit_call(
+        mock_log_event,
+        event_type="integration_succeeded",
+        tool_name="observer_source:goals",
+    )
+    return {
+        "summary": result["active_goals_summary"],
+        "goal_count": success["details"]["goal_count"],
+        "domain_count": success["details"]["domain_count"],
+    }
+
+
 async def _eval_strategist_tick_tool_audit() -> dict[str, Any]:
     mock_context_manager = MagicMock()
     mock_context_manager.refresh = AsyncMock(return_value=_make_context())
@@ -906,6 +931,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="observability",
         description="Observer git source records runtime integration coverage when the workspace has no git context.",
         runner=_eval_observer_git_source_audit,
+    ),
+    EvalScenario(
+        name="observer_goal_source_audit",
+        category="observability",
+        description="Observer goal source records runtime integration coverage for active-goal summaries.",
+        runner=_eval_observer_goal_source_audit,
     ),
     EvalScenario(
         name="strategist_tick_tool_audit",

--- a/backend/src/observer/sources/goal_source.py
+++ b/backend/src/observer/sources/goal_source.py
@@ -3,6 +3,8 @@
 import logging
 from collections import defaultdict
 
+from src.audit.runtime import log_integration_event
+
 logger = logging.getLogger(__name__)
 
 
@@ -14,6 +16,12 @@ async def gather_goals() -> dict:
         goals = await goal_repository.list_goals(status="active")
 
         if not goals:
+            await log_integration_event(
+                integration_type="observer_source",
+                name="goals",
+                outcome="empty_result",
+                details={"goal_count": 0},
+            )
             return {"active_goals_summary": ""}
 
         by_domain: dict[str, list[str]] = defaultdict(list)
@@ -26,8 +34,23 @@ async def gather_goals() -> dict:
             suffix = f" (+{len(titles) - 3} more)" if len(titles) > 3 else ""
             parts.append(f"{domain}: {', '.join(truncated)}{suffix}")
 
+        await log_integration_event(
+            integration_type="observer_source",
+            name="goals",
+            outcome="succeeded",
+            details={
+                "goal_count": len(goals),
+                "domain_count": len(by_domain),
+            },
+        )
         return {"active_goals_summary": "; ".join(parts)}
 
-    except Exception:
+    except Exception as exc:
+        await log_integration_event(
+            integration_type="observer_source",
+            name="goals",
+            outcome="failed",
+            details={"error": str(exc)},
+        )
         logger.exception("Goal source failed")
         return {"active_goals_summary": ""}

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -51,6 +51,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "web_search_empty_result_audit" in captured.out
     assert "observer_calendar_source_audit" in captured.out
     assert "observer_git_source_audit" in captured.out
+    assert "observer_goal_source_audit" in captured.out
     assert "observer_daemon_ingest_audit" in captured.out
 
 
@@ -79,6 +80,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "web_search_empty_result_audit",
                 "observer_calendar_source_audit",
                 "observer_git_source_audit",
+                "observer_goal_source_audit",
                 "observer_delivery_gate_audit",
                 "observer_daemon_ingest_audit",
             ]
@@ -113,6 +115,8 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["web_search_empty_result_audit"]["result_count"] == 0
     assert details_by_name["observer_calendar_source_audit"]["upcoming_event_count"] == 1
     assert details_by_name["observer_git_source_audit"]["reason"] == "missing_git_dir"
+    assert details_by_name["observer_goal_source_audit"]["goal_count"] == 2
+    assert details_by_name["observer_goal_source_audit"]["domain_count"] == 2
     assert details_by_name["observer_delivery_gate_audit"]["delivered_user_state"] == "available"
     assert details_by_name["observer_delivery_gate_audit"]["queued_user_state"] == "deep_work"
     assert details_by_name["observer_daemon_ingest_audit"]["persisted_app"] == "VS Code"

--- a/backend/tests/test_observer_goals.py
+++ b/backend/tests/test_observer_goals.py
@@ -2,12 +2,13 @@ from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 
+from src.audit.repository import audit_repository
 from src.observer.sources.goal_source import gather_goals
 
 
 class TestGoalSource:
     @pytest.mark.asyncio
-    async def test_no_goals(self):
+    async def test_no_goals(self, async_db):
         mock_repo = AsyncMock()
         mock_repo.list_goals.return_value = []
 
@@ -15,9 +16,16 @@ class TestGoalSource:
             result = await gather_goals()
 
         assert result["active_goals_summary"] == ""
+        events = await audit_repository.list_events(limit=5)
+        assert any(
+            event["event_type"] == "integration_empty_result"
+            and event["tool_name"] == "observer_source:goals"
+            and event["details"]["goal_count"] == 0
+            for event in events
+        )
 
     @pytest.mark.asyncio
-    async def test_multiple_domains(self):
+    async def test_multiple_domains(self, async_db):
         goal1 = MagicMock(domain="productivity", title="Write docs")
         goal2 = MagicMock(domain="productivity", title="Review PR")
         goal3 = MagicMock(domain="health", title="Exercise")
@@ -33,6 +41,14 @@ class TestGoalSource:
         assert "health" in summary
         assert "Write docs" in summary
         assert "Exercise" in summary
+        events = await audit_repository.list_events(limit=5)
+        assert any(
+            event["event_type"] == "integration_succeeded"
+            and event["tool_name"] == "observer_source:goals"
+            and event["details"]["goal_count"] == 3
+            and event["details"]["domain_count"] == 2
+            for event in events
+        )
 
     @pytest.mark.asyncio
     async def test_truncates_per_domain(self):
@@ -48,7 +64,7 @@ class TestGoalSource:
         assert "(+2 more)" in summary
 
     @pytest.mark.asyncio
-    async def test_exception_returns_empty(self):
+    async def test_exception_returns_empty(self, async_db):
         mock_repo = AsyncMock()
         mock_repo.list_goals.side_effect = RuntimeError("db error")
 
@@ -56,3 +72,10 @@ class TestGoalSource:
             result = await gather_goals()
 
         assert result["active_goals_summary"] == ""
+        events = await audit_repository.list_events(limit=5)
+        assert any(
+            event["event_type"] == "integration_failed"
+            and event["tool_name"] == "observer_source:goals"
+            and event["details"]["error"] == "db error"
+            for event in events
+        )

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -46,11 +46,12 @@ uv run python -m src.evals.harness --scenario web_search_runtime_audit
 uv run python -m src.evals.harness --scenario web_search_empty_result_audit
 uv run python -m src.evals.harness --scenario observer_calendar_source_audit
 uv run python -m src.evals.harness --scenario observer_git_source_audit
+uv run python -m src.evals.harness --scenario observer_goal_source_audit
 uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, observer source availability, sandbox and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, observer source availability and goal summaries, sandbox and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -93,7 +94,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_observer_api.py` | 7 | Observer API endpoints — state, context POST, daemon status |
 | `test_observer_calendar.py` | 4 | Calendar observer source — event parsing, empty/failure handling, runtime audit logging |
 | `test_observer_git.py` | 7 | Git observer source — commit parsing, missing repo/reflog handling, runtime audit logging |
-| `test_observer_goals.py` | 4 | Goals observer source — active goals summary |
+| `test_observer_goals.py` | 4 | Goals observer source — active goals summary and runtime audit logging |
 | `test_observer_manager.py` | 20 | ContextManager — refresh, state transitions, budget reset |
 | `test_observer_time.py` | 12 | Time observer source — time-of-day, working hours, timezone |
 | `test_onboarding_edge_cases.py` | 2 | Onboarding edge cases — skip, restart |

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -43,7 +43,7 @@ If you want the current truth, use this page plus the workstream files linked be
 
 ### 03. [Runtime Reliability](../plan/runtime-reliability)
 
-- [x] ordered fallbacks, health-aware provider rerouting, local helper/agent/scheduler-profile routing, tool/integration observability across MCP, browser, sandbox, web search, and observer-source boundaries, and eval foundations are shipped
+- [x] ordered fallbacks, health-aware provider rerouting, local helper/agent/scheduler-profile routing, tool/integration observability across MCP, browser, sandbox, web search, and observer-source boundaries including goals, and eval foundations are shipped
 - [ ] deeper policy-aware provider selection and remaining edge coverage are still left
 - focus: routing, fallbacks, observability, evals, and degraded-mode behavior
 

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -25,7 +25,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] strategist tool calls and background helper flows now emit runtime audit coverage
 - [x] MCP server connection lifecycle emits runtime audit coverage for connect, disconnect, auth-required, and failure states
 - [x] sandbox, browser, and web-search tool boundaries emit runtime integration coverage for success, blocked, timeout, empty-result, and failure paths
-- [x] observer calendar and git source boundaries emit runtime integration coverage for unavailable, empty-result, success, and failure paths
+- [x] observer calendar, git, and goal source boundaries emit runtime integration coverage for unavailable, empty-result, success, and failure paths
 - [x] observer context refresh and queued-bundle delivery emit background runtime audit coverage
 - [x] proactive delivery-gate decisions emit runtime audit coverage for delivered, queued, and failed paths
 - [x] observer daemon screen-context ingest emits runtime audit coverage for receive, persist success, and persist failure
@@ -38,7 +38,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 
 - [ ] deepen provider routing beyond the current ordered fallback and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduled completion, and core agent-model paths into any remaining runtime paths where it makes sense
-- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, and the browser/sandbox/web-search tool boundaries
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git/goal sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, and the browser/sandbox/web-search tool boundaries
 - [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing, local-profile behavior, and remaining edge-path contracts
 
 ## Done Means


### PR DESCRIPTION
## Summary
- add runtime integration audit coverage for the observer goal source
- add deterministic eval and regression coverage for goal-source empty-result, success, and failure paths
- update the runtime reliability and testing docs to keep shipped observer-source coverage aligned with the repo

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/observer/sources/goal_source.py backend/src/evals/harness.py backend/tests/test_observer_goals.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_observer_goals.py tests/test_eval_harness.py tests/test_observer_manager.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario observer_goal_source_audit --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build

## Risks
- observer source coverage is broader now, but the workstream still has remaining edge helpers and integrations explicitly called out in the plan
