### PR TITLE
Trace skills runtime audit

### DIFF
--- a/backend/src/api/skills.py
+++ b/backend/src/api/skills.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from src.audit.runtime import log_integration_event
 from src.skills.manager import skill_manager
 
 router = APIRouter()
@@ -26,7 +27,24 @@ async def update_skill(name: str, req: UpdateSkillRequest):
     else:
         ok = skill_manager.disable(name)
     if not ok:
+        await log_integration_event(
+            integration_type="skill",
+            name=name,
+            outcome="failed",
+            details={
+                "status": "not_found",
+                "enabled": req.enabled,
+            },
+        )
         raise HTTPException(status_code=404, detail=f"Skill '{name}' not found")
+    await log_integration_event(
+        integration_type="skill",
+        name=name,
+        outcome="succeeded",
+        details={
+            "enabled": req.enabled,
+        },
+    )
     return {"status": "updated", "name": name, "enabled": req.enabled}
 
 
@@ -34,4 +52,14 @@ async def update_skill(name: str, req: UpdateSkillRequest):
 async def reload_skills():
     """Re-scan the skills directory."""
     skills = skill_manager.reload()
+    await log_integration_event(
+        integration_type="skills",
+        name="reload",
+        outcome="succeeded",
+        details={
+            "count": len(skills),
+            "enabled_count": sum(1 for skill in skills if skill.get("enabled", False)),
+            "skill_names": [skill["name"] for skill in skills],
+        },
+    )
     return {"status": "reloaded", "count": len(skills), "skills": skills}

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -28,6 +28,7 @@ from src.agent.specialists import create_mcp_specialist, create_specialist, mcp_
 from src.agent.strategist import create_strategist_agent
 from src.api.mcp import test_server as test_mcp_server
 from src.api.observer import ScreenContextRequest, ScreenObservationData, post_screen_context
+from src.api.skills import UpdateSkillRequest, reload_skills as reload_skill_api, update_skill as update_skill_api
 from src.audit.repository import audit_repository
 from src.llm_runtime import FallbackLiteLLMModel, _reset_target_health, completion_with_fallback_sync
 from src.memory.embedder import _reset_embedder_state, embed
@@ -1666,6 +1667,69 @@ async def _eval_mcp_test_api_audit() -> dict[str, Any]:
     }
 
 
+async def _eval_skills_api_audit() -> dict[str, Any]:
+    mock_log_event = AsyncMock()
+    mock_skill_manager = MagicMock()
+    mock_skill_manager.disable.return_value = True
+    mock_skill_manager.enable.return_value = False
+    mock_skill_manager.reload.return_value = [
+        {
+            "name": "test-skill",
+            "description": "A test skill",
+            "requires_tools": ["web_search"],
+            "user_invocable": True,
+            "enabled": True,
+            "file_path": "/tmp/skills/test-skill.md",
+        },
+        {
+            "name": "simple-skill",
+            "description": "No tool requirements",
+            "requires_tools": [],
+            "user_invocable": False,
+            "enabled": True,
+            "file_path": "/tmp/skills/simple-skill.md",
+        },
+    ]
+
+    with (
+        patch("src.api.skills.skill_manager", mock_skill_manager),
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        updated = await update_skill_api("test-skill", UpdateSkillRequest(enabled=False))
+        try:
+            await update_skill_api("missing-skill", UpdateSkillRequest(enabled=True))
+        except HTTPException as exc:
+            missing_status_code = exc.status_code
+        else:  # pragma: no cover - defensive guard
+            raise AssertionError("Expected missing skill update to raise HTTPException")
+        reloaded = await reload_skill_api()
+
+    updated_event = _find_audit_call(
+        mock_log_event,
+        event_type="integration_succeeded",
+        tool_name="skill:test-skill",
+    )
+    missing_event = _find_audit_call(
+        mock_log_event,
+        event_type="integration_failed",
+        tool_name="skill:missing-skill",
+    )
+    reloaded_event = _find_audit_call(
+        mock_log_event,
+        event_type="integration_succeeded",
+        tool_name="skills:reload",
+    )
+    return {
+        "updated_status": updated["status"],
+        "updated_enabled": updated_event["details"]["enabled"],
+        "missing_status_code": missing_status_code,
+        "missing_status": missing_event["details"]["status"],
+        "reload_count": reloaded["count"],
+        "reload_enabled_count": reloaded_event["details"]["enabled_count"],
+        "reload_skill_names": reloaded_event["details"]["skill_names"],
+    }
+
+
 _SCENARIOS: tuple[EvalScenario, ...] = (
     EvalScenario(
         name="chat_model_wrapper",
@@ -1888,6 +1952,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="observability",
         description="Manual MCP server test requests record auth-required and successful tool-discovery audit events.",
         runner=_eval_mcp_test_api_audit,
+    ),
+    EvalScenario(
+        name="skills_api_audit",
+        category="observability",
+        description="Skill toggle and reload requests record succeeded and failed runtime audit events.",
+        runner=_eval_skills_api_audit,
     ),
 )
 

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -70,6 +70,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "observer_delivery_transport_audit" in captured.out
     assert "observer_daemon_ingest_audit" in captured.out
     assert "mcp_test_api_audit" in captured.out
+    assert "skills_api_audit" in captured.out
 
 
 def test_main_emits_json_summary(capsys):
@@ -116,6 +117,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "observer_delivery_transport_audit",
                 "observer_daemon_ingest_audit",
                 "mcp_test_api_audit",
+                "skills_api_audit",
             ]
         )
     )
