### PR TITLE
Trace browser timeout audit boundaries

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -34,6 +34,7 @@ from src.observer.delivery import deliver_or_queue
 from src.scheduler.jobs.daily_briefing import run_daily_briefing
 from src.scheduler.jobs.strategist_tick import run_strategist_tick
 from src.tools.audit import wrap_tools_for_audit
+from src.tools.browser_tool import browse_webpage
 from src.tools.shell_tool import shell_execute
 from src.tools.web_search_tool import web_search
 from src.models.schemas import WSResponse
@@ -684,6 +685,42 @@ async def _eval_web_search_empty_result_audit() -> dict[str, Any]:
     }
 
 
+async def _eval_browser_runtime_audit() -> dict[str, Any]:
+    class _ImmediateFuture:
+        def result(self):
+            raise TimeoutError("Timed out")
+
+    class _ImmediateExecutor:
+        def __enter__(self) -> "_ImmediateExecutor":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def submit(self, _fn, *args, **kwargs) -> _ImmediateFuture:
+            return _ImmediateFuture()
+
+    with (
+        patch("concurrent.futures.ThreadPoolExecutor", return_value=_ImmediateExecutor()),
+        patch.object(audit_repository, "log_event", AsyncMock()) as mock_log_event,
+    ):
+        result = browse_webpage("https://example.com/slow", action="extract")
+        await asyncio.sleep(0)
+
+    assert "timed out after" in result.lower()
+    timed_out = _find_audit_call(
+        mock_log_event,
+        event_type="integration_timed_out",
+        tool_name="browser:playwright",
+    )
+    return {
+        "result": result,
+        "timeout_seconds": timed_out["details"]["timeout_seconds"],
+        "hostname": timed_out["details"]["hostname"],
+        "action": timed_out["details"]["action"],
+    }
+
+
 async def _eval_observer_calendar_source_audit() -> dict[str, Any]:
     mock_path = MagicMock()
     mock_path.exists.return_value = True
@@ -1065,6 +1102,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="observability",
         description="Web search no-hit responses record a distinct empty-result audit outcome.",
         runner=_eval_web_search_empty_result_audit,
