### PR TITLE
Trace observer time source runtime boundaries

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -8,6 +8,7 @@ import json
 import sys
 import time
 from dataclasses import asdict, dataclass, field
+from datetime import datetime
 from typing import Any, Awaitable, Callable, Sequence
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -26,6 +27,7 @@ from src.llm_runtime import FallbackLiteLLMModel, _reset_target_health, completi
 from src.observer.sources.calendar_source import gather_calendar
 from src.observer.sources.goal_source import gather_goals
 from src.observer.sources.git_source import gather_git
+from src.observer.sources.time_source import gather_time
 from src.memory.consolidator import consolidate_session
 from src.observer.context import CurrentContext
 from src.observer.delivery import deliver_or_queue
@@ -650,6 +652,35 @@ async def _eval_observer_goal_source_audit() -> dict[str, Any]:
     }
 
 
+async def _eval_observer_time_source_audit() -> dict[str, Any]:
+    fixed = datetime(2025, 6, 2, 10, 0)
+    mock_dt = MagicMock(wraps=datetime)
+    mock_dt.now.return_value = fixed
+
+    with (
+        patch("src.observer.sources.time_source.datetime", mock_dt),
+        patch("src.observer.sources.time_source.settings", MagicMock(
+            user_timezone="UTC",
+            working_hours_start=9,
+            working_hours_end=17,
+        )),
+        patch.object(audit_repository, "log_event", AsyncMock()) as mock_log_event,
+    ):
+        result = gather_time()
+        await asyncio.sleep(0)
+
+    success = _find_audit_call(
+        mock_log_event,
+        event_type="integration_succeeded",
+        tool_name="observer_source:time",
+    )
+    return {
+        "time_of_day": result["time_of_day"],
+        "timezone": success["details"]["timezone"],
+        "is_working_hours": success["details"]["is_working_hours"],
+    }
+
+
 async def _eval_strategist_tick_tool_audit() -> dict[str, Any]:
     mock_context_manager = MagicMock()
     mock_context_manager.refresh = AsyncMock(return_value=_make_context())
@@ -937,6 +968,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="observability",
         description="Observer goal source records runtime integration coverage for active-goal summaries.",
         runner=_eval_observer_goal_source_audit,
+    ),
+    EvalScenario(
+        name="observer_time_source_audit",
+        category="observability",
+        description="Observer time source records runtime integration coverage for successful time classification.",
+        runner=_eval_observer_time_source_audit,
     ),
     EvalScenario(
         name="strategist_tick_tool_audit",

--- a/backend/src/observer/sources/time_source.py
+++ b/backend/src/observer/sources/time_source.py
@@ -4,29 +4,52 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from config.settings import settings
+from src.audit.runtime import log_integration_event_sync
 
 
 def gather_time() -> dict:
     """Return time-of-day classification, day of week, and working hours flag."""
-    tz = ZoneInfo(settings.user_timezone)
-    now = datetime.now(tz)
-    hour = now.hour
+    try:
+        tz = ZoneInfo(settings.user_timezone)
+        now = datetime.now(tz)
+        hour = now.hour
 
-    if 5 <= hour < 12:
-        time_of_day = "morning"
-    elif 12 <= hour < 17:
-        time_of_day = "afternoon"
-    elif 17 <= hour < 21:
-        time_of_day = "evening"
-    else:
-        time_of_day = "night"
+        if 5 <= hour < 12:
+            time_of_day = "morning"
+        elif 12 <= hour < 17:
+            time_of_day = "afternoon"
+        elif 17 <= hour < 21:
+            time_of_day = "evening"
+        else:
+            time_of_day = "night"
 
-    day_of_week = now.strftime("%A")
-    is_weekday = now.weekday() < 5
-    is_working_hours = is_weekday and settings.working_hours_start <= hour < settings.working_hours_end
+        day_of_week = now.strftime("%A")
+        is_weekday = now.weekday() < 5
+        is_working_hours = is_weekday and settings.working_hours_start <= hour < settings.working_hours_end
 
-    return {
-        "time_of_day": time_of_day,
-        "day_of_week": day_of_week,
-        "is_working_hours": is_working_hours,
-    }
+        log_integration_event_sync(
+            integration_type="observer_source",
+            name="time",
+            outcome="succeeded",
+            details={
+                "timezone": settings.user_timezone,
+                "time_of_day": time_of_day,
+                "is_working_hours": is_working_hours,
+            },
+        )
+        return {
+            "time_of_day": time_of_day,
+            "day_of_week": day_of_week,
+            "is_working_hours": is_working_hours,
+        }
+    except Exception as exc:
+        log_integration_event_sync(
+            integration_type="observer_source",
+            name="time",
+            outcome="failed",
+            details={
+                "timezone": settings.user_timezone,
+                "error": str(exc),
+            },
+        )
+        raise

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -52,6 +52,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "observer_calendar_source_audit" in captured.out
     assert "observer_git_source_audit" in captured.out
     assert "observer_goal_source_audit" in captured.out
+    assert "observer_time_source_audit" in captured.out
     assert "observer_daemon_ingest_audit" in captured.out
 
 
@@ -81,6 +82,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "observer_calendar_source_audit",
                 "observer_git_source_audit",
                 "observer_goal_source_audit",
+                "observer_time_source_audit",
                 "observer_delivery_gate_audit",
                 "observer_daemon_ingest_audit",
             ]