@@ -259,3 +261,10 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["mcp_test_api_audit"]["failure_status_code"] == 502
     assert details_by_name["mcp_test_api_audit"]["failure_status"] == "connection_failed"
     assert details_by_name["mcp_test_api_audit"]["failure_error"] == "refused"
+    assert details_by_name["skills_api_audit"]["updated_status"] == "updated"
+    assert details_by_name["skills_api_audit"]["updated_enabled"] is False
+    assert details_by_name["skills_api_audit"]["missing_status_code"] == 404
+    assert details_by_name["skills_api_audit"]["missing_status"] == "not_found"
+    assert details_by_name["skills_api_audit"]["reload_count"] == 2
+    assert details_by_name["skills_api_audit"]["reload_enabled_count"] == 2
+    assert details_by_name["skills_api_audit"]["reload_skill_names"] == ["test-skill", "simple-skill"]

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -7,6 +7,7 @@ import tempfile
 import pytest
 import pytest_asyncio
 
+from src.audit.repository import audit_repository
 from src.skills.loader import Skill, _parse_skill_file, load_skills
 from src.skills.manager import SkillManager
 
@@ -355,3 +356,49 @@ class TestSkillAPI:
         data = resp.json()
         assert data["status"] == "reloaded"
         assert data["count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_update_skill_logs_runtime_audit(self, async_db, client, _setup_skill_manager):
+        resp = await client.put(
+            "/api/skills/test-skill",
+            json={"enabled": False},
+        )
+        assert resp.status_code == 200
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_succeeded"
+            and event["tool_name"] == "skill:test-skill"
+            and event["details"]["enabled"] is False
+            for event in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_nonexistent_skill_logs_runtime_audit(self, async_db, client, _setup_skill_manager):
+        resp = await client.put(
+            "/api/skills/nonexistent",
+            json={"enabled": False},
+        )
+        assert resp.status_code == 404
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_failed"
+            and event["tool_name"] == "skill:nonexistent"
+            and event["details"]["status"] == "not_found"
+            for event in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_reload_skills_logs_runtime_audit(self, async_db, client, _setup_skill_manager):
+        resp = await client.post("/api/skills/reload")
+        assert resp.status_code == 200
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_succeeded"
+            and event["tool_name"] == "skills:reload"
+            and event["details"]["count"] == 3
+            and sorted(event["details"]["skill_names"]) == ["disabled-skill", "simple-skill", "test-skill"]
+            for event in events
+        )

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -65,9 +65,10 @@ uv run python -m src.evals.harness --scenario observer_delivery_gate_audit
 uv run python -m src.evals.harness --scenario observer_delivery_transport_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 uv run python -m src.evals.harness --scenario mcp_test_api_audit
