### PR TITLE
Log provider routing decisions

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -1893,6 +1893,111 @@ def _eval_provider_policy_capabilities() -> dict[str, Any]:
     }
 
 
+async def _eval_provider_routing_decision_audit() -> dict[str, Any]:
+    completion_response = _make_litellm_response("Policy matched the fast fallback.")
+    first_agent_response = MagicMock()
+    rerouted_agent_response = MagicMock()
+
+    _reset_target_health()
+    try:
+        with (
+            patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+            patch.object(settings, "llm_api_key", "primary-key"),
+            patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+            patch.object(settings, "fallback_model", "ollama/llama3.2"),
+            patch.object(settings, "fallback_models", "openai/gpt-4.1-nano,openai/gpt-4o-mini"),
+            patch.object(settings, "fallback_llm_api_key", ""),
+            patch.object(settings, "fallback_llm_api_base", "http://localhost:11434/v1"),
+            patch.object(
+                settings,
+                "runtime_fallback_overrides",
+                "session_title_generation=openai/gpt-4o-mini|openai/gpt-4.1-nano|openai/gpt-4.1-mini",
+            ),
+            patch.object(
+                settings,
+                "provider_capability_overrides",
+                "openai/gpt-4.1-nano=cheap;openai/gpt-4o-mini=fast|cheap",
+            ),
+            patch.object(settings, "runtime_policy_intents", "session_title_generation=fast|cheap"),
+            patch.object(settings, "llm_target_cooldown_seconds", 300),
+            patch.object(audit_repository, "log_event", AsyncMock()) as mock_log_event,
+            patch(
+                "litellm.completion",
+                side_effect=[RuntimeError("primary down"), completion_response],
+            ),
+            patch(
+                "src.llm_runtime.BaseLiteLLMModel.generate",
+                autospec=True,
+                side_effect=[
+                    RuntimeError("primary down"),
+                    first_agent_response,
+                    rerouted_agent_response,
+                ],
+            ),
+        ):
+            completion_with_fallback_sync(
+                messages=[{"role": "user", "content": "pick the fastest fallback"}],
+                temperature=0.2,
+                max_tokens=128,
+                runtime_path="session_title_generation",
+            )
+
+            first_model = FallbackLiteLLMModel(
+                model_id="openrouter/anthropic/claude-sonnet-4",
+                api_key="primary-key",
+                api_base="https://openrouter.ai/api/v1",
+                temperature=0.3,
+                max_tokens=256,
+            )
+            first_model.generate([{"role": "user", "content": "hello"}])
+
+            rerouted_model = FallbackLiteLLMModel(
+                model_id="openrouter/anthropic/claude-sonnet-4",
+                api_key="primary-key",
+                api_base="https://openrouter.ai/api/v1",
+                temperature=0.3,
+                max_tokens=256,
+            )
+            rerouted_model.generate([{"role": "user", "content": "hello again"}])
+            await asyncio.sleep(0)
+    finally:
+        _reset_target_health()
+
+    routing_calls = [
+        call.kwargs
+        for call in mock_log_event.call_args_list
+        if call.kwargs.get("event_type") == "llm_routing_decision"
+    ]
+    completion_decision = next(
+        call
+        for call in routing_calls
+        if call["details"]["runtime_path"] == "session_title_generation"
+    )
+    rerouted_agent_decision = next(
+        call
+        for call in routing_calls
+        if call["details"]["runtime_path"] == "agent_generate"
+        and call["details"]["rerouted_from_unhealthy_primary"] is True
+    )
+    primary_candidate = next(
+        candidate
+        for candidate in rerouted_agent_decision["details"]["candidate_targets"]
+        if candidate["source"] == "primary"
+    )
+    return {
+        "completion_selected_model": completion_decision["details"]["selected_model"],
+        "completion_attempt_order": completion_decision["details"]["attempt_order"],
+        "completion_rejected_models": [
+            candidate["model_id"]
+            for candidate in completion_decision["details"]["rejected_targets"]
+        ],
+        "agent_selected_model": rerouted_agent_decision["details"]["selected_model"],
+        "agent_attempt_order": rerouted_agent_decision["details"]["attempt_order"],
+        "agent_primary_decision": primary_candidate["decision"],
+        "agent_primary_reason_codes": primary_candidate["reason_codes"],
+    }
+
+
 def _eval_onboarding_model_wrapper() -> dict[str, Any]:
     with (
         patch.object(settings, "fallback_model", "ollama/llama3.2"),
@@ -3181,6 +3286,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="runtime",
         description="Runtime-path policy intents can prefer local-first primary routing and capability-matched fallback targets.",
         runner=_eval_provider_policy_capabilities,
+    ),
+    EvalScenario(
+        name="provider_routing_decision_audit",
+        category="runtime",
+        description="Runtime routing writes structured decision records that explain selected and deferred targets.",
+        runner=_eval_provider_routing_decision_audit,
     ),
     EvalScenario(
         name="onboarding_model_wrapper",

--- a/backend/src/llm_runtime.py
+++ b/backend/src/llm_runtime.py
@@ -445,6 +445,7 @@ def _fallback_targets(
                 "api_base": candidate_api_base,
                 "api_key": candidate_api_key,
                 "profile": candidate_profile,
+                "source": "alternate_profile",
             }
         )
 
