### PR TITLE
Trace filesystem runtime audit paths

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 import sys
 import time
 import tempfile
@@ -41,6 +42,7 @@ from src.scheduler.jobs.daily_briefing import run_daily_briefing
 from src.scheduler.jobs.strategist_tick import run_strategist_tick
 from src.tools.audit import wrap_tools_for_audit
 from src.tools.browser_tool import browse_webpage
+from src.tools.filesystem_tool import read_file, write_file
 from src.tools.shell_tool import shell_execute
 from src.tools.web_search_tool import web_search
 from src.models.schemas import WSResponse
@@ -703,6 +705,70 @@ async def _eval_soul_runtime_audit() -> dict[str, Any]:
             }
         finally:
             soul_mod._soul_path = original_path
+
+
+async def _eval_filesystem_runtime_audit() -> dict[str, Any]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with (
+            patch.object(settings, "workspace_dir", tmpdir),
+            patch.object(audit_repository, "log_event", AsyncMock()) as mock_log_event,
+        ):
+            missing_result = read_file.forward("missing.txt")
+            write_result = write_file.forward("notes/today.txt", "hello filesystem")
+            read_result = read_file.forward("notes/today.txt")
+            directory_path = f"{tmpdir}/directory_only"
+            os.mkdir(directory_path)
+            not_a_file_result = read_file.forward("directory_only")
+            try:
+                read_file.forward("../../etc/passwd")
+            except ValueError as blocked_error:
+                blocked_message = str(blocked_error)
+            else:  # pragma: no cover - defensive guard
+                raise AssertionError("Expected path traversal guard to raise")
+
+            with patch("pathlib.Path.write_text", side_effect=PermissionError("denied")):
+                write_failure = write_file.forward("blocked.txt", "denied content")
+
+            await asyncio.sleep(0)
+
+        empty = _find_audit_call(
+            mock_log_event,
+            event_type="integration_empty_result",
+            tool_name="filesystem:workspace",
+        )
+        success_calls = [
+            call.kwargs for call in mock_log_event.call_args_list
+            if call.kwargs.get("event_type") == "integration_succeeded"
+            and call.kwargs.get("tool_name") == "filesystem:workspace"
+        ]
+        blocked = _find_audit_call(
+            mock_log_event,
+            event_type="integration_blocked",
+            tool_name="filesystem:workspace",
+        )
+        failed_calls = [
+            call.kwargs for call in mock_log_event.call_args_list
+            if call.kwargs.get("event_type") == "integration_failed"
+            and call.kwargs.get("tool_name") == "filesystem:workspace"
+        ]
+        read_success = next(call for call in success_calls if call["details"]["operation"] == "read")
+        write_success = next(call for call in success_calls if call["details"]["operation"] == "write")
+        not_a_file = next(call for call in failed_calls if call["details"].get("reason") == "not_a_file")
+        write_failed = next(call for call in failed_calls if call["details"]["operation"] == "write")
+        return {
+            "missing_reason": empty["details"]["reason"],
+            "write_length": write_success["details"]["length"],
+            "read_length": read_success["details"]["length"],
+            "blocked_path": blocked["details"]["file_path"],
+            "blocked_error_contains_traversal": "Path traversal blocked" in blocked_message,
+            "not_a_file_reason": not_a_file["details"]["reason"],
+            "write_failed_error": write_failed["details"]["error"],
+            "write_result_contains_success": "Successfully wrote" in write_result,
+            "missing_result_contains_not_found": "File not found" in missing_result,
+            "read_result_matches": read_result == "hello filesystem",
+            "not_a_file_result_contains_error": "Not a file" in not_a_file_result,
+            "write_failure_contains_error": "Failed to write file" in write_failure,
+        }
 
 
 def _eval_runtime_model_overrides() -> dict[str, Any]:
@@ -1426,6 +1492,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="observability",
         description="The local soul-file boundary records defaulted reads, writes, ensure skips, and write failures without live dependencies.",
         runner=_eval_soul_runtime_audit,
