### PR TITLE
Trace embedding runtime failures

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import sys
 import time
+import types
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any, Awaitable, Callable, Sequence
@@ -25,6 +26,7 @@ from src.agent.strategist import create_strategist_agent
 from src.api.observer import ScreenContextRequest, ScreenObservationData, post_screen_context
 from src.audit.repository import audit_repository
 from src.llm_runtime import FallbackLiteLLMModel, _reset_target_health, completion_with_fallback_sync
+from src.memory.embedder import _reset_embedder_state, embed
 from src.observer.sources.calendar_source import gather_calendar
 from src.observer.sources.goal_source import gather_goals
 from src.observer.sources.git_source import gather_git
@@ -535,6 +537,61 @@ def _eval_mcp_specialist_local_runtime_profile() -> dict[str, Any]:
         "runtime_path": runtime_path,
         "routed_model": specialist.model.model_id,
     }
+
+
+async def _eval_embedding_runtime_audit() -> dict[str, Any]:
+    class _Vector:
+        def __init__(self, payload: Any):
+            self._payload = payload
+
+        def tolist(self) -> Any:
+            return self._payload
+
+    class _FakeSentenceTransformer:
+        def __init__(self, model_name: str):
+            self.model_name = model_name
+
+        def encode(self, value: Any, normalize_embeddings: bool = True) -> _Vector:
+            if value == "fail":
+                raise RuntimeError("encode crashed")
+            if isinstance(value, list):
+                return _Vector([[0.1, 0.2] for _ in value])
+            return _Vector([0.1, 0.2])
+
+    _reset_embedder_state()
+    fake_module = types.SimpleNamespace(SentenceTransformer=_FakeSentenceTransformer)
+
+    try:
+        with (
+            patch.dict(sys.modules, {"sentence_transformers": fake_module}),
+            patch.object(audit_repository, "log_event", AsyncMock()) as mock_log_event,
+        ):
+            vector = embed("hello")
+            try:
+                embed("fail")
+            except RuntimeError:
+                pass
+            await asyncio.sleep(0)
+
+        loaded = _find_audit_call(
+            mock_log_event,
+            event_type="integration_loaded",
+            tool_name=f"embedding_model:{settings.embedding_model}",
+        )
+        failed = _find_audit_call(
+            mock_log_event,
+            event_type="integration_failed",
+            tool_name=f"embedding_model:{settings.embedding_model}",
+        )
+        return {
+            "loaded_model": loaded["details"]["name"],
+            "loaded_integration_type": loaded["details"]["integration_type"],
+            "vector_length": len(vector),
+            "failure_stage": failed["details"]["stage"],
+            "failure_error": failed["details"]["error"],
+        }
+    finally:
+        _reset_embedder_state()
 
 
 def _eval_runtime_model_overrides() -> dict[str, Any]:
@@ -1240,6 +1297,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="runtime",
         description="Dynamic MCP specialists can route through the local profile using their sanitized runtime path.",
         runner=_eval_mcp_specialist_local_runtime_profile,