@@ -117,6 +119,8 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["observer_git_source_audit"]["reason"] == "missing_git_dir"
     assert details_by_name["observer_goal_source_audit"]["goal_count"] == 2
     assert details_by_name["observer_goal_source_audit"]["domain_count"] == 2
+    assert details_by_name["observer_time_source_audit"]["time_of_day"] == "morning"
+    assert details_by_name["observer_time_source_audit"]["timezone"] == "UTC"
     assert details_by_name["observer_delivery_gate_audit"]["delivered_user_state"] == "available"
     assert details_by_name["observer_delivery_gate_audit"]["queued_user_state"] == "deep_work"
     assert details_by_name["observer_daemon_ingest_audit"]["persisted_app"] == "VS Code"

--- a/backend/tests/test_observer_time.py
+++ b/backend/tests/test_observer_time.py
@@ -1,6 +1,10 @@
 from datetime import datetime
+import asyncio
 from unittest.mock import patch, MagicMock
 
+import pytest
+
+from src.audit.repository import audit_repository
 from src.observer.sources.time_source import gather_time
 
 
@@ -76,3 +80,39 @@ class TestDayOfWeek:
         # June 4, 2025 = Wednesday
         with _mock_time(day=4, hour=10), _mock_settings():
             assert gather_time()["day_of_week"] == "Wednesday"
+
+
+class TestRuntimeAudit:
+    def test_success_logs_runtime_audit(self, async_db):
+        with _mock_time(hour=10), _mock_settings():
+            result = gather_time()
+
+        assert result["time_of_day"] == "morning"
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_succeeded"]
+
+        events = asyncio.run(_fetch())
+        assert any(
+            event["tool_name"] == "observer_source:time"
+            and event["details"]["timezone"] == "UTC"
+            and event["details"]["time_of_day"] == "morning"
+            for event in events
+        )
+
+    def test_failure_logs_runtime_audit(self, async_db):
+        with _mock_settings(user_timezone="Bad/Timezone"):
+            with pytest.raises(Exception):
+                gather_time()
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_failed"]
+
+        events = asyncio.run(_fetch())
+        assert any(
+            event["tool_name"] == "observer_source:time"
+            and event["details"]["timezone"] == "Bad/Timezone"
+            for event in events
+        )

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -47,11 +47,12 @@ uv run python -m src.evals.harness --scenario web_search_empty_result_audit
 uv run python -m src.evals.harness --scenario observer_calendar_source_audit
 uv run python -m src.evals.harness --scenario observer_git_source_audit
 uv run python -m src.evals.harness --scenario observer_goal_source_audit
