### PR TITLE
Audit context window runtime degradation

### DIFF
--- a/backend/src/agent/context_window.py
+++ b/backend/src/agent/context_window.py
@@ -1,5 +1,6 @@
 """Token-aware context window for conversation history."""
 
+import hashlib
 import logging
 import math
 from functools import lru_cache
@@ -7,6 +8,7 @@ from functools import lru_cache
 import tiktoken
 
 from config.settings import settings
+from src.audit.runtime import log_background_task_event_sync
 from src.llm_runtime import completion_with_fallback_sync
 
 logger = logging.getLogger(__name__)
@@ -55,6 +57,8 @@ def _summarize_middle(messages: list[dict], session_id: str, range_key: str) -> 
         return _summary_cache[cache_key]
 
     text = _format_messages(messages)
+    message_count = len(messages)
+    text_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
     try:
         response = completion_with_fallback_sync(
             messages=[{
@@ -70,9 +74,34 @@ def _summarize_middle(messages: list[dict], session_id: str, range_key: str) -> 
             runtime_path="context_window_summary",
         )
         summary = response.choices[0].message.content.strip()
+        log_background_task_event_sync(
+            task_name="context_window_summary",
+            session_id=session_id or None,
+            outcome="succeeded",
+            details={
+                "range_key": range_key,
+                "message_count": message_count,
+                "summary_length": len(summary),
+                "source_hash": text_hash,
+                "runtime_path": "context_window_summary",
+            },
+        )
     except Exception:
         logger.warning("Failed to summarize middle section, using truncation fallback")
         summary = text[:500] + "\n[...earlier conversation truncated...]"
+        log_background_task_event_sync(
+            task_name="context_window_summary",
+            session_id=session_id or None,
+            outcome="degraded",
+            details={
+                "range_key": range_key,
+                "message_count": message_count,
+                "summary_length": len(summary),
+                "source_hash": text_hash,
+                "fallback": "truncation",
+                "runtime_path": "context_window_summary",
+            },
+        )
 
     _summary_cache[cache_key] = summary
     # Keep cache bounded

--- a/backend/src/audit/runtime.py
+++ b/backend/src/audit/runtime.py
@@ -178,3 +178,36 @@ def log_integration_event_sync(
         ))
     except Exception:
         logger.debug("Failed to run integration runtime audit logger", exc_info=True)
+
+
+def log_background_task_event_sync(
+    *,
+    task_name: str,
+    outcome: str,
+    session_id: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> None:
+    """Sync wrapper for background/helper runtime events used by non-async callers."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        try:
+            asyncio.run(log_background_task_event(
+                task_name=task_name,
+                outcome=outcome,
+                session_id=session_id,
+                details=details,
+            ))
+        except Exception:
+            logger.debug("Failed to run background runtime audit logger", exc_info=True)
+        return
+
+    try:
+        loop.create_task(log_background_task_event(
+            task_name=task_name,
+            outcome=outcome,
+            session_id=session_id,
+            details=details,
+        ))
+    except Exception:
+        logger.debug("Failed to run background runtime audit logger", exc_info=True)

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -17,7 +17,8 @@ from smolagents import Tool
 
 from config.settings import settings
 from src.agent.session import SessionManager, session_manager
-from src.agent.factory import get_model
+from src.agent.context_window import _summarize_middle, _summary_cache
+from src.agent.factory import create_orchestrator, get_model
 from src.agent.onboarding import create_onboarding_agent
 from src.agent.specialists import create_specialist
 from src.agent.strategist import create_strategist_agent
@@ -325,6 +326,93 @@ def _eval_local_runtime_profile() -> dict[str, Any]:
     }
 
 
+def _eval_helper_local_runtime_paths() -> dict[str, Any]:
+    completion_response = _make_litellm_response("Handled by a local helper profile.")
+
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "local_model", "ollama/llama3.2"),
+        patch.object(settings, "local_llm_api_key", ""),
+        patch.object(settings, "local_llm_api_base", "http://localhost:11434/v1"),
+        patch.object(
+            settings,
+            "local_runtime_paths",
+            "context_window_summary,session_title_generation,session_consolidation",
+        ),
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", ""),
+        patch("litellm.completion", return_value=completion_response) as mock_completion,
+    ):
+        routed_models: dict[str, str] = {}
+        for runtime_path in (
+            "context_window_summary",
+            "session_title_generation",
+            "session_consolidation",
+        ):
+            completion_with_fallback_sync(
+                messages=[{"role": "user", "content": f"keep {runtime_path} local"}],
+                temperature=0.2,
+                max_tokens=128,
+                runtime_path=runtime_path,
+            )
+            routed_models[runtime_path] = mock_completion.call_args.kwargs["model"]
+
+    assert set(routed_models.values()) == {"ollama/llama3.2"}
+    return {
+        "runtime_profile": "local",
+        "routed_models": routed_models,
+    }
+
+
+async def _eval_context_window_summary_audit() -> dict[str, Any]:
+    _summary_cache.clear()
+    success_response = _make_litellm_response("Condensed summary from local helper path.")
+    messages = [{"role": "user", "content": "important context " * 10}]
+
+    try:
+        with (
+            patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+            patch.object(settings, "llm_api_key", "primary-key"),
+            patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+            patch.object(settings, "local_model", "ollama/llama3.2"),
+            patch.object(settings, "local_llm_api_key", ""),
+            patch.object(settings, "local_llm_api_base", "http://localhost:11434/v1"),
+            patch.object(settings, "local_runtime_paths", "context_window_summary"),
+            patch.object(settings, "fallback_model", ""),
+            patch.object(settings, "fallback_models", ""),
+            patch("litellm.completion", return_value=success_response) as mock_completion,
+            patch.object(audit_repository, "log_event", AsyncMock()) as mock_log_event,
+        ):
+            success_summary = _summarize_middle(messages, session_id="ctx-success", range_key="0-1")
+            _summary_cache.clear()
+            with patch("src.agent.context_window.completion_with_fallback_sync", side_effect=RuntimeError("provider down")):
+                degraded_summary = _summarize_middle(messages, session_id="ctx-fail", range_key="1-2")
+            await asyncio.sleep(0)
+
+        success = _find_audit_call(
+            mock_log_event,
+            event_type="background_task_succeeded",
+            tool_name="context_window_summary",
+        )
+        degraded = _find_audit_call(
+            mock_log_event,
+            event_type="background_task_degraded",
+            tool_name="context_window_summary",
+        )
+        return {
+            "success_summary": success_summary,
+            "success_model": mock_completion.call_args.kwargs["model"],
+            "success_runtime_path": success["details"]["runtime_path"],
+            "degraded_fallback": degraded["details"]["fallback"],
+            "degraded_runtime_path": degraded["details"]["runtime_path"],
+            "degraded_contains_truncation": "truncated" in degraded_summary,
+        }
+    finally:
+        _summary_cache.clear()
+
+
 def _eval_agent_local_runtime_profile() -> dict[str, Any]:
     with (
         patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
@@ -355,6 +443,58 @@ def _eval_agent_local_runtime_profile() -> dict[str, Any]:
         "onboarding_agent": onboarding_agent.model.model_id,
         "strategist_agent": strategist_agent.model.model_id,
         "memory_keeper": specialist.model.model_id,
+    }
+    assert set(routed_models.values()) == {"ollama/llama3.2"}
+    return {
+        "runtime_profile": "local",
+        "routed_models": routed_models,
+    }
+
+
+def _eval_delegation_local_runtime_profile() -> dict[str, Any]:
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "local_model", "ollama/llama3.2"),
+        patch.object(settings, "local_llm_api_key", ""),
+        patch.object(settings, "local_llm_api_base", "http://localhost:11434/v1"),
+        patch.object(
+            settings,
+            "local_runtime_paths",
+            "orchestrator_agent,goal_planner,web_researcher,file_worker",
+        ),
+        patch("src.agent.specialists.build_all_specialists", return_value=[]),
+        patch("src.agent.factory.skill_manager.get_active_skills", return_value=[]),
+    ):
+        orchestrator = create_orchestrator()
+        goal_planner = create_specialist(
+            "goal_planner",
+            "Goal planner specialist",
+            [],
+            temperature=0.4,
+            max_steps=5,
+        )
+        web_researcher = create_specialist(
+            "web_researcher",
+            "Web researcher specialist",
+            [],
+            temperature=0.3,
+            max_steps=8,
+        )
+        file_worker = create_specialist(
+            "file_worker",
+            "File worker specialist",
+            [],
+            temperature=0.3,
+            max_steps=6,
+        )
+
+    routed_models = {
+        "orchestrator_agent": orchestrator.model.model_id,
+        "goal_planner": goal_planner.model.model_id,
+        "web_researcher": web_researcher.model.model_id,
+        "file_worker": file_worker.model.model_id,
     }
     assert set(routed_models.values()) == {"ollama/llama3.2"}
     return {
@@ -1038,10 +1178,28 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         runner=_eval_local_runtime_profile,
     ),
     EvalScenario(
+        name="helper_local_runtime_paths",
+        category="runtime",
+        description="The helper runtime-path matrix can route context window, title generation, and consolidation completions through the local profile.",
+        runner=_eval_helper_local_runtime_paths,
+    ),
+    EvalScenario(
+        name="context_window_summary_audit",
+        category="observability",
+        description="Context window summarization records success and degraded truncation outcomes while still routing through the named helper path.",
+        runner=_eval_context_window_summary_audit,
+    ),
+    EvalScenario(
         name="agent_local_runtime_profile",
         category="runtime",
         description="Core agent model factories can route through the first-class local runtime profile.",
         runner=_eval_agent_local_runtime_profile,
+    ),
+    EvalScenario(
+        name="delegation_local_runtime_profile",
+        category="runtime",
+        description="Delegation paths can route the orchestrator and remaining built-in specialists through the local profile.",
+        runner=_eval_delegation_local_runtime_profile,
     ),
     EvalScenario(
         name="runtime_model_overrides",

--- a/backend/tests/test_context_window.py
+++ b/backend/tests/test_context_window.py
@@ -1,9 +1,11 @@
 """Tests for the token-aware context window."""
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.audit.repository import audit_repository
 from src.agent.context_window import (
     build_context_window,
     _format_messages,
@@ -196,6 +198,54 @@ class TestSummaryCache:
 
         assert result == "short summary"
         assert mock_completion.call_args.kwargs["runtime_path"] == "context_window_summary"
+
+    def test_cache_miss_logs_runtime_audit_success(self, async_db):
+        from src.agent.context_window import _summarize_middle
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "short summary"
+
+        with patch("src.agent.context_window.completion_with_fallback_sync", return_value=mock_response):
+            result = _summarize_middle(
+                [_msg("user", "hello world")],
+                session_id="sess",
+                range_key="0-1",
+            )
+
+        assert result == "short summary"
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "background_task_succeeded"]
+
+        events = asyncio.run(_fetch())
+        assert events
+        assert events[0]["tool_name"] == "context_window_summary"
+        assert events[0]["details"]["runtime_path"] == "context_window_summary"
+        assert events[0]["details"]["message_count"] == 1
+
+    def test_cache_miss_logs_runtime_audit_degraded(self, async_db):
+        from src.agent.context_window import _summarize_middle
+
+        with patch("src.agent.context_window.completion_with_fallback_sync", side_effect=RuntimeError("provider down")):
+            result = _summarize_middle(
+                [_msg("user", "hello world")],
+                session_id="sess",
+                range_key="0-1-fail",
+            )
+
+        assert "truncated" in result
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "background_task_degraded"]
+
+        events = asyncio.run(_fetch())
+        assert events
+        assert events[0]["tool_name"] == "context_window_summary"
+        assert events[0]["details"]["runtime_path"] == "context_window_summary"
+        assert events[0]["details"]["fallback"] == "truncation"
 
 
 class TestSettingsIntegration:

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -44,7 +44,10 @@ def test_main_lists_available_scenarios(capsys):
     assert "provider_fallback_chain" in captured.out
     assert "provider_health_reroute" in captured.out
     assert "local_runtime_profile" in captured.out
+    assert "helper_local_runtime_paths" in captured.out
+    assert "context_window_summary_audit" in captured.out
     assert "agent_local_runtime_profile" in captured.out
+    assert "delegation_local_runtime_profile" in captured.out
     assert "runtime_model_overrides" in captured.out
     assert "runtime_fallback_overrides" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
@@ -77,7 +80,10 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "provider_fallback_chain",
                 "provider_health_reroute",
                 "local_runtime_profile",
+                "helper_local_runtime_paths",
+                "context_window_summary_audit",
                 "agent_local_runtime_profile",
+                "delegation_local_runtime_profile",
                 "runtime_model_overrides",
                 "runtime_fallback_overrides",
                 "scheduled_local_runtime_profile",
@@ -112,8 +118,20 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["provider_health_reroute"]["rerouted_model"] == "openai/gpt-4o-mini"
     assert details_by_name["local_runtime_profile"]["runtime_profile"] == "local"
     assert details_by_name["local_runtime_profile"]["routed_model"] == "ollama/llama3.2"
+    assert details_by_name["helper_local_runtime_paths"]["routed_models"]["context_window_summary"] == "ollama/llama3.2"
+    assert details_by_name["helper_local_runtime_paths"]["routed_models"]["session_title_generation"] == "ollama/llama3.2"
+    assert details_by_name["helper_local_runtime_paths"]["routed_models"]["session_consolidation"] == "ollama/llama3.2"
+    assert details_by_name["context_window_summary_audit"]["success_model"] == "ollama/llama3.2"
+    assert details_by_name["context_window_summary_audit"]["success_runtime_path"] == "context_window_summary"
+    assert details_by_name["context_window_summary_audit"]["degraded_runtime_path"] == "context_window_summary"
+    assert details_by_name["context_window_summary_audit"]["degraded_fallback"] == "truncation"
+    assert details_by_name["context_window_summary_audit"]["degraded_contains_truncation"] is True
     assert details_by_name["agent_local_runtime_profile"]["routed_models"]["chat_agent"] == "ollama/llama3.2"
     assert details_by_name["agent_local_runtime_profile"]["routed_models"]["memory_keeper"] == "ollama/llama3.2"
+    assert details_by_name["delegation_local_runtime_profile"]["routed_models"]["orchestrator_agent"] == "ollama/llama3.2"
+    assert details_by_name["delegation_local_runtime_profile"]["routed_models"]["goal_planner"] == "ollama/llama3.2"
+    assert details_by_name["delegation_local_runtime_profile"]["routed_models"]["web_researcher"] == "ollama/llama3.2"
+    assert details_by_name["delegation_local_runtime_profile"]["routed_models"]["file_worker"] == "ollama/llama3.2"
     assert details_by_name["runtime_model_overrides"]["completion_runtime_profile"] == "default"
     assert details_by_name["runtime_model_overrides"]["completion_model"] == "openai/gpt-4o-mini"
     assert details_by_name["runtime_model_overrides"]["agent_runtime_profile"] == "default"

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -38,7 +38,10 @@ uv run python -m src.evals.harness
 uv run python -m src.evals.harness --scenario provider_fallback_chain
 uv run python -m src.evals.harness --scenario provider_health_reroute
 uv run python -m src.evals.harness --scenario local_runtime_profile
+uv run python -m src.evals.harness --scenario helper_local_runtime_paths
+uv run python -m src.evals.harness --scenario context_window_summary_audit
 uv run python -m src.evals.harness --scenario agent_local_runtime_profile
+uv run python -m src.evals.harness --scenario delegation_local_runtime_profile
 uv run python -m src.evals.harness --scenario runtime_model_overrides
 uv run python -m src.evals.harness --scenario runtime_fallback_overrides
 uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
@@ -55,7 +58,7 @@ uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path primary and fallback overrides, local helper/agent/scheduler profile routing, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation profile routing, context-window degradation, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -81,7 +84,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_chat_api.py` | 5 | REST chat endpoint — success, session continuity, errors |
 | `test_consolidation_reliability.py` | 6 | Memory consolidation reliability — edge cases, retry behavior |
 | `test_consolidator.py` | 5 | Memory consolidation — extract facts, soul updates, markdown fences, LLM failure |
-| `test_context_window.py` | 17 | Token-aware context window — budget management, keep first/last, summarization |
+| `test_context_window.py` | 19 | Token-aware context window — budget management, keep first/last, summarization, runtime audit logging |
 | `test_daily_briefing.py` | 5 | Daily briefing — happy path, context/LLM failure, empty data, events in prompt |
 | `test_delegation.py` | 10 | Delegation architecture — orchestrator, specialist routing, depth limits |
 | `test_delivery.py` | 9 | Delivery coordinator — deliver/queue/drop routing, budget decrement, bundle formatting |

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -28,7 +28,7 @@ Legend for the checklist column:
 |---|---|---|
 | 01. Trust Boundaries | `[ ]` | Policy modes, approvals, audit logging, secret redaction, and scoped secret references are shipped; deeper execution isolation and narrower secret-use paths are still left |
 | 02. Execution Plane | `[ ]` | Shell, browser, MCP, discovery, and visible tool execution foundations are shipped; richer process, browser, and workflow execution are still left |
-| 03. Runtime Reliability | `[ ]` | Ordered fallbacks, runtime-path primary and fallback overrides, local routing, runtime audit visibility, and deterministic eval foundations are shipped; richer provider selection, broader local routing, remaining edge coverage, and broader evals are still left |
+| 03. Runtime Reliability | `[ ]` | Ordered fallbacks, runtime-path primary and fallback overrides, local routing across helper/agent/delegation paths, runtime audit visibility, and deterministic eval foundations are shipped; richer provider selection, remaining edge coverage, and broader evals are still left |
 | 04. Presence And Reach | `[ ]` | Browser, WebSocket, proactive delivery, and the native observer daemon are shipped foundations; desktop presence, notifications, channels, and cross-surface continuity are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, strategist, goals, daily briefing, and evening review foundations are shipped; the deeper adaptive guardian layer is still left |
 | 06. Embodied UX | `[ ]` | Village UI, quest log, avatar, ambient indicators, and settings surfaces are shipped; the fuller life-OS shell is still left |
@@ -48,7 +48,7 @@ Legend for the checklist column:
 
 - [x] policy-controlled tool and MCP access with approval gates, audit logging, secret redaction, and scoped secret references
 - [x] shell, browser, vault, filesystem, goals, and web-search tool foundations with live tool execution in chat
-- [x] ordered LLM fallbacks, health-aware rerouting, runtime-path primary and fallback overrides, local helper and agent runtime paths, and broad runtime audit coverage
+- [x] ordered LLM fallbacks, health-aware rerouting, runtime-path primary and fallback overrides, local helper, agent, and delegation runtime paths, and broad runtime audit coverage
 - [x] deterministic runtime eval harness coverage for fallback routing, local routing, browser/sandbox/web-search tool boundaries, observer boundaries, and audit seams
 - [x] browser UI, WebSocket chat, proactive delivery, and a native observer daemon
 - [x] soul, memory, goals, strategist, daily briefing, and evening review foundations

--- a/docs/docs/overview/status-report.md
+++ b/docs/docs/overview/status-report.md
@@ -48,9 +48,9 @@ title: Development Status
 - [x] Health-aware rerouting away from recently failed targets
 - [x] Runtime-path-specific primary model overrides for completion and agent-model paths
 - [x] Runtime-path-specific fallback-chain overrides for completion and agent-model paths
-- [x] First-class local runtime routing for helper, scheduler, and core agent paths
+- [x] First-class local runtime routing for helper, scheduler, core agent, and delegation paths
 - [x] Runtime audit visibility across chat, WebSocket, scheduler, strategist, MCP, observer, browser, sandbox, and web search flows
-- [x] Deterministic runtime eval harness for fallback, routing, browser/sandbox/web-search tool, and observer contracts
+- [x] Deterministic runtime eval harness for fallback, local routing, context-window degradation, browser/sandbox/web-search tool, and observer contracts
 
 ### Product surfaces
 

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -22,13 +22,13 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] health-aware cooldown rerouting across shared completion and agent-model paths
 - [x] runtime-path-specific primary model overrides across shared completion and agent-model paths
 - [x] runtime-path-specific ordered fallback-chain overrides across shared completion and agent-model paths
-- [x] first-class local runtime profile for bounded helper flows, scheduled completion-based jobs, and core agent model factories
+- [x] first-class local runtime profile for bounded helper flows, scheduled completion-based jobs, core agent model factories, and delegation paths
 - [x] timeout-safe audit visibility into primary-vs-fallback LLM completion and agent-model behavior
 - [x] fallback-capable `smolagents` model wrappers for chat, onboarding, strategist, and specialists
 - [x] repeatable runtime eval harness for core guardian, tool, and observer/audit-runtime reliability contracts
 - [x] lifecycle audit events for REST chat, WebSocket chat, and the full scheduler job surface
 - [x] real tool execution audit events for call, result, and failure across agent transports
-- [x] strategist tool calls and background helper flows now emit runtime audit coverage
+- [x] strategist tool calls and background helper flows, including context-window summarization, now emit runtime audit coverage
 - [x] MCP server connection lifecycle emits runtime audit coverage for connect, disconnect, auth-required, and failure states
 - [x] sandbox, browser, and web-search tool boundaries emit runtime integration coverage for success, blocked, timeout, empty-result, and failure paths
 - [x] observer calendar, git, goal, and time source boundaries emit runtime integration coverage for unavailable, empty-result, success, and failure paths
@@ -44,14 +44,14 @@ Make Seraph more resilient, observable, and predictable under real usage.
 ## Still To Do On `develop`
 
 - [ ] deepen provider routing beyond the current explicit runtime-path primary and fallback overrides, ordered fallback, and cooldown rerouting with richer policy-aware selection
-- [ ] broaden local-model routing beyond the current helper, scheduled completion, and core agent-model paths into any remaining runtime paths where it makes sense
+- [ ] broaden local-model routing beyond the current helper, scheduled completion, core agent-model, and delegation paths into any remaining runtime paths where it makes sense
 - [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git/goal/time sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, and the browser/sandbox/web-search tool boundaries
-- [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing, local-profile behavior, and remaining edge-path contracts
+- [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing and remaining edge-path contracts
 
 ## Acceptance Checklist
 
 - [x] provider failure with configured fallbacks does not collapse the entire chat path
-- [x] a local or non-OpenRouter path is demonstrably possible across more than the current helper and scheduled completion flows
+- [x] a local or non-OpenRouter path is demonstrably possible across helper, scheduled completion, core agent, and delegation flows
 - [x] runtime paths can force distinct primary and fallback routing without changing the global runtime baseline
 - [ ] key flows are observable and easier to debug
 - [ ] the project has repeatable eval coverage for core behavior


### PR DESCRIPTION
## Done on develop
- [x] Ordered fallbacks, health-aware rerouting, runtime-path primary and fallback overrides, and local routing across helper, scheduler, agent, and delegation paths
- [x] Runtime audit visibility across chat, scheduler, observer, MCP, browser, sandbox, and web-search boundaries
- [x] Deterministic eval coverage for provider routing, observer boundaries, and runtime tool/integration seams

## Working in this PR
- [x] Log `context_window_summary` success and truncation-degraded outcomes through the background-task audit surface
- [x] Expand deterministic eval coverage for helper local runtime paths, delegation local runtime paths, and the context-window degradation contract
- [x] Update Runtime Reliability status docs and testing guidance so the shipped surface matches the repo

## Still to do after this PR
- [ ] Deepen provider routing beyond explicit overrides, ordered fallback chains, and cooldown rerouting
- [ ] Add observability coverage for any remaining edge helpers and external integration paths
- [ ] Expand eval coverage beyond seam checks into broader runtime behavior

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/audit/runtime.py backend/src/agent/context_window.py backend/src/evals/harness.py backend/tests/test_context_window.py backend/tests/test_eval_harness.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_context_window.py tests/test_eval_harness.py tests/test_delegation.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario helper_local_runtime_paths --scenario context_window_summary_audit --scenario delegation_local_runtime_profile --indent 2`
- `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`
- `cd docs && npm run build`