+    ),
+    EvalScenario(
+        name="embedding_runtime_audit",
+        category="observability",
+        description="The local embedding model boundary records load success and encode failures without live dependencies.",
+        runner=_eval_embedding_runtime_audit,
     ),
     EvalScenario(
         name="runtime_model_overrides",

--- a/backend/src/memory/embedder.py
+++ b/backend/src/memory/embedder.py
@@ -3,34 +3,81 @@ import threading
 from typing import Optional
 
 from config.settings import settings
+from src.audit.runtime import log_integration_event_sync
 
 logger = logging.getLogger(__name__)
 
 _model: Optional[object] = None
 _model_lock = threading.Lock()
+_LOAD_EVENT_EMITTED = False
+
+
+def _embedder_name() -> str:
+    return settings.embedding_model
+
+
+def _log_embedding_event(outcome: str, details: dict | None = None) -> None:
+    log_integration_event_sync(
+        integration_type="embedding_model",
+        name=_embedder_name(),
+        outcome=outcome,
+        details=details,
+    )
 
 
 def _get_model():
     """Lazy-load the sentence-transformers model (singleton, thread-safe)."""
-    global _model
+    global _model, _LOAD_EVENT_EMITTED
     if _model is None:
         with _model_lock:
             if _model is None:
                 logger.info("Loading embedding model: %s", settings.embedding_model)
-                from sentence_transformers import SentenceTransformer
+                try:
+                    from sentence_transformers import SentenceTransformer
 
-                _model = SentenceTransformer(settings.embedding_model)
-                logger.info("Embedding model loaded")
+                    _model = SentenceTransformer(settings.embedding_model)
+                    logger.info("Embedding model loaded")
+                    if not _LOAD_EVENT_EMITTED:
+                        _log_embedding_event("loaded")
+                        _LOAD_EVENT_EMITTED = True
+                except Exception as exc:
+                    _log_embedding_event(
+                        "failed",
+                        details={"stage": "load", "error": str(exc)},
+                    )
+                    raise
     return _model
 
 
 def embed(text: str) -> list[float]:
     """Embed a single text string into a vector."""
     model = _get_model()
-    return model.encode(text, normalize_embeddings=True).tolist()
+    try:
+        return model.encode(text, normalize_embeddings=True).tolist()
+    except Exception as exc:
+        _log_embedding_event(
+            "failed",
+            details={"stage": "encode", "batch_size": 1, "error": str(exc)},
+        )
+        raise
 
 
 def embed_batch(texts: list[str]) -> list[list[float]]:
     """Embed multiple texts into vectors."""
     model = _get_model()
-    return model.encode(texts, normalize_embeddings=True).tolist()
+    try:
+        return model.encode(texts, normalize_embeddings=True).tolist()
+    except Exception as exc:
+        _log_embedding_event(
+            "failed",
+            details={"stage": "encode", "batch_size": len(texts), "error": str(exc)},
+        )
+        raise
+
+
+def _reset_embedder_state() -> None:
+    """Reset cached embedder state for tests and deterministic evals."""
+    global _model, _LOAD_EVENT_EMITTED
+    with _model_lock:
+        _model = None
+        _LOAD_EVENT_EMITTED = False

--- a/backend/tests/test_embedder.py
+++ b/backend/tests/test_embedder.py
@@ -1,0 +1,97 @@
+"""Tests for embedding-model runtime audit coverage."""
+
+import asyncio
+import types
+from unittest.mock import patch
+
+import pytest
+
+from config.settings import settings
+from src.audit.repository import audit_repository
+from src.memory import embedder
+
+
+class _Vector:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def tolist(self):
+        return self._payload
+
+
+class _FakeSentenceTransformer:
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+
+    def encode(self, value, normalize_embeddings: bool = True):
+        if value == "fail":
+            raise RuntimeError("encode crashed")
+        if isinstance(value, list):
+            return _Vector([[0.1, 0.2] for _ in value])
+        return _Vector([0.1, 0.2])
+
+
+@pytest.fixture(autouse=True)
+def _reset_embedder_state():
+    embedder._reset_embedder_state()
+    yield
+    embedder._reset_embedder_state()
+
+
+def test_embed_logs_model_load(async_db):
+    fake_module = types.SimpleNamespace(SentenceTransformer=_FakeSentenceTransformer)
+
+    with patch.dict("sys.modules", {"sentence_transformers": fake_module}):
+        vector = embedder.embed("hello")
+
+    assert vector == [0.1, 0.2]
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "integration_loaded"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["tool_name"] == f"embedding_model:{settings.embedding_model}"
+    assert events[0]["details"]["integration_type"] == "embedding_model"
+    assert events[0]["details"]["name"] == settings.embedding_model
+
+
+def test_embed_logs_encode_failure(async_db):
+    fake_module = types.SimpleNamespace(SentenceTransformer=_FakeSentenceTransformer)
+
+    with patch.dict("sys.modules", {"sentence_transformers": fake_module}):
+        with pytest.raises(RuntimeError, match="encode crashed"):
+            embedder.embed("fail")
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "integration_failed"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["tool_name"] == f"embedding_model:{settings.embedding_model}"
+    assert events[0]["details"]["stage"] == "encode"
+    assert events[0]["details"]["batch_size"] == 1
+
+
+def test_embed_logs_model_load_failure(async_db):
+    class _BrokenSentenceTransformer:
+        def __init__(self, model_name: str):
+            raise RuntimeError("model missing")
+
+    fake_module = types.SimpleNamespace(SentenceTransformer=_BrokenSentenceTransformer)
+
+    with patch.dict("sys.modules", {"sentence_transformers": fake_module}):
+        with pytest.raises(RuntimeError, match="model missing"):
+            embedder.embed("hello")
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "integration_failed"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["tool_name"] == f"embedding_model:{settings.embedding_model}"
+    assert events[0]["details"]["stage"] == "load"
+    assert events[0]["details"]["error"] == "model missing"

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -49,6 +49,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "agent_local_runtime_profile" in captured.out
     assert "delegation_local_runtime_profile" in captured.out
     assert "mcp_specialist_local_runtime_profile" in captured.out
+    assert "embedding_runtime_audit" in captured.out
     assert "runtime_model_overrides" in captured.out
     assert "runtime_fallback_overrides" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
@@ -86,6 +87,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "agent_local_runtime_profile",
                 "delegation_local_runtime_profile",
                 "mcp_specialist_local_runtime_profile",
+                "embedding_runtime_audit",
                 "runtime_model_overrides",
                 "runtime_fallback_overrides",
                 "scheduled_local_runtime_profile",
@@ -136,6 +138,11 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["delegation_local_runtime_profile"]["routed_models"]["file_worker"] == "ollama/llama3.2"
     assert details_by_name["mcp_specialist_local_runtime_profile"]["runtime_path"] == "mcp_github_actions"
     assert details_by_name["mcp_specialist_local_runtime_profile"]["routed_model"] == "ollama/llama3.2"
+    assert details_by_name["embedding_runtime_audit"]["loaded_integration_type"] == "embedding_model"
+    assert details_by_name["embedding_runtime_audit"]["loaded_model"] == "all-MiniLM-L6-v2"
+    assert details_by_name["embedding_runtime_audit"]["vector_length"] == 2
+    assert details_by_name["embedding_runtime_audit"]["failure_stage"] == "encode"
+    assert details_by_name["embedding_runtime_audit"]["failure_error"] == "encode crashed"
     assert details_by_name["runtime_model_overrides"]["completion_runtime_profile"] == "default"
     assert details_by_name["runtime_model_overrides"]["completion_model"] == "openai/gpt-4o-mini"
     assert details_by_name["runtime_model_overrides"]["agent_runtime_profile"] == "default"

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -43,6 +43,7 @@ uv run python -m src.evals.harness --scenario context_window_summary_audit
 uv run python -m src.evals.harness --scenario agent_local_runtime_profile
 uv run python -m src.evals.harness --scenario delegation_local_runtime_profile
 uv run python -m src.evals.harness --scenario mcp_specialist_local_runtime_profile
+uv run python -m src.evals.harness --scenario embedding_runtime_audit
 uv run python -m src.evals.harness --scenario runtime_model_overrides
 uv run python -m src.evals.harness --scenario runtime_fallback_overrides
 uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
@@ -59,7 +60,7 @@ uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, context-window degradation, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model load/encode failures, context-window degradation, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -89,6 +90,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_daily_briefing.py` | 5 | Daily briefing — happy path, context/LLM failure, empty data, events in prompt |
 | `test_delegation.py` | 10 | Delegation architecture — orchestrator, specialist routing, depth limits |
 | `test_delivery.py` | 9 | Delivery coordinator — deliver/queue/drop routing, budget decrement, bundle formatting |
+| `test_embedder.py` | 3 | Embedding model boundary — load success, load failure, encode failure runtime audit logging |
 | `test_e2e_conversation.py` | 3 | End-to-end conversation flow — full agent interaction paths |
 | `test_evening_review.py` | 8 | Evening review — happy path, no goals/messages, DB/LLM failure, date filtering |
 | `test_goal_tree_integrity.py` | 12 | Goal tree integrity — parent-child relationships, path consistency, cascading |

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -28,7 +28,7 @@ Legend for the checklist column:
 |---|---|---|
 | 01. Trust Boundaries | `[ ]` | Policy modes, approvals, audit logging, secret redaction, and scoped secret references are shipped; deeper execution isolation and narrower secret-use paths are still left |
 | 02. Execution Plane | `[ ]` | Shell, browser, MCP, discovery, and visible tool execution foundations are shipped; richer process, browser, and workflow execution are still left |
-| 03. Runtime Reliability | `[ ]` | Ordered fallbacks, runtime-path primary and fallback overrides, local routing across helper/agent/delegation/MCP-specialist paths, runtime audit visibility, and deterministic eval foundations are shipped; richer provider selection, remaining edge coverage, and broader evals are still left |
+| 03. Runtime Reliability | `[ ]` | Ordered fallbacks, runtime-path primary and fallback overrides, local routing across helper/agent/delegation/MCP-specialist paths, runtime audit visibility including the embedding boundary, and deterministic eval foundations are shipped; richer provider selection, remaining edge coverage, and broader evals are still left |
 | 04. Presence And Reach | `[ ]` | Browser, WebSocket, proactive delivery, and the native observer daemon are shipped foundations; desktop presence, notifications, channels, and cross-surface continuity are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, strategist, goals, daily briefing, and evening review foundations are shipped; the deeper adaptive guardian layer is still left |
 | 06. Embodied UX | `[ ]` | Village UI, quest log, avatar, ambient indicators, and settings surfaces are shipped; the fuller life-OS shell is still left |
@@ -49,7 +49,7 @@ Legend for the checklist column:
 - [x] policy-controlled tool and MCP access with approval gates, audit logging, secret redaction, and scoped secret references
 - [x] shell, browser, vault, filesystem, goals, and web-search tool foundations with live tool execution in chat
 - [x] ordered LLM fallbacks, health-aware rerouting, runtime-path primary and fallback overrides, local helper, agent, delegation, and MCP-specialist runtime paths, and broad runtime audit coverage
-- [x] deterministic runtime eval harness coverage for fallback routing, local routing, browser/sandbox/web-search tool boundaries, observer boundaries, and audit seams
+- [x] deterministic runtime eval harness coverage for fallback routing, local routing, embedding/model boundaries, browser/sandbox/web-search tool boundaries, observer boundaries, and audit seams
 - [x] browser UI, WebSocket chat, proactive delivery, and a native observer daemon
 - [x] soul, memory, goals, strategist, daily briefing, and evening review foundations
 - [x] skills, MCP integration, and recursive delegation foundations

--- a/docs/docs/overview/status-report.md
+++ b/docs/docs/overview/status-report.md
@@ -49,8 +49,8 @@ title: Development Status
 - [x] Runtime-path-specific primary model overrides for completion and agent-model paths
 - [x] Runtime-path-specific fallback-chain overrides for completion and agent-model paths
 - [x] First-class local runtime routing for helper, scheduler, core agent, delegation, and connected MCP specialist paths
-- [x] Runtime audit visibility across chat, WebSocket, scheduler, strategist, MCP, observer, browser, sandbox, and web search flows
-- [x] Deterministic runtime eval harness for fallback, local routing, context-window degradation, MCP specialist routing, browser/sandbox/web-search tool, and observer contracts
+- [x] Runtime audit visibility across chat, WebSocket, scheduler, strategist, MCP, observer, embedding, browser, sandbox, and web search flows
+- [x] Deterministic runtime eval harness for fallback, local routing, context-window degradation, MCP specialist routing, embedding-model boundaries, browser/sandbox/web-search tool, and observer contracts
 
 ### Product surfaces
 

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -30,6 +30,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] real tool execution audit events for call, result, and failure across agent transports
 - [x] strategist tool calls and background helper flows, including context-window summarization, now emit runtime audit coverage
 - [x] MCP server connection lifecycle emits runtime audit coverage for connect, disconnect, auth-required, and failure states
+- [x] the local embedding-model boundary emits runtime audit coverage for model load success/failure and encode failures
 - [x] sandbox, browser, and web-search tool boundaries emit runtime integration coverage for success, blocked, timeout, empty-result, and failure paths
 - [x] observer calendar, git, goal, and time source boundaries emit runtime integration coverage for unavailable, empty-result, success, and failure paths
 - [x] observer context refresh and queued-bundle delivery emit background runtime audit coverage
@@ -45,8 +46,8 @@ Make Seraph more resilient, observable, and predictable under real usage.
 
 - [ ] deepen provider routing beyond the current explicit runtime-path primary and fallback overrides, ordered fallback, and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduled completion, core agent-model, delegation, and connected MCP specialist paths into any remaining runtime paths where it makes sense
-- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git/goal/time sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, and the browser/sandbox/web-search tool boundaries
-- [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing and remaining edge-path contracts
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git/goal/time sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, the embedding boundary, and the browser/sandbox/web-search tool boundaries
+- [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing and remaining edge-path contracts beyond the current MCP-specialist and embedding-model coverage
 
 ## Acceptance Checklist
 


### PR DESCRIPTION
## Done on develop
- [x] Ordered fallbacks, health-aware rerouting, runtime-path primary and fallback overrides, and local routing across helper, scheduler, agent, delegation, and MCP-specialist paths
- [x] Runtime audit visibility across chat, scheduler, observer, MCP, browser, sandbox, and web-search boundaries
- [x] Deterministic eval coverage for provider routing, observer boundaries, and runtime tool/integration seams

## Working in this PR
- [x] Add fail-open runtime audit logging for embedding model load success/failure and encode failures
- [x] Add deterministic eval and focused unit coverage for the embedding-model runtime boundary
- [x] Update Runtime Reliability and status docs so the shipped surface includes verified embedding coverage

## Still to do after this PR
- [ ] Deepen provider routing beyond explicit overrides, ordered fallback chains, and cooldown rerouting
- [ ] Broaden local-model routing into any remaining worthwhile runtime paths beyond the currently covered helper, scheduler, agent, delegation, MCP-specialist, and embedding surfaces
- [ ] Expand observability and eval coverage beyond the current seam-focused contracts

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/memory/embedder.py backend/src/evals/harness.py backend/tests/test_embedder.py backend/tests/test_eval_harness.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_embedder.py tests/test_eval_harness.py tests/test_consolidation_reliability.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario embedding_runtime_audit --indent 2`
- `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`
- `cd docs && npm run build`
