### PR TITLE
Trace delivery transport outcomes

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -37,9 +37,10 @@ from src.memory.consolidator import consolidate_session
 from src.memory import soul as soul_mod
 from src.memory.vector_store import _reset_vector_store_state, add_memory, search
 from src.observer.context import CurrentContext
-from src.observer.delivery import deliver_or_queue
+from src.observer.delivery import deliver_or_queue, deliver_queued_bundle
 from src.scheduler.jobs.daily_briefing import run_daily_briefing
 from src.scheduler.jobs.strategist_tick import run_strategist_tick
+from src.scheduler.connection_manager import BroadcastResult
 from src.tools.audit import wrap_tools_for_audit
 from src.tools.browser_tool import browse_webpage
 from src.tools.filesystem_tool import read_file, write_file
@@ -1435,7 +1436,11 @@ async def _eval_observer_delivery_gate_audit() -> dict[str, Any]:
     mock_context_manager.get_context.side_effect = [delivered_ctx, queued_ctx]
     mock_context_manager.decrement_attention_budget = MagicMock()
     mock_ws_manager = MagicMock()
-    mock_ws_manager.broadcast = AsyncMock()
+    mock_ws_manager.broadcast = AsyncMock(return_value=BroadcastResult(
+        attempted_connections=2,
+        delivered_connections=2,
+        failed_connections=0,
+    ))
     mock_insight_queue = MagicMock()
     mock_insight_queue.enqueue = AsyncMock()
     mock_log_event = AsyncMock()
@@ -1466,8 +1471,78 @@ async def _eval_observer_delivery_gate_audit() -> dict[str, Any]:
     return {
         "delivered_user_state": delivered["details"]["user_state"],
         "queued_user_state": queued["details"]["user_state"],
+        "delivered_connections": delivered["details"]["delivered_connections"],
         "broadcast_calls": mock_ws_manager.broadcast.await_count,
         "enqueue_calls": mock_insight_queue.enqueue.await_count,
+    }
+
+
+async def _eval_observer_delivery_transport_audit() -> dict[str, Any]:
+    delivered_ctx = _make_context(user_state="available", interruption_mode="balanced", attention_budget_remaining=3)
+    failed_ctx = _make_context(user_state="available", interruption_mode="balanced", attention_budget_remaining=3)
+    mock_context_manager = MagicMock()
+    mock_context_manager.get_context.side_effect = [delivered_ctx, failed_ctx]
+    mock_context_manager.decrement_attention_budget = MagicMock()
+    mock_ws_manager = MagicMock()
+    mock_ws_manager.broadcast = AsyncMock(
+        side_effect=[
+            BroadcastResult(attempted_connections=2, delivered_connections=2, failed_connections=0),
+            BroadcastResult(attempted_connections=1, delivered_connections=0, failed_connections=1),
+            BroadcastResult(attempted_connections=2, delivered_connections=2, failed_connections=0),
+            BroadcastResult(attempted_connections=1, delivered_connections=0, failed_connections=1),
+        ]
+    )
+    mock_insight_queue = MagicMock()
+    mock_insight_queue.enqueue = AsyncMock()
+    mock_insight_queue.drain = AsyncMock(
+        side_effect=[
+            [MagicMock(content="Calendar alert: standup")],
+            [MagicMock(content="Goal reminder: exercise")],
+        ]
+    )
+    mock_log_event = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_context_manager),
+        patch("src.scheduler.connection_manager.ws_manager", mock_ws_manager),
+        patch("src.observer.insight_queue.insight_queue", mock_insight_queue),
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        await deliver_or_queue(
+            WSResponse(type="proactive", content="Ship it", intervention_type="advisory", urgency=3)
+        )
+        await deliver_or_queue(
+            WSResponse(type="proactive", content="Missed transport", intervention_type="advisory", urgency=3)
+        )
+        delivered_bundle_count = await deliver_queued_bundle()
+        failed_bundle_count = await deliver_queued_bundle()
+
+    direct_failure = _find_audit_call(
+        mock_log_event,
+        event_type="observer_delivery_failed",
+        tool_name="observer_delivery_gate",
+    )
+    bundle_delivered = None
+    bundle_failed = None
+    for call in mock_log_event.call_args_list:
+        kwargs = call.kwargs
+        if kwargs.get("tool_name") != "observer_delivery_gate":
+            continue
+        details = kwargs.get("details", {})
+        if kwargs.get("event_type") == "observer_delivery_delivered" and details.get("intervention_type") == "proactive_bundle":
+            bundle_delivered = kwargs
+        if kwargs.get("event_type") == "observer_delivery_failed" and details.get("intervention_type") == "proactive_bundle":
+            bundle_failed = kwargs
+    assert bundle_delivered is not None
+    assert bundle_failed is not None
+
+    return {
+        "direct_failure_error": direct_failure["details"]["error"],
+        "direct_failure_delivered_connections": direct_failure["details"]["delivered_connections"],
+        "bundle_delivered_count": delivered_bundle_count,
+        "bundle_delivered_connections": bundle_delivered["details"]["delivered_connections"],
+        "bundle_failed_count": failed_bundle_count,
+        "bundle_failed_error": bundle_failed["details"]["error"],
     }
 
 