+    ),
+    EvalScenario(
+        name="filesystem_runtime_audit",
+        category="observability",
+        description="Filesystem tool reads and writes record workspace runtime audit coverage for success, empty, blocked, and failure outcomes.",
+        runner=_eval_filesystem_runtime_audit,
     ),
     EvalScenario(
         name="runtime_model_overrides",

--- a/backend/src/tools/filesystem_tool.py
+++ b/backend/src/tools/filesystem_tool.py
@@ -1,9 +1,20 @@
-import os
+import logging
 from pathlib import Path
 
 from smolagents import tool
 
 from config.settings import settings
+from src.audit.runtime import log_integration_event_sync
+
+logger = logging.getLogger(__name__)
+
+
+def _filesystem_details(file_path: str, operation: str, **extra: object) -> dict[str, object]:
+    return {
+        "file_path": file_path,
+        "operation": operation,
+        **extra,
+    }
 
 
 def _safe_resolve(file_path: str) -> Path:
@@ -25,12 +36,52 @@ def read_file(file_path: str) -> str:
     Returns:
         The text contents of the file.
     """
-    resolved = _safe_resolve(file_path)
+    try:
+        resolved = _safe_resolve(file_path)
+    except ValueError as exc:
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="blocked",
+            details=_filesystem_details(file_path, "read", error=str(exc)),
+        )
+        raise
+
     if not resolved.exists():
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="empty_result",
+            details=_filesystem_details(file_path, "read", reason="missing_file"),
+        )
         return f"Error: File not found: {file_path}"
     if not resolved.is_file():
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="failed",
+            details=_filesystem_details(file_path, "read", reason="not_a_file"),
+        )
         return f"Error: Not a file: {file_path}"
-    return resolved.read_text(encoding="utf-8")
+
+    try:
+        content = resolved.read_text(encoding="utf-8")
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="succeeded",
+            details=_filesystem_details(file_path, "read", length=len(content)),
+        )
+        return content
+    except Exception as exc:
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="failed",
+            details=_filesystem_details(file_path, "read", error=str(exc)),
+        )
+        logger.exception("Failed to read file from workspace")
+        return f"Error: Failed to read file: {exc}"
 
 
 @tool
@@ -44,7 +95,33 @@ def write_file(file_path: str, content: str) -> str:
     Returns:
         A confirmation message.
     """
-    resolved = _safe_resolve(file_path)
-    resolved.parent.mkdir(parents=True, exist_ok=True)
-    resolved.write_text(content, encoding="utf-8")
-    return f"Successfully wrote {len(content)} characters to {file_path}"
+    try:
+        resolved = _safe_resolve(file_path)
+    except ValueError as exc:
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="blocked",
+            details=_filesystem_details(file_path, "write", length=len(content), error=str(exc)),
+        )
+        raise
+
+    try:
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        resolved.write_text(content, encoding="utf-8")
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="succeeded",
+            details=_filesystem_details(file_path, "write", length=len(content)),
+        )
+        return f"Successfully wrote {len(content)} characters to {file_path}"
+    except Exception as exc:
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="failed",
+            details=_filesystem_details(file_path, "write", length=len(content), error=str(exc)),
+        )
+        logger.exception("Failed to write file into workspace")
+        return f"Error: Failed to write file: {exc}"

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -52,6 +52,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "embedding_runtime_audit" in captured.out
     assert "vector_store_runtime_audit" in captured.out
     assert "soul_runtime_audit" in captured.out
+    assert "filesystem_runtime_audit" in captured.out
     assert "runtime_model_overrides" in captured.out
     assert "runtime_fallback_overrides" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
@@ -92,6 +93,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "embedding_runtime_audit",
                 "vector_store_runtime_audit",
                 "soul_runtime_audit",
+                "filesystem_runtime_audit",
                 "runtime_model_overrides",
                 "runtime_fallback_overrides",
                 "scheduled_local_runtime_profile",
@@ -163,6 +165,18 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["soul_runtime_audit"]["failed_operation"] == "write"
     assert details_by_name["soul_runtime_audit"]["failed_error"] == "denied"
     assert details_by_name["soul_runtime_audit"]["read_back_contains_hero"] is True
