### PR TITLE
Add wildcard runtime path routing

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -70,10 +70,10 @@ Receive (streamed):
 | `WORKSPACE_DIR` | `/app/data` | Agent file workspace |
 | `LOCAL_MODEL` | - | Model id for the local runtime profile |
 | `LOCAL_LLM_API_BASE` | - | API base for the local runtime profile |
-| `LOCAL_RUNTIME_PATHS` | - | Comma-separated runtime paths that should prefer the local profile |
-| `RUNTIME_PROFILE_PREFERENCES` | - | Semicolon-separated `runtime_path=profile_a|profile_b` preference chains |
-| `RUNTIME_MODEL_OVERRIDES` | - | Comma-separated `runtime_path=model` or `runtime_path=profile:model` overrides |
-| `RUNTIME_FALLBACK_OVERRIDES` | - | Semicolon-separated `runtime_path=model_a|model_b` fallback chains |
+| `LOCAL_RUNTIME_PATHS` | - | Comma-separated runtime paths or glob patterns that should prefer the local profile |
+| `RUNTIME_PROFILE_PREFERENCES` | - | Semicolon-separated `runtime_path=profile_a|profile_b` chains; `runtime_path` may be an exact path or glob |
+| `RUNTIME_MODEL_OVERRIDES` | - | Comma-separated `runtime_path=model` or `runtime_path=profile:model` overrides; `runtime_path` may be an exact path or glob |
+| `RUNTIME_FALLBACK_OVERRIDES` | - | Semicolon-separated `runtime_path=model_a|model_b` fallback chains; `runtime_path` may be an exact path or glob |
 | `FALLBACK_MODEL` | - | Legacy single fallback target |
 | `FALLBACK_MODELS` | - | Comma-separated ordered global fallback chain |
 | `FALLBACK_LLM_API_BASE` | - | Optional API base override for fallback calls |
@@ -90,6 +90,15 @@ LOCAL_RUNTIME_PATHS=chat_agent,session_consolidation,daily_briefing
 RUNTIME_PROFILE_PREFERENCES=chat_agent=local|default;session_consolidation=local|default
 RUNTIME_MODEL_OVERRIDES=chat_agent=default:openai/gpt-4.1-mini
 RUNTIME_FALLBACK_OVERRIDES=chat_agent=openai/gpt-4.1-mini|openai/gpt-4.1-nano;session_title_generation=openai/gpt-4o-mini|openai/gpt-4.1-mini