@@ -1732,6 +1807,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="observability",
         description="Proactive delivery gate records delivered and queued audit outcomes with observer context details.",
         runner=_eval_observer_delivery_gate_audit,
+    ),
+    EvalScenario(
+        name="observer_delivery_transport_audit",
+        category="observability",
+        description="Direct and bundled proactive delivery record transport-level delivered versus failed audit outcomes.",
+        runner=_eval_observer_delivery_transport_audit,
     ),
     EvalScenario(
         name="observer_daemon_ingest_audit",

--- a/backend/src/observer/delivery.py
+++ b/backend/src/observer/delivery.py
@@ -9,6 +9,14 @@ from src.observer.user_state import DeliveryDecision, user_state_machine
 logger = logging.getLogger(__name__)
 
 
+def _transport_failure_reason(*, attempted_connections: int, failed_connections: int) -> str:
+    if attempted_connections <= 0:
+        return "no_active_connections"
+    if failed_connections >= attempted_connections:
+        return "all_connections_failed"
+    return "unknown_transport_failure"
+
+
 async def deliver_or_queue(
     message: WSResponse,
     is_scheduled: bool = False,
@@ -44,7 +52,36 @@ async def deliver_or_queue(
         }
 
         if decision == DeliveryDecision.deliver:
-            await ws_manager.broadcast(message)
+            broadcast_result = await ws_manager.broadcast(message)
+            event_details.update(
+                {
+                    "attempted_connections": broadcast_result.attempted_connections,
+                    "delivered_connections": broadcast_result.delivered_connections,
+                    "failed_connections": broadcast_result.failed_connections,
+                }
+            )
+            if broadcast_result.delivered_connections <= 0:
+                logger.warning(
+                    "Failed to deliver proactive message over WebSocket transport (attempted=%d failed=%d)",
+                    broadcast_result.attempted_connections,
+                    broadcast_result.failed_connections,
+                )
+                await log_observer_delivery_event(
+                    decision="failed",
+                    message_type=message.type,
+                    intervention_type=intervention_type,
+                    urgency=urgency,
+                    is_scheduled=is_scheduled,
+                    details={
+                        **event_details,
+                        "delivery_decision": decision.value,
+                        "error": _transport_failure_reason(
+                            attempted_connections=broadcast_result.attempted_connections,
+                            failed_connections=broadcast_result.failed_connections,
+                        ),
+                    },
+                )
+                return decision
             # Decrement budget if this delivery costs budget
             if user_state_machine.should_cost_budget(
                 intervention_type=intervention_type,
@@ -128,14 +165,50 @@ async def deliver_queued_bundle() -> int:
         parts.append(f"- {item.content}")
     bundle_content = f"While you were away ({len(items)} update{'s' if len(items) != 1 else ''}):\n" + "\n".join(parts)
 
-    await ws_manager.broadcast(
-        WSResponse(
-            type="proactive",
-            content=bundle_content,
-            intervention_type="proactive_bundle",
-            urgency=3,
-            reasoning=f"Bundle of {len(items)} queued insight(s) delivered on state transition",
-        )
+    message = WSResponse(
+        type="proactive",
+        content=bundle_content,
+        intervention_type="proactive_bundle",
+        urgency=3,
+        reasoning=f"Bundle of {len(items)} queued insight(s) delivered on state transition",
     )
+    broadcast_result = await ws_manager.broadcast(message)
+    details = {
+        "bundle_item_count": len(items),
+        "attempted_connections": broadcast_result.attempted_connections,
+        "delivered_connections": broadcast_result.delivered_connections,
+        "failed_connections": broadcast_result.failed_connections,
+        "delivery_decision": "deliver",
+    }
+    if broadcast_result.delivered_connections <= 0:
+        logger.warning(
+            "Failed to deliver queued bundle over WebSocket transport (attempted=%d failed=%d)",
+            broadcast_result.attempted_connections,
+            broadcast_result.failed_connections,
+        )
+        await log_observer_delivery_event(
+            decision="failed",
+            message_type=message.type,
+            intervention_type=message.intervention_type,
+            urgency=message.urgency,
+            is_scheduled=False,
+            details={
+                **details,
+                "error": _transport_failure_reason(
+                    attempted_connections=broadcast_result.attempted_connections,
+                    failed_connections=broadcast_result.failed_connections,
+                ),
+            },
+        )
+        return 0
+
     logger.info("Delivered bundle of %d queued insight(s)", len(items))
+    await log_observer_delivery_event(
+        decision="delivered",
+        message_type=message.type,
+        intervention_type=message.intervention_type,
+        urgency=message.urgency,
+        is_scheduled=False,
+        details=details,
+    )
     return len(items)

--- a/backend/src/scheduler/connection_manager.py
+++ b/backend/src/scheduler/connection_manager.py
@@ -1,10 +1,18 @@
 import logging
+from dataclasses import dataclass
 
 from fastapi import WebSocket
 
 from src.models.schemas import WSResponse
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BroadcastResult:
+    attempted_connections: int
+    delivered_connections: int
+    failed_connections: int
 
 
 class ConnectionManager:
@@ -25,18 +33,27 @@ class ConnectionManager:
         self._connections.discard(ws)
         logger.debug("WS unregistered (%d active)", self.active_count)
 
-    async def broadcast(self, message: WSResponse) -> None:
+    async def broadcast(self, message: WSResponse) -> BroadcastResult:
         """Send a message to all connected clients, dropping any that error."""
         payload = message.model_dump_json()
         dead: list[WebSocket] = []
+        attempted_connections = len(self._connections)
+        failed_connections = 0
         for ws in self._connections:
             try:
                 await ws.send_text(payload)
             except Exception:
                 dead.append(ws)
+                failed_connections += 1
         for ws in dead:
             self._connections.discard(ws)
             logger.debug("Removed dead WS connection (%d active)", self.active_count)
+        delivered_connections = attempted_connections - failed_connections
+        return BroadcastResult(
+            attempted_connections=attempted_connections,
+            delivered_connections=delivered_connections,
+            failed_connections=failed_connections,
+        )
 
 
 ws_manager = ConnectionManager()

--- a/backend/tests/test_delivery.py
+++ b/backend/tests/test_delivery.py
@@ -9,6 +9,7 @@ from src.models.schemas import WSResponse
 from src.observer.context import CurrentContext
 from src.observer.delivery import deliver_or_queue, deliver_queued_bundle
 from src.observer.user_state import DeliveryDecision
+from src.scheduler.connection_manager import BroadcastResult
 
 
 def _make_context(**overrides) -> CurrentContext:
@@ -26,7 +27,11 @@ def _patch_deps(ctx):
     mock_cm = MagicMock()
     mock_cm.get_context.return_value = ctx
     mock_ws = MagicMock()
-    mock_ws.broadcast = AsyncMock()
+    mock_ws.broadcast = AsyncMock(return_value=BroadcastResult(
+        attempted_connections=1,
+        delivered_connections=1,
+        failed_connections=0,
+    ))
     mock_iq = MagicMock()
     mock_iq.enqueue = AsyncMock()
     mock_iq.drain = AsyncMock(return_value=[])
@@ -73,6 +78,7 @@ async def test_deliver_logs_runtime_audit(async_db):
             and event["tool_name"] == "observer_delivery_gate"
             and event["details"]["intervention_type"] == "advisory"
             and event["details"]["user_state"] == "available"
+            and event["details"]["delivered_connections"] == 1
             for event in events
         )
     finally:
@@ -218,6 +224,39 @@ async def test_delivery_failure_logs_runtime_audit(async_db):
 
 
 @pytest.mark.asyncio
+async def test_delivery_transport_failure_logs_runtime_audit(async_db):
+    ctx = _make_context()
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    mock_ws.broadcast = AsyncMock(return_value=BroadcastResult(
+        attempted_connections=1,
+        delivered_connections=0,
+        failed_connections=1,
+    ))
+    for p in patches:
+        p.start()
+    try:
+        msg = WSResponse(type="proactive", content="Test", intervention_type="advisory", urgency=3)
+        decision = await deliver_or_queue(msg)
+
+        assert decision == DeliveryDecision.deliver
+        mock_cm.decrement_attention_budget.assert_not_called()
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "observer_delivery_failed"
+            and event["tool_name"] == "observer_delivery_gate"
+            and event["details"]["delivery_decision"] == "deliver"
+            and event["details"]["error"] == "all_connections_failed"
+            and event["details"]["attempted_connections"] == 1
+            and event["details"]["delivered_connections"] == 0
+            for event in events
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
 async def test_delivery_audit_fails_open():
     ctx = _make_context()
     patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
@@ -240,7 +279,11 @@ async def test_deliver_queued_bundle_empty():
     mock_iq = MagicMock()
     mock_iq.drain = AsyncMock(return_value=[])
     mock_ws = MagicMock()
-    mock_ws.broadcast = AsyncMock()
+    mock_ws.broadcast = AsyncMock(return_value=BroadcastResult(
+        attempted_connections=1,
+        delivered_connections=1,
+        failed_connections=0,
+    ))
 
     with (
         patch("src.observer.insight_queue.insight_queue", mock_iq),
@@ -260,7 +303,11 @@ async def test_deliver_queued_bundle_formats_correctly():
     mock_iq = MagicMock()
     mock_iq.drain = AsyncMock(return_value=[mock_item1, mock_item2])
     mock_ws = MagicMock()
-    mock_ws.broadcast = AsyncMock()
+    mock_ws.broadcast = AsyncMock(return_value=BroadcastResult(
+        attempted_connections=1,
+        delivered_connections=1,
+        failed_connections=0,
+    ))
 
     with (
         patch("src.observer.insight_queue.insight_queue", mock_iq),
@@ -285,7 +332,11 @@ async def test_deliver_queued_bundle_single_item():
     mock_iq = MagicMock()
     mock_iq.drain = AsyncMock(return_value=[mock_item])
     mock_ws = MagicMock()
-    mock_ws.broadcast = AsyncMock()
+    mock_ws.broadcast = AsyncMock(return_value=BroadcastResult(
+        attempted_connections=1,
+        delivered_connections=1,
+        failed_connections=0,
+    ))
 
     with (
         patch("src.observer.insight_queue.insight_queue", mock_iq),
@@ -296,3 +347,63 @@ async def test_deliver_queued_bundle_single_item():
         assert count == 1
         call_args = mock_ws.broadcast.call_args[0][0]
         assert "1 update)" in call_args.content
+
+
+@pytest.mark.asyncio
+async def test_deliver_queued_bundle_logs_delivery_runtime_audit(async_db):
+    mock_item = MagicMock(content="Bundle update")
+    mock_iq = MagicMock()
+    mock_iq.drain = AsyncMock(return_value=[mock_item])
+    mock_ws = MagicMock()
+    mock_ws.broadcast = AsyncMock(return_value=BroadcastResult(
+        attempted_connections=2,
+        delivered_connections=2,
+        failed_connections=0,
+    ))
+
+    with (
+        patch("src.observer.insight_queue.insight_queue", mock_iq),
+        patch("src.scheduler.connection_manager.ws_manager", mock_ws),
+    ):
+        count = await deliver_queued_bundle()
+
+    assert count == 1
+    events = await audit_repository.list_events(limit=10)
+    assert any(
+        event["event_type"] == "observer_delivery_delivered"
+        and event["tool_name"] == "observer_delivery_gate"
+        and event["details"]["intervention_type"] == "proactive_bundle"
+        and event["details"]["bundle_item_count"] == 1
+        and event["details"]["delivered_connections"] == 2
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_deliver_queued_bundle_logs_transport_failure(async_db):
+    mock_item = MagicMock(content="Bundle update")
+    mock_iq = MagicMock()
+    mock_iq.drain = AsyncMock(return_value=[mock_item])
+    mock_ws = MagicMock()
+    mock_ws.broadcast = AsyncMock(return_value=BroadcastResult(
+        attempted_connections=1,
+        delivered_connections=0,
+        failed_connections=1,
+    ))
+
+    with (
+        patch("src.observer.insight_queue.insight_queue", mock_iq),
+        patch("src.scheduler.connection_manager.ws_manager", mock_ws),
+    ):
+        count = await deliver_queued_bundle()
+
+    assert count == 0
+    events = await audit_repository.list_events(limit=10)
+    assert any(
+        event["event_type"] == "observer_delivery_failed"
+        and event["tool_name"] == "observer_delivery_gate"
+        and event["details"]["intervention_type"] == "proactive_bundle"
+        and event["details"]["bundle_item_count"] == 1
+        and event["details"]["error"] == "all_connections_failed"
+        for event in events
+    )

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -66,6 +66,8 @@ def test_main_lists_available_scenarios(capsys):
     assert "observer_git_source_audit" in captured.out
     assert "observer_goal_source_audit" in captured.out
     assert "observer_time_source_audit" in captured.out
+    assert "observer_delivery_gate_audit" in captured.out
+    assert "observer_delivery_transport_audit" in captured.out
     assert "observer_daemon_ingest_audit" in captured.out
 
 
@@ -110,6 +112,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "observer_goal_source_audit",
                 "observer_time_source_audit",
                 "observer_delivery_gate_audit",
+                "observer_delivery_transport_audit",
                 "observer_daemon_ingest_audit",
             ]
         )
@@ -236,5 +239,12 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["observer_time_source_audit"]["timezone"] == "UTC"
     assert details_by_name["observer_delivery_gate_audit"]["delivered_user_state"] == "available"
     assert details_by_name["observer_delivery_gate_audit"]["queued_user_state"] == "deep_work"
+    assert details_by_name["observer_delivery_gate_audit"]["delivered_connections"] == 2
+    assert details_by_name["observer_delivery_transport_audit"]["direct_failure_error"] == "all_connections_failed"
+    assert details_by_name["observer_delivery_transport_audit"]["direct_failure_delivered_connections"] == 0
+    assert details_by_name["observer_delivery_transport_audit"]["bundle_delivered_count"] == 1
+    assert details_by_name["observer_delivery_transport_audit"]["bundle_delivered_connections"] == 2
+    assert details_by_name["observer_delivery_transport_audit"]["bundle_failed_count"] == 0
+    assert details_by_name["observer_delivery_transport_audit"]["bundle_failed_error"] == "all_connections_failed"
     assert details_by_name["observer_daemon_ingest_audit"]["persisted_app"] == "VS Code"
     assert details_by_name["observer_daemon_ingest_audit"]["persist_failed_error"] == "db down"

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -5,7 +5,7 @@ import pytest
 import pytest_asyncio
 
 from src.models.schemas import WSResponse
-from src.scheduler.connection_manager import ConnectionManager
+from src.scheduler.connection_manager import BroadcastResult, ConnectionManager
 
 
 # ── ConnectionManager ──────────────────────────────────────
@@ -45,11 +45,16 @@ class TestConnectionManager:
         mgr.connect(ws2)
 
         msg = WSResponse(type="proactive", content="hello")
-        await mgr.broadcast(msg)
+        result = await mgr.broadcast(msg)
 
         expected_payload = msg.model_dump_json()
         ws1.send_text.assert_called_once_with(expected_payload)
         ws2.send_text.assert_called_once_with(expected_payload)
+        assert result == BroadcastResult(
+            attempted_connections=2,
+            delivered_connections=2,
+            failed_connections=0,
+        )
 
     @pytest.mark.asyncio
     async def test_broadcast_removes_dead_connections(self):
@@ -62,16 +67,26 @@ class TestConnectionManager:
         assert mgr.active_count == 2
 
         msg = WSResponse(type="ambient", content="tick", state="idle")
-        await mgr.broadcast(msg)
+        result = await mgr.broadcast(msg)
 
         alive.send_text.assert_called_once()
         assert mgr.active_count == 1
+        assert result == BroadcastResult(
+            attempted_connections=2,
+            delivered_connections=1,
+            failed_connections=1,
+        )
 
     @pytest.mark.asyncio
     async def test_broadcast_no_connections(self):
         mgr = ConnectionManager()
         msg = WSResponse(type="proactive", content="nobody home")
-        await mgr.broadcast(msg)  # should not raise
+        result = await mgr.broadcast(msg)  # should not raise
+        assert result == BroadcastResult(
+            attempted_connections=0,
+            delivered_connections=0,
+            failed_connections=0,
+        )
 
 
 # ── Scheduler engine ───────────────────────────────────────

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -62,10 +62,11 @@ uv run python -m src.evals.harness --scenario observer_git_source_audit
 uv run python -m src.evals.harness --scenario observer_goal_source_audit
 uv run python -m src.evals.harness --scenario observer_time_source_audit
 uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
+uv run python -m src.evals.harness --scenario observer_delivery_transport_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, and filesystem boundary failures, context-window degradation, proactive delivery, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, and filesystem boundary failures, context-window degradation, proactive delivery transport, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -62,7 +62,7 @@ Legend for the checklist column:
 - [x] 17 built-in tool capabilities exposed through the registry, with native and MCP-backed execution surfaces
 - [x] 9 scheduler jobs and 5 observer source boundaries wired into the current product
 - [x] provider-agnostic LLM runtime with ordered fallback chains, health-aware rerouting, runtime-path profile preferences, wildcard path rules, runtime-path model overrides, runtime-path fallback overrides, and local-runtime routing
-- [x] runtime audit visibility across chat, scheduler, observer, MCP, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
+- [x] runtime audit visibility across chat, scheduler, observer, proactive delivery transport, MCP, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
 - [x] deterministic eval harness coverage for core runtime, audit, observer, storage, and tool-boundary contracts
 
 ## Recommended Reading Order

--- a/docs/implementation/03-runtime-reliability.md
+++ b/docs/implementation/03-runtime-reliability.md
@@ -18,7 +18,7 @@
 - [x] timeout-safe audit visibility into primary-vs-fallback completion and agent-model behavior
 - [x] fallback-capable model wrappers for chat, onboarding, strategist, and specialists
 - [x] repeatable runtime eval harness for guardian, observer, storage, and integration seam checks
-- [x] runtime audit coverage across chat, WebSocket, scheduler jobs, strategist helpers, MCP lifecycle, observer lifecycle, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
+- [x] runtime audit coverage across chat, WebSocket, scheduler jobs, strategist helpers, proactive delivery transport, MCP lifecycle, observer lifecycle, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
 
 ## Working On Now
 
@@ -29,7 +29,7 @@
 
 - [ ] deepen provider routing beyond profile preferences, path patterns, model overrides, ordered fallback chains, and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduler, core agent, delegation, and connected MCP-specialist paths into any remaining runtime paths where it makes sense
-- [ ] add observability coverage across any remaining edge helpers and external integration paths
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond the proactive delivery transport boundary
 - [ ] expand eval coverage beyond deterministic seam checks into broader behavioral contracts
 
 ## Non-Goals

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -61,7 +61,7 @@ title: Seraph Development Status
 - [x] runtime-path-specific primary model overrides
 - [x] runtime-path-specific fallback-chain overrides
 - [x] first-class local runtime routing for helper, scheduler, core agent, delegation, and connected MCP-specialist paths
-- [x] runtime audit visibility across chat, WebSocket, scheduler, strategist, MCP, observer, embedding, vector store, soul file, filesystem, browser, sandbox, and web search flows
+- [x] runtime audit visibility across chat, WebSocket, scheduler, strategist, proactive delivery transport, MCP, observer, embedding, vector store, soul file, filesystem, browser, sandbox, and web search flows
 - [x] deterministic runtime eval harness for fallback, routing, storage, observer, and integration seam contracts
 
 ### Guardian intelligence and proactive behavior
@@ -86,7 +86,7 @@ title: Seraph Development Status
 
 - [ ] richer provider selection policy beyond path patterns, explicit overrides, ordered fallbacks, and cooldown rerouting
 - [ ] broader local-model routing into any remaining runtime paths that are worth it
-- [ ] remaining edge observability beyond the already-covered chat, scheduler, observer, storage, and integration boundaries
+- [ ] remaining edge observability beyond the already-covered chat, scheduler, observer, proactive delivery, storage, and integration boundaries
 - [ ] broader eval coverage beyond deterministic seam checks
 
 ### Product expansion


### PR DESCRIPTION
## Done on develop
- [x] runtime audit already covers chat, WebSocket agent runs, scheduler jobs, observer refresh, MCP lifecycle, storage boundaries, and tool/integration seams
- [x] deterministic runtime evals already cover delivery-gate decisions, observer boundaries, runtime routing, fallback behavior, and storage/integration seam checks

## Working in this PR
- [ ] make websocket broadcast return transport counts instead of silently hiding failed recipients
- [ ] record proactive direct-delivery and queued-bundle transport outcomes as delivered versus failed in runtime audit data
- [ ] extend delivery/scheduler tests, deterministic eval coverage, and implementation docs to reflect the new transport boundary visibility

## Still to do after this PR
- [ ] add richer provider selection policy beyond path patterns, explicit overrides, ordered fallbacks, and cooldown rerouting
- [ ] expand runtime evals beyond seam checks into broader behavioral contracts
- [ ] cover the remaining edge observability gaps outside the already-covered delivery transport, scheduler, observer, storage, and integration boundaries

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/scheduler/connection_manager.py backend/src/observer/delivery.py backend/src/evals/harness.py backend/tests/test_scheduler.py backend/tests/test_delivery.py backend/tests/test_eval_harness.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_scheduler.py tests/test_delivery.py tests/test_eval_harness.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario observer_delivery_transport_audit --indent 2`
- `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`
- `cd docs && npm run build`