+    assert details_by_name["filesystem_runtime_audit"]["missing_reason"] == "missing_file"
+    assert details_by_name["filesystem_runtime_audit"]["write_length"] == len("hello filesystem")
+    assert details_by_name["filesystem_runtime_audit"]["read_length"] == len("hello filesystem")
+    assert details_by_name["filesystem_runtime_audit"]["blocked_path"] == "../../etc/passwd"
+    assert details_by_name["filesystem_runtime_audit"]["blocked_error_contains_traversal"] is True
+    assert details_by_name["filesystem_runtime_audit"]["not_a_file_reason"] == "not_a_file"
+    assert details_by_name["filesystem_runtime_audit"]["write_failed_error"] == "denied"
+    assert details_by_name["filesystem_runtime_audit"]["write_result_contains_success"] is True
+    assert details_by_name["filesystem_runtime_audit"]["missing_result_contains_not_found"] is True
+    assert details_by_name["filesystem_runtime_audit"]["read_result_matches"] is True
+    assert details_by_name["filesystem_runtime_audit"]["not_a_file_result_contains_error"] is True
+    assert details_by_name["filesystem_runtime_audit"]["write_failure_contains_error"] is True
     assert details_by_name["runtime_model_overrides"]["completion_runtime_profile"] == "default"
     assert details_by_name["runtime_model_overrides"]["completion_model"] == "openai/gpt-4o-mini"
     assert details_by_name["runtime_model_overrides"]["agent_runtime_profile"] == "default"

--- a/backend/tests/test_tools.py
+++ b/backend/tests/test_tools.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import patch
 
 import pytest
 
@@ -18,6 +19,21 @@ class TestFilesystemTool:
         result = read_file.forward("nonexistent.txt")
         assert "Error: File not found" in result
 
+    def test_read_file_not_found_logs_runtime_audit(self, tmp_path, monkeypatch, async_db):
+        monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
+        result = read_file.forward("nonexistent.txt")
+        assert "Error: File not found" in result
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_empty_result"]
+
+        events = asyncio.run(_fetch())
+        assert events
+        assert events[0]["tool_name"] == "filesystem:workspace"
+        assert events[0]["details"]["operation"] == "read"
+        assert events[0]["details"]["reason"] == "missing_file"
+
     def test_write_and_read_file(self, tmp_path, monkeypatch):
         monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
         write_result = write_file.forward("test.txt", "Hello, Seraph!")
@@ -25,6 +41,26 @@ class TestFilesystemTool:
 
         read_result = read_file.forward("test.txt")
         assert read_result == "Hello, Seraph!"
+
+    def test_write_and_read_file_log_runtime_audit(self, tmp_path, monkeypatch, async_db):
+        monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
+        write_result = write_file.forward("test.txt", "Hello, Seraph!")
+        read_result = read_file.forward("test.txt")
+
+        assert "Successfully wrote" in write_result
+        assert read_result == "Hello, Seraph!"
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=10)
+            return [e for e in events if e["event_type"] == "integration_succeeded"]
+
+        events = asyncio.run(_fetch())
+        assert len(events) >= 2
+        write_event = next(e for e in events if e["details"]["operation"] == "write")
+        read_event = next(e for e in events if e["details"]["operation"] == "read")
+        assert write_event["tool_name"] == "filesystem:workspace"
+        assert write_event["details"]["length"] == len("Hello, Seraph!")
+        assert read_event["details"]["length"] == len("Hello, Seraph!")
 
     def test_write_creates_subdirectories(self, tmp_path, monkeypatch):
         monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
@@ -36,6 +72,70 @@ class TestFilesystemTool:
         (tmp_path / "adir").mkdir()
         result = read_file.forward("adir")
         assert "Error: Not a file" in result
