### PR TITLE
Trace soul file runtime audit paths

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import sys
 import time
+import tempfile
 import types
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
@@ -32,6 +33,7 @@ from src.observer.sources.goal_source import gather_goals
 from src.observer.sources.git_source import gather_git
 from src.observer.sources.time_source import gather_time
 from src.memory.consolidator import consolidate_session
+from src.memory import soul as soul_mod
 from src.memory.vector_store import _reset_vector_store_state, add_memory, search
 from src.observer.context import CurrentContext
 from src.observer.delivery import deliver_or_queue
@@ -647,6 +649,60 @@ async def _eval_vector_store_runtime_audit() -> dict[str, Any]:
         }
     finally:
         _reset_vector_store_state()
+
+
+async def _eval_soul_runtime_audit() -> dict[str, Any]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        soul_path = f"{tmpdir}/soul.md"
+        original_path = soul_mod._soul_path
+        soul_mod._soul_path = soul_path
+        try:
+            with patch.object(audit_repository, "log_event", AsyncMock()) as mock_log_event:
+                default_text = soul_mod.read_soul()
+                soul_mod.write_soul("# Soul\n\n## Identity\nHero")
+                read_back = soul_mod.read_soul()
+                soul_mod.ensure_soul_exists()
+                with patch("src.memory.soul.open", side_effect=PermissionError("denied")):
+                    try:
+                        soul_mod.write_soul("broken")
+                    except PermissionError:
+                        pass
+                await asyncio.sleep(0)
+
+            empty = _find_audit_call(
+                mock_log_event,
+                event_type="integration_empty_result",
+                tool_name="soul_file:soul.md",
+            )
+            success_calls = [
+                call.kwargs for call in mock_log_event.call_args_list
+                if call.kwargs.get("event_type") == "integration_succeeded"
+                and call.kwargs.get("tool_name") == "soul_file:soul.md"
+            ]
+            skipped = _find_audit_call(
+                mock_log_event,
+                event_type="integration_skipped",
+                tool_name="soul_file:soul.md",
+            )
+            failed = _find_audit_call(
+                mock_log_event,
+                event_type="integration_failed",
+                tool_name="soul_file:soul.md",
+            )
+            write_success = next(call for call in success_calls if call["details"]["operation"] == "write")
+            read_success = next(call for call in success_calls if call["details"]["operation"] == "read")
+            return {
+                "default_used": empty["details"]["used_default"],
+                "default_contains_title": "# Soul of the Traveler" in default_text,
+                "write_length": write_success["details"]["length"],
+                "read_length": read_success["details"]["length"],
+                "ensure_created": skipped["details"]["created"],
+                "failed_operation": failed["details"]["operation"],
+                "failed_error": failed["details"]["error"],
+                "read_back_contains_hero": "Hero" in read_back,
+            }
+        finally:
+            soul_mod._soul_path = original_path
 
 
 def _eval_runtime_model_overrides() -> dict[str, Any]:
@@ -1364,6 +1420,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="observability",
         description="The local vector-store boundary records add success, search empty-result, and storage failures without live dependencies.",
         runner=_eval_vector_store_runtime_audit,
