### PR TITLE
Add proactive behavioral eval contracts

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -54,6 +54,7 @@ from src.memory import soul as soul_mod
 from src.memory.vector_store import _reset_vector_store_state, add_memory, search
 from src.observer.context import CurrentContext
 from src.observer.delivery import deliver_or_queue, deliver_queued_bundle
+from src.observer.user_state import DeliveryDecision
 from src.scheduler.jobs.activity_digest import run_activity_digest
 from src.scheduler.jobs.daily_briefing import run_daily_briefing
 from src.scheduler.jobs.evening_review import run_evening_review
@@ -1655,6 +1656,53 @@ async def _eval_daily_briefing_degraded_memories_audit() -> dict[str, Any]:
     }
 
 
+async def _eval_daily_briefing_delivery_behavior() -> dict[str, Any]:
+    ctx = _make_context(
+        upcoming_events=[{"summary": "Design review", "start": "09:30"}],
+        active_goals_summary="Close the proactive eval gap",
+    )
+    mock_context_manager = MagicMock()
+    mock_context_manager.refresh = AsyncMock(return_value=ctx)
+    mock_deliver = AsyncMock(return_value=DeliveryDecision.deliver)
+    mock_log_event = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_context_manager),
+        patch("src.memory.soul.read_soul", return_value="# Soul\nName: Hero"),
+        patch(
+            "src.memory.vector_store.search_with_status",
+            return_value=([{"category": "fact", "text": "Morning briefings should be concrete."}], False),
+        ),
+        patch(
+            "src.scheduler.jobs.daily_briefing.completion_with_fallback",
+            AsyncMock(
+                return_value=_make_litellm_response(
+                    "Good morning. Design review at 09:30. Focus on proactive eval coverage."
+                )
+            ),
+        ),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        await run_daily_briefing()
+
+    delivered_message = mock_deliver.await_args.args[0]
+    delivered_kwargs = mock_deliver.await_args.kwargs
+    succeeded = _find_audit_call(
+        mock_log_event,
+        event_type="scheduler_job_succeeded",
+        tool_name="daily_briefing",
+    )
+    return {
+        "message_type": delivered_message.type,
+        "intervention_type": delivered_message.intervention_type,
+        "scheduled_delivery": delivered_kwargs["is_scheduled"],
+        "content_contains_design_review": "design review" in delivered_message.content.lower(),
+        "upcoming_event_count": succeeded["details"]["upcoming_event_count"],
+        "data_quality": succeeded["details"]["data_quality"],
+    }
+
+
 async def _eval_activity_digest_degraded_summary_audit() -> dict[str, Any]:
     mock_repo = MagicMock()
     mock_repo.get_daily_summary = AsyncMock(return_value={
@@ -1696,6 +1744,50 @@ async def _eval_activity_digest_degraded_summary_audit() -> dict[str, Any]:
     }
 
 
+async def _eval_activity_digest_degraded_delivery_behavior() -> dict[str, Any]:
+    mock_repo = MagicMock()
+    mock_repo.get_daily_summary = AsyncMock(return_value={
+        "date": date.today().isoformat(),
+        "total_observations": 5,
+        "by_activity": {"coding": 3600},
+    })
+    mock_deliver = AsyncMock(return_value=DeliveryDecision.deliver)
+    mock_log_event = AsyncMock()
+
+    with (
+        patch("src.observer.screen_repository.screen_observation_repo", mock_repo),
+        patch("src.memory.soul.read_soul", return_value="# Soul\nName: Hero"),
+        patch(
+            "src.scheduler.jobs.activity_digest.completion_with_fallback",
+            AsyncMock(return_value=_make_litellm_response("You spent most of today coding. Keep tomorrow calmer.")),
+        ),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        await run_activity_digest()
+
+    delivered_message = mock_deliver.await_args.args[0]
+    delivered_kwargs = mock_deliver.await_args.kwargs
+    degraded = _find_audit_call(
+        mock_log_event,
+        event_type="background_task_degraded",
+        tool_name="activity_digest_inputs",
+    )
+    succeeded = _find_audit_call(
+        mock_log_event,
+        event_type="scheduler_job_succeeded",
+        tool_name="activity_digest",
+    )
+    return {
+        "message_type": delivered_message.type,
+        "scheduled_delivery": delivered_kwargs["is_scheduled"],
+        "content_mentions_coding": "coding" in delivered_message.content.lower(),
+        "background_source": degraded["details"]["source"],
+        "degraded_inputs": succeeded["details"]["degraded_inputs"],
+        "data_quality": succeeded["details"]["data_quality"],
+    }
+
+
 async def _eval_evening_review_degraded_inputs_audit() -> dict[str, Any]:
     ctx = _make_context(time_of_day="evening", is_working_hours=False)
     mock_context_manager = MagicMock()
@@ -1728,6 +1820,44 @@ async def _eval_evening_review_degraded_inputs_audit() -> dict[str, Any]:
         "message_count": succeeded["details"]["message_count"],
         "completed_goal_count": succeeded["details"]["completed_goal_count"],
         "delivered": mock_deliver.await_count == 1,
+    }
+
+
+async def _eval_evening_review_degraded_delivery_behavior() -> dict[str, Any]:
+    ctx = _make_context(time_of_day="evening", is_working_hours=False, recent_git_activity=[{"msg": "fix eval gap"}])
+    mock_context_manager = MagicMock()
+    mock_context_manager.refresh = AsyncMock(return_value=ctx)
+    mock_deliver = AsyncMock(return_value=DeliveryDecision.deliver)
+    mock_log_event = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_context_manager),
+        patch("src.memory.soul.read_soul", return_value="# Soul\nName: Hero"),
+        patch("src.scheduler.jobs.evening_review._count_messages_today", AsyncMock(return_value=(0, True))),
+        patch("src.scheduler.jobs.evening_review._get_completed_goals_today", AsyncMock(return_value=([], True))),
+        patch(
+            "src.scheduler.jobs.evening_review.completion_with_fallback",
+            AsyncMock(return_value=_make_litellm_response("Quiet day. Rest well and reset for tomorrow.")),
+        ),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        await run_evening_review()
+
+    delivered_message = mock_deliver.await_args.args[0]
+    delivered_kwargs = mock_deliver.await_args.kwargs
+    succeeded = _find_audit_call(
+        mock_log_event,
+        event_type="scheduler_job_succeeded",
+        tool_name="evening_review",
+    )
+    return {
+        "message_type": delivered_message.type,
+        "scheduled_delivery": delivered_kwargs["is_scheduled"],
+        "content_mentions_tomorrow": "tomorrow" in delivered_message.content.lower(),
+        "data_quality": succeeded["details"]["data_quality"],
+        "degraded_inputs": succeeded["details"]["degraded_inputs"],
+        "message_count": succeeded["details"]["message_count"],
     }
 
 
