### PR TITLE
Trace MCP test API runtime audit

### DIFF
--- a/backend/src/api/mcp.py
+++ b/backend/src/api/mcp.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from src.audit.runtime import log_integration_event
 from src.tools.mcp_manager import mcp_manager
 
 router = APIRouter()
@@ -87,6 +88,15 @@ async def test_server(name: str):
     raw_headers = config.get("headers")
     missing_vars = mcp_manager._check_unresolved_vars(raw_headers)
     if missing_vars:
+        await log_integration_event(
+            integration_type="mcp_test",
+            name=name,
+            outcome="auth_required",
+            details={
+                "url": url,
+                "missing_env_vars": missing_vars,
+            },
+        )
         return {
             "status": "auth_required",
             "message": f"Missing environment variables: {', '.join(missing_vars)}",
@@ -104,9 +114,40 @@ async def test_server(name: str):
         tools = client.get_tools()
         tool_names = [t.name for t in tools]
         client.disconnect()
+        await log_integration_event(
+            integration_type="mcp_test",
+            name=name,
+            outcome="succeeded",
+            details={
+                "url": url,
+                "tool_count": len(tools),
+                "tool_names": tool_names,
+                "used_headers": bool(raw_headers),
+            },
+        )
         return {"status": "ok", "tool_count": len(tools), "tools": tool_names}
     except Exception as e:
         exc_str = str(e).lower()
         if any(kw in exc_str for kw in ("401", "403", "unauthorized", "forbidden")):
+            await log_integration_event(
+                integration_type="mcp_test",
+                name=name,
+                outcome="failed",
+                details={
+                    "url": url,
+                    "status": "auth_failed",
+                    "error": str(e),
+                },
+            )
             return {"status": "auth_failed", "message": f"Authentication failed: {e}"}
+        await log_integration_event(
+            integration_type="mcp_test",
+            name=name,
+            outcome="failed",
+            details={
+                "url": url,
+                "status": "connection_failed",
+                "error": str(e),
+            },
+        )
         raise HTTPException(status_code=502, detail=f"Connection failed: {e}")

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -16,6 +16,7 @@ from typing import Any, Awaitable, Callable, Sequence
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+from fastapi import HTTPException
 from smolagents import Tool
 
 from config.settings import settings
@@ -25,6 +26,7 @@ from src.agent.factory import create_orchestrator, get_model
 from src.agent.onboarding import create_onboarding_agent
 from src.agent.specialists import create_mcp_specialist, create_specialist, mcp_specialist_runtime_path
 from src.agent.strategist import create_strategist_agent
+from src.api.mcp import test_server as test_mcp_server
 from src.api.observer import ScreenContextRequest, ScreenObservationData, post_screen_context
 from src.audit.repository import audit_repository
 from src.llm_runtime import FallbackLiteLLMModel, _reset_target_health, completion_with_fallback_sync
@@ -1603,6 +1605,67 @@ async def _eval_observer_daemon_ingest_audit() -> dict[str, Any]:
     }
 
 