+    ),
+    EvalScenario(
+        name="soul_runtime_audit",
+        category="observability",
+        description="The local soul-file boundary records defaulted reads, writes, ensure skips, and write failures without live dependencies.",
+        runner=_eval_soul_runtime_audit,
     ),
     EvalScenario(
         name="runtime_model_overrides",

--- a/backend/src/memory/soul.py
+++ b/backend/src/memory/soul.py
@@ -2,6 +2,7 @@ import os
 import logging
 
 from config.settings import settings
+from src.audit.runtime import log_integration_event_sync
 
 logger = logging.getLogger(__name__)
 
@@ -25,21 +26,56 @@ _DEFAULT_SOUL = """# Soul of the Traveler
 """
 
 
+def _log_soul_event(outcome: str, details: dict | None = None) -> None:
+    log_integration_event_sync(
+        integration_type="soul_file",
+        name=os.path.basename(_soul_path),
+        outcome=outcome,
+        details=details,
+    )
+
+
 def read_soul() -> str:
     """Read the soul file. Returns default template if not found."""
     try:
         with open(_soul_path, "r", encoding="utf-8") as f:
-            return f.read()
+            text = f.read()
+            _log_soul_event(
+                "succeeded",
+                details={"operation": "read", "used_default": False, "length": len(text)},
+            )
+            return text
     except FileNotFoundError:
+        _log_soul_event(
+            "empty_result",
+            details={"operation": "read", "reason": "missing_file", "used_default": True},
+        )
         return _DEFAULT_SOUL
+    except Exception as exc:
+        _log_soul_event(
+            "failed",
+            details={"operation": "read", "error": str(exc)},
+        )
+        raise
 
 
 def write_soul(content: str) -> None:
     """Write the full soul file."""
-    os.makedirs(os.path.dirname(_soul_path), exist_ok=True)
-    with open(_soul_path, "w", encoding="utf-8") as f:
-        f.write(content)
-    logger.info("Soul file updated")
+    try:
+        os.makedirs(os.path.dirname(_soul_path), exist_ok=True)
+        with open(_soul_path, "w", encoding="utf-8") as f:
+            f.write(content)
+        logger.info("Soul file updated")
+        _log_soul_event(
+            "succeeded",
+            details={"operation": "write", "length": len(content)},
+        )
+    except Exception as exc:
+        _log_soul_event(
+            "failed",
+            details={"operation": "write", "length": len(content), "error": str(exc)},
+        )
+        raise
 
 
 def update_soul_section(section: str, content: str) -> str:
@@ -86,3 +122,12 @@ def ensure_soul_exists() -> None:
     if not os.path.exists(_soul_path):
         write_soul(_DEFAULT_SOUL)
         logger.info("Created default soul file at %s", _soul_path)
+        _log_soul_event(
+            "succeeded",
+            details={"operation": "ensure", "created": True},
+        )
+    else:
+        _log_soul_event(
+            "skipped",
+            details={"operation": "ensure", "created": False},
+        )

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -51,6 +51,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "mcp_specialist_local_runtime_profile" in captured.out
     assert "embedding_runtime_audit" in captured.out
     assert "vector_store_runtime_audit" in captured.out
+    assert "soul_runtime_audit" in captured.out
     assert "runtime_model_overrides" in captured.out
     assert "runtime_fallback_overrides" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
@@ -90,6 +91,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "mcp_specialist_local_runtime_profile",
                 "embedding_runtime_audit",
                 "vector_store_runtime_audit",
+                "soul_runtime_audit",
                 "runtime_model_overrides",
                 "runtime_fallback_overrides",
                 "scheduled_local_runtime_profile",
@@ -153,6 +155,14 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["vector_store_runtime_audit"]["failed_error"] == "db down"
     assert details_by_name["vector_store_runtime_audit"]["failed_memory_id"] == ""
     assert details_by_name["vector_store_runtime_audit"]["empty_results"] == 0
+    assert details_by_name["soul_runtime_audit"]["default_used"] is True
+    assert details_by_name["soul_runtime_audit"]["default_contains_title"] is True
+    assert details_by_name["soul_runtime_audit"]["write_length"] == len("# Soul\n\n## Identity\nHero")
+    assert details_by_name["soul_runtime_audit"]["read_length"] == len("# Soul\n\n## Identity\nHero")
+    assert details_by_name["soul_runtime_audit"]["ensure_created"] is False
+    assert details_by_name["soul_runtime_audit"]["failed_operation"] == "write"
+    assert details_by_name["soul_runtime_audit"]["failed_error"] == "denied"
+    assert details_by_name["soul_runtime_audit"]["read_back_contains_hero"] is True
     assert details_by_name["runtime_model_overrides"]["completion_runtime_profile"] == "default"
     assert details_by_name["runtime_model_overrides"]["completion_model"] == "openai/gpt-4o-mini"
     assert details_by_name["runtime_model_overrides"]["agent_runtime_profile"] == "default"

--- a/backend/tests/test_soul.py
+++ b/backend/tests/test_soul.py
@@ -1,10 +1,13 @@
 """Tests for soul file persistence (src/memory/soul.py)."""
 
+import asyncio
 import os
+from unittest.mock import patch
 
 import pytest
 
 import src.memory.soul as soul_mod
+from src.audit.repository import audit_repository
 
 
 @pytest.fixture
@@ -16,10 +19,20 @@ def soul_dir(tmp_path, monkeypatch):
 
 
 class TestReadSoul:
-    def test_returns_default_when_missing(self, soul_dir):
+    def test_returns_default_when_missing(self, soul_dir, async_db):
         text = soul_mod.read_soul()
         assert "# Soul of the Traveler" in text
         assert "## Identity" in text
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_empty_result"]
+
+        events = asyncio.run(_fetch())
+        assert events
+        assert events[0]["tool_name"] == "soul_file:soul.md"
+        assert events[0]["details"]["operation"] == "read"
+        assert events[0]["details"]["used_default"] is True
 
     def test_returns_file_content(self, soul_dir):
         soul_mod.write_soul("custom content")
@@ -27,14 +40,38 @@ class TestReadSoul:
 
 
 class TestWriteSoul:
-    def test_creates_file(self, soul_dir):
+    def test_creates_file(self, soul_dir, async_db):
         soul_mod.write_soul("hello")
         assert soul_mod.read_soul() == "hello"
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_succeeded"]
+
+        events = asyncio.run(_fetch())
+        assert events
+        write_event = next(e for e in events if e["details"]["operation"] == "write")
+        assert write_event["tool_name"] == "soul_file:soul.md"
 
     def test_overwrites_file(self, soul_dir):
         soul_mod.write_soul("first")
         soul_mod.write_soul("second")
         assert soul_mod.read_soul() == "second"
+
+    def test_write_failure_logs_runtime_audit(self, soul_dir, async_db):
+        with patch("src.memory.soul.open", side_effect=PermissionError("denied")):
+            with pytest.raises(PermissionError, match="denied"):
+                soul_mod.write_soul("blocked")
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_failed"]
+
+        events = asyncio.run(_fetch())
+        assert events
+        assert events[0]["tool_name"] == "soul_file:soul.md"
+        assert events[0]["details"]["operation"] == "write"
+        assert events[0]["details"]["error"] == "denied"
 
 
 class TestUpdateSoulSection:
@@ -67,7 +104,17 @@ class TestEnsureSoulExists:
         text = soul_mod.read_soul()
         assert "# Soul of the Traveler" in text
 
-    def test_does_not_overwrite(self, soul_dir):
+    def test_does_not_overwrite(self, soul_dir, async_db):
         soul_mod.write_soul("custom")
         soul_mod.ensure_soul_exists()
         assert soul_mod.read_soul() == "custom"
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=10)
+            return [e for e in events if e["event_type"] == "integration_skipped"]
+
+        events = asyncio.run(_fetch())
+        assert events
+        assert events[0]["tool_name"] == "soul_file:soul.md"
+        assert events[0]["details"]["operation"] == "ensure"
+        assert events[0]["details"]["created"] is False

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -45,6 +45,7 @@ uv run python -m src.evals.harness --scenario delegation_local_runtime_profile
 uv run python -m src.evals.harness --scenario mcp_specialist_local_runtime_profile
 uv run python -m src.evals.harness --scenario embedding_runtime_audit
 uv run python -m src.evals.harness --scenario vector_store_runtime_audit