+
+    def test_read_file_not_a_file_logs_runtime_audit(self, tmp_path, monkeypatch, async_db):
+        monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
+        (tmp_path / "adir").mkdir()
+        result = read_file.forward("adir")
+        assert "Error: Not a file" in result
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_failed"]
+
+        events = asyncio.run(_fetch())
+        assert events
+        assert events[0]["tool_name"] == "filesystem:workspace"
+        assert events[0]["details"]["operation"] == "read"
+        assert events[0]["details"]["reason"] == "not_a_file"
+
+    def test_read_file_traversal_logs_blocked_runtime_audit(self, tmp_path, monkeypatch, async_db):
+        monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
+        with pytest.raises(ValueError, match="Path traversal blocked"):
+            read_file.forward("../../etc/passwd")
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_blocked"]
+
+        events = asyncio.run(_fetch())
+        assert events
+        assert events[0]["tool_name"] == "filesystem:workspace"
+        assert events[0]["details"]["operation"] == "read"
+
+    def test_write_file_failure_logs_runtime_audit(self, tmp_path, monkeypatch, async_db):
+        monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
+        with patch("pathlib.Path.write_text", side_effect=PermissionError("denied")):
+            result = write_file.forward("blocked.txt", "secret")
+
+        assert "Failed to write file" in result
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_failed"]
+
+        events = asyncio.run(_fetch())
+        write_event = next(e for e in events if e["details"]["operation"] == "write")
+        assert write_event["tool_name"] == "filesystem:workspace"
+        assert write_event["details"]["error"] == "denied"
+
+    def test_read_file_failure_logs_runtime_audit(self, tmp_path, monkeypatch, async_db):
+        monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
+        (tmp_path / "broken.txt").write_text("hello", encoding="utf-8")
+
+        with patch("pathlib.Path.read_text", side_effect=OSError("boom")):
+            result = read_file.forward("broken.txt")
+
+        assert "Failed to read file" in result
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_failed"]
+
+        events = asyncio.run(_fetch())
+        read_event = next(e for e in events if e["details"]["operation"] == "read")
+        assert read_event["tool_name"] == "filesystem:workspace"
+        assert read_event["details"]["error"] == "boom"
 
 
 class TestTemplateTool:
@@ -59,8 +159,6 @@ class TestTemplateTool:
 class TestWebSearch:
     def test_web_search_returns_string(self, monkeypatch):
         """Test with mocked DuckDuckGo results."""
-        from unittest.mock import patch
-
         class MockDDGS:
             def __init__(self, **kwargs):
                 pass
@@ -82,8 +180,6 @@ class TestWebSearch:
         assert "https://example.com" in result
 
     def test_web_search_no_results(self):
-        from unittest.mock import patch
-
         class MockDDGS:
             def __init__(self, **kwargs):
                 pass
@@ -102,8 +198,6 @@ class TestWebSearch:
         assert "No results found" in result
 
     def test_web_search_no_results_logs_runtime_audit(self, async_db):
-        from unittest.mock import patch
-
         class MockDDGS:
             def __init__(self, **kwargs):
                 pass
@@ -133,8 +227,6 @@ class TestWebSearch:
         assert events[0]["details"]["result_count"] == 0
 
     def test_web_search_logs_runtime_audit(self, async_db):
-        from unittest.mock import patch
-
         class MockDDGS:
             def __init__(self, **kwargs):
                 pass
@@ -167,8 +259,6 @@ class TestWebSearch:
         assert events[0]["details"]["result_count"] == 2
 
     def test_web_search_timeout_logs_runtime_audit(self, async_db):
-        from unittest.mock import patch
-
         class MockDDGS:
             def __init__(self, **kwargs):
                 pass

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -46,6 +46,7 @@ uv run python -m src.evals.harness --scenario mcp_specialist_local_runtime_profi
 uv run python -m src.evals.harness --scenario embedding_runtime_audit
 uv run python -m src.evals.harness --scenario vector_store_runtime_audit
 uv run python -m src.evals.harness --scenario soul_runtime_audit
+uv run python -m src.evals.harness --scenario filesystem_runtime_audit
 uv run python -m src.evals.harness --scenario runtime_model_overrides
 uv run python -m src.evals.harness --scenario runtime_fallback_overrides
 uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