@@ -465,6 +466,7 @@ def _fallback_targets(
                 "api_base": fallback_api_base,
                 "api_key": fallback_api_key,
                 "profile": None,
+                "source": "fallback_chain",
             }
         )
     return _order_targets_by_policy(targets, runtime_path=runtime_path)
@@ -572,6 +574,162 @@ def _order_targets_by_policy(
         target
         for _, target in sorted(enumerate(targets), key=_sort_key)
     ]
+
+
+def _matched_policy_intents(
+    *,
+    model_id: str,
+    profile: str | None,
+    policy_intents: list[str],
+) -> list[str]:
+    capabilities = provider_capabilities(model_id, profile=profile)
+    matched: list[str] = []
+    if "local_first" in policy_intents and profile == "local":
+        matched.append("local_first")
+    matched.extend(
+        intent
+        for intent in policy_intents
+        if intent != "local_first" and intent in capabilities
+    )
+    return matched
+
+
+def _candidate_reason_codes(
+    *,
+    source: str,
+    decision: str,
+    healthy: bool,
+    rerouted_primary: bool,
+) -> list[str]:
+    reasons: list[str] = []
+    if source == "primary":
+        reasons.append("primary_target")
+    elif source == "alternate_profile":
+        reasons.append("alternate_profile_candidate")
+    elif source == "fallback_chain":
+        reasons.append("configured_fallback_chain")
+
+    if decision == "selected":
+        reasons.append("selected_for_attempt")
+    elif decision == "deferred":
+        reasons.append("kept_as_standby")
+    elif decision == "deprioritized":
+        reasons.append("deprioritized_after_healthy_targets")
+    elif decision == "skipped":
+        reasons.append("skipped_for_current_attempt")
+
+    if not healthy:
+        reasons.append("unhealthy_cooldown")
+    if rerouted_primary:
+        reasons.append("rerouted_away_from_primary")
+    return reasons
+
+
+def _build_routing_decision_details(
+    *,
+    runtime_path: str,
+    runtime_profile: str,
+    primary_model: str,
+    primary_api_base: str | None,
+    primary_api_key: str | None,
+    primary_profile: str | None,
+    primary_unhealthy: bool,
+    ordered_fallbacks: list[dict[str, Any]],
+    rerouted: bool,
+) -> dict[str, Any]:
+    policy_intents = runtime_policy_intents(runtime_path)
+    selected_target = (
+        ordered_fallbacks[0]
+        if rerouted and ordered_fallbacks
+        else {
+            "model_id": primary_model,
+            "api_base": primary_api_base,
+            "api_key": primary_api_key,
+            "profile": primary_profile,
+            "source": "primary",
+        }
+    )
+    selected_target_key = _target_key(
+        model_id=str(selected_target["model_id"]),
+        api_base=selected_target.get("api_base"),
+        api_key=selected_target.get("api_key"),
+    )
+    attempt_order = (
+        [str(target["model_id"]) for target in ordered_fallbacks]
+        if rerouted
+        else [primary_model, *[str(target["model_id"]) for target in ordered_fallbacks]]
+    )
+
+    candidate_targets: list[dict[str, Any]] = []
+    for target in [
+        {
+            "model_id": primary_model,
+            "api_base": primary_api_base,
+            "api_key": primary_api_key,
+            "profile": primary_profile,
+            "source": "primary",
+        },
+        *ordered_fallbacks,
+    ]:
+        healthy = not primary_unhealthy if target["source"] == "primary" else _is_target_healthy(
+            model_id=str(target["model_id"]),
+            api_base=target.get("api_base"),
+            api_key=target.get("api_key"),
+        )
+        target_key = _target_key(
+            model_id=str(target["model_id"]),
+            api_base=target.get("api_base"),
+            api_key=target.get("api_key"),
+        )
+        is_selected = target_key == selected_target_key
+        rerouted_primary = bool(rerouted and target["source"] == "primary")
+        if is_selected:
+            decision = "selected"
+        elif rerouted_primary:
+            decision = "skipped"
+        elif not healthy:
+            decision = "deprioritized"
+        else:
+            decision = "deferred"
+
+        candidate_targets.append(
+            {
+                "model_id": str(target["model_id"]),
+                "profile": target.get("profile"),
+                "source": target["source"],
+                "healthy": healthy,
+                "decision": decision,
+                "matched_policy_intents": _matched_policy_intents(
+                    model_id=str(target["model_id"]),
+                    profile=target.get("profile"),
+                    policy_intents=policy_intents,
+                ),
+                "reason_codes": _candidate_reason_codes(
+                    source=target["source"],
+                    decision=decision,
+                    healthy=healthy,
+                    rerouted_primary=rerouted_primary,
+                ),
+            }
+        )
+
+    return {
+        "runtime_path": runtime_path,
+        "runtime_profile": runtime_profile,
+        "policy_intents": policy_intents,
+        "primary_model": primary_model,
+        "selected_model": str(selected_target["model_id"]),
+        "selected_profile": selected_target.get("profile"),
+        "selected_source": selected_target["source"],
+        "attempt_order": attempt_order,
+        "rerouted_from_unhealthy_primary": rerouted,
+        "candidate_targets": candidate_targets,
+        "rejected_targets": [
+            target
+            for target in candidate_targets
+            if target["decision"] != "selected"
+        ],
+    }
 
 
 def _register_request(request_id: str) -> None:
@@ -707,6 +865,7 @@ class FallbackLiteLLMModel(BaseLiteLLMModel):
                     **fallback_kwargs,
                 )
             setattr(fallback_model, "runtime_profile", target.get("profile"))
+            setattr(fallback_model, "runtime_source", target.get("source"))
             fallback_models.append(fallback_model)
 
         self._fallback_models = tuple(fallback_models)
@@ -729,6 +888,7 @@ class FallbackLiteLLMModel(BaseLiteLLMModel):
                 "api_key": fallback_model.api_key,
                 "model": fallback_model,
                 "profile": getattr(fallback_model, "runtime_profile", None),
+                "source": getattr(fallback_model, "runtime_source", "fallback_chain"),
             }
             for fallback_model in self._fallback_models
         ]
@@ -739,6 +899,27 @@ class FallbackLiteLLMModel(BaseLiteLLMModel):
             api_key=self.api_key,
         )
         rerouted = primary_unhealthy and bool(healthy_fallbacks)
+        ordered_fallbacks = healthy_fallbacks + unhealthy_fallbacks
+
+        if _can_log_request(request_id):
+            _log_llm_runtime_event_sync(
+                event_type="llm_routing_decision",
+                summary=(
+                    f"Agent model routing selected "
+                    f"{ordered_fallbacks[0]['model_id'] if rerouted else primary_model}"
+                ),
+                details=_build_routing_decision_details(
+                    runtime_path="agent_generate",
+                    runtime_profile=self._runtime_profile,
+                    primary_model=primary_model,
+                    primary_api_base=self.api_base,
+                    primary_api_key=self.api_key,
+                    primary_profile=self._runtime_profile,
+                    primary_unhealthy=primary_unhealthy,
+                    ordered_fallbacks=ordered_fallbacks,
+                    rerouted=rerouted,
+                ),
+            )
 
         if rerouted and _can_log_request(request_id):
             _log_llm_runtime_event_sync(
@@ -757,7 +938,6 @@ class FallbackLiteLLMModel(BaseLiteLLMModel):
                 },
             )
 
-        ordered_fallbacks = healthy_fallbacks + unhealthy_fallbacks
         primary_attempted = False
         primary_error: Exception | None = None
         attempted_fallback_models: list[str] = []
@@ -938,6 +1118,27 @@ def completion_with_fallback_sync(
             api_key=primary_kwargs.get("api_key"),
         )
         rerouted = primary_unhealthy and bool(healthy_fallbacks)