+uv run python -m src.evals.harness --scenario soul_runtime_audit
 uv run python -m src.evals.harness --scenario runtime_model_overrides
 uv run python -m src.evals.harness --scenario runtime_fallback_overrides
 uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
@@ -61,7 +62,7 @@ uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model and vector-store boundary failures, context-window degradation, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, and soul-file boundary failures, context-window degradation, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -118,7 +119,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_settings_api.py` | 6 | Settings API — interruption mode get/set |
 | `test_shell_tool.py` | 9 | Shell execution — success, errors, size limits, timeout, connection errors, runtime audit logging |
 | `test_skills.py` | 27 | Skills system — loading, gating, enable/disable, frontmatter parsing, API |
-| `test_soul.py` | 9 | Soul file persistence — read/write, section update, ensure exists |
+| `test_soul.py` | 12 | Soul file persistence — read/write, section update, ensure exists, runtime audit logging |
 | `test_specialists.py` | 30 | Specialist agents — factory, tool domains, MCP specialist generation, runtime-path routing |
 | `test_strategist.py` | 12 | Strategist agent — JSON parsing (valid, fenced, invalid, empty, partial), agent creation |
 | `test_timeouts.py` | 5 | Execution timeouts — agent, briefing, consolidation timeouts |

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -28,7 +28,7 @@ Legend for the checklist column:
 |---|---|---|
 | 01. Trust Boundaries | `[ ]` | Policy modes, approvals, audit logging, secret redaction, and scoped secret references are shipped; deeper execution isolation and narrower secret-use paths are still left |
 | 02. Execution Plane | `[ ]` | Shell, browser, MCP, discovery, and visible tool execution foundations are shipped; richer process, browser, and workflow execution are still left |
-| 03. Runtime Reliability | `[ ]` | Ordered fallbacks, runtime-path primary and fallback overrides, local routing across helper/agent/delegation/MCP-specialist paths, runtime audit visibility including embedding and vector-store boundaries, and deterministic eval foundations are shipped; richer provider selection, remaining edge coverage, and broader evals are still left |
+| 03. Runtime Reliability | `[ ]` | Ordered fallbacks, runtime-path primary and fallback overrides, local routing across helper/agent/delegation/MCP-specialist paths, runtime audit visibility including embedding, vector-store, and soul-file boundaries, and deterministic eval foundations are shipped; richer provider selection, remaining edge coverage, and broader evals are still left |
 | 04. Presence And Reach | `[ ]` | Browser, WebSocket, proactive delivery, and the native observer daemon are shipped foundations; desktop presence, notifications, channels, and cross-surface continuity are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, strategist, goals, daily briefing, and evening review foundations are shipped; the deeper adaptive guardian layer is still left |
 | 06. Embodied UX | `[ ]` | Village UI, quest log, avatar, ambient indicators, and settings surfaces are shipped; the fuller life-OS shell is still left |
@@ -49,7 +49,7 @@ Legend for the checklist column:
 - [x] policy-controlled tool and MCP access with approval gates, audit logging, secret redaction, and scoped secret references
 - [x] shell, browser, vault, filesystem, goals, and web-search tool foundations with live tool execution in chat
 - [x] ordered LLM fallbacks, health-aware rerouting, runtime-path primary and fallback overrides, local helper, agent, delegation, and MCP-specialist runtime paths, and broad runtime audit coverage
-- [x] deterministic runtime eval harness coverage for fallback routing, local routing, embedding/vector-store boundaries, browser/sandbox/web-search tool boundaries, observer boundaries, and audit seams
+- [x] deterministic runtime eval harness coverage for fallback routing, local routing, embedding/vector-store/soul-file boundaries, browser/sandbox/web-search tool boundaries, observer boundaries, and audit seams
 - [x] browser UI, WebSocket chat, proactive delivery, and a native observer daemon
 - [x] soul, memory, goals, strategist, daily briefing, and evening review foundations
 - [x] skills, MCP integration, and recursive delegation foundations

--- a/docs/docs/overview/status-report.md
+++ b/docs/docs/overview/status-report.md
@@ -49,8 +49,8 @@ title: Development Status
 - [x] Runtime-path-specific primary model overrides for completion and agent-model paths
 - [x] Runtime-path-specific fallback-chain overrides for completion and agent-model paths
 - [x] First-class local runtime routing for helper, scheduler, core agent, delegation, and connected MCP specialist paths
-- [x] Runtime audit visibility across chat, WebSocket, scheduler, strategist, MCP, observer, embedding, vector-store, browser, sandbox, and web search flows
-- [x] Deterministic runtime eval harness for fallback, local routing, context-window degradation, MCP specialist routing, embedding/vector-store boundaries, browser/sandbox/web-search tool, and observer contracts
+- [x] Runtime audit visibility across chat, WebSocket, scheduler, strategist, MCP, observer, embedding, vector-store, soul-file, browser, sandbox, and web search flows
+- [x] Deterministic runtime eval harness for fallback, local routing, context-window degradation, MCP specialist routing, embedding/vector-store/soul-file boundaries, browser/sandbox/web-search tool, and observer contracts
 
 ### Product surfaces
 

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -32,6 +32,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] MCP server connection lifecycle emits runtime audit coverage for connect, disconnect, auth-required, and failure states
 - [x] the local embedding-model boundary emits runtime audit coverage for model load success/failure and encode failures
 - [x] the local vector-store boundary emits runtime audit coverage for add success, search empty-result, and storage failures
+- [x] the local soul-file boundary emits runtime audit coverage for defaulted reads, writes, ensure skips, and write failures
 - [x] sandbox, browser, and web-search tool boundaries emit runtime integration coverage for success, blocked, timeout, empty-result, and failure paths
 - [x] observer calendar, git, goal, and time source boundaries emit runtime integration coverage for unavailable, empty-result, success, and failure paths
 - [x] observer context refresh and queued-bundle delivery emit background runtime audit coverage
@@ -47,8 +48,8 @@ Make Seraph more resilient, observable, and predictable under real usage.
 
 - [ ] deepen provider routing beyond the current explicit runtime-path primary and fallback overrides, ordered fallback, and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduled completion, core agent-model, delegation, and connected MCP specialist paths into any remaining runtime paths where it makes sense
-- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git/goal/time sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, the embedding/vector-store boundaries, and the browser/sandbox/web-search tool boundaries
-- [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing and remaining edge-path contracts beyond the current MCP-specialist, embedding-model, and vector-store coverage
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git/goal/time sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, the embedding/vector-store/soul-file boundaries, and the browser/sandbox/web-search tool boundaries
+- [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing and remaining edge-path contracts beyond the current MCP-specialist, embedding-model, vector-store, and soul-file coverage
 
 ## Acceptance Checklist
 


### PR DESCRIPTION
## Done on develop
- [x] Runtime Reliability already has broad shipped audit coverage across chat, scheduler, observer, MCP, browser, shell, embedding, vector-store, and web-search boundaries.
- [x] The deterministic runtime eval harness already covers fallback routing, local runtime paths, observer seams, and several integration boundaries.

## Working in this PR
- [x] Add fail-open runtime audit coverage for the local soul-file boundary, including defaulted reads, writes, ensure skips, and write failures.
- [x] Expand the deterministic runtime eval harness and soul tests to verify the soul-file boundary contract.
- [x] Update the live roadmap, status report, runtime workstream file, and testing guide so soul-file coverage is reflected accurately.

## Still to do after this PR
- [ ] Deepen provider routing beyond the current runtime-path overrides, ordered fallback chains, and cooldown rerouting.
- [ ] Broaden local-model routing into any remaining worthwhile runtime paths.
- [ ] Expand observability and eval coverage beyond the current seam-focused runtime contracts.

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/memory/soul.py backend/src/evals/harness.py backend/tests/test_soul.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario soul_runtime_audit --indent 2
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_soul.py tests/test_eval_harness.py tests/test_consolidator.py tests/test_daily_briefing.py tests/test_evening_review.py
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build