+uv run python -m src.evals.harness --scenario observer_time_source_audit
 uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, observer source availability and goal summaries, sandbox and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -96,7 +97,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_observer_git.py` | 7 | Git observer source — commit parsing, missing repo/reflog handling, runtime audit logging |
 | `test_observer_goals.py` | 4 | Goals observer source — active goals summary and runtime audit logging |
 | `test_observer_manager.py` | 20 | ContextManager — refresh, state transitions, budget reset |
-| `test_observer_time.py` | 12 | Time observer source — time-of-day, working hours, timezone |
+| `test_observer_time.py` | 14 | Time observer source — time-of-day, working hours, timezone, runtime audit logging |
 | `test_onboarding_edge_cases.py` | 2 | Onboarding edge cases — skip, restart |
 | `test_plugin_loader.py` | 5 | Tool auto-discovery — scan, expected tools, no duplicates, caching, reload |
 | `test_profile.py` | 7 | User profile + onboarding — get/create, mark/reset complete, HTTP endpoints |

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -43,7 +43,7 @@ If you want the current truth, use this page plus the workstream files linked be
 
 ### 03. [Runtime Reliability](../plan/runtime-reliability)
 
-- [x] ordered fallbacks, health-aware provider rerouting, local helper/agent/scheduler-profile routing, tool/integration observability across MCP, browser, sandbox, web search, and observer-source boundaries including goals, and eval foundations are shipped
+- [x] ordered fallbacks, health-aware provider rerouting, local helper/agent/scheduler-profile routing, tool/integration observability across MCP, browser, sandbox, web search, and observer-source boundaries including time and goals, and eval foundations are shipped
 - [ ] deeper policy-aware provider selection and remaining edge coverage are still left
 - focus: routing, fallbacks, observability, evals, and degraded-mode behavior
 

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -25,7 +25,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] strategist tool calls and background helper flows now emit runtime audit coverage
 - [x] MCP server connection lifecycle emits runtime audit coverage for connect, disconnect, auth-required, and failure states
 - [x] sandbox, browser, and web-search tool boundaries emit runtime integration coverage for success, blocked, timeout, empty-result, and failure paths
-- [x] observer calendar, git, and goal source boundaries emit runtime integration coverage for unavailable, empty-result, success, and failure paths
+- [x] observer calendar, git, goal, and time source boundaries emit runtime integration coverage for unavailable, empty-result, success, and failure paths
 - [x] observer context refresh and queued-bundle delivery emit background runtime audit coverage
 - [x] proactive delivery-gate decisions emit runtime audit coverage for delivered, queued, and failed paths
 - [x] observer daemon screen-context ingest emits runtime audit coverage for receive, persist success, and persist failure
@@ -38,7 +38,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 
 - [ ] deepen provider routing beyond the current ordered fallback and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduled completion, and core agent-model paths into any remaining runtime paths where it makes sense
-- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git/goal sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, and the browser/sandbox/web-search tool boundaries
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git/goal/time sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, and the browser/sandbox/web-search tool boundaries
 - [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing, local-profile behavior, and remaining edge-path contracts
 
 ## Done Means


### PR DESCRIPTION
## Summary
- add runtime integration audit coverage for the observer time source on both success and failure paths
- extend the deterministic eval harness and backend tests to cover the new time-source audit contract
- update runtime reliability and testing docs so the shipped observer-source coverage matches the repo state

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/observer/sources/time_source.py backend/src/evals/harness.py backend/tests/test_observer_time.py backend/tests/test_eval_harness.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_observer_time.py tests/test_eval_harness.py tests/test_observer_manager.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario observer_time_source_audit --indent 2`
- `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`
- `cd docs && npm run build`

## Risks
- this continues to harden runtime seam checks rather than broad end-to-end behavioral evals