+async def _eval_mcp_test_api_audit() -> dict[str, Any]:
+    mock_tool = MagicMock()
+    mock_tool.name = "list_prs"
+    mock_client = MagicMock()
+    mock_client.get_tools.return_value = [mock_tool]
+    mock_log_event = AsyncMock()
+
+    with (
+        patch("src.api.mcp.mcp_manager") as mock_mgr,
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        mock_mgr._config = {
+            "gh": {
+                "url": "http://gh/mcp",
+                "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
+            }
+        }
+        mock_mgr._check_unresolved_vars.side_effect = [["GITHUB_TOKEN"], [], []]
+        mock_mgr._resolve_env_vars.side_effect = lambda value: value.replace("${GITHUB_TOKEN}", "ghp_test")
+
+        auth_required = await test_mcp_server("gh")
+
+        with patch("smolagents.MCPClient", return_value=mock_client):
+            success = await test_mcp_server("gh")
+
+        with patch("smolagents.MCPClient", side_effect=ConnectionError("refused")):
+            try:
+                await test_mcp_server("gh")
+            except HTTPException as exc:
+                failure_status_code = exc.status_code
+            else:  # pragma: no cover - defensive guard
+                raise AssertionError("Expected MCP test API failure to raise HTTPException")
+
+    auth_required_event = _find_audit_call(
+        mock_log_event,
+        event_type="integration_auth_required",
+        tool_name="mcp_test:gh",
+    )
+    success_event = _find_audit_call(
+        mock_log_event,
+        event_type="integration_succeeded",
+        tool_name="mcp_test:gh",
+    )
+    failed_event = _find_audit_call(
+        mock_log_event,
+        event_type="integration_failed",
+        tool_name="mcp_test:gh",
+    )
+    return {
+        "auth_required_status": auth_required["status"],
+        "missing_env_vars": auth_required_event["details"]["missing_env_vars"],
+        "success_status": success["status"],
+        "tool_count": success_event["details"]["tool_count"],
+        "tool_names": success_event["details"]["tool_names"],
+        "used_headers": success_event["details"]["used_headers"],
+        "failure_status_code": failure_status_code,
+        "failure_status": failed_event["details"]["status"],
+        "failure_error": failed_event["details"]["error"],
+    }
+
+
 _SCENARIOS: tuple[EvalScenario, ...] = (
     EvalScenario(
         name="chat_model_wrapper",
@@ -1819,6 +1882,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="observability",
         description="Observer daemon screen-context ingest records receive, persist success, and persist failure audit events.",
         runner=_eval_observer_daemon_ingest_audit,
+    ),
+    EvalScenario(
+        name="mcp_test_api_audit",
+        category="observability",
+        description="Manual MCP server test requests record auth-required and successful tool-discovery audit events.",
+        runner=_eval_mcp_test_api_audit,
     ),
 )
 

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -69,6 +69,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "observer_delivery_gate_audit" in captured.out
     assert "observer_delivery_transport_audit" in captured.out
     assert "observer_daemon_ingest_audit" in captured.out
+    assert "mcp_test_api_audit" in captured.out
 
 
 def test_main_emits_json_summary(capsys):
@@ -114,6 +115,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "observer_delivery_gate_audit",
                 "observer_delivery_transport_audit",
                 "observer_daemon_ingest_audit",
+                "mcp_test_api_audit",
             ]
         )
     )
@@ -248,3 +250,12 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["observer_delivery_transport_audit"]["bundle_failed_error"] == "all_connections_failed"
     assert details_by_name["observer_daemon_ingest_audit"]["persisted_app"] == "VS Code"
     assert details_by_name["observer_daemon_ingest_audit"]["persist_failed_error"] == "db down"
+    assert details_by_name["mcp_test_api_audit"]["auth_required_status"] == "auth_required"
+    assert details_by_name["mcp_test_api_audit"]["missing_env_vars"] == ["GITHUB_TOKEN"]
+    assert details_by_name["mcp_test_api_audit"]["success_status"] == "ok"
+    assert details_by_name["mcp_test_api_audit"]["tool_count"] == 1
+    assert details_by_name["mcp_test_api_audit"]["tool_names"] == ["list_prs"]
+    assert details_by_name["mcp_test_api_audit"]["used_headers"] is True
+    assert details_by_name["mcp_test_api_audit"]["failure_status_code"] == 502
+    assert details_by_name["mcp_test_api_audit"]["failure_status"] == "connection_failed"
+    assert details_by_name["mcp_test_api_audit"]["failure_error"] == "refused"

--- a/backend/tests/test_mcp_api.py
+++ b/backend/tests/test_mcp_api.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.audit.repository import audit_repository
+
 
 @pytest.mark.asyncio
 async def test_set_token_happy_path(client):