+    ),
+    EvalScenario(
+        name="browser_runtime_audit",
+        category="observability",
+        description="Browser timeouts record a distinct runtime audit outcome instead of collapsing into generic failures.",
+        runner=_eval_browser_runtime_audit,
     ),
     EvalScenario(
         name="observer_calendar_source_audit",

--- a/backend/src/tools/browser_tool.py
+++ b/backend/src/tools/browser_tool.py
@@ -98,6 +98,11 @@ async def _browse(url: str, action: str) -> str:
             await browser.close()
 
 
+def _run_browse_sync(url: str, action: str) -> str:
+    """Bridge the async browser implementation into the thread pool."""
+    return asyncio.run(_browse(url, action))
+
+
 @tool
 def browse_webpage(url: str, action: str = "extract") -> str:
     """Browse a webpage and extract its content.
@@ -132,9 +137,14 @@ def browse_webpage(url: str, action: str = "extract") -> str:
         return f"Error: action must be 'extract', 'html', or 'screenshot', got '{action}'"
 
     try:
+        from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+    except Exception:  # pragma: no cover - playwright import failures are handled below
+        PlaywrightTimeoutError = TimeoutError
+
+    try:
         import concurrent.futures
         with concurrent.futures.ThreadPoolExecutor() as pool:
-            result = pool.submit(asyncio.run, _browse(url, action)).result()
+            result = pool.submit(_run_browse_sync, url, action).result()
         log_integration_event_sync(
             integration_type="browser",
             name="playwright",
@@ -142,6 +152,19 @@ def browse_webpage(url: str, action: str = "extract") -> str:
             details=_browser_details(url, action),
         )
         return result
+    except (TimeoutError, PlaywrightTimeoutError) as e:
+        log_integration_event_sync(
+            integration_type="browser",
+            name="playwright",
+            outcome="timed_out",
+            details={
+                **_browser_details(url, action),
+                "timeout_seconds": settings.browser_timeout,
+                "error": str(e),
+            },
+        )
+        logger.exception("Browser automation timed out")
+        return f"Error browsing {url}: timed out after {settings.browser_timeout}s"
     except Exception as e:
         log_integration_event_sync(
             integration_type="browser",

--- a/backend/tests/test_browser_tool.py
+++ b/backend/tests/test_browser_tool.py
@@ -59,3 +59,23 @@ def test_browse_webpage_logs_success_runtime_audit(async_db):
     assert events[0]["tool_name"] == "browser:playwright"
     assert events[0]["details"]["hostname"] == "example.com"
     assert events[0]["details"]["action"] == "extract"
+
+
+def test_browse_webpage_logs_timeout_runtime_audit(async_db):
+    with (
+        patch("src.tools.browser_tool._browse", new=AsyncMock(side_effect=TimeoutError("Timed out"))),
+        patch("concurrent.futures.ThreadPoolExecutor", return_value=_ImmediateExecutor()),
+    ):
+        result = browse_webpage("https://example.com/slow")
+
+    assert "timed out after" in result.lower()
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "integration_timed_out"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["tool_name"] == "browser:playwright"
+    assert events[0]["details"]["hostname"] == "example.com"
+    assert events[0]["details"]["timeout_seconds"] == 30

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -49,6 +49,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "runtime_fallback_overrides" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
     assert "shell_tool_runtime_audit" in captured.out
+    assert "browser_runtime_audit" in captured.out
     assert "web_search_runtime_audit" in captured.out
     assert "web_search_empty_result_audit" in captured.out
     assert "observer_calendar_source_audit" in captured.out
@@ -81,6 +82,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "runtime_fallback_overrides",
                 "scheduled_local_runtime_profile",
                 "shell_tool_runtime_audit",
+                "browser_runtime_audit",
                 "web_search_runtime_audit",
                 "web_search_empty_result_audit",
                 "observer_calendar_source_audit",
@@ -129,6 +131,8 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["scheduled_local_runtime_profile"]["job_name"] == "daily_briefing"
     assert details_by_name["scheduled_local_runtime_profile"]["routed_model"] == "ollama/llama3.2"
     assert details_by_name["shell_tool_runtime_audit"]["timeout_seconds"] == 35
+    assert details_by_name["browser_runtime_audit"]["timeout_seconds"] == 30
+    assert details_by_name["browser_runtime_audit"]["hostname"] == "example.com"
     assert details_by_name["web_search_runtime_audit"]["timeout_seconds"] == 15
     assert details_by_name["web_search_runtime_audit"]["query_length"] == len("slow search")
     assert details_by_name["web_search_empty_result_audit"]["query_length"] == len("empty query")

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -44,6 +44,7 @@ uv run python -m src.evals.harness --scenario runtime_fallback_overrides
 uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
 uv run python -m src.evals.harness --scenario daily_briefing_fallback
 uv run python -m src.evals.harness --scenario shell_tool_runtime_audit
+uv run python -m src.evals.harness --scenario browser_runtime_audit
 uv run python -m src.evals.harness --scenario web_search_runtime_audit
 uv run python -m src.evals.harness --scenario web_search_empty_result_audit
 uv run python -m src.evals.harness --scenario observer_calendar_source_audit
@@ -54,7 +55,7 @@ uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path primary and fallback overrides, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path primary and fallback overrides, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -76,7 +77,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 |---|---|---|
 | `test_agent.py` | 8 | Agent factory — tool count, model creation, context injection |
 | `test_catalog_api.py` | 9 | Catalog API — browse catalog, install skills/MCP servers |
-| `test_browser_tool.py` | 2 | Browser tool — blocked internal URLs and successful runtime audit logging |
+| `test_browser_tool.py` | 3 | Browser tool — blocked internal URLs plus success and timeout runtime audit logging |
 | `test_chat_api.py` | 5 | REST chat endpoint — success, session continuity, errors |
 | `test_consolidation_reliability.py` | 6 | Memory consolidation reliability — edge cases, retry behavior |
 | `test_consolidator.py` | 5 | Memory consolidation — extract facts, soul updates, markdown fences, LLM failure |

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -49,7 +49,7 @@ Legend for the checklist column:
 - [x] policy-controlled tool and MCP access with approval gates, audit logging, secret redaction, and scoped secret references
 - [x] shell, browser, vault, filesystem, goals, and web-search tool foundations with live tool execution in chat
 - [x] ordered LLM fallbacks, health-aware rerouting, runtime-path primary and fallback overrides, local helper and agent runtime paths, and broad runtime audit coverage
-- [x] deterministic runtime eval harness coverage for fallback routing, local routing, tool boundaries, observer boundaries, and audit seams
+- [x] deterministic runtime eval harness coverage for fallback routing, local routing, browser/sandbox/web-search tool boundaries, observer boundaries, and audit seams
 - [x] browser UI, WebSocket chat, proactive delivery, and a native observer daemon
 - [x] soul, memory, goals, strategist, daily briefing, and evening review foundations
 - [x] skills, MCP integration, and recursive delegation foundations

--- a/docs/docs/overview/status-report.md
+++ b/docs/docs/overview/status-report.md
@@ -50,7 +50,7 @@ title: Development Status
 - [x] Runtime-path-specific fallback-chain overrides for completion and agent-model paths
 - [x] First-class local runtime routing for helper, scheduler, and core agent paths
 - [x] Runtime audit visibility across chat, WebSocket, scheduler, strategist, MCP, observer, browser, sandbox, and web search flows
-- [x] Deterministic runtime eval harness for fallback, routing, tool, and observer contracts
+- [x] Deterministic runtime eval harness for fallback, routing, browser/sandbox/web-search tool, and observer contracts
 
 ### Product surfaces
 


### PR DESCRIPTION
## Done on develop
- [x] runtime audit coverage already exists across chat, WebSocket, scheduler jobs, MCP lifecycle, observer flows, sandbox, browser, and web search boundaries
- [x] deterministic runtime eval coverage already exists for fallback routing, local routing, tool boundaries, and observer boundaries

## Working in this PR
- [ ] split browser timeouts into a distinct runtime audit outcome instead of generic browser failures
- [ ] add browser timeout regression coverage plus a deterministic eval harness scenario
- [ ] update testing and status docs so browser timeout coverage is reflected accurately

## Still to do after this PR
- [ ] deepen provider routing beyond explicit runtime-path primary and fallback overrides, ordered fallback chains, and cooldown rerouting
- [ ] broaden local-model routing into the remaining runtime paths where it makes sense
- [ ] expand eval coverage beyond the current deterministic seam checks

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/tools/browser_tool.py backend/src/evals/harness.py backend/tests/test_browser_tool.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_browser_tool.py tests/test_eval_harness.py tests/test_tools.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario browser_runtime_audit --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build