@@ -2035,6 +2165,41 @@ async def _eval_strategist_tick_tool_audit() -> dict[str, Any]:
         "tool_name": tool_call["tool_name"],
         "session_id": tool_call["session_id"],
         "policy_mode": tool_call["policy_mode"],
+    }
+
+
+async def _eval_strategist_tick_behavior() -> dict[str, Any]:
+    mock_context_manager = MagicMock()
+    mock_context_manager.refresh = AsyncMock(return_value=_make_context(time_of_day="afternoon"))
+    mock_agent = MagicMock()
+    mock_agent.run.return_value = (
+        '{"should_intervene": true, "content": "Time to refocus on the eval roadmap.", '
+        '"intervention_type": "advisory", "urgency": 3, "reasoning": "Focus drift"}'
+    )
+    mock_deliver = AsyncMock(return_value=DeliveryDecision.deliver)
+    mock_log_event = AsyncMock()
+
+    with (
+        patch("src.observer.manager.context_manager", mock_context_manager),
+        patch("src.scheduler.jobs.strategist_tick.create_strategist_agent", return_value=mock_agent),
+        patch("src.observer.delivery.deliver_or_queue", mock_deliver),
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        await run_strategist_tick()
+
+    delivered_message = mock_deliver.await_args.args[0]
+    succeeded = _find_audit_call(
+        mock_log_event,
+        event_type="scheduler_job_succeeded",
+        tool_name="strategist_tick",
+    )
+    return {
+        "message_type": delivered_message.type,
+        "intervention_type": delivered_message.intervention_type,
+        "urgency": delivered_message.urgency,
+        "content_mentions_refocus": "refocus" in delivered_message.content.lower(),
+        "delivery": succeeded["details"]["delivery"],
+        "reasoning": delivered_message.reasoning,
     }
 
 
@@ -2659,10 +2824,22 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         runner=_eval_strategist_model_wrapper,
     ),
     EvalScenario(
+        name="strategist_tick_behavior",
+        category="behavior",
+        description="Strategist tick delivers the modeled intervention and records the resulting delivery outcome.",
+        runner=_eval_strategist_tick_behavior,
+    ),
+    EvalScenario(
         name="daily_briefing_fallback",
         category="proactive",
         description="Daily briefing survives a primary provider failure and still delivers via fallback.",
         runner=_eval_daily_briefing_fallback,
+    ),
+    EvalScenario(
+        name="daily_briefing_delivery_behavior",
+        category="behavior",
+        description="Daily briefing delivers a scheduled proactive message and records a good-quality success contract.",
+        runner=_eval_daily_briefing_delivery_behavior,
     ),
     EvalScenario(
         name="daily_briefing_degraded_memories_audit",
@@ -2671,10 +2848,22 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         runner=_eval_daily_briefing_degraded_memories_audit,
     ),
     EvalScenario(
+        name="activity_digest_degraded_delivery_behavior",
+        category="behavior",
+        description="Activity digest still delivers a scheduled message when summary inputs degrade, while surfacing the degraded contract.",
+        runner=_eval_activity_digest_degraded_delivery_behavior,
+    ),
+    EvalScenario(
         name="activity_digest_degraded_summary_audit",
         category="observability",
         description="Activity digest records degraded input quality when the daily screen summary is structurally incomplete.",
         runner=_eval_activity_digest_degraded_summary_audit,
+    ),
+    EvalScenario(
+        name="evening_review_degraded_delivery_behavior",
+        category="behavior",
+        description="Evening review still delivers a scheduled message when helper inputs degrade, while surfacing the degraded contract.",
+        runner=_eval_evening_review_degraded_delivery_behavior,
     ),
     EvalScenario(
         name="evening_review_degraded_inputs_audit",

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -50,6 +50,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "websocket_chat_behavior" in captured.out
     assert "websocket_chat_approval_contract" in captured.out
     assert "websocket_chat_timeout_contract" in captured.out
+    assert "strategist_tick_behavior" in captured.out
     assert "provider_fallback_chain" in captured.out
     assert "provider_health_reroute" in captured.out
     assert "local_runtime_profile" in captured.out
@@ -68,6 +69,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "runtime_profile_preferences" in captured.out
     assert "runtime_path_patterns" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
+    assert "daily_briefing_delivery_behavior" in captured.out
     assert "shell_tool_runtime_audit" in captured.out
     assert "browser_runtime_audit" in captured.out
     assert "web_search_runtime_audit" in captured.out
@@ -83,7 +85,9 @@ def test_main_lists_available_scenarios(capsys):
     assert "skills_api_audit" in captured.out
     assert "screen_repository_runtime_audit" in captured.out
     assert "daily_briefing_degraded_memories_audit" in captured.out
+    assert "activity_digest_degraded_delivery_behavior" in captured.out
     assert "activity_digest_degraded_summary_audit" in captured.out
+    assert "evening_review_degraded_delivery_behavior" in captured.out
     assert "evening_review_degraded_inputs_audit" in captured.out
 
 
@@ -123,6 +127,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "websocket_chat_behavior",
                 "websocket_chat_approval_contract",
                 "websocket_chat_timeout_contract",
+                "strategist_tick_behavior",
                 "agent_local_runtime_profile",
                 "delegation_local_runtime_profile",
                 "mcp_specialist_local_runtime_profile",
@@ -136,6 +141,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "runtime_profile_preferences",
                 "runtime_path_patterns",
                 "scheduled_local_runtime_profile",
+                "daily_briefing_delivery_behavior",
                 "shell_tool_runtime_audit",
                 "browser_runtime_audit",
                 "web_search_runtime_audit",
@@ -151,7 +157,9 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "skills_api_audit",
                 "screen_repository_runtime_audit",
                 "daily_briefing_degraded_memories_audit",
+                "activity_digest_degraded_delivery_behavior",
                 "activity_digest_degraded_summary_audit",
+                "evening_review_degraded_delivery_behavior",
                 "evening_review_degraded_inputs_audit",
             ]
         )