+```
+
+Pattern-based examples for dynamic runtime paths:
+
+```bash
+LOCAL_RUNTIME_PATHS=mcp_*
+RUNTIME_PROFILE_PREFERENCES=mcp_*=local|default
+RUNTIME_MODEL_OVERRIDES=mcp_*=openai/gpt-4.1-mini,mcp_github_actions=local:ollama/coder
+RUNTIME_FALLBACK_OVERRIDES=mcp_*=openai/gpt-4.1-mini|openai/gpt-4.1-nano;mcp_github_actions=openai/gpt-4o-mini|openai/gpt-4.1-mini
 ```
 
 ## Testing

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -929,6 +929,59 @@ def _eval_runtime_profile_preferences() -> dict[str, Any]:
         _reset_target_health()
 
 
+def _eval_runtime_path_patterns() -> dict[str, Any]:
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "local_model", "ollama/llama3.2"),
+        patch.object(settings, "local_llm_api_key", ""),
+        patch.object(settings, "local_llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "runtime_profile_preferences", "mcp_*=local|default"),
+        patch.object(
+            settings,
+            "runtime_model_overrides",
+            "mcp_*=openai/gpt-4.1-mini,mcp_github_actions=local:ollama/coder",
+        ),
+        patch.object(
+            settings,
+            "runtime_fallback_overrides",
+            (
+                "mcp_*=openai/gpt-4.1-mini|openai/gpt-4.1-nano;"
+                "mcp_github_actions=openai/gpt-4o-mini|openai/gpt-4.1-mini"
+            ),
+        ),
+    ):
+        wildcard_model = get_model(runtime_path="mcp_linear")
+        exact_model = get_model(runtime_path="mcp_github_actions")
+
+    assert wildcard_model.model_id == "openai/gpt-4.1-mini"
+    assert wildcard_model._runtime_profile == "local"
+    assert [fallback.model_id for fallback in wildcard_model._fallback_models] == [
+        "openai/gpt-4.1-mini",
+        "openai/gpt-4.1-nano",
+    ]
+
+    assert exact_model.model_id == "ollama/coder"
+    assert exact_model._runtime_profile == "local"
+    assert [fallback.model_id for fallback in exact_model._fallback_models] == [
+        "openrouter/anthropic/claude-sonnet-4",
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-mini",
+    ]
+
+    return {
+        "wildcard_runtime_path": "mcp_linear",
+        "wildcard_runtime_profile": wildcard_model._runtime_profile,
+        "wildcard_model": wildcard_model.model_id,
+        "wildcard_fallback_models": [fallback.model_id for fallback in wildcard_model._fallback_models],
+        "exact_runtime_path": "mcp_github_actions",
+        "exact_runtime_profile": exact_model._runtime_profile,
+        "exact_model": exact_model.model_id,
+        "exact_fallback_models": [fallback.model_id for fallback in exact_model._fallback_models],
+    }
+
+
 def _eval_onboarding_model_wrapper() -> dict[str, Any]:
     with (
         patch.object(settings, "fallback_model", "ollama/llama3.2"),
@@ -1571,6 +1624,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="runtime",
         description="Runtime paths can prefer an ordered local-vs-default profile chain before explicit fallback models.",
         runner=_eval_runtime_profile_preferences,
+    ),
+    EvalScenario(
+        name="runtime_path_patterns",
+        category="runtime",
+        description="Runtime-path routing rules can use wildcard patterns, while exact path rules still override the wildcard baseline.",
+        runner=_eval_runtime_path_patterns,
     ),
     EvalScenario(
         name="onboarding_model_wrapper",

--- a/backend/src/llm_runtime.py
+++ b/backend/src/llm_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextvars
 import logging
+from fnmatch import fnmatchcase
 from threading import Lock
 from time import monotonic
 from typing import Any
@@ -45,28 +46,64 @@ def local_runtime_paths() -> set[str]:
     }
 
 
-def _runtime_model_override(runtime_path: str | None) -> tuple[str | None, str] | None:
-    """Return an optional runtime-path-specific profile/model override."""
-    if not runtime_path:
+def _runtime_path_match_kind(pattern: str, runtime_path: str | None) -> str | None:
+    """Return whether a config pattern matches the runtime path exactly or via glob."""
+    if runtime_path is None:
         return None
-    for raw_entry in settings.runtime_model_overrides.split(","):
+    normalized_pattern = pattern.strip()
+    if not normalized_pattern:
+        return None
+    if normalized_pattern == runtime_path:
+        return "exact"
+    if any(char in normalized_pattern for char in "*?[]") and fnmatchcase(runtime_path, normalized_pattern):
+        return "pattern"
+    return None
+
+
+def _select_runtime_entry(raw_entries: str, *, runtime_path: str | None, separator: str) -> str | None:
+    """Return the best matching config value for a runtime path.
+
+    Exact path matches win over wildcard matches. If multiple wildcard entries
+    match, the first configured wildcard wins.
+    """
+    wildcard_value: str | None = None
+    for raw_entry in raw_entries.split(separator):
         entry = raw_entry.strip()
         if not entry or "=" not in entry:
             continue
         path, _, raw_value = entry.partition("=")
-        if path.strip() != runtime_path:
-            continue
-        value = raw_value.strip()
-        if not value:
-            return None
-        if ":" in value:
-            maybe_profile, model_id = value.split(":", 1)
-            normalized_profile = maybe_profile.strip()
-            normalized_model_id = model_id.strip()
-            if normalized_profile in {"default", "local"} and normalized_model_id:
-                return normalized_profile, normalized_model_id
-        return None, value
-    return None
+        match_kind = _runtime_path_match_kind(path, runtime_path)
+        if match_kind == "exact":
+            return raw_value.strip()
+        if match_kind == "pattern" and wildcard_value is None:
+            wildcard_value = raw_value.strip()
+    return wildcard_value
+
+
+def prefers_local_runtime_path(runtime_path: str | None) -> bool:
+    """Return whether the runtime path should prefer the local profile."""
+    return any(
+        _runtime_path_match_kind(path, runtime_path)
+        for path in local_runtime_paths()
+    )
+
+
+def _runtime_model_override(runtime_path: str | None) -> tuple[str | None, str] | None:
+    """Return an optional runtime-path-specific profile/model override."""
+    value = _select_runtime_entry(
+        settings.runtime_model_overrides,
+        runtime_path=runtime_path,
+        separator=",",
+    )
+    if not value:
+        return None
+    if ":" in value:
+        maybe_profile, model_id = value.split(":", 1)
+        normalized_profile = maybe_profile.strip()
+        normalized_model_id = model_id.strip()
+        if normalized_profile in {"default", "local"} and normalized_model_id:
+            return normalized_profile, normalized_model_id
+    return None, value
 
 
 def _normalize_runtime_profile(profile: str) -> str | None:
@@ -80,23 +117,19 @@ def _normalize_runtime_profile(profile: str) -> str | None:
 
 def runtime_profile_preferences(runtime_path: str | None) -> list[str]:
     """Return the configured ordered profile preferences for a runtime path."""
-    if not runtime_path:
+    value = _select_runtime_entry(
+        settings.runtime_profile_preferences,
+        runtime_path=runtime_path,
+        separator=";",
+    )
+    if not value:
         return []
-
-    for raw_entry in settings.runtime_profile_preferences.split(";"):
-        entry = raw_entry.strip()
-        if not entry or "=" not in entry:
-            continue
-        path, _, raw_value = entry.partition("=")
-        if path.strip() != runtime_path:
-            continue
-        preferences: list[str] = []
-        for raw_profile in raw_value.split("|"):
-            normalized = _normalize_runtime_profile(raw_profile)
-            if normalized and normalized not in preferences:
-                preferences.append(normalized)
-        return preferences
-    return []
+    preferences: list[str] = []
+    for raw_profile in value.split("|"):
+        normalized = _normalize_runtime_profile(raw_profile)
+        if normalized and normalized not in preferences:
+            preferences.append(normalized)
+    return preferences
 
 
 def runtime_profile_candidates(
@@ -131,7 +164,7 @@ def runtime_profile_candidates(
             candidates.append(normalized)
 
     if not candidates:
-        if runtime_path and runtime_path in local_runtime_paths() and has_local_model_profile():
+        if prefers_local_runtime_path(runtime_path) and has_local_model_profile():
             candidates.append("local")
         else:
             candidates.append("default")
@@ -182,19 +215,16 @@ def _profile_api_base(profile: str) -> str:
 def fallback_model_ids(*, runtime_path: str | None = None) -> list[str]:
     """Return the ordered list of configured fallback model ids."""
     runtime_override_ids: list[str] = []
-    if runtime_path:
-        for raw_entry in settings.runtime_fallback_overrides.split(";"):
-            entry = raw_entry.strip()
-            if not entry or "=" not in entry:
-                continue
-            path, _, raw_value = entry.partition("=")
-            if path.strip() != runtime_path:
-                continue
-            for model_id in raw_value.split("|"):
-                normalized = model_id.strip()
-                if normalized and normalized not in runtime_override_ids:
-                    runtime_override_ids.append(normalized)
-            break
+    value = _select_runtime_entry(
+        settings.runtime_fallback_overrides,
+        runtime_path=runtime_path,
+        separator=";",
+    )
+    if value:
+        for model_id in value.split("|"):
+            normalized = model_id.strip()
+            if normalized and normalized not in runtime_override_ids:
+                runtime_override_ids.append(normalized)
     if runtime_override_ids:
         return runtime_override_ids
 

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -56,6 +56,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "runtime_model_overrides" in captured.out
     assert "runtime_fallback_overrides" in captured.out
     assert "runtime_profile_preferences" in captured.out
+    assert "runtime_path_patterns" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
     assert "shell_tool_runtime_audit" in captured.out
     assert "browser_runtime_audit" in captured.out
@@ -98,6 +99,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "runtime_model_overrides",
                 "runtime_fallback_overrides",
                 "runtime_profile_preferences",
+                "runtime_path_patterns",
                 "scheduled_local_runtime_profile",
                 "shell_tool_runtime_audit",
                 "browser_runtime_audit",
@@ -202,6 +204,19 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["runtime_profile_preferences"]["agent_runtime_profile"] == "local"
     assert details_by_name["runtime_profile_preferences"]["agent_fallback_models"] == [
         "openrouter/anthropic/claude-sonnet-4",
+        "openai/gpt-4.1-mini",
+    ]
+    assert details_by_name["runtime_path_patterns"]["wildcard_runtime_profile"] == "local"
+    assert details_by_name["runtime_path_patterns"]["wildcard_model"] == "openai/gpt-4.1-mini"
+    assert details_by_name["runtime_path_patterns"]["wildcard_fallback_models"] == [
+        "openai/gpt-4.1-mini",
+        "openai/gpt-4.1-nano",
+    ]
+    assert details_by_name["runtime_path_patterns"]["exact_runtime_profile"] == "local"
+    assert details_by_name["runtime_path_patterns"]["exact_model"] == "ollama/coder"
+    assert details_by_name["runtime_path_patterns"]["exact_fallback_models"] == [
+        "openrouter/anthropic/claude-sonnet-4",
+        "openai/gpt-4o-mini",
         "openai/gpt-4.1-mini",
     ]
     assert details_by_name["scheduled_local_runtime_profile"]["job_name"] == "daily_briefing"

--- a/backend/tests/test_llm_runtime.py
+++ b/backend/tests/test_llm_runtime.py
@@ -120,6 +120,28 @@ def test_build_model_kwargs_uses_runtime_profile_preferences_for_primary_target(
     assert kwargs["api_base"] == "http://localhost:11434/v1"
 
 
+def test_build_model_kwargs_uses_runtime_profile_preference_glob():
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "local_model", "ollama/llama3.2"),
+        patch.object(settings, "local_llm_api_key", ""),
+        patch.object(settings, "local_llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "runtime_profile_preferences", "mcp_*=local|default"),
+    ):
+        kwargs = build_model_kwargs(
+            temperature=0.2,
+            max_tokens=256,
+            runtime_path="mcp_github_actions",
+        )
+
+    assert kwargs["model_id"] == "ollama/llama3.2"
+    assert kwargs["runtime_profile"] == "local"
+    assert kwargs["api_key"] == "primary-key"
+    assert kwargs["api_base"] == "http://localhost:11434/v1"
+
+
 def test_build_model_kwargs_honors_unscoped_runtime_override_for_local_first_path():
     with (
         patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
@@ -135,6 +157,29 @@ def test_build_model_kwargs_honors_unscoped_runtime_override_for_local_first_pat
             temperature=0.2,
             max_tokens=256,
             runtime_path="chat_agent",
+        )
+
+    assert kwargs["model_id"] == "openai/gpt-4.1-mini"
+    assert kwargs["runtime_profile"] == "local"
+    assert kwargs["api_key"] == "primary-key"
+    assert kwargs["api_base"] == "http://localhost:11434/v1"
+
+
+def test_build_model_kwargs_uses_runtime_model_override_glob():
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "local_model", "ollama/llama3.2"),
+        patch.object(settings, "local_llm_api_key", ""),
+        patch.object(settings, "local_llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "runtime_profile_preferences", "mcp_*=local|default"),
+        patch.object(settings, "runtime_model_overrides", "mcp_*=openai/gpt-4.1-mini"),
+    ):
+        kwargs = build_model_kwargs(
+            temperature=0.2,
+            max_tokens=256,
+            runtime_path="mcp_linear",
         )
 
     assert kwargs["model_id"] == "openai/gpt-4.1-mini"
@@ -164,6 +209,33 @@ def test_build_model_kwargs_runtime_override_can_force_default_profile_over_loca
     assert kwargs["runtime_profile"] == "default"
     assert kwargs["api_key"] == "primary-key"
     assert kwargs["api_base"] == "https://openrouter.ai/api/v1"
+
+
+def test_build_model_kwargs_exact_override_wins_over_runtime_glob():
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "local_model", "ollama/llama3.2"),
+        patch.object(settings, "local_llm_api_key", ""),
+        patch.object(settings, "local_llm_api_base", "http://localhost:11434/v1"),
+        patch.object(settings, "runtime_profile_preferences", "mcp_*=local|default"),
+        patch.object(
+            settings,
+            "runtime_model_overrides",
+            "mcp_*=openai/gpt-4.1-mini,mcp_github_actions=local:ollama/coder",
+        ),
+    ):
+        kwargs = build_model_kwargs(
+            temperature=0.2,
+            max_tokens=256,
+            runtime_path="mcp_github_actions",
+        )
+
+    assert kwargs["model_id"] == "ollama/coder"
+    assert kwargs["runtime_profile"] == "local"
+    assert kwargs["api_key"] == "primary-key"
+    assert kwargs["api_base"] == "http://localhost:11434/v1"
 
 
 def test_build_model_kwargs_explicit_profile_wins_over_runtime_override():
@@ -275,6 +347,63 @@ def test_build_completion_kwargs_uses_runtime_fallback_override_chain():
         )
 
     assert kwargs["model"] == "openai/gpt-4.1-mini"
+    assert kwargs["api_key"] == "primary-key"
+    assert kwargs["api_base"] == "https://openrouter.ai/api/v1"
+
+
+def test_build_completion_kwargs_uses_runtime_fallback_override_glob():
+    with (
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", "openai/gpt-4o-mini"),
+        patch.object(
+            settings,
+            "runtime_fallback_overrides",
+            "mcp_*=openai/gpt-4.1-mini|openai/gpt-4.1-nano",
+        ),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", ""),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+    ):
+        kwargs = build_completion_kwargs(
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.2,
+            max_tokens=128,
+            use_fallback=True,
+            runtime_path="mcp_github_actions",
+        )
+
+    assert kwargs["model"] == "openai/gpt-4.1-mini"
+    assert kwargs["api_key"] == "primary-key"
+    assert kwargs["api_base"] == "https://openrouter.ai/api/v1"
+
+
+def test_build_completion_kwargs_exact_fallback_override_wins_over_runtime_glob():
+    with (
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", "openai/gpt-4o-mini"),
+        patch.object(
+            settings,
+            "runtime_fallback_overrides",
+            (
+                "mcp_*=openai/gpt-4.1-mini|openai/gpt-4.1-nano;"
+                "mcp_github_actions=openai/gpt-4o-mini|openai/gpt-4.1-mini"
+            ),
+        ),
+        patch.object(settings, "fallback_llm_api_key", ""),
+        patch.object(settings, "fallback_llm_api_base", ""),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+    ):
+        kwargs = build_completion_kwargs(
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.2,
+            max_tokens=128,
+            use_fallback=True,
+            runtime_path="mcp_github_actions",
+        )
+
+    assert kwargs["model"] == "openai/gpt-4o-mini"
     assert kwargs["api_key"] == "primary-key"
     assert kwargs["api_base"] == "https://openrouter.ai/api/v1"
 

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -50,6 +50,7 @@ uv run python -m src.evals.harness --scenario filesystem_runtime_audit
 uv run python -m src.evals.harness --scenario runtime_model_overrides
 uv run python -m src.evals.harness --scenario runtime_fallback_overrides
 uv run python -m src.evals.harness --scenario runtime_profile_preferences
+uv run python -m src.evals.harness --scenario runtime_path_patterns
 uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
 uv run python -m src.evals.harness --scenario daily_briefing_fallback
 uv run python -m src.evals.harness --scenario shell_tool_runtime_audit
@@ -64,7 +65,7 @@ uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, and filesystem boundary failures, context-window degradation, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, and filesystem boundary failures, context-window degradation, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -42,10 +42,10 @@ These control which model/profile a specific runtime path uses, plus how that pa
 |---|---|---|
 | `LOCAL_MODEL` | (empty) | Model id for the local runtime profile |
 | `LOCAL_LLM_API_BASE` | (empty) | API base for the local runtime profile |
-| `LOCAL_RUNTIME_PATHS` | (empty) | Comma-separated runtime paths that should prefer the local profile |
-| `RUNTIME_PROFILE_PREFERENCES` | (empty) | Semicolon-separated `runtime_path=profile_a|profile_b` preference chains |
-| `RUNTIME_MODEL_OVERRIDES` | (empty) | Comma-separated `runtime_path=model` or `runtime_path=profile:model` entries |
-| `RUNTIME_FALLBACK_OVERRIDES` | (empty) | Semicolon-separated `runtime_path=model_a|model_b` fallback chains |
+| `LOCAL_RUNTIME_PATHS` | (empty) | Comma-separated runtime paths or glob patterns that should prefer the local profile |
+| `RUNTIME_PROFILE_PREFERENCES` | (empty) | Semicolon-separated `runtime_path=profile_a|profile_b` preference chains; `runtime_path` may be exact or a glob |
+| `RUNTIME_MODEL_OVERRIDES` | (empty) | Comma-separated `runtime_path=model` or `runtime_path=profile:model` entries; `runtime_path` may be exact or a glob |
+| `RUNTIME_FALLBACK_OVERRIDES` | (empty) | Semicolon-separated `runtime_path=model_a|model_b` fallback chains; `runtime_path` may be exact or a glob |
 | `FALLBACK_MODEL` | (empty) | Legacy single fallback target |
 | `FALLBACK_MODELS` | (empty) | Comma-separated ordered global fallback chain |
 | `FALLBACK_LLM_API_BASE` | (empty) | Optional API base override for fallback calls |
@@ -57,6 +57,15 @@ LOCAL_RUNTIME_PATHS=chat_agent,session_consolidation,daily_briefing
 RUNTIME_PROFILE_PREFERENCES=chat_agent=local|default;session_consolidation=local|default
 RUNTIME_MODEL_OVERRIDES=chat_agent=default:openai/gpt-4.1-mini,session_consolidation=default:openai/gpt-4o-mini
 RUNTIME_FALLBACK_OVERRIDES=chat_agent=openai/gpt-4.1-mini|openai/gpt-4.1-nano;session_title_generation=openai/gpt-4o-mini|openai/gpt-4.1-mini
+```
+
+Pattern-based examples for dynamic runtime paths:
+
+```bash
+LOCAL_RUNTIME_PATHS=mcp_*
+RUNTIME_PROFILE_PREFERENCES=mcp_*=local|default
+RUNTIME_MODEL_OVERRIDES=mcp_*=openai/gpt-4.1-mini,mcp_github_actions=local:ollama/coder
+RUNTIME_FALLBACK_OVERRIDES=mcp_*=openai/gpt-4.1-mini|openai/gpt-4.1-nano;mcp_github_actions=openai/gpt-4o-mini|openai/gpt-4.1-mini
 ```
 
 Current built-in runtime paths include `chat_agent`, `onboarding_agent`, `strategist_agent`, `context_window_summary`, `session_title_generation`, `session_consolidation`, `daily_briefing`, `evening_review`, `activity_digest`, and `weekly_activity_review`.

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -32,7 +32,7 @@ Legend for the checklist column:
 |---|---|---|
 | 01. Trust Boundaries | `[ ]` | Policy modes, approvals, audit logging, and secret redaction are shipped; deeper isolation and narrower privileged execution paths are still left |
 | 02. Execution Plane | `[ ]` | Real tool execution, MCP, browser, shell, filesystem, goals, vault, and web search are shipped; richer workflow and external execution depth are still left |