@@ -62,7 +63,7 @@ uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, and soul-file boundary failures, context-window degradation, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, and filesystem boundary failures, context-window degradation, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -124,7 +125,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_strategist.py` | 12 | Strategist agent — JSON parsing (valid, fenced, invalid, empty, partial), agent creation |
 | `test_timeouts.py` | 5 | Execution timeouts — agent, briefing, consolidation timeouts |
 | `test_tool_registry.py` | 4 | Tool metadata registry — lookup, required fields, copy safety |
-| `test_tools.py` | 14 | Filesystem tools, template tool, web search, runtime audit logging |
+| `test_tools.py` | 20 | Filesystem tools, template tool, web search, and filesystem/web-search runtime audit logging |
 | `test_user_state.py` | 57 | User state machine — derive_state, IDE deep work, should_deliver, budget, interruption modes |
 | `test_vault_api.py` | 4 | Vault API — list keys, delete keys |
 | `test_vault_crypto.py` | 4 | Vault crypto — Fernet encrypt/decrypt, key generation |

--- a/docs/docs/overview/roadmap.md
+++ b/docs/docs/overview/roadmap.md
@@ -28,7 +28,7 @@ Legend for the checklist column:
 |---|---|---|
 | 01. Trust Boundaries | `[ ]` | Policy modes, approvals, audit logging, secret redaction, and scoped secret references are shipped; deeper execution isolation and narrower secret-use paths are still left |
 | 02. Execution Plane | `[ ]` | Shell, browser, MCP, discovery, and visible tool execution foundations are shipped; richer process, browser, and workflow execution are still left |
-| 03. Runtime Reliability | `[ ]` | Ordered fallbacks, runtime-path primary and fallback overrides, local routing across helper/agent/delegation/MCP-specialist paths, runtime audit visibility including embedding, vector-store, and soul-file boundaries, and deterministic eval foundations are shipped; richer provider selection, remaining edge coverage, and broader evals are still left |
+| 03. Runtime Reliability | `[ ]` | Ordered fallbacks, runtime-path primary and fallback overrides, local routing across helper/agent/delegation/MCP-specialist paths, runtime audit visibility including embedding, vector-store, soul-file, and filesystem boundaries, and deterministic eval foundations are shipped; richer provider selection, remaining edge coverage, and broader evals are still left |
 | 04. Presence And Reach | `[ ]` | Browser, WebSocket, proactive delivery, and the native observer daemon are shipped foundations; desktop presence, notifications, channels, and cross-surface continuity are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, strategist, goals, daily briefing, and evening review foundations are shipped; the deeper adaptive guardian layer is still left |
 | 06. Embodied UX | `[ ]` | Village UI, quest log, avatar, ambient indicators, and settings surfaces are shipped; the fuller life-OS shell is still left |
@@ -49,7 +49,7 @@ Legend for the checklist column:
 - [x] policy-controlled tool and MCP access with approval gates, audit logging, secret redaction, and scoped secret references
 - [x] shell, browser, vault, filesystem, goals, and web-search tool foundations with live tool execution in chat
 - [x] ordered LLM fallbacks, health-aware rerouting, runtime-path primary and fallback overrides, local helper, agent, delegation, and MCP-specialist runtime paths, and broad runtime audit coverage
-- [x] deterministic runtime eval harness coverage for fallback routing, local routing, embedding/vector-store/soul-file boundaries, browser/sandbox/web-search tool boundaries, observer boundaries, and audit seams
+- [x] deterministic runtime eval harness coverage for fallback routing, local routing, embedding/vector-store/soul-file/filesystem boundaries, browser/sandbox/web-search tool boundaries, observer boundaries, and audit seams
 - [x] browser UI, WebSocket chat, proactive delivery, and a native observer daemon
 - [x] soul, memory, goals, strategist, daily briefing, and evening review foundations
 - [x] skills, MCP integration, and recursive delegation foundations

--- a/docs/docs/overview/status-report.md
+++ b/docs/docs/overview/status-report.md
@@ -49,8 +49,8 @@ title: Development Status
 - [x] Runtime-path-specific primary model overrides for completion and agent-model paths
 - [x] Runtime-path-specific fallback-chain overrides for completion and agent-model paths
 - [x] First-class local runtime routing for helper, scheduler, core agent, delegation, and connected MCP specialist paths
-- [x] Runtime audit visibility across chat, WebSocket, scheduler, strategist, MCP, observer, embedding, vector-store, soul-file, browser, sandbox, and web search flows
-- [x] Deterministic runtime eval harness for fallback, local routing, context-window degradation, MCP specialist routing, embedding/vector-store/soul-file boundaries, browser/sandbox/web-search tool, and observer contracts
+- [x] Runtime audit visibility across chat, WebSocket, scheduler, strategist, MCP, observer, embedding, vector-store, soul-file, filesystem, browser, sandbox, and web search flows
+- [x] Deterministic runtime eval harness for fallback, local routing, context-window degradation, MCP specialist routing, embedding/vector-store/soul-file/filesystem boundaries, browser/sandbox/web-search tool, and observer contracts
 
 ### Product surfaces
 

--- a/docs/docs/plan/runtime-reliability.md
+++ b/docs/docs/plan/runtime-reliability.md
@@ -33,6 +33,7 @@ Make Seraph more resilient, observable, and predictable under real usage.
 - [x] the local embedding-model boundary emits runtime audit coverage for model load success/failure and encode failures
 - [x] the local vector-store boundary emits runtime audit coverage for add success, search empty-result, and storage failures
 - [x] the local soul-file boundary emits runtime audit coverage for defaulted reads, writes, ensure skips, and write failures
+- [x] the local filesystem boundary emits runtime audit coverage for read/write success, missing files, traversal blocks, and read/write failures
 - [x] sandbox, browser, and web-search tool boundaries emit runtime integration coverage for success, blocked, timeout, empty-result, and failure paths
 - [x] observer calendar, git, goal, and time source boundaries emit runtime integration coverage for unavailable, empty-result, success, and failure paths
 - [x] observer context refresh and queued-bundle delivery emit background runtime audit coverage
@@ -48,8 +49,8 @@ Make Seraph more resilient, observable, and predictable under real usage.
 
 - [ ] deepen provider routing beyond the current explicit runtime-path primary and fallback overrides, ordered fallback, and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduled completion, core agent-model, delegation, and connected MCP specialist paths into any remaining runtime paths where it makes sense
-- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git/goal/time sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, the embedding/vector-store/soul-file boundaries, and the browser/sandbox/web-search tool boundaries
-- [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing and remaining edge-path contracts beyond the current MCP-specialist, embedding-model, vector-store, and soul-file coverage
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond observer refresh, calendar/git/goal/time sources, daemon ingest, proactive delivery gating, current MCP lifecycle coverage, the embedding/vector-store/soul-file/filesystem boundaries, and the browser/sandbox/web-search tool boundaries
+- [ ] expand eval coverage beyond the current runtime seam checks, including broader provider-routing and remaining edge-path contracts beyond the current MCP-specialist, embedding-model, vector-store, soul-file, and filesystem coverage
 
 ## Acceptance Checklist
 


### PR DESCRIPTION
## Done on develop
- [x] Runtime Reliability already has shipped audit coverage across chat, scheduler, observer, MCP, browser, shell, embedding, vector-store, soul-file, and web-search boundaries.
- [x] The deterministic runtime eval harness already covers fallback routing, local runtime paths, observer seams, and several integration boundaries.

## Working in this PR
- [x] Add fail-open runtime audit coverage for the filesystem boundary, including read/write success, missing-file, traversal-blocked, and read/write failure outcomes.
- [x] Expand the deterministic runtime eval harness and backend tests to verify the filesystem boundary contract.
- [x] Update the live roadmap, status report, runtime workstream file, and testing guide so filesystem coverage is reflected accurately.

## Still to do after this PR
- [ ] Deepen provider routing beyond the current runtime-path overrides, ordered fallback chains, and cooldown rerouting.
- [ ] Broaden local-model routing into any remaining worthwhile runtime paths.
- [ ] Expand observability and eval coverage beyond the current seam-focused runtime contracts.

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/tools/filesystem_tool.py backend/src/evals/harness.py backend/tests/test_tools.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_tools.py tests/test_eval_harness.py tests/test_tool_audit.py tests/test_browser_tool.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario filesystem_runtime_audit --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build