@@ -211,6 +219,12 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["websocket_chat_timeout_contract"]["final_contains_timeout_copy"] is True
     assert details_by_name["websocket_chat_timeout_contract"]["timeout_seconds"] == 120
     assert details_by_name["websocket_chat_timeout_contract"]["succeeded_event_present"] is False
+    assert details_by_name["strategist_tick_behavior"]["message_type"] == "proactive"
+    assert details_by_name["strategist_tick_behavior"]["intervention_type"] == "advisory"
+    assert details_by_name["strategist_tick_behavior"]["urgency"] == 3
+    assert details_by_name["strategist_tick_behavior"]["content_mentions_refocus"] is True
+    assert details_by_name["strategist_tick_behavior"]["delivery"] == "deliver"
+    assert details_by_name["strategist_tick_behavior"]["reasoning"] == "Focus drift"
     assert details_by_name["agent_local_runtime_profile"]["routed_models"]["chat_agent"] == "ollama/llama3.2"
     assert details_by_name["agent_local_runtime_profile"]["routed_models"]["memory_keeper"] == "ollama/llama3.2"
     assert details_by_name["delegation_local_runtime_profile"]["routed_models"]["orchestrator_agent"] == "ollama/llama3.2"
@@ -305,6 +319,12 @@ def test_runtime_eval_scenarios_expose_expected_details():
     ]
     assert details_by_name["scheduled_local_runtime_profile"]["job_name"] == "daily_briefing"
     assert details_by_name["scheduled_local_runtime_profile"]["routed_model"] == "ollama/llama3.2"