-| 03. Runtime Reliability | `[ ]` | Profile preferences, fallback chains, runtime-path overrides, local routing, broad runtime audit coverage, and deterministic eval foundations are shipped; richer routing policy and broader eval depth are still left |
+| 03. Runtime Reliability | `[ ]` | Profile preferences, wildcard path rules, fallback chains, runtime-path overrides, local routing, broad runtime audit coverage, and deterministic eval foundations are shipped; richer routing policy and broader eval depth are still left |
 | 04. Presence And Reach | `[ ]` | Browser UI, WebSocket chat, proactive delivery, observer refresh, and native daemon foundations are shipped; richer native presence, notifications, and channels are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, goals, strategist, briefings, reviews, and observer-driven state are shipped foundations; stronger learning loops and intervention quality are still left |
 | 06. Embodied UX | `[ ]` | Village UI, avatar casting, quest surfaces, and settings exist; the fuller life-OS shell and stronger ambient UX are still left |
@@ -61,7 +61,7 @@ Legend for the checklist column:
 - [x] local guardian stack with browser UI, backend APIs, WebSocket chat, scheduler, observer loop, and native macOS daemon
 - [x] 17 built-in tool capabilities exposed through the registry, with native and MCP-backed execution surfaces
 - [x] 9 scheduler jobs and 5 observer source boundaries wired into the current product