+uv run python -m src.evals.harness --scenario skills_api_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, and filesystem boundary failures, context-window degradation, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, and filesystem boundary failures, context-window degradation, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -123,7 +124,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_sessions_api.py` | 8 | Session HTTP endpoints — list, messages, update title, delete |
 | `test_settings_api.py` | 6 | Settings API — interruption mode get/set |
 | `test_shell_tool.py` | 9 | Shell execution — success, errors, size limits, timeout, connection errors, runtime audit logging |
-| `test_skills.py` | 27 | Skills system — loading, gating, enable/disable, frontmatter parsing, API |
+| `test_skills.py` | 30 | Skills system — loading, gating, enable/disable, frontmatter parsing, API, and runtime audit logging for toggle/reload |
 | `test_soul.py` | 12 | Soul file persistence — read/write, section update, ensure exists, runtime audit logging |
 | `test_specialists.py` | 30 | Specialist agents — factory, tool domains, MCP specialist generation, runtime-path routing |
 | `test_strategist.py` | 12 | Strategist agent — JSON parsing (valid, fenced, invalid, empty, partial), agent creation |

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -32,7 +32,7 @@ Legend for the checklist column:
 |---|---|---|
 | 01. Trust Boundaries | `[ ]` | Policy modes, approvals, audit logging, and secret redaction are shipped; deeper isolation and narrower privileged execution paths are still left |
 | 02. Execution Plane | `[ ]` | Real tool execution, MCP, browser, shell, filesystem, goals, vault, and web search are shipped; richer workflow and external execution depth are still left |
-| 03. Runtime Reliability | `[ ]` | Profile preferences, wildcard path rules, fallback chains, runtime-path overrides, local routing, broad runtime audit coverage including MCP test boundaries, and deterministic eval foundations are shipped; richer routing policy and broader eval depth are still left |
+| 03. Runtime Reliability | `[ ]` | Profile preferences, wildcard path rules, fallback chains, runtime-path overrides, local routing, broad runtime audit coverage including MCP test and skills API boundaries, and deterministic eval foundations are shipped; richer routing policy and broader eval depth are still left |
 | 04. Presence And Reach | `[ ]` | Browser UI, WebSocket chat, proactive delivery, observer refresh, and native daemon foundations are shipped; richer native presence, notifications, and channels are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, goals, strategist, briefings, reviews, and observer-driven state are shipped foundations; stronger learning loops and intervention quality are still left |
 | 06. Embodied UX | `[ ]` | Village UI, avatar casting, quest surfaces, and settings exist; the fuller life-OS shell and stronger ambient UX are still left |
@@ -62,8 +62,8 @@ Legend for the checklist column:
 - [x] 17 built-in tool capabilities exposed through the registry, with native and MCP-backed execution surfaces
 - [x] 9 scheduler jobs and 5 observer source boundaries wired into the current product
 - [x] provider-agnostic LLM runtime with ordered fallback chains, health-aware rerouting, runtime-path profile preferences, wildcard path rules, runtime-path model overrides, runtime-path fallback overrides, and local-runtime routing
-- [x] runtime audit visibility across chat, scheduler, observer, proactive delivery transport, MCP lifecycle and manual test API flows, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
-- [x] deterministic eval harness coverage for core runtime, audit, observer, storage, tool-boundary, and MCP test API contracts
+- [x] runtime audit visibility across chat, scheduler, observer, proactive delivery transport, MCP lifecycle and manual test API flows, skills toggle/reload flows, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
+- [x] deterministic eval harness coverage for core runtime, audit, observer, storage, tool-boundary, MCP test API, and skills API contracts
 
 ## Recommended Reading Order
 

--- a/docs/implementation/03-runtime-reliability.md
+++ b/docs/implementation/03-runtime-reliability.md
@@ -18,7 +18,7 @@
 - [x] timeout-safe audit visibility into primary-vs-fallback completion and agent-model behavior
 - [x] fallback-capable model wrappers for chat, onboarding, strategist, and specialists
 - [x] repeatable runtime eval harness for guardian, observer, storage, and integration seam checks
-- [x] runtime audit coverage across chat, WebSocket, scheduler jobs, strategist helpers, proactive delivery transport, MCP lifecycle and manual test API paths, observer lifecycle, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
+- [x] runtime audit coverage across chat, WebSocket, scheduler jobs, strategist helpers, proactive delivery transport, MCP lifecycle and manual test API paths, skills toggle/reload paths, observer lifecycle, embedding, vector store, soul file, filesystem, browser, sandbox, and web search paths
 
 ## Working On Now
 
@@ -29,7 +29,7 @@
 
 - [ ] deepen provider routing beyond profile preferences, path patterns, model overrides, ordered fallback chains, and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduler, core agent, delegation, and connected MCP-specialist paths into any remaining runtime paths where it makes sense
-- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond the proactive delivery transport and MCP management/test boundaries
+- [ ] add observability coverage across any remaining edge helpers and external integration paths beyond the proactive delivery transport, MCP management/test, and skills state-management boundaries
 - [ ] expand eval coverage beyond deterministic seam checks into broader behavioral contracts
 
 ## Non-Goals

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -61,8 +61,8 @@ title: Seraph Development Status
 - [x] runtime-path-specific primary model overrides
 - [x] runtime-path-specific fallback-chain overrides
 - [x] first-class local runtime routing for helper, scheduler, core agent, delegation, and connected MCP-specialist paths
-- [x] runtime audit visibility across chat, WebSocket, scheduler, strategist, proactive delivery transport, MCP lifecycle and manual test API flows, observer, embedding, vector store, soul file, filesystem, browser, sandbox, and web search flows
-- [x] deterministic runtime eval harness for fallback, routing, storage, observer, and integration seam contracts, including the MCP test API boundary
+- [x] runtime audit visibility across chat, WebSocket, scheduler, strategist, proactive delivery transport, MCP lifecycle and manual test API flows, skills toggle/reload flows, observer, embedding, vector store, soul file, filesystem, browser, sandbox, and web search flows
+- [x] deterministic runtime eval harness for fallback, routing, storage, observer, and integration seam contracts, including the MCP test API and skills API boundaries
 
 ### Guardian intelligence and proactive behavior
 
@@ -86,7 +86,7 @@ title: Seraph Development Status
 
 - [ ] richer provider selection policy beyond path patterns, explicit overrides, ordered fallbacks, and cooldown rerouting
 - [ ] broader local-model routing into any remaining runtime paths that are worth it
-- [ ] remaining edge observability beyond the already-covered chat, scheduler, observer, proactive delivery, storage, MCP management/test, and integration boundaries
+- [ ] remaining edge observability beyond the already-covered chat, scheduler, observer, proactive delivery, storage, MCP management/test, skills state-management, and integration boundaries
 - [ ] broader eval coverage beyond deterministic seam checks
 
 ### Product expansion


### PR DESCRIPTION
## Done on develop
- [x] runtime audit coverage already exists across chat, WebSocket, scheduler jobs, strategist helpers, proactive delivery transport, MCP lifecycle and manual test API flows, observer lifecycle, storage boundaries, browser, sandbox, and web search paths
- [x] the deterministic eval harness already covers the core routing, observer, storage, tool, and MCP test seam contracts shipped so far

## Working in this PR
- [ ] add runtime audit visibility to skills toggle and reload API flows, including not-found failures
- [ ] extend the deterministic eval harness and backend tests to cover the skills API audit boundary
- [ ] update the implementation status and testing docs so the Runtime Reliability surface matches the current repo state

## Still to do after this PR
- [ ] deepen provider selection beyond the current path preferences, overrides, ordered fallbacks, wildcard rules, and cooldown rerouting
- [ ] broaden local-model routing into any remaining worthwhile runtime paths
- [ ] close the remaining edge observability gaps beyond the currently covered agent, observer, delivery, storage, MCP, and skills boundaries
- [ ] expand eval coverage beyond deterministic seam checks into broader behavioral contracts

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/api/skills.py backend/src/evals/harness.py backend/tests/test_skills.py backend/tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_skills.py tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario skills_api_audit --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build
- git diff --check