+        ordered_fallbacks = healthy_fallbacks + unhealthy_fallbacks
+
+        if _can_log_request(request_id):
+            _log_llm_runtime_event_sync(
+                event_type="llm_routing_decision",
+                summary=(
+                    f"LLM completion routing selected "
+                    f"{ordered_fallbacks[0]['model_id'] if rerouted else primary_model}"
+                ),
+                details=_build_routing_decision_details(
+                    runtime_path=runtime_path,
+                    runtime_profile=resolved_profile,
+                    primary_model=primary_model,
+                    primary_api_base=primary_kwargs.get("api_base"),
+                    primary_api_key=primary_kwargs.get("api_key"),
+                    primary_profile=resolved_profile,
+                    primary_unhealthy=primary_unhealthy,
+                    ordered_fallbacks=ordered_fallbacks,
+                    rerouted=rerouted,
+                ),
+            )
 
         if rerouted and _can_log_request(request_id):
             _log_llm_runtime_event_sync(
@@ -957,7 +1158,6 @@ def completion_with_fallback_sync(
                 },
             )
 
-        ordered_fallbacks = healthy_fallbacks + unhealthy_fallbacks
         primary_attempted = False
         primary_error: Exception | None = None
         attempted_fallback_models: list[str] = []

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -71,6 +71,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "runtime_profile_preferences" in captured.out
     assert "runtime_path_patterns" in captured.out
     assert "provider_policy_capabilities" in captured.out
+    assert "provider_routing_decision_audit" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
     assert "daily_briefing_delivery_behavior" in captured.out
     assert "shell_tool_runtime_audit" in captured.out
@@ -146,6 +147,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "runtime_profile_preferences",
                 "runtime_path_patterns",
                 "provider_policy_capabilities",
+                "provider_routing_decision_audit",
                 "scheduled_local_runtime_profile",
                 "daily_briefing_delivery_behavior",
                 "shell_tool_runtime_audit",
@@ -357,6 +359,30 @@ def test_runtime_eval_scenarios_expose_expected_details():
         "openai/gpt-4o-mini",
     ]
     assert details_by_name["provider_policy_capabilities"]["completion_final_model"] == "openai/gpt-4o-mini"
+    assert details_by_name["provider_routing_decision_audit"]["completion_selected_model"] == (
+        "openrouter/anthropic/claude-sonnet-4"
+    )
+    assert details_by_name["provider_routing_decision_audit"]["completion_attempt_order"] == [
+        "openrouter/anthropic/claude-sonnet-4",
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-nano",
+        "openai/gpt-4.1-mini",
+    ]
+    assert details_by_name["provider_routing_decision_audit"]["completion_rejected_models"] == [
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-nano",
+        "openai/gpt-4.1-mini",
+    ]
+    assert details_by_name["provider_routing_decision_audit"]["agent_selected_model"] == "ollama/llama3.2"
+    assert details_by_name["provider_routing_decision_audit"]["agent_attempt_order"] == [
+        "ollama/llama3.2",
+        "openai/gpt-4.1-nano",
+        "openai/gpt-4o-mini",
+    ]
+    assert details_by_name["provider_routing_decision_audit"]["agent_primary_decision"] == "skipped"
+    assert "unhealthy_cooldown" in details_by_name["provider_routing_decision_audit"][
+        "agent_primary_reason_codes"
+    ]
     assert details_by_name["scheduled_local_runtime_profile"]["job_name"] == "daily_briefing"
     assert details_by_name["scheduled_local_runtime_profile"]["routed_model"] == "ollama/llama3.2"
     assert details_by_name["daily_briefing_delivery_behavior"]["message_type"] == "proactive"

--- a/backend/tests/test_llm_runtime.py
+++ b/backend/tests/test_llm_runtime.py
@@ -958,13 +958,28 @@ def test_completion_with_fallback_sync_reroutes_away_from_unhealthy_primary(asyn
     ]
 
     async def _fetch():
-        events = await audit_repository.list_events(limit=10)
-        return [e for e in events if e["event_type"] == "llm_target_rerouted"]
+        return await audit_repository.list_events(limit=20)
 
     events = asyncio.run(_fetch())