-- [x] provider-agnostic LLM runtime with ordered fallback chains, health-aware rerouting, runtime-path profile preferences, runtime-path model overrides, runtime-path fallback overrides, and local-runtime routing
+- [x] provider-agnostic LLM runtime with ordered fallback chains, health-aware rerouting, runtime-path profile preferences, wildcard path rules, runtime-path model overrides, runtime-path fallback overrides, and local-runtime routing
 - [x] runtime audit visibility across chat, scheduler, observer, MCP, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
 - [x] deterministic eval harness coverage for core runtime, audit, observer, storage, and tool-boundary contracts
 

--- a/docs/implementation/03-runtime-reliability.md
+++ b/docs/implementation/03-runtime-reliability.md
@@ -13,6 +13,7 @@
 - [x] runtime-path-specific profile preference chains across shared completion and agent-model paths
 - [x] runtime-path-specific primary model overrides
 - [x] runtime-path-specific fallback-chain overrides
+- [x] wildcard runtime-path routing rules, with exact-path overrides taking precedence
 - [x] first-class local runtime profile for helper, scheduler, core agent, delegation, and connected MCP-specialist paths
 - [x] timeout-safe audit visibility into primary-vs-fallback completion and agent-model behavior
 - [x] fallback-capable model wrappers for chat, onboarding, strategist, and specialists