+    assert details_by_name["daily_briefing_delivery_behavior"]["message_type"] == "proactive"
+    assert details_by_name["daily_briefing_delivery_behavior"]["intervention_type"] == "advisory"
+    assert details_by_name["daily_briefing_delivery_behavior"]["scheduled_delivery"] is True
+    assert details_by_name["daily_briefing_delivery_behavior"]["content_contains_design_review"] is True
+    assert details_by_name["daily_briefing_delivery_behavior"]["upcoming_event_count"] == 1
+    assert details_by_name["daily_briefing_delivery_behavior"]["data_quality"] == "good"
     assert details_by_name["shell_tool_runtime_audit"]["timeout_seconds"] == 35
     assert details_by_name["browser_runtime_audit"]["timeout_seconds"] == 30
     assert details_by_name["browser_runtime_audit"]["hostname"] == "example.com"
@@ -338,6 +358,17 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["daily_briefing_degraded_memories_audit"]["data_quality"] == "degraded"
     assert details_by_name["daily_briefing_degraded_memories_audit"]["degraded_inputs"] == ["relevant_memories"]
     assert details_by_name["daily_briefing_degraded_memories_audit"]["delivered"] is True
+    assert details_by_name["activity_digest_degraded_delivery_behavior"]["message_type"] == "proactive"
+    assert details_by_name["activity_digest_degraded_delivery_behavior"]["scheduled_delivery"] is True
+    assert details_by_name["activity_digest_degraded_delivery_behavior"]["content_mentions_coding"] is True
+    assert details_by_name["activity_digest_degraded_delivery_behavior"]["background_source"] == "screen_summary"
+    assert details_by_name["activity_digest_degraded_delivery_behavior"]["degraded_inputs"] == [
+        "total_tracked_minutes",
+        "switch_count",
+        "by_project",
+        "longest_streaks",
+    ]
+    assert details_by_name["activity_digest_degraded_delivery_behavior"]["data_quality"] == "degraded"
     assert details_by_name["activity_digest_degraded_summary_audit"]["background_source"] == "screen_summary"
     assert details_by_name["activity_digest_degraded_summary_audit"]["missing_fields"] == [
         "total_tracked_minutes",
@@ -353,6 +384,15 @@ def test_runtime_eval_scenarios_expose_expected_details():
         "longest_streaks",
     ]
     assert details_by_name["activity_digest_degraded_summary_audit"]["delivered"] is True
