### PR TITLE
Cover MCP specialist runtime routing

### DIFF
--- a/backend/src/agent/specialists.py
+++ b/backend/src/agent/specialists.py
@@ -102,6 +102,11 @@ def _sanitize_agent_name(name: str) -> str:
     return sanitized or "unnamed_agent"
 
 
+def mcp_specialist_runtime_path(server_name: str) -> str:
+    """Return the runtime path/name used for a connected MCP specialist."""
+    return _sanitize_agent_name(f"mcp_{server_name}")
+
+
 def _create_model(temperature: float, runtime_path: str) -> LiteLLMModel:
     """Create a LiteLLMModel with specialist-specific temperature."""
     return LiteLLMModel(**build_model_kwargs(
@@ -171,7 +176,7 @@ def create_mcp_specialist(
     description: str = "",
 ) -> ToolCallingAgent:
     """Create a specialist agent for a single MCP server's tools."""
-    name = _sanitize_agent_name(f"mcp_{server_name}")
+    name = mcp_specialist_runtime_path(server_name)
     if not description:
         tool_names = [getattr(t, "name", str(t)) for t in tools]
         description = f"MCP server '{server_name}' with tools: {', '.join(tool_names)}"

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -20,7 +20,7 @@ from src.agent.session import SessionManager, session_manager
 from src.agent.context_window import _summarize_middle, _summary_cache
 from src.agent.factory import create_orchestrator, get_model
 from src.agent.onboarding import create_onboarding_agent
-from src.agent.specialists import create_specialist
+from src.agent.specialists import create_mcp_specialist, create_specialist, mcp_specialist_runtime_path
 from src.agent.strategist import create_strategist_agent
 from src.api.observer import ScreenContextRequest, ScreenObservationData, post_screen_context
 from src.audit.repository import audit_repository
@@ -500,6 +500,40 @@ def _eval_delegation_local_runtime_profile() -> dict[str, Any]:
     return {
         "runtime_profile": "local",
         "routed_models": routed_models,
+    }
+
+
+def _eval_mcp_specialist_local_runtime_profile() -> dict[str, Any]:
+    runtime_path = mcp_specialist_runtime_path("github-actions")
+    tool = MagicMock()
+    tool.name = "list_workflows"
+
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "local_model", "ollama/llama3.2"),
+        patch.object(settings, "local_llm_api_key", ""),
+        patch.object(settings, "local_llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "local_runtime_paths", runtime_path),
+        patch("src.agent.specialists.ToolCallingAgent") as mock_agent_cls,
+    ):
+        def _make_agent(**kwargs: Any) -> MagicMock:
+            agent = MagicMock()
+            agent.name = kwargs["name"]
+            agent.model = kwargs["model"]
+            agent.description = kwargs["description"]
+            return agent
+
+        mock_agent_cls.side_effect = _make_agent
+        specialist = create_mcp_specialist("github-actions", [tool], description="GitHub workflows MCP")
+
+    assert specialist.name == runtime_path
+    assert specialist.model.model_id == "ollama/llama3.2"
+    return {
+        "runtime_profile": "local",
+        "runtime_path": runtime_path,
+        "routed_model": specialist.model.model_id,
     }
 
 
@@ -1200,6 +1234,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="runtime",
         description="Delegation paths can route the orchestrator and remaining built-in specialists through the local profile.",
         runner=_eval_delegation_local_runtime_profile,
+    ),
+    EvalScenario(
+        name="mcp_specialist_local_runtime_profile",
+        category="runtime",
+        description="Dynamic MCP specialists can route through the local profile using their sanitized runtime path.",
+        runner=_eval_mcp_specialist_local_runtime_profile,
     ),
     EvalScenario(
         name="runtime_model_overrides",

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -48,6 +48,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "context_window_summary_audit" in captured.out
     assert "agent_local_runtime_profile" in captured.out
     assert "delegation_local_runtime_profile" in captured.out
+    assert "mcp_specialist_local_runtime_profile" in captured.out
     assert "runtime_model_overrides" in captured.out
     assert "runtime_fallback_overrides" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
@@ -84,6 +85,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "context_window_summary_audit",
                 "agent_local_runtime_profile",
                 "delegation_local_runtime_profile",
+                "mcp_specialist_local_runtime_profile",
                 "runtime_model_overrides",
                 "runtime_fallback_overrides",
                 "scheduled_local_runtime_profile",
@@ -132,6 +134,8 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["delegation_local_runtime_profile"]["routed_models"]["goal_planner"] == "ollama/llama3.2"
     assert details_by_name["delegation_local_runtime_profile"]["routed_models"]["web_researcher"] == "ollama/llama3.2"
     assert details_by_name["delegation_local_runtime_profile"]["routed_models"]["file_worker"] == "ollama/llama3.2"
+    assert details_by_name["mcp_specialist_local_runtime_profile"]["runtime_path"] == "mcp_github_actions"
+    assert details_by_name["mcp_specialist_local_runtime_profile"]["routed_model"] == "ollama/llama3.2"
     assert details_by_name["runtime_model_overrides"]["completion_runtime_profile"] == "default"
     assert details_by_name["runtime_model_overrides"]["completion_model"] == "openai/gpt-4o-mini"
     assert details_by_name["runtime_model_overrides"]["agent_runtime_profile"] == "default"

--- a/backend/tests/test_specialists.py
+++ b/backend/tests/test_specialists.py
@@ -16,6 +16,7 @@ from src.agent.specialists import (
     create_memory_keeper,
     create_specialist,
     create_web_researcher,
+    mcp_specialist_runtime_path,
 )
 from src.observer.context import CurrentContext
 
@@ -214,6 +215,9 @@ class TestNamedFactories:
 
 
 class TestMcpSpecialist:
+    def test_runtime_path_helper_matches_sanitized_name(self):
+        assert mcp_specialist_runtime_path("my-server") == "mcp_my_server"
+
     @patch("src.agent.specialists.ToolCallingAgent")
     @patch("src.agent.specialists.LiteLLMModel")
     def test_name_sanitization(self, mock_model_cls, mock_agent_cls):
@@ -247,6 +251,29 @@ class TestMcpSpecialist:
         create_mcp_specialist("things3", [tool], description="Task manager")
         agent_kwargs = mock_agent_cls.call_args[1]
         assert agent_kwargs["description"] == "Task manager"
+
+    @patch("src.agent.specialists.ToolCallingAgent")
+    @patch("src.agent.specialists.LiteLLMModel")
+    def test_uses_local_profile_for_dynamic_runtime_path(self, mock_model_cls, mock_agent_cls):
+        mock_model_cls.return_value = MagicMock()
+        mock_agent_cls.return_value = MagicMock()
+        tool = MagicMock()
+        tool.name = "list_tasks"
+
+        with (
+            patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+            patch.object(settings, "llm_api_key", "primary-key"),
+            patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+            patch.object(settings, "local_model", "ollama/llama3.2"),
+            patch.object(settings, "local_llm_api_key", ""),
+            patch.object(settings, "local_llm_api_base", "http://localhost:11434/v1"),
+            patch.object(settings, "local_runtime_paths", "mcp_things3"),
+        ):
+            create_mcp_specialist("things3", [tool], description="Task manager")
+
+        call_kwargs = mock_model_cls.call_args[1]
+        assert call_kwargs["model_id"] == "ollama/llama3.2"
+        assert call_kwargs["api_base"] == "http://localhost:11434/v1"
 
 
 class TestBuildAllSpecialists:

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -42,6 +42,7 @@ uv run python -m src.evals.harness --scenario helper_local_runtime_paths
 uv run python -m src.evals.harness --scenario context_window_summary_audit
 uv run python -m src.evals.harness --scenario agent_local_runtime_profile
 uv run python -m src.evals.harness --scenario delegation_local_runtime_profile
+uv run python -m src.evals.harness --scenario mcp_specialist_local_runtime_profile
 uv run python -m src.evals.harness --scenario runtime_model_overrides
 uv run python -m src.evals.harness --scenario runtime_fallback_overrides
 uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
@@ -58,7 +59,7 @@ uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation profile routing, context-window degradation, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, context-window degradation, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -115,7 +116,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_shell_tool.py` | 9 | Shell execution — success, errors, size limits, timeout, connection errors, runtime audit logging |
 | `test_skills.py` | 27 | Skills system — loading, gating, enable/disable, frontmatter parsing, API |
 | `test_soul.py` | 9 | Soul file persistence — read/write, section update, ensure exists |
-| `test_specialists.py` | 28 | Specialist agents — factory, tool domains, MCP specialist generation |
+| `test_specialists.py` | 30 | Specialist agents — factory, tool domains, MCP specialist generation, runtime-path routing |
 | `test_strategist.py` | 12 | Strategist agent — JSON parsing (valid, fenced, invalid, empty, partial), agent creation |
 | `test_timeouts.py` | 5 | Execution timeouts — agent, briefing, consolidation timeouts |
 | `test_tool_registry.py` | 4 | Tool metadata registry — lookup, required fields, copy safety |

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -28,7 +28,7 @@ Legend for the checklist column:
 |---|---|---|
 | 01. Trust Boundaries | `[ ]` | Policy modes, approvals, audit logging, secret redaction, and scoped secret references are shipped; deeper execution isolation and narrower secret-use paths are still left |
 | 02. Execution Plane | `[ ]` | Shell, browser, MCP, discovery, and visible tool execution foundations are shipped; richer process, browser, and workflow execution are still left |
-| 03. Runtime Reliability | `[ ]` | Ordered fallbacks, runtime-path primary and fallback overrides, local routing across helper/agent/delegation paths, runtime audit visibility, and deterministic eval foundations are shipped; richer provider selection, remaining edge coverage, and broader evals are still left |
+| 03. Runtime Reliability | `[ ]` | Ordered fallbacks, runtime-path primary and fallback overrides, local routing across helper/agent/delegation/MCP-specialist paths, runtime audit visibility, and deterministic eval foundations are shipped; richer provider selection, remaining edge coverage, and broader evals are still left |
 | 04. Presence And Reach | `[ ]` | Browser, WebSocket, proactive delivery, and the native observer daemon are shipped foundations; desktop presence, notifications, channels, and cross-surface continuity are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, strategist, goals, daily briefing, and evening review foundations are shipped; the deeper adaptive guardian layer is still left |
 | 06. Embodied UX | `[ ]` | Village UI, quest log, avatar, ambient indicators, and settings surfaces are shipped; the fuller life-OS shell is still left |
@@ -48,7 +48,7 @@ Legend for the checklist column:
 
 - [x] policy-controlled tool and MCP access with approval gates, audit logging, secret redaction, and scoped secret references
 - [x] shell, browser, vault, filesystem, goals, and web-search tool foundations with live tool execution in chat
-- [x] ordered LLM fallbacks, health-aware rerouting, runtime-path primary and fallback overrides, local helper, agent, and delegation runtime paths, and broad runtime audit coverage
+- [x] ordered LLM fallbacks, health-aware rerouting, runtime-path primary and fallback overrides, local helper, agent, delegation, and MCP-specialist runtime paths, and broad runtime audit coverage
 - [x] deterministic runtime eval harness coverage for fallback routing, local routing, browser/sandbox/web-search tool boundaries, observer boundaries, and audit seams
 - [x] browser UI, WebSocket chat, proactive delivery, and a native observer daemon
 - [x] soul, memory, goals, strategist, daily briefing, and evening review foundations

--- a/docs/docs/overview/status-report.md
+++ b/docs/docs/overview/status-report.md
@@ -48,9 +48,9 @@ title: Development Status
 - [x] Health-aware rerouting away from recently failed targets
 - [x] Runtime-path-specific primary model overrides for completion and agent-model paths
 - [x] Runtime-path-specific fallback-chain overrides for completion and agent-model paths
-- [x] First-class local runtime routing for helper, scheduler, core agent, and delegation paths
+- [x] First-class local runtime routing for helper, scheduler, core agent, delegation, and connected MCP specialist paths
 - [x] Runtime audit visibility across chat, WebSocket, scheduler, strategist, MCP, observer, browser, sandbox, and web search flows
-- [x] Deterministic runtime eval harness for fallback, local routing, context-window degradation, browser/sandbox/web-search tool, and observer contracts
+- [x] Deterministic runtime eval harness for fallback, local routing, context-window degradation, MCP specialist routing, browser/sandbox/web-search tool, and observer contracts
 
 ### Product surfaces
 

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -22,10 +22,10 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] health-aware cooldown rerouting across shared completion and agent-model paths
 - [x] runtime-path-specific primary model overrides across shared completion and agent-model paths
 - [x] runtime-path-specific ordered fallback-chain overrides across shared completion and agent-model paths
-- [x] first-class local runtime profile for bounded helper flows, scheduled completion-based jobs, core agent model factories, and delegation paths
+- [x] first-class local runtime profile for bounded helper flows, scheduled completion-based jobs, core agent model factories, delegation paths, and connected MCP specialists
 - [x] timeout-safe audit visibility into primary-vs-fallback LLM completion and agent-model behavior
 - [x] fallback-capable `smolagents` model wrappers for chat, onboarding, strategist, and specialists
-- [x] repeatable runtime eval harness for core guardian, tool, and observer/audit-runtime reliability contracts
+- [x] repeatable runtime eval harness for core guardian, tool, MCP specialist, and observer/audit-runtime reliability contracts
 - [x] lifecycle audit events for REST chat, WebSocket chat, and the full scheduler job surface
 - [x] real tool execution audit events for call, result, and failure across agent transports
 - [x] strategist tool calls and background helper flows, including context-window summarization, now emit runtime audit coverage
@@ -44,14 +44,14 @@ Make Seraph more resilient, observable, and predictable under real usage.
 ## Still To Do On `develop`
 
 - [ ] deepen provider routing beyond the current explicit runtime-path primary and fallback overrides, ordered fallback, and cooldown rerouting with richer policy-aware selection
-- [ ] broaden local-model routing beyond the current helper, scheduled completion, core agent-model, and delegation paths into any remaining runtime paths where it makes sense
+- [ ] broaden local-model routing beyond the current helper, scheduled completion, core agent-model, delegation, and connected MCP specialist paths into any remaining runtime paths where it makes sense
 - [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git/goal/time sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, and the browser/sandbox/web-search tool boundaries
 - [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing and remaining edge-path contracts
 
 ## Acceptance Checklist
 
 - [x] provider failure with configured fallbacks does not collapse the entire chat path
-- [x] a local or non-OpenRouter path is demonstrably possible across helper, scheduled completion, core agent, and delegation flows
+- [x] a local or non-OpenRouter path is demonstrably possible across helper, scheduled completion, core agent, delegation, and connected MCP specialist flows
 - [x] runtime paths can force distinct primary and fallback routing without changing the global runtime baseline
 - [ ] key flows are observable and easier to debug
 - [ ] the project has repeatable eval coverage for core behavior


### PR DESCRIPTION
## Done on develop
- [x] Ordered fallbacks, health-aware rerouting, runtime-path primary and fallback overrides, and local routing across helper, scheduler, agent, and built-in delegation paths
- [x] Runtime audit visibility across chat, scheduler, observer, MCP, browser, sandbox, and web-search boundaries
- [x] Deterministic eval coverage for provider routing, observer boundaries, and runtime tool/integration seams

## Working in this PR
- [x] Make the sanitized runtime path for dynamic MCP specialists explicit in the specialist factory
- [x] Add deterministic eval and unit coverage proving local runtime routing for connected MCP specialist paths
- [x] Update Runtime Reliability and status docs so the shipped surface matches the verified repo state

## Still to do after this PR
- [ ] Deepen provider routing beyond explicit overrides, ordered fallback chains, and cooldown rerouting
- [ ] Broaden local-model routing into any remaining worthwhile runtime paths beyond the currently covered helper, scheduler, agent, delegation, and MCP-specialist surfaces
- [ ] Expand observability and eval coverage beyond the current seam-focused contracts

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/agent/specialists.py backend/src/evals/harness.py backend/tests/test_specialists.py backend/tests/test_eval_harness.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_specialists.py tests/test_eval_harness.py tests/test_delegation.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario mcp_specialist_local_runtime_profile --indent 2`
- `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`
- `cd docs && npm run build`