@@ -26,7 +27,7 @@
 
 ## Still To Do On `develop`
 
-- [ ] deepen provider routing beyond explicit profile preferences, model overrides, ordered fallback chains, and cooldown rerouting with richer policy-aware selection
+- [ ] deepen provider routing beyond profile preferences, path patterns, model overrides, ordered fallback chains, and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduler, core agent, delegation, and connected MCP-specialist paths into any remaining runtime paths where it makes sense
 - [ ] add observability coverage across any remaining edge helpers and external integration paths
 - [ ] expand eval coverage beyond deterministic seam checks into broader behavioral contracts
@@ -40,6 +41,7 @@
 
 - [x] provider failure with configured fallbacks does not collapse the entire chat path
 - [x] runtime paths can force distinct primary and fallback routing without changing the global baseline
+- [x] dynamic runtime paths can inherit wildcard routing rules without losing exact-path control
 - [x] a local or non-OpenRouter path is demonstrably possible across helper, scheduler, core agent, delegation, and connected MCP-specialist flows
 - [ ] key flows are observable and easy to debug
 - [ ] the project has broad repeatable eval coverage for core behavior

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -57,6 +57,7 @@ title: Seraph Development Status
 - [x] ordered fallback chains across completion and agent-model paths
 - [x] health-aware rerouting away from recently failed targets
 - [x] runtime-path-specific profile preference chains across completion and agent-model paths