+    assert details_by_name["evening_review_degraded_delivery_behavior"]["message_type"] == "proactive"
+    assert details_by_name["evening_review_degraded_delivery_behavior"]["scheduled_delivery"] is True
+    assert details_by_name["evening_review_degraded_delivery_behavior"]["content_mentions_tomorrow"] is True
+    assert details_by_name["evening_review_degraded_delivery_behavior"]["data_quality"] == "degraded"
+    assert details_by_name["evening_review_degraded_delivery_behavior"]["degraded_inputs"] == [
+        "messages_today",
+        "completed_goals_today",
+    ]
+    assert details_by_name["evening_review_degraded_delivery_behavior"]["message_count"] == 0
     assert details_by_name["evening_review_degraded_inputs_audit"]["data_quality"] == "degraded"
     assert details_by_name["evening_review_degraded_inputs_audit"]["degraded_inputs"] == [
         "messages_today",

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -41,6 +41,7 @@ uv run python -m src.evals.harness --scenario rest_chat_timeout_contract
 uv run python -m src.evals.harness --scenario websocket_chat_behavior
 uv run python -m src.evals.harness --scenario websocket_chat_approval_contract
 uv run python -m src.evals.harness --scenario websocket_chat_timeout_contract
+uv run python -m src.evals.harness --scenario strategist_tick_behavior
 uv run python -m src.evals.harness --scenario provider_fallback_chain
 uv run python -m src.evals.harness --scenario provider_health_reroute
 uv run python -m src.evals.harness --scenario local_runtime_profile
@@ -60,6 +61,7 @@ uv run python -m src.evals.harness --scenario runtime_profile_preferences
 uv run python -m src.evals.harness --scenario runtime_path_patterns
 uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
 uv run python -m src.evals.harness --scenario daily_briefing_fallback
+uv run python -m src.evals.harness --scenario daily_briefing_delivery_behavior
 uv run python -m src.evals.harness --scenario shell_tool_runtime_audit
 uv run python -m src.evals.harness --scenario browser_runtime_audit
 uv run python -m src.evals.harness --scenario web_search_runtime_audit
@@ -75,11 +77,13 @@ uv run python -m src.evals.harness --scenario mcp_test_api_audit
 uv run python -m src.evals.harness --scenario skills_api_audit
 uv run python -m src.evals.harness --scenario screen_repository_runtime_audit
 uv run python -m src.evals.harness --scenario daily_briefing_degraded_memories_audit
+uv run python -m src.evals.harness --scenario activity_digest_degraded_delivery_behavior
 uv run python -m src.evals.harness --scenario activity_digest_degraded_summary_audit
+uv run python -m src.evals.harness --scenario evening_review_degraded_delivery_behavior
 uv run python -m src.evals.harness --scenario evening_review_degraded_inputs_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so REST and WebSocket chat behavior, ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, vault-repository, and filesystem boundary failures, context-window degradation, daily-briefing, activity-digest, and evening-review degraded-input fallback auditing, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, screen observation summary/cleanup boundary behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so REST and WebSocket chat behavior, strategist and scheduled proactive flow behavior, ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, vault-repository, and filesystem boundary failures, context-window degradation, daily-briefing, activity-digest, and evening-review degraded-input fallback auditing, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, screen observation summary/cleanup boundary behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -32,7 +32,7 @@ Legend for the checklist column:
 |---|---|---|
 | 01. Trust Boundaries | `[ ]` | Policy modes, approvals, audit logging, and secret redaction are shipped; deeper isolation and narrower privileged execution paths are still left |
 | 02. Execution Plane | `[ ]` | Real tool execution, MCP, browser, shell, filesystem, goals, vault, and web search are shipped; richer workflow and external execution depth are still left |
-| 03. Runtime Reliability | `[ ]` | Profile preferences, wildcard path rules, fallback chains, runtime-path overrides, local routing, broad runtime audit coverage including MCP test, skills API, and screen repository boundaries, plus the first core chat behavioral eval contracts are shipped; richer routing policy and broader eval depth are still left |
+| 03. Runtime Reliability | `[ ]` | Profile preferences, wildcard path rules, fallback chains, runtime-path overrides, local routing, broad runtime audit coverage including MCP test, skills API, and screen repository boundaries, plus the first core chat and proactive behavioral eval contracts are shipped; richer routing policy and broader eval depth are still left |
 | 04. Presence And Reach | `[ ]` | Browser UI, WebSocket chat, proactive delivery, observer refresh, and native daemon foundations are shipped; richer native presence, notifications, and channels are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, goals, strategist, briefings, reviews, and observer-driven state are shipped foundations; stronger learning loops and intervention quality are still left |
 | 06. Embodied UX | `[ ]` | Village UI, avatar casting, quest surfaces, and settings exist; the fuller life-OS shell and stronger ambient UX are still left |
@@ -63,7 +63,7 @@ Legend for the checklist column:
 - [x] 9 scheduler jobs and 5 observer source boundaries wired into the current product
 - [x] provider-agnostic LLM runtime with ordered fallback chains, health-aware rerouting, runtime-path profile preferences, wildcard path rules, runtime-path model overrides, runtime-path fallback overrides, and local-runtime routing
 - [x] runtime audit visibility across chat, scheduler including daily-briefing, activity-digest, and evening-review degraded-input fallbacks, observer, screen observation summary/cleanup, proactive delivery transport, MCP lifecycle and manual test API flows, skills toggle/reload flows, embedding, vector store, soul file, vault repository, filesystem, browser, sandbox, and web search paths
-- [x] deterministic eval harness coverage for core runtime, audit, REST and WebSocket chat behavior, observer, storage, tool-boundary, vault repository, MCP test API, skills API, screen repository, and daily-briefing, activity-digest, plus evening-review degraded-input contracts
+- [x] deterministic eval harness coverage for core runtime, audit, REST and WebSocket chat behavior, proactive flow behavior, observer, storage, tool-boundary, vault repository, MCP test API, skills API, screen repository, and daily-briefing, activity-digest, plus evening-review degraded-input contracts
 
 ## Recommended Reading Order
 

--- a/docs/implementation/03-runtime-reliability.md
+++ b/docs/implementation/03-runtime-reliability.md
@@ -17,13 +17,13 @@
 - [x] first-class local runtime profile for helper, scheduler, core agent, delegation, and connected MCP-specialist paths
 - [x] timeout-safe audit visibility into primary-vs-fallback completion and agent-model behavior
 - [x] fallback-capable model wrappers for chat, onboarding, strategist, and specialists
-- [x] repeatable runtime eval harness for guardian, core chat behavior, observer, storage, and integration seam checks
+- [x] repeatable runtime eval harness for guardian, core chat behavior, proactive flow behavior, observer, storage, and integration seam checks
 - [x] runtime audit coverage across chat, WebSocket, scheduler jobs including daily-briefing, activity-digest, and evening-review degraded-input fallbacks, strategist helpers, proactive delivery transport, MCP lifecycle and manual test API paths, skills toggle/reload paths, observer lifecycle plus screen observation summary/cleanup boundaries, embedding, vector store, soul file, vault repository, filesystem, browser, sandbox, and web search paths
 
 ## Working On Now
 
 - [x] Runtime Reliability remains the repo-wide hardening track
-- [x] `behavioral-evals-core-chat` is the active PR from the numbered sequence below
+- [x] `behavioral-evals-proactive-flows` is the active PR from the numbered sequence below
 - [ ] close the remaining routing, observability, and eval gaps outside the already-covered seams
 
 ## Still To Do On `develop`
@@ -31,7 +31,7 @@
 - [ ] deepen provider routing beyond profile preferences, path patterns, model overrides, ordered fallback chains, and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduler, core agent, delegation, and connected MCP-specialist paths into any remaining runtime paths where it makes sense
 - [ ] add observability coverage across any remaining edge helpers and external integration paths beyond the proactive delivery transport, MCP management/test, skills state-management, and screen observation repository boundaries
-- [ ] expand eval coverage beyond the shipped REST and WebSocket chat behavioral contracts into broader behavioral coverage, even with daily-briefing, activity-digest, and evening-review degraded-input auditing already covered
+- [ ] expand eval coverage beyond the shipped REST, WebSocket, and proactive behavioral contracts into broader behavioral coverage
 
 ## Planned PR Sequence
 
@@ -39,7 +39,7 @@ This sequence is execution order for upcoming PRs. A checked item can be in an o
 
 1. [x] `behavioral-evals-core-chat`:
    add behavioral eval contracts for REST chat and WebSocket chat, including fallback, timeout, approval, and audit expectations
-2. [ ] `behavioral-evals-proactive-flows`:
+2. [x] `behavioral-evals-proactive-flows`:
    add behavioral evals for strategist tick, daily briefing, evening review, and activity digest with expected degraded behavior and delivery outcomes
 3. [ ] `behavioral-evals-tool-heavy-flow`:
    add one delegated tool-heavy workflow contract covering routing, tool execution, audit, and degraded or failure handling
@@ -64,4 +64,4 @@ This sequence is execution order for upcoming PRs. A checked item can be in an o
 - [x] dynamic runtime paths can inherit wildcard routing rules without losing exact-path control
 - [x] a local or non-OpenRouter path is demonstrably possible across helper, scheduler, core agent, delegation, and connected MCP-specialist flows
 - [ ] key flows are observable and easy to debug
-- [ ] the project has broad repeatable eval coverage for core behavior beyond the shipped REST and WebSocket chat contracts
+- [ ] the project has broad repeatable eval coverage for core behavior beyond the shipped REST, WebSocket, and proactive behavioral contracts

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -63,7 +63,7 @@ title: Seraph Development Status
 - [x] runtime-path-specific fallback-chain overrides
 - [x] first-class local runtime routing for helper, scheduler, core agent, delegation, and connected MCP-specialist paths
 - [x] runtime audit visibility across chat, WebSocket, scheduler including daily-briefing, activity-digest, and evening-review degraded-input fallback paths, strategist, proactive delivery transport, MCP lifecycle and manual test API flows, skills toggle/reload flows, observer plus screen observation summary/cleanup boundaries, embedding, vector store, soul file, vault repository, filesystem, browser, sandbox, and web search flows
-- [x] deterministic runtime eval harness for fallback, routing, core chat behavior, storage, observer, and integration seam contracts, including vault repository, the MCP test API, skills API, screen repository boundaries, and daily-briefing, activity-digest, plus evening-review degraded-input audit behavior
+- [x] deterministic runtime eval harness for fallback, routing, core chat behavior, proactive flow behavior, storage, observer, and integration seam contracts, including vault repository, the MCP test API, skills API, screen repository boundaries, and daily-briefing, activity-digest, plus evening-review degraded-input audit behavior
 
 ### Guardian intelligence and proactive behavior
 
@@ -88,7 +88,7 @@ title: Seraph Development Status
 - [ ] richer provider selection policy beyond path patterns, explicit overrides, ordered fallbacks, and cooldown rerouting
 - [ ] broader local-model routing into any remaining runtime paths that are worth it
 - [ ] remaining edge observability beyond the already-covered chat, scheduler, observer, screen observation repository, proactive delivery, storage, MCP management/test, skills state-management, and integration boundaries
-- [ ] broader eval coverage beyond the shipped REST and WebSocket chat behavioral contracts
+- [ ] broader eval coverage beyond the shipped REST, WebSocket, and proactive behavioral contracts
 
 ### Product expansion
 


### PR DESCRIPTION
## Done on develop
- [x] Core runtime seam coverage, fallback routing, local runtime routing, and broad runtime audit coverage are already shipped on `develop`
- [x] The first behavioral eval slice for REST and WebSocket chat is already shipped on `develop`

## Working in this PR
- [x] Add deterministic behavioral eval contracts for strategist tick, daily briefing, activity digest, and evening review
- [x] Assert proactive delivery outcomes plus degraded-input behavior in the eval harness test surface
- [x] Advance the source-of-truth runtime docs and numbered PR queue to show proactive behavioral eval coverage

## Still to do after this PR
- [ ] Add the delegated tool-heavy behavioral eval contract
- [ ] Add richer provider capability and routing-decision policy on top of the current runtime router
- [ ] Close only the remaining real incident-trace blind spots after the behavioral eval slices land

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/evals/harness.py backend/tests/test_eval_harness.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_eval_harness.py tests/test_daily_briefing.py tests/test_evening_review.py tests/test_activity_digest.py tests/test_strategist_tick.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario strategist_tick_behavior --scenario daily_briefing_delivery_behavior --scenario activity_digest_degraded_delivery_behavior --scenario evening_review_degraded_delivery_behavior --indent 2`
- `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`
- `cd docs && npm run build`