-    assert events
-    assert events[0]["details"]["primary_model"] == "openrouter/anthropic/claude-sonnet-4"
-    assert events[0]["details"]["rerouted_model"] == "openai/gpt-4o-mini"
+    reroute_events = [e for e in events if e["event_type"] == "llm_target_rerouted"]
+    assert reroute_events
+    assert reroute_events[0]["details"]["primary_model"] == "openrouter/anthropic/claude-sonnet-4"
+    assert reroute_events[0]["details"]["rerouted_model"] == "openai/gpt-4o-mini"
+
+    routing_events = [e for e in events if e["event_type"] == "llm_routing_decision"]
+    assert routing_events
+    rerouted_details = routing_events[0]["details"]
+    assert rerouted_details["runtime_path"] == "completion"
+    assert rerouted_details["selected_model"] == "openai/gpt-4o-mini"
+    assert rerouted_details["rerouted_from_unhealthy_primary"] is True
+    assert rerouted_details["attempt_order"] == ["openai/gpt-4o-mini"]
+    primary_candidate = next(
+        candidate
+        for candidate in rerouted_details["candidate_targets"]
+        if candidate["source"] == "primary"
+    )
+    assert primary_candidate["decision"] == "skipped"
+    assert "unhealthy_cooldown" in primary_candidate["reason_codes"]
 
 
 def test_completion_with_fallback_sync_logs_primary_success(async_db):
@@ -1349,6 +1364,58 @@ def test_completion_with_fallback_prefers_alternate_runtime_profile_before_expli
     assert events[0]["details"]["attempted_fallback_models"] == [
         "openrouter/anthropic/claude-sonnet-4",
     ]