@@ -67,3 +69,119 @@ async def test_test_server_auth_required_for_missing_vars(client):
         data = resp.json()
         assert data["status"] == "auth_required"
         assert "GITHUB_TOKEN" in data["missing_env_vars"]
+
+
+@pytest.mark.asyncio
+async def test_test_server_auth_required_logs_runtime_audit(async_db, client):
+    with patch("src.api.mcp.mcp_manager") as mock_mgr:
+        mock_mgr._config = {
+            "gh": {
+                "url": "http://gh/mcp",
+                "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
+            }
+        }
+        mock_mgr._check_unresolved_vars.return_value = ["GITHUB_TOKEN"]
+
+        resp = await client.post("/api/mcp/servers/gh/test")
+        assert resp.status_code == 200
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_auth_required"
+            and event["tool_name"] == "mcp_test:gh"
+            and event["details"]["missing_env_vars"] == ["GITHUB_TOKEN"]
+            for event in events
+        )
+
+
+@pytest.mark.asyncio
+async def test_test_server_success_logs_runtime_audit(async_db, client):
+    mock_tool = MagicMock(name="list_prs")
+    mock_tool.name = "list_prs"
+    mock_client = MagicMock()
+    mock_client.get_tools.return_value = [mock_tool]
+
+    with (
+        patch("src.api.mcp.mcp_manager") as mock_mgr,
+        patch("smolagents.MCPClient", return_value=mock_client),
+    ):
+        mock_mgr._config = {
+            "gh": {
+                "url": "http://gh/mcp",
+                "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
+            }
+        }
+        mock_mgr._check_unresolved_vars.return_value = []
+        mock_mgr._resolve_env_vars.side_effect = lambda value: value.replace("${GITHUB_TOKEN}", "ghp_test")
+
+        resp = await client.post("/api/mcp/servers/gh/test")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["tool_count"] == 1
+        assert data["tools"] == ["list_prs"]
+        mock_client.disconnect.assert_called_once()
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_succeeded"
+            and event["tool_name"] == "mcp_test:gh"
+            and event["details"]["tool_count"] == 1
+            and event["details"]["tool_names"] == ["list_prs"]
+            for event in events
+        )
+
+
+@pytest.mark.asyncio
+async def test_test_server_auth_failed_logs_runtime_audit(async_db, client):
+    with (
+        patch("src.api.mcp.mcp_manager") as mock_mgr,
+        patch("smolagents.MCPClient", side_effect=Exception("HTTP 401 Unauthorized")),
+    ):
+        mock_mgr._config = {
+            "gh": {
+                "url": "http://gh/mcp",
+                "headers": None,
+            }
+        }
+        mock_mgr._check_unresolved_vars.return_value = []
+
+        resp = await client.post("/api/mcp/servers/gh/test")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "auth_failed"
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_failed"
+            and event["tool_name"] == "mcp_test:gh"
+            and event["details"]["status"] == "auth_failed"
+            for event in events
+        )
+
+
+@pytest.mark.asyncio
+async def test_test_server_connection_failure_logs_runtime_audit(async_db, client):
+    with (
+        patch("src.api.mcp.mcp_manager") as mock_mgr,
+        patch("smolagents.MCPClient", side_effect=ConnectionError("refused")),
+    ):
+        mock_mgr._config = {
+            "gh": {
+                "url": "http://gh/mcp",
+                "headers": None,
+            }
+        }
+        mock_mgr._check_unresolved_vars.return_value = []
+
+        resp = await client.post("/api/mcp/servers/gh/test")
+        assert resp.status_code == 502
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_failed"
+            and event["tool_name"] == "mcp_test:gh"
+            and event["details"]["status"] == "connection_failed"
+            and event["details"]["error"] == "refused"
+            for event in events
+        )

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -64,9 +64,10 @@ uv run python -m src.evals.harness --scenario observer_time_source_audit
 uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_delivery_transport_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
