### PR TITLE
Add guardian behavioral eval contracts

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -53,6 +53,7 @@ from src.memory.consolidator import consolidate_session
 from src.memory import soul as soul_mod
 from src.memory.vector_store import _reset_vector_store_state, add_memory, search
 from src.observer.context import CurrentContext
+from src.observer.manager import ContextManager
 from src.observer.delivery import deliver_or_queue, deliver_queued_bundle
 from src.observer.user_state import DeliveryDecision
 from src.scheduler.jobs.activity_digest import run_activity_digest
@@ -385,6 +386,7 @@ def _make_sync_client_with_db():
         "src.goals.repository.get_session",
         "src.vault.repository.get_session",
         "src.api.profile.get_db",
+        "src.api.settings.get_db",
     ]
     patches = [patch(target, _get_session) for target in targets]
     patches.append(patch("src.app.init_db", _test_init_db))
@@ -2877,6 +2879,48 @@ async def _eval_session_consolidation_background_audit() -> dict[str, Any]:
     }
 
 
+async def _eval_session_consolidation_behavior() -> dict[str, Any]:
+    mock_log_event = AsyncMock()
+    llm_response = _make_litellm_response(json.dumps({
+        "facts": ["User is building a guardian cockpit"],
+        "patterns": [],
+        "goals": ["Ship behavioral guardian evals"],
+        "reflections": [],
+        "soul_updates": {"Goals": "- Ship the guardian cockpit pivot"},
+    }))
+
+    with (
+        patch.object(
+            session_manager,
+            "get_history_text",
+            AsyncMock(return_value=(
+                "User: I want Seraph to become a dense guardian cockpit.\n"
+                "Assistant: Then we need behavioral evals, stronger state, and better operator UX."
+            )),
+        ),
+        patch("src.memory.consolidator.read_soul", return_value="# Soul\n\n## Goals\n- Keep the system grounded"),
+        patch("src.memory.consolidator.completion_with_fallback", AsyncMock(return_value=llm_response)),
+        patch("src.memory.consolidator.add_memory") as mock_add_memory,
+        patch("src.memory.consolidator.update_soul_section") as mock_update_soul,
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        await consolidate_session("guardian-session")
+
+    success = _find_audit_call(
+        mock_log_event,
+        event_type="background_task_succeeded",
+        tool_name="session_consolidation",
+    )
+    return {
+        "stored_memory_count": success["details"]["stored_memory_count"],
+        "soul_update_count": success["details"]["soul_update_count"],
+        "memory_categories": [call.kwargs["category"] for call in mock_add_memory.call_args_list],
+        "stored_texts": [call.kwargs["text"] for call in mock_add_memory.call_args_list],
+        "updated_soul_section": mock_update_soul.call_args.args[0],
+        "updated_soul_mentions_cockpit": "guardian cockpit" in mock_update_soul.call_args.args[1].lower(),
+    }
+
+
 async def _eval_session_title_generation_background_audit() -> dict[str, Any]:
     sm = SessionManager()
     mock_log_event = AsyncMock()
@@ -3022,6 +3066,118 @@ async def _eval_observer_delivery_transport_audit() -> dict[str, Any]:
         "bundle_delivered_connections": bundle_delivered["details"]["delivered_connections"],
         "bundle_failed_count": failed_bundle_count,
         "bundle_failed_error": bundle_failed["details"]["error"],
+    }
+
+
+async def _eval_observer_refresh_behavior() -> dict[str, Any]:
+    mgr = ContextManager()
+    mgr.update_screen_context("VS Code", "Editing guardian eval contracts")
+    mgr._context.user_state = "deep_work"
+    mock_log_event = AsyncMock()
+
+    with (
+        patch(
+            "src.observer.sources.time_source.gather_time",
+            return_value={
+                "time_of_day": "morning",
+                "day_of_week": "Monday",
+                "is_working_hours": True,
+            },
+        ),
+        patch(
+            "src.observer.sources.calendar_source.gather_calendar",
+            new_callable=AsyncMock,
+            return_value={
+                "upcoming_events": [{"summary": "Design review", "start": "10:00"}],
+                "current_event": None,
+            },
+        ),
+        patch(
+            "src.observer.sources.git_source.gather_git",
+            return_value={"recent_git_activity": [{"msg": "ship guardian evals"}]},
+        ),
+        patch(
+            "src.observer.sources.goal_source.gather_goals",
+            new_callable=AsyncMock,
+            return_value={"active_goals_summary": "Ship guardian behavioral evals"},
+        ),
+        patch("src.observer.manager.user_state_machine.derive_state", return_value="transitioning"),
+        patch.object(mgr, "_deliver_bundle", AsyncMock()) as mock_deliver_bundle,
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        ctx = await mgr.refresh()
+        await asyncio.sleep(0)
+
+    succeeded = _find_audit_call(
+        mock_log_event,
+        event_type="background_task_succeeded",
+        tool_name="observer_context_refresh",
+    )
+    return {
+        "new_user_state": ctx.user_state,
+        "data_quality": ctx.data_quality,
+        "screen_context_preserved": ctx.screen_context == "Editing guardian eval contracts",
+        "active_window_preserved": ctx.active_window == "VS Code",
+        "goal_summary": ctx.active_goals_summary,
+        "upcoming_event_count": len(ctx.upcoming_events),
+        "triggered_bundle_delivery": succeeded["details"]["triggered_bundle_delivery"],
+        "bundle_task_scheduled": mock_deliver_bundle.call_count == 1,
+    }
+
+
+async def _eval_observer_delivery_decision_behavior() -> dict[str, Any]:
+    available_ctx = _make_context(
+        user_state="available",
+        interruption_mode="balanced",
+        attention_budget_remaining=3,
+    )
+    blocked_ctx = _make_context(
+        user_state="deep_work",
+        interruption_mode="balanced",
+        attention_budget_remaining=3,
+    )
+    mock_context_manager = MagicMock()
+    mock_context_manager.get_context.side_effect = [available_ctx, blocked_ctx]
+    mock_context_manager.decrement_attention_budget = MagicMock()
+    mock_ws_manager = MagicMock()
+    mock_ws_manager.broadcast = AsyncMock(return_value=BroadcastResult(1, 1, 0))
+    mock_insight_queue = MagicMock()
+    mock_insight_queue.enqueue = AsyncMock()
+    mock_log_event = AsyncMock()
+    message = WSResponse(
+        type="proactive",
+        content="Guardian note: wrap the next guardian flow slice.",
+        intervention_type="advisory",
+        urgency=3,
+        reasoning="Guardian flow follow-up",
+    )
+
+    with (
+        patch("src.observer.manager.context_manager", mock_context_manager),
+        patch("src.scheduler.connection_manager.ws_manager", mock_ws_manager),
+        patch("src.observer.insight_queue.insight_queue", mock_insight_queue),
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        delivered = await deliver_or_queue(message)
+        queued = await deliver_or_queue(message)
+
+    delivered_event = _find_audit_call(
+        mock_log_event,
+        event_type="observer_delivery_delivered",
+        tool_name="observer_delivery_gate",
+    )
+    queued_event = _find_audit_call(
+        mock_log_event,
+        event_type="observer_delivery_queued",
+        tool_name="observer_delivery_gate",
+    )
+    return {
+        "delivered_decision": delivered.value,
+        "queued_decision": queued.value,
+        "budget_decremented": mock_context_manager.decrement_attention_budget.call_count == 1,
+        "queued_content_matches": mock_insight_queue.enqueue.await_args.kwargs["content"] == message.content,
+        "delivered_connections": delivered_event["details"]["delivered_connections"],
+        "queued_user_state": queued_event["details"]["user_state"],
     }
 
 
@@ -3204,6 +3360,55 @@ async def _eval_skills_api_audit() -> dict[str, Any]:
         "reload_enabled_count": reloaded_event["details"]["enabled_count"],
         "reload_skill_names": reloaded_event["details"]["skill_names"],
     }
+
+
+def _eval_tool_policy_guardrails_behavior() -> dict[str, Any]:
+    client, patches, stack = _make_sync_client_with_db()
+    policy_context_manager = ContextManager()
+    mcp_tool = MagicMock()
+    mcp_tool.name = "mcp_tasks"
+    mcp_tool.description = "Task MCP"
+
+    try:
+        with (
+            patch("src.api.settings.context_manager", policy_context_manager),
+            patch("src.tools.policy.context_manager", policy_context_manager),
+            patch("src.agent.factory.mcp_manager.get_tools", return_value=[mcp_tool]),
+        ):
+            safe_response = client.put("/api/settings/tool-policy-mode", json={"mode": "safe"})
+            safe_tools = {tool["name"]: tool for tool in client.get("/api/tools").json()}
+
+            balanced_response = client.put("/api/settings/tool-policy-mode", json={"mode": "balanced"})
+            balanced_tools = {tool["name"]: tool for tool in client.get("/api/tools").json()}
+
+            full_response = client.put("/api/settings/tool-policy-mode", json={"mode": "full"})
+            full_tools = {tool["name"]: tool for tool in client.get("/api/tools").json()}
+
+            disabled_response = client.put("/api/settings/mcp-policy-mode", json={"mode": "disabled"})
+            disabled_tools = {tool["name"]: tool for tool in client.get("/api/tools").json()}
+
+            approval_response = client.put("/api/settings/mcp-policy-mode", json={"mode": "approval"})
+            approval_tools = {tool["name"]: tool for tool in client.get("/api/tools").json()}
+
+        return {
+            "safe_status": safe_response.status_code,
+            "balanced_status": balanced_response.status_code,
+            "full_status": full_response.status_code,
+            "mcp_disabled_status": disabled_response.status_code,
+            "mcp_approval_status": approval_response.status_code,
+            "safe_hides_write_file": "write_file" not in safe_tools,
+            "safe_hides_shell_execute": "shell_execute" not in safe_tools,
+            "balanced_shows_write_file": "write_file" in balanced_tools,
+            "balanced_hides_shell_execute": "shell_execute" not in balanced_tools,
+            "full_shows_shell_execute": "shell_execute" in full_tools,
+            "mcp_disabled_hides_tool": "mcp_tasks" not in disabled_tools,
+            "mcp_approval_shows_tool": "mcp_tasks" in approval_tools,
+            "mcp_approval_requires_approval": approval_tools["mcp_tasks"]["requires_approval"],
+        }
+    finally:
+        stack.close()
+        for item in patches:
+            item.stop()
 
 
 async def _eval_screen_repository_runtime_audit() -> dict[str, Any]:
@@ -3509,6 +3714,18 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         runner=_eval_strategist_tick_behavior,
     ),
     EvalScenario(
+        name="observer_refresh_behavior",
+        category="behavior",
+        description="Observer refresh preserves screen context, rebuilds guardian context, and schedules queued-bundle delivery on unblock transitions.",
+        runner=_eval_observer_refresh_behavior,
+    ),
+    EvalScenario(
+        name="observer_delivery_decision_behavior",
+        category="behavior",
+        description="Proactive delivery delivers while available, queues while blocked, and decrements budget only for delivered guardian nudges.",
+        runner=_eval_observer_delivery_decision_behavior,
+    ),
+    EvalScenario(
         name="daily_briefing_fallback",
         category="proactive",
         description="Daily briefing survives a primary provider failure and still delivers via fallback.",
@@ -3623,6 +3840,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         runner=_eval_session_consolidation_background_audit,
     ),
     EvalScenario(
+        name="session_consolidation_behavior",
+        category="behavior",
+        description="Session consolidation stores long-term memories and soul updates from the modeled guardian conversation summary.",
+        runner=_eval_session_consolidation_behavior,
+    ),
+    EvalScenario(
         name="session_title_generation_background_audit",
         category="observability",
         description="Session title generation records background-task audit success without live providers.",
@@ -3657,6 +3880,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="observability",
         description="Skill toggle and reload requests record succeeded and failed runtime audit events.",
         runner=_eval_skills_api_audit,
+    ),
+    EvalScenario(
+        name="tool_policy_guardrails_behavior",
+        category="behavior",
+        description="Tool and MCP policy modes expose a graduated public control surface instead of leaking high-risk capability in safer modes.",
+        runner=_eval_tool_policy_guardrails_behavior,
     ),
     EvalScenario(
         name="screen_repository_runtime_audit",

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -51,6 +51,8 @@ def test_main_lists_available_scenarios(capsys):
     assert "websocket_chat_approval_contract" in captured.out
     assert "websocket_chat_timeout_contract" in captured.out
     assert "strategist_tick_behavior" in captured.out
+    assert "observer_refresh_behavior" in captured.out
+    assert "observer_delivery_decision_behavior" in captured.out
     assert "provider_fallback_chain" in captured.out
     assert "provider_health_reroute" in captured.out
     assert "local_runtime_profile" in captured.out
@@ -74,6 +76,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "provider_policy_scoring" in captured.out
     assert "provider_routing_decision_audit" in captured.out
     assert "session_bound_llm_trace" in captured.out
+    assert "session_consolidation_behavior" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
     assert "daily_briefing_delivery_behavior" in captured.out
     assert "shell_tool_runtime_audit" in captured.out
@@ -89,6 +92,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "observer_daemon_ingest_audit" in captured.out
     assert "mcp_test_api_audit" in captured.out
     assert "skills_api_audit" in captured.out
+    assert "tool_policy_guardrails_behavior" in captured.out
     assert "screen_repository_runtime_audit" in captured.out
     assert "daily_briefing_degraded_memories_audit" in captured.out
     assert "activity_digest_degraded_delivery_behavior" in captured.out
@@ -134,6 +138,8 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "websocket_chat_approval_contract",
                 "websocket_chat_timeout_contract",
                 "strategist_tick_behavior",
+                "observer_refresh_behavior",
+                "observer_delivery_decision_behavior",
                 "agent_local_runtime_profile",
                 "delegation_local_runtime_profile",
                 "delegated_tool_workflow_behavior",
@@ -152,6 +158,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "provider_policy_scoring",
                 "provider_routing_decision_audit",
                 "session_bound_llm_trace",
+                "session_consolidation_behavior",
                 "scheduled_local_runtime_profile",
                 "daily_briefing_delivery_behavior",
                 "shell_tool_runtime_audit",
@@ -167,6 +174,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "observer_daemon_ingest_audit",
                 "mcp_test_api_audit",
                 "skills_api_audit",
+                "tool_policy_guardrails_behavior",
                 "screen_repository_runtime_audit",
                 "daily_briefing_degraded_memories_audit",
                 "activity_digest_degraded_delivery_behavior",
@@ -237,6 +245,20 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["strategist_tick_behavior"]["content_mentions_refocus"] is True
     assert details_by_name["strategist_tick_behavior"]["delivery"] == "deliver"
     assert details_by_name["strategist_tick_behavior"]["reasoning"] == "Focus drift"
+    assert details_by_name["observer_refresh_behavior"]["new_user_state"] == "transitioning"
+    assert details_by_name["observer_refresh_behavior"]["data_quality"] == "good"
+    assert details_by_name["observer_refresh_behavior"]["screen_context_preserved"] is True
+    assert details_by_name["observer_refresh_behavior"]["active_window_preserved"] is True
+    assert details_by_name["observer_refresh_behavior"]["goal_summary"] == "Ship guardian behavioral evals"
+    assert details_by_name["observer_refresh_behavior"]["upcoming_event_count"] == 1
+    assert details_by_name["observer_refresh_behavior"]["triggered_bundle_delivery"] is True
+    assert details_by_name["observer_refresh_behavior"]["bundle_task_scheduled"] is True
+    assert details_by_name["observer_delivery_decision_behavior"]["delivered_decision"] == "deliver"
+    assert details_by_name["observer_delivery_decision_behavior"]["queued_decision"] == "queue"
+    assert details_by_name["observer_delivery_decision_behavior"]["budget_decremented"] is True
+    assert details_by_name["observer_delivery_decision_behavior"]["queued_content_matches"] is True
+    assert details_by_name["observer_delivery_decision_behavior"]["delivered_connections"] == 1
+    assert details_by_name["observer_delivery_decision_behavior"]["queued_user_state"] == "deep_work"
     assert details_by_name["agent_local_runtime_profile"]["routed_models"]["chat_agent"] == "ollama/llama3.2"
     assert details_by_name["agent_local_runtime_profile"]["routed_models"]["onboarding_agent"] == "ollama/llama3.2"
     assert details_by_name["agent_local_runtime_profile"]["routed_models"]["strategist_agent"] == "ollama/llama3.2"
@@ -412,6 +434,15 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["session_bound_llm_trace"]["title_trace_has_request_id"] is True
     assert details_by_name["session_bound_llm_trace"]["consolidation_trace_has_request_id"] is True
     assert details_by_name["session_bound_llm_trace"]["request_ids_differ"] is True
+    assert details_by_name["session_consolidation_behavior"]["stored_memory_count"] == 2
+    assert details_by_name["session_consolidation_behavior"]["soul_update_count"] == 1
+    assert details_by_name["session_consolidation_behavior"]["memory_categories"] == ["fact", "goal"]
+    assert details_by_name["session_consolidation_behavior"]["stored_texts"] == [
+        "User is building a guardian cockpit",
+        "Ship behavioral guardian evals",
+    ]
+    assert details_by_name["session_consolidation_behavior"]["updated_soul_section"] == "Goals"
+    assert details_by_name["session_consolidation_behavior"]["updated_soul_mentions_cockpit"] is True
     assert details_by_name["scheduled_local_runtime_profile"]["runtime_profile"] == "local"
     assert details_by_name["scheduled_local_runtime_profile"]["routed_models"] == {
         "daily_briefing": "ollama/llama3.2",
@@ -520,6 +551,19 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["skills_api_audit"]["reload_count"] == 2
     assert details_by_name["skills_api_audit"]["reload_enabled_count"] == 2
     assert details_by_name["skills_api_audit"]["reload_skill_names"] == ["test-skill", "simple-skill"]
+    assert details_by_name["tool_policy_guardrails_behavior"]["safe_status"] == 200
+    assert details_by_name["tool_policy_guardrails_behavior"]["balanced_status"] == 200
+    assert details_by_name["tool_policy_guardrails_behavior"]["full_status"] == 200
+    assert details_by_name["tool_policy_guardrails_behavior"]["mcp_disabled_status"] == 200
+    assert details_by_name["tool_policy_guardrails_behavior"]["mcp_approval_status"] == 200
+    assert details_by_name["tool_policy_guardrails_behavior"]["safe_hides_write_file"] is True
+    assert details_by_name["tool_policy_guardrails_behavior"]["safe_hides_shell_execute"] is True
+    assert details_by_name["tool_policy_guardrails_behavior"]["balanced_shows_write_file"] is True
+    assert details_by_name["tool_policy_guardrails_behavior"]["balanced_hides_shell_execute"] is True
+    assert details_by_name["tool_policy_guardrails_behavior"]["full_shows_shell_execute"] is True
+    assert details_by_name["tool_policy_guardrails_behavior"]["mcp_disabled_hides_tool"] is True
+    assert details_by_name["tool_policy_guardrails_behavior"]["mcp_approval_shows_tool"] is True
+    assert details_by_name["tool_policy_guardrails_behavior"]["mcp_approval_requires_approval"] is True
     assert details_by_name["screen_repository_runtime_audit"]["empty_daily_reason"] == "no_observations"
     assert details_by_name["screen_repository_runtime_audit"]["empty_daily_total_observations"] == 0
     assert details_by_name["screen_repository_runtime_audit"]["success_daily_total_observations"] == 1

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -42,6 +42,8 @@ uv run python -m src.evals.harness --scenario websocket_chat_behavior
 uv run python -m src.evals.harness --scenario websocket_chat_approval_contract
 uv run python -m src.evals.harness --scenario websocket_chat_timeout_contract
 uv run python -m src.evals.harness --scenario strategist_tick_behavior
+uv run python -m src.evals.harness --scenario observer_refresh_behavior
+uv run python -m src.evals.harness --scenario observer_delivery_decision_behavior
 uv run python -m src.evals.harness --scenario provider_fallback_chain
 uv run python -m src.evals.harness --scenario provider_health_reroute
 uv run python -m src.evals.harness --scenario local_runtime_profile
@@ -65,6 +67,7 @@ uv run python -m src.evals.harness --scenario provider_policy_capabilities
 uv run python -m src.evals.harness --scenario provider_policy_scoring
 uv run python -m src.evals.harness --scenario provider_routing_decision_audit
 uv run python -m src.evals.harness --scenario session_bound_llm_trace
+uv run python -m src.evals.harness --scenario session_consolidation_behavior
 uv run python -m src.evals.harness --scenario scheduled_local_runtime_profile
 uv run python -m src.evals.harness --scenario daily_briefing_fallback
 uv run python -m src.evals.harness --scenario daily_briefing_delivery_behavior
@@ -81,6 +84,7 @@ uv run python -m src.evals.harness --scenario observer_delivery_transport_audit
 uv run python -m src.evals.harness --scenario observer_daemon_ingest_audit
 uv run python -m src.evals.harness --scenario mcp_test_api_audit
 uv run python -m src.evals.harness --scenario skills_api_audit
+uv run python -m src.evals.harness --scenario tool_policy_guardrails_behavior
 uv run python -m src.evals.harness --scenario screen_repository_runtime_audit
 uv run python -m src.evals.harness --scenario daily_briefing_degraded_memories_audit
 uv run python -m src.evals.harness --scenario activity_digest_degraded_delivery_behavior
@@ -89,7 +93,7 @@ uv run python -m src.evals.harness --scenario evening_review_degraded_delivery_b
 uv run python -m src.evals.harness --scenario evening_review_degraded_inputs_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so REST and WebSocket chat behavior, strategist and scheduled proactive flow behavior, delegated tool-heavy workflow behavior, ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, capability-aware runtime policy intents, weighted provider policy scoring, structured routing decision auditing, session-bound helper LLM trace visibility, runtime-path primary and fallback overrides, local helper/agent/all current scheduled-job/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, vault-repository, and filesystem boundary failures, context-window degradation, daily-briefing, activity-digest, and evening-review degraded-input fallback auditing, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, screen observation summary/cleanup boundary behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so REST and WebSocket chat behavior, observer refresh and delivery behavior, session consolidation behavior, strategist and scheduled proactive flow behavior, delegated tool-heavy workflow behavior, ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, capability-aware runtime policy intents, weighted provider policy scoring, structured routing decision auditing, session-bound helper LLM trace visibility, runtime-path primary and fallback overrides, local helper/agent/all current scheduled-job/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, vault-repository, and filesystem boundary failures, context-window degradation, daily-briefing, activity-digest, and evening-review degraded-input fallback auditing, tool/MCP policy guardrails, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, screen observation summary/cleanup boundary behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -33,7 +33,7 @@ Legend for the checklist column:
 |---|---|---|
 | 01. Trust Boundaries | `[ ]` | Policy modes, approvals, audit logging, and secret handling are shipped; deeper isolation and narrower privileged execution paths are still left |
 | 02. Execution Plane | `[ ]` | Real tools, MCP, browser, shell, filesystem, goals, vault, and web search are shipped; richer workflow execution and stronger execution safety are still left |
-| 03. Runtime Reliability | `[ ]` | Fallback chains, routing rules, local runtime paths, broad audit visibility, and deterministic runtime evals are shipped; provider scoring and broader guardian eval depth are still left |
+| 03. Runtime Reliability | `[ ]` | Fallback chains, routing rules, local runtime paths, provider scoring, broad audit visibility, and guardian-behavior runtime evals are shipped; richer provider policy and still broader eval depth are still left |
 | 04. Presence And Reach | `[ ]` | Browser UI, WebSocket chat, proactive delivery, observer refresh, and native daemon foundations are shipped; native notifications and broader channel reach are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, goals, strategist, briefings, reviews, and observer-driven state are shipped foundations; explicit guardian state, intervention policy, and feedback loops are still left |
 | 06. Embodied UX | `[ ]` | The current village UI is shipped, but the target interface is now a dense guardian cockpit rather than a village-first shell |
@@ -53,7 +53,7 @@ This is the rolling execution queue. It should always show the next 10 most valu
 
 1. [x] `provider-policy-scoring`:
    add weighted capability scoring on top of the current routing stack so target selection reflects value, not only explicit preference order
-2. [ ] `behavioral-evals-guardian-flows`:
+2. [x] `behavioral-evals-guardian-flows`:
    extend behavioral evals into observer refresh, consolidation, proactive delivery, and guardrail-sensitive guardian flows
 3. [ ] `guardian-state-synthesis`:
    merge observer signals, memory, goals, sessions, and confidence into one structured guardian-state input
@@ -104,7 +104,7 @@ This is the rolling execution queue. It should always show the next 10 most valu
 - [x] 9 scheduler jobs and 5 observer source boundaries wired into the current product
 - [x] provider-agnostic LLM runtime with ordered fallback chains, health-aware rerouting, runtime-path profile preferences, wildcard path rules, runtime-path model overrides, runtime-path fallback overrides, and local-runtime routing across helper, scheduled, agent, delegation, and MCP-specialist paths
 - [x] runtime audit visibility across chat, session-bound helper and agent LLM traces, scheduler including daily-briefing, activity-digest, and evening-review degraded-input fallbacks, observer, screen observation summary/cleanup, proactive delivery transport, MCP lifecycle and manual test API flows, skills toggle/reload flows, embedding, vector store, soul file, vault repository, filesystem, browser, sandbox, and web search paths
-- [x] deterministic eval harness coverage for core runtime, audit, REST and WebSocket chat behavior, proactive flow behavior, delegated workflow behavior, observer, storage, tool-boundary, vault repository, MCP test API, skills API, screen repository, and daily-briefing, activity-digest, plus evening-review degraded-input contracts
+- [x] deterministic eval harness coverage for core runtime, audit, REST and WebSocket chat behavior, observer refresh and delivery behavior, session consolidation behavior, tool/MCP guardrail behavior, proactive flow behavior, delegated workflow behavior, observer, storage, tool-boundary, vault repository, MCP test API, skills API, screen repository, and daily-briefing, activity-digest, plus evening-review degraded-input contracts
 
 ## Recommended Reading Order
 

--- a/docs/implementation/03-runtime-reliability.md
+++ b/docs/implementation/03-runtime-reliability.md
@@ -18,19 +18,19 @@
 - [x] timeout-safe audit visibility into primary-vs-fallback completion and agent-model behavior
 - [x] session-bound LLM runtime traces for helper and agent flows, including request-id visibility for routing and fallback decisions
 - [x] fallback-capable model wrappers for chat, onboarding, strategist, and specialists
-- [x] repeatable runtime eval harness for guardian, core chat behavior, proactive flow behavior, delegated workflow behavior, observer, storage, and integration seam checks
+- [x] repeatable runtime eval harness for guardian, core chat behavior, observer refresh and delivery behavior, session consolidation behavior, tool/MCP policy guardrails, proactive flow behavior, delegated workflow behavior, observer, storage, and integration seam checks
 - [x] runtime audit coverage across chat, WebSocket, scheduler jobs including daily-briefing, activity-digest, and evening-review degraded-input fallbacks, strategist helpers, proactive delivery transport, MCP lifecycle and manual test API paths, skills toggle/reload paths, observer lifecycle plus screen observation summary/cleanup boundaries, embedding, vector store, soul file, vault repository, filesystem, browser, sandbox, and web search paths
 
 ## Working On Now
 
 - [x] Runtime Reliability remains the repo-wide hardening track
-- [x] this workstream owns the first two items in the repo-wide 10-PR horizon
-- [ ] close the remaining routing and eval gaps outside the already-covered seams
+- [x] this workstream has shipped the first two items in the current repo-wide 10-PR horizon
+- [ ] richer provider policy and broader eval depth still remain after the current guardian-flow branch
 
 ## Still To Do On `develop`
 
-- [ ] add weighted provider policy scoring on top of the current capability-intent routing
-- [ ] expand eval coverage beyond the shipped REST, WebSocket, proactive, and delegated behavioral contracts into broader guardian behavioral coverage
+- [ ] deepen provider selection policy beyond weighted capability scoring, path patterns, explicit overrides, ordered fallbacks, and cooldown rerouting
+- [ ] expand eval coverage beyond the shipped REST, WebSocket, observer refresh, delivery policy, consolidation, proactive, tool-policy guardrail, and delegated behavioral contracts
 
 ## Completed PR Sequence
 
@@ -57,7 +57,7 @@ This is the next ordered Runtime Reliability slice after the completed incident-
 
 1. [x] `provider-policy-scoring`:
    deepen provider routing with weighted policy scoring, explicit capability preferences, and clearer target ranking so runtime-path selection is stronger than simple preference chains and cooldown skips
-2. [ ] `behavioral-evals-guardian-flows`:
+2. [x] `behavioral-evals-guardian-flows`:
    expand behavioral eval coverage beyond chat and scheduler seams into observer refresh, consolidation, proactive delivery, and policy-mode guardrails so broader guardian behavior is regression-tested
 
 ## Non-Goals
@@ -72,4 +72,4 @@ This is the next ordered Runtime Reliability slice after the completed incident-
 - [x] dynamic runtime paths can inherit wildcard routing rules without losing exact-path control
 - [x] a local or non-OpenRouter path is demonstrably possible across helper, all current scheduled completion jobs, core agent, delegation, and connected MCP-specialist flows
 - [x] key flows are observable and easy to debug
-- [ ] the project has broad repeatable eval coverage for core guardian behavior beyond the shipped REST, WebSocket, proactive, and delegated behavioral contracts
+- [ ] the project has broad repeatable eval coverage for core guardian behavior beyond the shipped REST, WebSocket, observer refresh, delivery policy, consolidation, proactive, tool-policy guardrail, and delegated behavioral contracts

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -74,7 +74,7 @@ title: Seraph Development Status
 - [x] runtime-path-specific fallback-chain overrides
 - [x] first-class local runtime routing for helper, all current scheduled completion jobs, core agent, delegation, and connected MCP-specialist paths
 - [x] runtime audit visibility across chat, WebSocket, session-bound helper LLM traces, scheduler including daily-briefing, activity-digest, and evening-review degraded-input fallback paths, strategist, proactive delivery transport, MCP lifecycle and manual test API flows, skills toggle/reload flows, observer plus screen observation summary/cleanup boundaries, embedding, vector store, soul file, vault repository, filesystem, browser, sandbox, and web search flows
-- [x] deterministic runtime eval harness for fallback, routing, core chat behavior, proactive flow behavior, delegated workflow behavior, storage, observer, and integration seam contracts, including vault repository, the MCP test API, skills API, screen repository boundaries, and daily-briefing, activity-digest, plus evening-review degraded-input audit behavior
+- [x] deterministic runtime eval harness for fallback, routing, core chat behavior, observer refresh and delivery behavior, session consolidation behavior, tool/MCP policy guardrails, proactive flow behavior, delegated workflow behavior, storage, observer, and integration seam contracts, including vault repository, the MCP test API, skills API, screen repository boundaries, and daily-briefing, activity-digest, plus evening-review degraded-input audit behavior
 
 ### Guardian intelligence and proactive behavior
 
@@ -102,8 +102,8 @@ title: Seraph Development Status
 
 ### Runtime and execution
 
-- [ ] richer provider selection policy beyond path patterns, explicit overrides, ordered fallbacks, and cooldown rerouting
-- [ ] broader eval coverage beyond the shipped REST, WebSocket, proactive, and delegated behavioral contracts
+- [ ] richer provider selection policy beyond weighted scoring, path patterns, explicit overrides, ordered fallbacks, and cooldown rerouting
+- [ ] broader eval coverage beyond the shipped REST, WebSocket, observer refresh, delivery policy, consolidation, proactive, tool/MCP guardrail, and delegated behavioral contracts
 - [ ] stronger execution isolation and privileged-path hardening
 
 ### Guardian intelligence


### PR DESCRIPTION
## Done on develop
- [x] runtime routing already ships provider scoring, structured routing audit, and local runtime coverage across helper, scheduled, agent, delegation, and MCP-specialist paths
- [x] the deterministic eval harness already covers chat, proactive jobs, delegated workflows, and observer/storage/integration seam contracts

## Working in this PR
- [x] add guardian behavioral evals for observer refresh, delivery decisions, session consolidation, and tool/MCP policy guardrails
- [x] extend the harness test surface and public scenario list so those guardian contracts are pinned in code
- [x] update the roadmap, runtime reliability doc, status ledger, and testing guide so behavioral-evals-guardian-flows is reflected accurately and the queue hands off to guardian-state-synthesis

## Still to do after this PR
- [ ] guardian-state-synthesis
- [ ] intervention-policy-v1
- [ ] native-presence-notifications

## Validation
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_eval_harness.py tests/test_observer_manager.py tests/test_consolidator.py tests/test_delivery.py tests/test_tools_api.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario observer_refresh_behavior --scenario observer_delivery_decision_behavior --scenario session_consolidation_behavior --scenario tool_policy_guardrails_behavior --indent 2
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m py_compile src/evals/harness.py tests/test_eval_harness.py
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build