+
+
+def test_completion_with_fallback_logs_routing_decision(async_db):
+    completion_response = MagicMock()
+    completion_response.choices = [MagicMock(message=MagicMock(content="fast path won"))]
+
+    with (
+        patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
+        patch.object(settings, "llm_api_key", "primary-key"),
+        patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", "openai/gpt-4.1-nano,openai/gpt-4o-mini"),
+        patch.object(
+            settings,
+            "provider_capability_overrides",
+            "openai/gpt-4.1-nano=cheap;openai/gpt-4o-mini=fast|cheap",
+        ),
+        patch.object(settings, "runtime_policy_intents", "session_title_generation=fast|cheap"),
+        patch(
+            "litellm.completion",
+            side_effect=[RuntimeError("primary down"), completion_response],
+        ),
+    ):
+        result = completion_with_fallback_sync(
+            messages=[{"role": "user", "content": "pick the fastest fallback"}],
+            temperature=0.2,
+            max_tokens=128,
+            runtime_path="session_title_generation",
+        )
+
+    assert result is completion_response
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=10)
+        return [e for e in events if e["event_type"] == "llm_routing_decision"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    details = events[0]["details"]
+    assert details["runtime_path"] == "session_title_generation"
+    assert details["selected_model"] == "openrouter/anthropic/claude-sonnet-4"
+    assert details["attempt_order"] == [
+        "openrouter/anthropic/claude-sonnet-4",
+        "openai/gpt-4o-mini",
+        "openai/gpt-4.1-nano",
+    ]
+    assert details["policy_intents"] == ["fast", "cheap"]
+    assert details["candidate_targets"][1]["model_id"] == "openai/gpt-4o-mini"
+    assert details["candidate_targets"][1]["matched_policy_intents"] == ["fast", "cheap"]
+    assert details["candidate_targets"][1]["decision"] == "deferred"
+    assert details["candidate_targets"][2]["model_id"] == "openai/gpt-4.1-nano"
+    assert details["candidate_targets"][2]["matched_policy_intents"] == ["cheap"]
 
 
 def test_fallback_litellm_model_skips_duplicate_fallback_target():

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -62,6 +62,7 @@ uv run python -m src.evals.harness --scenario runtime_fallback_overrides
 uv run python -m src.evals.harness --scenario runtime_profile_preferences
 uv run python -m src.evals.harness --scenario runtime_path_patterns
 uv run python -m src.evals.harness --scenario provider_policy_capabilities
+uv run python -m src.evals.harness --scenario provider_routing_decision_audit
 uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
 uv run python -m src.evals.harness --scenario daily_briefing_fallback
 uv run python -m src.evals.harness --scenario daily_briefing_delivery_behavior
@@ -86,7 +87,7 @@ uv run python -m src.evals.harness --scenario evening_review_degraded_delivery_b
 uv run python -m src.evals.harness --scenario evening_review_degraded_inputs_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so REST and WebSocket chat behavior, strategist and scheduled proactive flow behavior, delegated tool-heavy workflow behavior, ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, capability-aware runtime policy intents, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, vault-repository, and filesystem boundary failures, context-window degradation, daily-briefing, activity-digest, and evening-review degraded-input fallback auditing, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, screen observation summary/cleanup boundary behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so REST and WebSocket chat behavior, strategist and scheduled proactive flow behavior, delegated tool-heavy workflow behavior, ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, capability-aware runtime policy intents, structured routing decision auditing, runtime-path primary and fallback overrides, local helper/agent/scheduler/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, vault-repository, and filesystem boundary failures, context-window degradation, daily-briefing, activity-digest, and evening-review degraded-input fallback auditing, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, screen observation summary/cleanup boundary behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -68,7 +68,7 @@ Legend for the checklist column:
 ## Working On Now
 
 - [x] Runtime Reliability is the active hardening track.
-- [x] `provider-policy-capabilities` is the current queued PR after the shipped behavioral-eval slices.
+- [x] `provider-routing-decision-audit` is the current queued PR after the shipped behavioral-eval slices.
 - [ ] richer provider routing policy and broader behavioral eval depth are still ahead.
 
 ## Recommended Reading Order

--- a/docs/implementation/03-runtime-reliability.md
+++ b/docs/implementation/03-runtime-reliability.md
@@ -23,12 +23,12 @@
 ## Working On Now
 
 - [x] Runtime Reliability remains the repo-wide hardening track
-- [x] `provider-policy-capabilities` is the active PR from the numbered sequence below
+- [x] `provider-routing-decision-audit` is the active PR from the numbered sequence below
 - [ ] close the remaining routing, observability, and eval gaps outside the already-covered seams
 
 ## Still To Do On `develop`
 
-- [ ] deepen provider routing beyond profile preferences, path patterns, model overrides, ordered fallback chains, and cooldown rerouting with richer policy-aware selection and decision visibility
+- [ ] deepen provider routing beyond profile preferences, path patterns, model overrides, ordered fallback chains, and cooldown rerouting with richer policy-aware selection
 - [ ] broaden local-model routing beyond the current helper, scheduler, core agent, delegation, and connected MCP-specialist paths into any remaining runtime paths where it makes sense
 - [ ] add observability coverage across any remaining edge helpers and external integration paths beyond the proactive delivery transport, MCP management/test, skills state-management, and screen observation repository boundaries
 - [ ] expand eval coverage beyond the shipped REST, WebSocket, proactive, and delegated behavioral contracts into broader behavioral coverage
@@ -45,7 +45,7 @@ This sequence is execution order for upcoming PRs. A checked item can be in an o
    add one delegated tool-heavy workflow contract covering routing, tool execution, audit, and degraded or failure handling
 4. [x] `provider-policy-capabilities`:
    add provider capability metadata and runtime-path policy intents such as `fast`, `cheap`, `reasoning`, and `local_first`
-5. [ ] `provider-routing-decision-audit`:
+5. [x] `provider-routing-decision-audit`:
    log structured routing decisions that explain the chosen target, rejected targets, and rejection reasons
 6. [ ] `local-routing-gap-closure`:
    extend local routing only into the remaining runtime paths that still have clear product value after the eval and policy work lands

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -24,6 +24,7 @@ title: Seraph Development Status
 - [x] Runtime Reliability is still the active hardening track.
 - [ ] Runtime Reliability is not complete yet.
 - [x] The numbered next-PR sequence is tracked in `docs/implementation/03-runtime-reliability.md`.
+- [x] The active in-flight Runtime Reliability slice is `provider-routing-decision-audit`.
 
 ## Shipped On `develop`
 


### PR DESCRIPTION
## Done on develop
- [x] shipped the three behavioral eval slices for REST/WebSocket chat, proactive jobs, and a delegated tool-heavy workflow
- [x] added provider capability policy intents on top of runtime-path profile preferences, patterns, overrides, fallback chains, and cooldown rerouting
- [x] keep the Runtime Reliability numbered PR queue in the implementation docs as the source of truth

## Working in this PR
- [x] log structured `llm_routing_decision` audit events for both shared completions and agent-model generation
- [x] capture selected target, candidate targets, rejection reasons, policy-intent matches, and unhealthy-primary reroute details in runtime audit output
- [x] cover the routing-decision contract with backend tests, a deterministic eval harness scenario, and matching source-of-truth doc updates

## Still to do after this PR
- [ ] `local-routing-gap-closure`
- [ ] `incident-trace-gap-closure`
- [ ] broader behavioral eval depth beyond the current canonical flow set

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile backend/src/llm_runtime.py backend/src/evals/harness.py backend/tests/test_llm_runtime.py backend/tests/test_eval_harness.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_llm_runtime.py tests/test_eval_harness.py tests/test_agent.py tests/test_specialists.py`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario provider_routing_decision_audit --indent 2`
- `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`
- `cd docs && npm run build`