+uv run python -m src.evals.harness --scenario mcp_test_api_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, and filesystem boundary failures, context-window degradation, proactive delivery transport, daemon ingest, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, and filesystem boundary failures, context-window degradation, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -105,7 +106,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_http_mcp_server.py` | 16 | HTTP MCP server — request handling, internal URL blocking, timeout, truncation |
 | `test_insight_queue.py` | 12 | Insight queue — enqueue, drain, peek, ordering, expiry |
 | `test_insight_queue_expiry.py` | 8 | Insight queue expiry — TTL, cleanup, edge cases |
-| `test_mcp_api.py` | 3 | MCP HTTP API endpoints — list, add, remove servers |
+| `test_mcp_api.py` | 7 | MCP HTTP API endpoints — token update, manual server test auth/success/failure flows, and runtime audit logging |
 | `test_mcp_manager.py` | 31 | MCP server integration — connect, disconnect, failure handling, token auth, env var resolution |
 | `test_observer_api.py` | 7 | Observer API endpoints — state, context POST, daemon status |
 | `test_observer_calendar.py` | 4 | Calendar observer source — event parsing, empty/failure handling, runtime audit logging |

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -32,7 +32,7 @@ Legend for the checklist column:
 |---|---|---|
 | 01. Trust Boundaries | `[ ]` | Policy modes, approvals, audit logging, and secret redaction are shipped; deeper isolation and narrower privileged execution paths are still left |
 | 02. Execution Plane | `[ ]` | Real tool execution, MCP, browser, shell, filesystem, goals, vault, and web search are shipped; richer workflow and external execution depth are still left |
-| 03. Runtime Reliability | `[ ]` | Profile preferences, wildcard path rules, fallback chains, runtime-path overrides, local routing, broad runtime audit coverage, and deterministic eval foundations are shipped; richer routing policy and broader eval depth are still left |
+| 03. Runtime Reliability | `[ ]` | Profile preferences, wildcard path rules, fallback chains, runtime-path overrides, local routing, broad runtime audit coverage including MCP test boundaries, and deterministic eval foundations are shipped; richer routing policy and broader eval depth are still left |
 | 04. Presence And Reach | `[ ]` | Browser UI, WebSocket chat, proactive delivery, observer refresh, and native daemon foundations are shipped; richer native presence, notifications, and channels are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, goals, strategist, briefings, reviews, and observer-driven state are shipped foundations; stronger learning loops and intervention quality are still left |
 | 06. Embodied UX | `[ ]` | Village UI, avatar casting, quest surfaces, and settings exist; the fuller life-OS shell and stronger ambient UX are still left |
@@ -62,8 +62,8 @@ Legend for the checklist column:
 - [x] 17 built-in tool capabilities exposed through the registry, with native and MCP-backed execution surfaces
 - [x] 9 scheduler jobs and 5 observer source boundaries wired into the current product
 - [x] provider-agnostic LLM runtime with ordered fallback chains, health-aware rerouting, runtime-path profile preferences, wildcard path rules, runtime-path model overrides, runtime-path fallback overrides, and local-runtime routing
-- [x] runtime audit visibility across chat, scheduler, observer, proactive delivery transport, MCP, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
-- [x] deterministic eval harness coverage for core runtime, audit, observer, storage, and tool-boundary contracts
+- [x] runtime audit visibility across chat, scheduler, observer, proactive delivery transport, MCP lifecycle and manual test API flows, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
+- [x] deterministic eval harness coverage for core runtime, audit, observer, storage, tool-boundary, and MCP test API contracts
 
 ## Recommended Reading Order
 

--- a/docs/implementation/03-runtime-reliability.md
+++ b/docs/implementation/03-runtime-reliability.md
@@ -18,7 +18,7 @@
 - [x] timeout-safe audit visibility into primary-vs-fallback completion and agent-model behavior
 - [x] fallback-capable model wrappers for chat, onboarding, strategist, and specialists
 - [x] repeatable runtime eval harness for guardian, observer, storage, and integration seam checks
-- [x] runtime audit coverage across chat, WebSocket, scheduler jobs, strategist helpers, proactive delivery transport, MCP lifecycle, observer lifecycle, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
+- [x] runtime audit coverage across chat, WebSocket, scheduler jobs, strategist helpers, proactive delivery transport, MCP lifecycle and manual test API paths, observer lifecycle, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
 
 ## Working On Now
 
@@ -29,7 +29,7 @@
 
 - [ ] deepen provider routing beyond profile preferences, path patterns, model overrides, ordered fallback chains, and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduler, core agent, delegation, and connected MCP-specialist paths into any remaining runtime paths where it makes sense
-- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond the proactive delivery transport boundary
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond the proactive delivery transport and MCP management/test boundaries
 - [ ] expand eval coverage beyond deterministic seam checks into broader behavioral contracts
 
 ## Non-Goals

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -61,8 +61,8 @@ title: Seraph Development Status
 - [x] runtime-path-specific primary model overrides
 - [x] runtime-path-specific fallback-chain overrides
 - [x] first-class local runtime routing for helper, scheduler, core agent, delegation, and connected MCP-specialist paths
-- [x] runtime audit visibility across chat, WebSocket, scheduler, strategist, proactive delivery transport, MCP, observer, embedding, vector store, soul file, filesystem, browser, sandbox, and web search flows
-- [x] deterministic runtime eval harness for fallback, routing, storage, observer, and integration seam contracts
+- [x] runtime audit visibility across chat, WebSocket, scheduler, strategist, proactive delivery transport, MCP lifecycle and manual test API flows, observer, embedding, vector store, soul file, filesystem, browser, sandbox, and web search flows
+- [x] deterministic runtime eval harness for fallback, routing, storage, observer, and integration seam contracts, including the MCP test API boundary
 
 ### Guardian intelligence and proactive behavior
 
@@ -86,7 +86,7 @@ title: Seraph Development Status
 
 - [ ] richer provider selection policy beyond path patterns, explicit overrides, ordered fallbacks, and cooldown rerouting
 - [ ] broader local-model routing into any remaining runtime paths that are worth it
-- [ ] remaining edge observability beyond the already-covered chat, scheduler, observer, proactive delivery, storage, and integration boundaries
+- [ ] remaining edge observability beyond the already-covered chat, scheduler, observer, proactive delivery, storage, MCP management/test, and integration boundaries
 - [ ] broader eval coverage beyond deterministic seam checks
 
 ### Product expansion


### PR DESCRIPTION
## Done on develop
- [x] runtime audit coverage already exists across chat, WebSocket, scheduler jobs, strategist helpers, proactive delivery transport, MCP lifecycle, observer lifecycle, storage boundaries, browser, sandbox, and web search paths
- [x] the deterministic eval harness already covers the core routing, observer, storage, and tool/integration seam contracts shipped so far

## Working in this PR
- [ ] add runtime audit visibility to the manual MCP server test API for auth-required, success, auth-failed, and connection-failed paths
- [ ] extend the deterministic eval harness and endpoint tests to cover the MCP test API audit boundary
- [ ] update the implementation status and testing docs so the Runtime Reliability surface matches the current repo state

## Still to do after this PR
- [ ] deepen provider selection beyond the current path preferences, overrides, ordered fallbacks, wildcard rules, and cooldown rerouting
- [ ] broaden local-model routing into any remaining worthwhile runtime paths
- [ ] close the remaining edge observability gaps beyond the currently covered agent, observer, delivery, storage, and MCP boundaries
- [ ] expand eval coverage beyond deterministic seam checks into broader behavioral contracts

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/api/mcp.py backend/src/evals/harness.py backend/tests/test_mcp_api.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_mcp_api.py tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario mcp_test_api_audit --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build
- git diff --check