+- [x] wildcard runtime-path routing rules, with exact-path overrides taking precedence
 - [x] runtime-path-specific primary model overrides
 - [x] runtime-path-specific fallback-chain overrides
 - [x] first-class local runtime routing for helper, scheduler, core agent, delegation, and connected MCP-specialist paths
@@ -83,7 +84,7 @@ title: Seraph Development Status
 
 ### Runtime Reliability
 
-- [ ] richer provider selection policy beyond explicit overrides, ordered fallbacks, and cooldown rerouting
+- [ ] richer provider selection policy beyond path patterns, explicit overrides, ordered fallbacks, and cooldown rerouting
 - [ ] broader local-model routing into any remaining runtime paths that are worth it
 - [ ] remaining edge observability beyond the already-covered chat, scheduler, observer, storage, and integration boundaries
 - [ ] broader eval coverage beyond deterministic seam checks


### PR DESCRIPTION
## Done on develop
- [x] shared LLM runtime routing already supports named runtime paths, local/default profiles, ordered fallback chains, cooldown rerouting, and deterministic seam-check evals
- [x] core agent, scheduler, delegation, MCP-specialist, observer, storage, and tool/runtime audit foundations are already shipped on `develop`

## Working in this PR
- [ ] add wildcard runtime-path matching for local routing, profile preferences, model overrides, and fallback overrides
- [ ] cover wildcard routing and exact-path precedence in runtime tests and the deterministic eval harness
- [ ] update the source-of-truth implementation docs plus setup/testing docs so the shipped routing surface matches the repo

## Still to do after this PR
- [ ] add richer provider selection policy beyond path patterns, explicit overrides, ordered fallbacks, and cooldown rerouting
- [ ] expand runtime evals beyond seam checks into broader behavioral contracts
- [ ] cover the proactive delivery transport boundary and other remaining edge observability gaps

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/llm_runtime.py backend/src/evals/harness.py backend/tests/test_llm_runtime.py backend/tests/test_eval_harness.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_llm_runtime.py tests/test_eval_harness.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario runtime_path_patterns --indent 2`
- `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`
- `cd docs && npm run build`
