### PR TITLE
Add explicit guardian state synthesis

### DIFF
--- a/backend/src/agent/factory.py
+++ b/backend/src/agent/factory.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from smolagents import ToolCallingAgent
 
 from config.settings import settings
+from src.guardian.state import GuardianState
 from src.llm_runtime import FallbackLiteLLMModel as LiteLLMModel, build_model_kwargs
 from src.plugins.loader import discover_tools
 from src.skills.manager import skill_manager
@@ -59,6 +62,7 @@ def create_agent(
     soul_context: str = "",
     memory_context: str = "",
     observer_context: str = "",
+    guardian_state: GuardianState | None = None,
 ) -> ToolCallingAgent:
     """Create a ToolCallingAgent with LiteLLM model and tools.
 
@@ -78,12 +82,18 @@ def create_agent(
         "their highest potential across productivity, performance, health, influence, "
         "and growth. Be concise, strategic, and helpful."
     )
+    if guardian_state is not None:
+        soul_context = guardian_state.soul_context
+        memory_context = guardian_state.memory_context
+        additional_context = guardian_state.current_session_history or additional_context
+        instructions += f"\n\n--- GUARDIAN STATE ---\n{guardian_state.to_prompt_block()}"
+    elif observer_context:
+        instructions += f"\n\n--- CURRENT CONTEXT ---\n{observer_context}"
+
     if soul_context:
         instructions += f"\n\n--- USER IDENTITY ---\n{soul_context}"
     if memory_context:
         instructions += f"\n\n--- RELEVANT MEMORIES ---\n{memory_context}"
-    if observer_context:
-        instructions += f"\n\n--- CURRENT CONTEXT ---\n{observer_context}"
 
     # Inject active skills into instructions
     active_skills = skill_manager.get_active_skills(tool_names)
@@ -111,6 +121,7 @@ def create_orchestrator(
     soul_context: str = "",
     memory_context: str = "",
     observer_context: str = "",
+    guardian_state: GuardianState | None = None,
 ) -> ToolCallingAgent:
     """Create an orchestrator agent that delegates to specialist sub-agents.
 
@@ -142,12 +153,18 @@ def create_orchestrator(
         "- Give clear, specific task descriptions when delegating.\n"
         "- Synthesize specialist results into a natural response."
     )
+    if guardian_state is not None:
+        soul_context = guardian_state.soul_context
+        memory_context = guardian_state.memory_context
+        additional_context = guardian_state.current_session_history or additional_context
+        instructions += f"\n\n--- GUARDIAN STATE ---\n{guardian_state.to_prompt_block()}"
+    elif observer_context:
+        instructions += f"\n\n--- CURRENT CONTEXT ---\n{observer_context}"
+
     if soul_context:
         instructions += f"\n\n--- USER IDENTITY ---\n{soul_context}"
     if memory_context:
         instructions += f"\n\n--- RELEVANT MEMORIES ---\n{memory_context}"
-    if observer_context:
-        instructions += f"\n\n--- CURRENT CONTEXT ---\n{observer_context}"
 
     # Inject active skills into instructions
     active_skills = skill_manager.get_active_skills(all_tool_names)
@@ -176,11 +193,38 @@ def build_agent(
     soul_context: str = "",
     memory_context: str = "",
     observer_context: str = "",
+    guardian_state: GuardianState | None = None,
 ) -> ToolCallingAgent:
     """Build the appropriate agent based on delegation feature flag.
 
     Drop-in replacement for create_agent() at call sites.
     """
     if settings.use_delegation:
-        return create_orchestrator(additional_context, soul_context, memory_context, observer_context)
-    return create_agent(additional_context, soul_context, memory_context, observer_context)
+        if guardian_state is not None:
+            return create_orchestrator(
+                additional_context,
+                soul_context,
+                memory_context,
+                observer_context,
+                guardian_state=guardian_state,
+            )
+        return create_orchestrator(
+            additional_context,
+            soul_context,
+            memory_context,
+            observer_context,
+        )
+    if guardian_state is not None:
+        return create_agent(
+            additional_context,
+            soul_context,
+            memory_context,
+            observer_context,
+            guardian_state=guardian_state,
+        )
+    return create_agent(
+        additional_context,
+        soul_context,
+        memory_context,
+        observer_context,
+    )

--- a/backend/src/agent/session.py
+++ b/backend/src/agent/session.py
@@ -88,6 +88,46 @@ class SessionManager:
                 for r in rows
             ]
 
+    async def get_recent_sessions_summary(
+        self,
+        *,
+        exclude_session_id: str | None = None,
+        limit_sessions: int = 3,
+        snippet_chars: int = 140,
+    ) -> str:
+        """Summarize recent sessions outside the current thread for guardian state."""
+        async with get_session() as db:
+            stmt = select(Session)
+            if exclude_session_id:
+                stmt = stmt.where(Session.id != exclude_session_id)
+            result = await db.execute(
+                stmt.order_by(col(Session.updated_at).desc()).limit(limit_sessions)
+            )
+            sessions = result.scalars().all()
+            if not sessions:
+                return ""
+
+            lines: list[str] = []
+            for session in sessions:
+                msg_result = await db.execute(
+                    select(Message)
+                    .where(Message.session_id == session.id)
+                    .where(Message.role.in_(["user", "assistant"]))  # type: ignore[attr-defined]
+                    .order_by(col(Message.created_at).desc())
+                    .limit(1)
+                )
+                latest = msg_result.scalars().first()
+                title = session.title or "Untitled session"
+                if latest and latest.content:
+                    snippet = latest.content.replace("\n", " ").strip()
+                    if len(snippet) > snippet_chars:
+                        snippet = snippet[:snippet_chars] + "..."
+                    lines.append(f"- {title}: {latest.role} said \"{snippet}\"")
+                else:
+                    lines.append(f"- {title}: no user-facing messages yet")
+
+            return "\n".join(lines)
+
     async def update_title(self, session_id: str, title: str) -> bool:
         async with get_session() as db:
             result = await db.execute(select(Session).where(Session.id == session_id))

--- a/backend/src/agent/strategist.py
+++ b/backend/src/agent/strategist.py
@@ -1,5 +1,7 @@
 """Strategist agent — periodic strategic reasoning with restricted tool set."""
 
+from __future__ import annotations
+
 import json
 import logging
 from dataclasses import dataclass
@@ -7,6 +9,7 @@ from dataclasses import dataclass
 from smolagents import ToolCallingAgent
 
 from config.settings import settings
+from src.guardian.state import GuardianState
 from src.llm_runtime import FallbackLiteLLMModel as LiteLLMModel, build_model_kwargs
 from src.tools.audit import wrap_tools_for_audit
 from src.tools.soul_tool import view_soul
@@ -62,13 +65,20 @@ class StrategistDecision:
     reasoning: str
 
 
-def create_strategist_agent(context_block: str) -> ToolCallingAgent:
+def create_strategist_agent(
+    context_block: str = "",
+    *,
+    guardian_state: GuardianState | None = None,
+) -> ToolCallingAgent:
     """Create a restricted agent for strategic reasoning."""
     model = LiteLLMModel(**build_model_kwargs(
         temperature=0.4,
         max_tokens=settings.model_max_tokens,
         runtime_path="strategist_agent",
     ))
+
+    if guardian_state is not None:
+        context_block = guardian_state.to_prompt_block()
 
     instructions = STRATEGIST_INSTRUCTIONS.format(
         proactivity_level=settings.proactivity_level,

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -15,8 +15,7 @@ from src.agent.session import session_manager
 from src.audit.runtime import log_agent_run_event
 from src.audit.repository import audit_repository
 from src.api.profile import get_or_create_profile, mark_onboarding_complete
-from src.memory.soul import read_soul
-from src.memory.vector_store import search_formatted
+from src.guardian.state import build_guardian_state
 from src.models.schemas import ChatRequest, ChatResponse
 from src.tools.policy import get_current_tool_policy_mode
 from src.vault.redaction import redact_secrets_in_text
@@ -44,19 +43,11 @@ async def chat(request: ChatRequest):
     if not profile.onboarding_completed:
         agent = create_onboarding_agent()
     else:
-        history = await session_manager.get_history_text(session.id)
-        soul = read_soul()
-        memories = await asyncio.to_thread(search_formatted, request.message)
-
-        from src.observer.manager import context_manager as obs_manager
-        observer_context = obs_manager.get_context().to_prompt_block()
-
-        agent = build_agent(
-            additional_context=history,
-            soul_context=soul,
-            memory_context=memories,
-            observer_context=observer_context,
+        guardian_state = await build_guardian_state(
+            session_id=session.id,
+            user_message=request.message,
         )
+        agent = build_agent(guardian_state=guardian_state)
 
     try:
         from src.observer.manager import context_manager as obs_manager

--- a/backend/src/api/ws.py
+++ b/backend/src/api/ws.py
@@ -18,8 +18,7 @@ from src.audit.formatting import format_tool_call_summary
 from src.audit.runtime import log_agent_run_event
 from src.audit.repository import audit_repository
 from src.api.profile import get_or_create_profile, mark_onboarding_complete, reset_onboarding
-from src.memory.soul import read_soul
-from src.memory.vector_store import search_formatted
+from src.guardian.state import build_guardian_state
 from src.models.schemas import WSMessage, WSResponse
 from src.scheduler.connection_manager import ws_manager
 from src.tools.policy import get_current_tool_policy_mode
@@ -66,19 +65,11 @@ async def _build_agent(session_id: str, message: str):
     if not profile.onboarding_completed:
         return create_onboarding_agent(), True, set()
 
-    history = await session_manager.get_history_text(session_id)
-    soul = read_soul()
-    memories = await asyncio.to_thread(search_formatted, message)
-
-    from src.observer.manager import context_manager as obs_manager
-    observer_context = obs_manager.get_context().to_prompt_block()
-
-    agent = build_agent(
-        additional_context=history,
-        soul_context=soul,
-        memory_context=memories,
-        observer_context=observer_context,
+    guardian_state = await build_guardian_state(
+        session_id=session_id,
+        user_message=message,
     )
+    agent = build_agent(guardian_state=guardian_state)
     specialist_names = (
         set(agent.managed_agents.keys())
         if hasattr(agent, "managed_agents") and agent.managed_agents

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -33,10 +33,11 @@ from config.settings import settings
 from src.approval.exceptions import ApprovalRequired
 from src.agent.session import SessionManager, session_manager
 from src.agent.context_window import _summarize_middle, _summary_cache
-from src.agent.factory import create_orchestrator, get_model
+from src.agent.factory import create_agent, create_orchestrator, get_model
 from src.agent.onboarding import create_onboarding_agent
 from src.agent.specialists import create_mcp_specialist, create_specialist, mcp_specialist_runtime_path
 from src.agent.strategist import create_strategist_agent
+from src.guardian.state import build_guardian_state
 from src.api.mcp import test_server as test_mcp_server
 from src.api.observer import ScreenContextRequest, ScreenObservationData, post_screen_context
 from src.api.skills import UpdateSkillRequest, reload_skills as reload_skill_api, update_skill as update_skill_api
@@ -2799,7 +2800,7 @@ async def _eval_strategist_tick_tool_audit() -> dict[str, Any]:
             )
 
     with (
-        patch("src.observer.manager.context_manager", mock_context_manager),
+        patch("src.scheduler.jobs.strategist_tick.build_guardian_state", AsyncMock(return_value=MagicMock())),
         patch("src.scheduler.jobs.strategist_tick.create_strategist_agent", return_value=DummyAgent()),
         patch.object(audit_repository, "log_event", mock_log_event),
     ):
@@ -2825,7 +2826,7 @@ async def _eval_strategist_tick_behavior() -> dict[str, Any]:
     mock_log_event = AsyncMock()
 
     with (
-        patch("src.observer.manager.context_manager", mock_context_manager),
+        patch("src.scheduler.jobs.strategist_tick.build_guardian_state", AsyncMock(return_value=MagicMock())),
         patch("src.scheduler.jobs.strategist_tick.create_strategist_agent", return_value=mock_agent),
         patch("src.observer.delivery.deliver_or_queue", mock_deliver),
         patch.object(audit_repository, "log_event", mock_log_event),
@@ -2950,6 +2951,50 @@ async def _eval_session_title_generation_background_audit() -> dict[str, Any]:
         "session_id": success["session_id"],
         "title_length": success["details"]["title_length"],
     }
+
+
+async def _eval_guardian_state_synthesis() -> dict[str, Any]:
+    async with _patched_async_db("src.agent.session.get_session"):
+        await session_manager.get_or_create("current")
+        await session_manager.add_message("current", "user", "What should Seraph improve next?")
+        await session_manager.add_message("current", "assistant", "Build explicit guardian state.")
+        await session_manager.get_or_create("prior")
+        await session_manager.update_title("prior", "Prior roadmap")
+        await session_manager.add_message("prior", "assistant", "Land guardian-state synthesis next.")
+
+        ctx = _make_context(
+            active_goals_summary="Ship guardian state",
+            active_window="VS Code",
+            screen_context="Editing roadmap",
+            data_quality="good",
+        )
+
+        with (
+            patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+            patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
+            patch("src.memory.vector_store.search_formatted", return_value="- [goal] Ship guardian state"),
+            patch("src.agent.factory.get_model", return_value=MagicMock()),
+            patch("src.agent.factory.ToolCallingAgent") as mock_agent_cls,
+        ):
+            state = await build_guardian_state(
+                session_id="current",
+                user_message="What should Seraph improve next?",
+            )
+            create_agent(guardian_state=state)
+
+        instructions = mock_agent_cls.call_args.kwargs["instructions"]
+        return {
+            "overall_confidence": state.confidence.overall,
+            "observer_confidence": state.confidence.observer,
+            "memory_confidence": state.confidence.memory,
+            "current_session_confidence": state.confidence.current_session,
+            "recent_sessions_confidence": state.confidence.recent_sessions,
+            "goal_summary": state.active_goals_summary,
+            "recent_sessions_contains_title": "Prior roadmap" in state.recent_sessions_summary,
+            "current_history_mentions_guardian_state": "Build explicit guardian state." in state.current_session_history,
+            "instructions_include_guardian_state": "--- GUARDIAN STATE ---" in instructions,
+            "instructions_include_recent_sessions": "Recent sessions:" in instructions,
+        }
 
 
 async def _eval_observer_delivery_gate_audit() -> dict[str, Any]:
@@ -3712,6 +3757,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="behavior",
         description="Strategist tick delivers the modeled intervention and records the resulting delivery outcome.",
         runner=_eval_strategist_tick_behavior,
+    ),
+    EvalScenario(
+        name="guardian_state_synthesis",
+        category="guardian",
+        description="Guardian state synthesis unifies observer context, memories, recent sessions, and confidence into one downstream state object.",
+        runner=_eval_guardian_state_synthesis,
     ),
     EvalScenario(
         name="observer_refresh_behavior",

--- a/backend/src/guardian/__init__.py
+++ b/backend/src/guardian/__init__.py
@@ -1,0 +1,5 @@
+"""Guardian state synthesis utilities."""
+
+from .state import GuardianState, GuardianStateConfidence, build_guardian_state
+
+__all__ = ["GuardianState", "GuardianStateConfidence", "build_guardian_state"]

--- a/backend/src/guardian/state.py
+++ b/backend/src/guardian/state.py
@@ -1,0 +1,146 @@
+"""Explicit guardian-state synthesis for downstream agent and scheduler paths."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from src.agent.session import session_manager
+from src.observer.context import CurrentContext
+
+
+@dataclass(frozen=True)
+class GuardianStateConfidence:
+    overall: str
+    observer: str
+    memory: str
+    current_session: str
+    recent_sessions: str
+
+
+@dataclass(frozen=True)
+class GuardianState:
+    soul_context: str
+    observer_context: CurrentContext
+    memory_context: str
+    current_session_history: str
+    recent_sessions_summary: str
+    confidence: GuardianStateConfidence
+
+    @property
+    def active_goals_summary(self) -> str:
+        return self.observer_context.active_goals_summary
+
+    def to_prompt_block(self) -> str:
+        """Render the synthesized guardian state as one operator-facing block."""
+        lines = [
+            f"Overall confidence: {self.confidence.overall}",
+            f"Observer confidence: {self.confidence.observer}",
+            f"Memory confidence: {self.confidence.memory}",
+            f"Current session confidence: {self.confidence.current_session}",
+            f"Recent sessions confidence: {self.confidence.recent_sessions}",
+            "",
+            "Observer snapshot:",
+            self.observer_context.to_prompt_block(),
+        ]
+
+        if self.active_goals_summary:
+            lines.extend(["", "Active goals:", self.active_goals_summary])
+
+        if self.memory_context:
+            lines.extend(["", "Relevant memories:", self.memory_context])
+
+        if self.recent_sessions_summary:
+            lines.extend(["", "Recent sessions:", self.recent_sessions_summary])
+
+        return "\n".join(lines)
+
+
+def _status_for_text(text: str, *, requested: bool = True) -> str:
+    if not requested:
+        return "not_requested"
+    return "grounded" if text.strip() else "empty"
+
+
+def _overall_confidence(
+    *,
+    observer_quality: str,
+    memory_status: str,
+    current_session_status: str,
+    recent_sessions_status: str,
+) -> str:
+    grounded_signals = sum(
+        1
+        for status in (memory_status, current_session_status, recent_sessions_status)
+        if status == "grounded"
+    )
+    if observer_quality == "stale":
+        return "degraded"
+    if observer_quality == "degraded":
+        return "partial" if grounded_signals else "degraded"
+    if grounded_signals >= 2:
+        return "grounded"
+    return "partial"
+
+
+async def build_guardian_state(
+    *,
+    session_id: str | None = None,
+    user_message: str | None = None,
+    memory_query: str | None = None,
+    refresh_observer: bool = False,
+) -> GuardianState:
+    """Build one explicit guardian-state object from current repo surfaces."""
+    from src.memory.soul import read_soul
+    from src.memory.vector_store import search_formatted
+    from src.observer.manager import context_manager
+
+    observer_context = (
+        await context_manager.refresh() if refresh_observer else context_manager.get_context()
+    )
+    soul_context = read_soul()
+
+    current_session_history = (
+        await session_manager.get_history_text(session_id)
+        if session_id is not None
+        else ""
+    )
+    recent_sessions_summary = await session_manager.get_recent_sessions_summary(
+        exclude_session_id=session_id
+    )
+
+    query = user_message or memory_query or ""
+    memory_requested = bool(query.strip())
+    memory_context = (
+        await asyncio.to_thread(search_formatted, query)
+        if memory_requested
+        else ""
+    )
+
+    confidence = GuardianStateConfidence(
+        overall=_overall_confidence(
+            observer_quality=observer_context.data_quality,
+            memory_status=_status_for_text(memory_context, requested=memory_requested),
+            current_session_status=_status_for_text(
+                current_session_history,
+                requested=session_id is not None,
+            ),
+            recent_sessions_status=_status_for_text(recent_sessions_summary),
+        ),
+        observer=observer_context.data_quality,
+        memory=_status_for_text(memory_context, requested=memory_requested),
+        current_session=_status_for_text(
+            current_session_history,
+            requested=session_id is not None,
+        ),
+        recent_sessions=_status_for_text(recent_sessions_summary),
+    )
+
+    return GuardianState(
+        soul_context=soul_context,
+        observer_context=observer_context,
+        memory_context=memory_context,
+        current_session_history=current_session_history,
+        recent_sessions_summary=recent_sessions_summary,
+        confidence=confidence,
+    )

--- a/backend/src/scheduler/jobs/strategist_tick.py
+++ b/backend/src/scheduler/jobs/strategist_tick.py
@@ -9,6 +9,7 @@ from src.approval.runtime import reset_runtime_context, set_runtime_context
 from config.settings import settings
 from src.agent.strategist import create_strategist_agent, parse_strategist_response
 from src.audit.runtime import log_scheduler_job_event
+from src.guardian.state import build_guardian_state
 from src.llm_runtime import (
     _finish_request,
     _mark_request_timed_out,
@@ -26,12 +27,11 @@ async def run_strategist_tick() -> None:
     """Review context and decide if proactive intervention is warranted."""
     started_at = perf_counter()
     try:
-        from src.observer.manager import context_manager
-
-        ctx = await context_manager.refresh()
-        context_block = ctx.to_prompt_block()
-
-        agent = create_strategist_agent(context_block)
+        guardian_state = await build_guardian_state(
+            refresh_observer=True,
+            memory_query="current priorities, commitments, and recent intervention patterns",
+        )
+        agent = create_strategist_agent(guardian_state=guardian_state)
         llm_request_id = f"strategist_tick:{started_at}"
         _register_request(llm_request_id)
         runtime_tokens = set_runtime_context(_STRATEGIST_RUNTIME_SESSION_ID, "high_risk")

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -51,6 +51,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "websocket_chat_approval_contract" in captured.out
     assert "websocket_chat_timeout_contract" in captured.out
     assert "strategist_tick_behavior" in captured.out
+    assert "guardian_state_synthesis" in captured.out
     assert "observer_refresh_behavior" in captured.out
     assert "observer_delivery_decision_behavior" in captured.out
     assert "provider_fallback_chain" in captured.out
@@ -138,6 +139,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "websocket_chat_approval_contract",
                 "websocket_chat_timeout_contract",
                 "strategist_tick_behavior",
+                "guardian_state_synthesis",
                 "observer_refresh_behavior",
                 "observer_delivery_decision_behavior",
                 "agent_local_runtime_profile",
@@ -245,6 +247,16 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["strategist_tick_behavior"]["content_mentions_refocus"] is True
     assert details_by_name["strategist_tick_behavior"]["delivery"] == "deliver"
     assert details_by_name["strategist_tick_behavior"]["reasoning"] == "Focus drift"
+    assert details_by_name["guardian_state_synthesis"]["overall_confidence"] == "grounded"
+    assert details_by_name["guardian_state_synthesis"]["observer_confidence"] == "good"
+    assert details_by_name["guardian_state_synthesis"]["memory_confidence"] == "grounded"
+    assert details_by_name["guardian_state_synthesis"]["current_session_confidence"] == "grounded"
+    assert details_by_name["guardian_state_synthesis"]["recent_sessions_confidence"] == "grounded"
+    assert details_by_name["guardian_state_synthesis"]["goal_summary"] == "Ship guardian state"
+    assert details_by_name["guardian_state_synthesis"]["recent_sessions_contains_title"] is True
+    assert details_by_name["guardian_state_synthesis"]["current_history_mentions_guardian_state"] is True
+    assert details_by_name["guardian_state_synthesis"]["instructions_include_guardian_state"] is True
+    assert details_by_name["guardian_state_synthesis"]["instructions_include_recent_sessions"] is True
     assert details_by_name["observer_refresh_behavior"]["new_user_state"] == "transitioning"
     assert details_by_name["observer_refresh_behavior"]["data_quality"] == "good"
     assert details_by_name["observer_refresh_behavior"]["screen_context_preserved"] is True

--- a/backend/tests/test_guardian_state.py
+++ b/backend/tests/test_guardian_state.py
@@ -1,0 +1,112 @@
+"""Tests for explicit guardian-state synthesis."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.agent.factory import create_agent
+from src.agent.session import SessionManager
+from src.agent.strategist import create_strategist_agent
+from src.guardian.state import GuardianState, GuardianStateConfidence, build_guardian_state
+from src.observer.context import CurrentContext
+
+
+def _make_guardian_state() -> GuardianState:
+    return GuardianState(
+        soul_context="# Soul\n\n## Identity\nBuilder",
+        observer_context=CurrentContext(
+            time_of_day="morning",
+            day_of_week="Monday",
+            is_working_hours=True,
+            active_goals_summary="Ship guardian state",
+            active_window="VS Code",
+            screen_context="Editing roadmap",
+            data_quality="good",
+        ),
+        memory_context="- [goal] Ship guardian state\n- [pattern] Prefers dense dashboards",
+        current_session_history="User: What should Seraph improve next?\nAssistant: Build explicit guardian state.",
+        recent_sessions_summary='- Prior roadmap: assistant said "Land guardian-state synthesis next"',
+        confidence=GuardianStateConfidence(
+            overall="grounded",
+            observer="good",
+            memory="grounded",
+            current_session="grounded",
+            recent_sessions="grounded",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_guardian_state_collects_memory_and_recent_sessions(async_db):
+    sm = SessionManager()
+    await sm.get_or_create("current")
+    await sm.add_message("current", "user", "What should Seraph improve next?")
+    await sm.add_message("current", "assistant", "Build explicit guardian state.")
+    await sm.get_or_create("prior")
+    await sm.update_title("prior", "Prior roadmap")
+    await sm.add_message("prior", "assistant", "Land guardian-state synthesis next.")
+
+    ctx = CurrentContext(
+        time_of_day="morning",
+        day_of_week="Monday",
+        is_working_hours=True,
+        active_goals_summary="Ship guardian state",
+        active_window="VS Code",
+        screen_context="Editing roadmap",
+        data_quality="good",
+    )
+
+    with (
+        patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+        patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
+        patch("src.memory.vector_store.search_formatted", return_value="- [goal] Ship guardian state"),
+    ):
+        state = await build_guardian_state(session_id="current", user_message="What should Seraph improve next?")
+
+    assert state.soul_context == "# Soul\n\n## Identity\nBuilder"
+    assert state.active_goals_summary == "Ship guardian state"
+    assert state.confidence.overall == "grounded"
+    assert state.confidence.observer == "good"
+    assert state.confidence.memory == "grounded"
+    assert state.confidence.current_session == "grounded"
+    assert state.confidence.recent_sessions == "grounded"
+    assert "Build explicit guardian state." in state.current_session_history
+    assert "Prior roadmap" in state.recent_sessions_summary
+    assert "Ship guardian state" in state.memory_context
+
+
+def test_guardian_state_prompt_block_exposes_confidence_and_recent_sessions():
+    block = _make_guardian_state().to_prompt_block()
+
+    assert "Overall confidence: grounded" in block
+    assert "Observer snapshot:" in block
+    assert "Relevant memories:" in block
+    assert "Recent sessions:" in block
+    assert "Ship guardian state" in block
+    assert "Prior roadmap" in block
+
+
+@patch("src.agent.factory.ToolCallingAgent")
+@patch("src.agent.factory.get_model")
+def test_create_agent_injects_guardian_state(mock_get_model, mock_agent_cls):
+    mock_get_model.return_value = MagicMock()
+    mock_agent_cls.return_value = MagicMock()
+
+    create_agent(guardian_state=_make_guardian_state())
+
+    instructions = mock_agent_cls.call_args[1]["instructions"]
+    assert "GUARDIAN STATE" in instructions
+    assert "Overall confidence: grounded" in instructions
+    assert "USER IDENTITY" in instructions
+    assert "RELEVANT MEMORIES" in instructions
+    assert "CONVERSATION HISTORY" in instructions
+
+
+@patch("src.agent.strategist.LiteLLMModel")
+def test_create_strategist_agent_accepts_guardian_state(mock_model_cls):
+    mock_model_cls.return_value = MagicMock()
+
+    agent = create_strategist_agent(guardian_state=_make_guardian_state())
+
+    assert "Overall confidence: grounded" in agent.instructions
+    assert "Recent sessions:" in agent.instructions

--- a/backend/tests/test_strategist_tick.py
+++ b/backend/tests/test_strategist_tick.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.audit.repository import audit_repository
+from src.guardian.state import GuardianState, GuardianStateConfidence
 from src.observer.context import CurrentContext
 from src.observer.user_state import DeliveryDecision
 from src.scheduler.jobs.strategist_tick import run_strategist_tick
@@ -33,6 +34,23 @@ class DummyStrategistTool(Tool):
         return "2 active goals"
 
 
+def _make_guardian_state() -> GuardianState:
+    return GuardianState(
+        soul_context="# Soul\n\n## Goals\n- Ship guardian state",
+        observer_context=_make_context(),
+        memory_context="- [goal] Ship guardian state",
+        current_session_history="",
+        recent_sessions_summary='- Prior roadmap: assistant said "Land guardian-state synthesis next"',
+        confidence=GuardianStateConfidence(
+            overall="grounded",
+            observer="good",
+            memory="grounded",
+            current_session="not_requested",
+            recent_sessions="grounded",
+        ),
+    )
+
+
 @pytest.mark.asyncio
 async def test_strategist_tick_logs_skip(async_db):
     mock_cm = MagicMock()
@@ -44,7 +62,7 @@ async def test_strategist_tick_logs_skip(async_db):
     )
 
     with (
-        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.scheduler.jobs.strategist_tick.build_guardian_state", AsyncMock(return_value=_make_guardian_state())),
         patch("src.scheduler.jobs.strategist_tick.create_strategist_agent", return_value=mock_agent),
     ):
         await run_strategist_tick()
@@ -70,7 +88,7 @@ async def test_strategist_tick_logs_success(async_db):
     mock_deliver = AsyncMock(return_value=DeliveryDecision.deliver)
 
     with (
-        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.scheduler.jobs.strategist_tick.build_guardian_state", AsyncMock(return_value=_make_guardian_state())),
         patch("src.scheduler.jobs.strategist_tick.create_strategist_agent", return_value=mock_agent),
         patch("src.observer.delivery.deliver_or_queue", mock_deliver),
     ):
@@ -100,7 +118,7 @@ async def test_strategist_tick_binds_runtime_context_for_tool_audit(async_db):
             )
 
     with (
-        patch("src.observer.manager.context_manager", mock_cm),
+        patch("src.scheduler.jobs.strategist_tick.build_guardian_state", AsyncMock(return_value=_make_guardian_state())),
         patch("src.scheduler.jobs.strategist_tick.create_strategist_agent", return_value=DummyAgent()),
     ):
         await run_strategist_tick()

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -42,6 +42,7 @@ uv run python -m src.evals.harness --scenario websocket_chat_behavior
 uv run python -m src.evals.harness --scenario websocket_chat_approval_contract
 uv run python -m src.evals.harness --scenario websocket_chat_timeout_contract
 uv run python -m src.evals.harness --scenario strategist_tick_behavior
+uv run python -m src.evals.harness --scenario guardian_state_synthesis
 uv run python -m src.evals.harness --scenario observer_refresh_behavior
 uv run python -m src.evals.harness --scenario observer_delivery_decision_behavior
 uv run python -m src.evals.harness --scenario provider_fallback_chain
@@ -93,7 +94,7 @@ uv run python -m src.evals.harness --scenario evening_review_degraded_delivery_b
 uv run python -m src.evals.harness --scenario evening_review_degraded_inputs_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so REST and WebSocket chat behavior, observer refresh and delivery behavior, session consolidation behavior, strategist and scheduled proactive flow behavior, delegated tool-heavy workflow behavior, ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, capability-aware runtime policy intents, weighted provider policy scoring, structured routing decision auditing, session-bound helper LLM trace visibility, runtime-path primary and fallback overrides, local helper/agent/all current scheduled-job/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, vault-repository, and filesystem boundary failures, context-window degradation, daily-briefing, activity-digest, and evening-review degraded-input fallback auditing, tool/MCP policy guardrails, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, screen observation summary/cleanup boundary behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so REST and WebSocket chat behavior, guardian-state synthesis, observer refresh and delivery behavior, session consolidation behavior, strategist and scheduled proactive flow behavior, delegated tool-heavy workflow behavior, ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, capability-aware runtime policy intents, weighted provider policy scoring, structured routing decision auditing, session-bound helper LLM trace visibility, runtime-path primary and fallback overrides, local helper/agent/all current scheduled-job/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, vault-repository, and filesystem boundary failures, context-window degradation, daily-briefing, activity-digest, and evening-review degraded-input fallback auditing, tool/MCP policy guardrails, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, screen observation summary/cleanup boundary behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -130,6 +131,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_goal_tree_integrity.py` | 12 | Goal tree integrity — parent-child relationships, path consistency, cascading |
 | `test_goals_api.py` | 10 | Goals HTTP endpoints — create, list, filter, tree, dashboard, update, delete |
 | `test_goals_repository.py` | 21 | GoalRepository — CRUD, tree building, dashboard stats, cascading deletes |
+| `test_guardian_state.py` | 4 | Guardian-state synthesis — state assembly, confidence labels, agent injection, strategist context |
 | `test_http_mcp_server.py` | 16 | HTTP MCP server — request handling, internal URL blocking, timeout, truncation |
 | `test_insight_queue.py` | 12 | Insight queue — enqueue, drain, peek, ordering, expiry |
 | `test_insight_queue_expiry.py` | 8 | Insight queue expiry — TTL, cleanup, edge cases |

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -35,7 +35,7 @@ Legend for the checklist column:
 | 02. Execution Plane | `[ ]` | Real tools, MCP, browser, shell, filesystem, goals, vault, and web search are shipped; richer workflow execution and stronger execution safety are still left |
 | 03. Runtime Reliability | `[ ]` | Fallback chains, routing rules, local runtime paths, provider scoring, broad audit visibility, and guardian-behavior runtime evals are shipped; richer provider policy and still broader eval depth are still left |
 | 04. Presence And Reach | `[ ]` | Browser UI, WebSocket chat, proactive delivery, observer refresh, and native daemon foundations are shipped; native notifications and broader channel reach are still left |
-| 05. Guardian Intelligence | `[ ]` | Soul, memory, goals, strategist, briefings, reviews, and observer-driven state are shipped foundations; explicit guardian state, intervention policy, and feedback loops are still left |
+| 05. Guardian Intelligence | `[ ]` | Soul, memory, goals, strategist, briefings, reviews, observer-driven state, and explicit guardian state are shipped foundations; intervention policy, salience modeling, and feedback loops are still left |
 | 06. Embodied UX | `[ ]` | The current village UI is shipped, but the target interface is now a dense guardian cockpit rather than a village-first shell |
 | 07. Ecosystem And Leverage | `[ ]` | Skills, MCP, catalog/install surfaces, and delegation foundations are shipped; workflow composition and stronger extension ergonomics are still left |
 
@@ -55,7 +55,7 @@ This is the rolling execution queue. It should always show the next 10 most valu
    add weighted capability scoring on top of the current routing stack so target selection reflects value, not only explicit preference order
 2. [x] `behavioral-evals-guardian-flows`:
    extend behavioral evals into observer refresh, consolidation, proactive delivery, and guardrail-sensitive guardian flows
-3. [ ] `guardian-state-synthesis`:
+3. [x] `guardian-state-synthesis`:
    merge observer signals, memory, goals, sessions, and confidence into one structured guardian-state input
 4. [ ] `intervention-policy-v1`:
    make intervene, defer, bundle, request-approval, and stay-silent decisions explicit and state-aware
@@ -103,8 +103,9 @@ This is the rolling execution queue. It should always show the next 10 most valu
 - [x] 17 built-in tool capabilities exposed through the registry, with native and MCP-backed execution surfaces
 - [x] 9 scheduler jobs and 5 observer source boundaries wired into the current product
 - [x] provider-agnostic LLM runtime with ordered fallback chains, health-aware rerouting, runtime-path profile preferences, wildcard path rules, runtime-path model overrides, runtime-path fallback overrides, and local-runtime routing across helper, scheduled, agent, delegation, and MCP-specialist paths
+- [x] explicit guardian-state synthesis across chat, WebSocket, and strategist paths, combining observer context, memory recall, session history, recent sessions, and confidence into one structured downstream input
 - [x] runtime audit visibility across chat, session-bound helper and agent LLM traces, scheduler including daily-briefing, activity-digest, and evening-review degraded-input fallbacks, observer, screen observation summary/cleanup, proactive delivery transport, MCP lifecycle and manual test API flows, skills toggle/reload flows, embedding, vector store, soul file, vault repository, filesystem, browser, sandbox, and web search paths
-- [x] deterministic eval harness coverage for core runtime, audit, REST and WebSocket chat behavior, observer refresh and delivery behavior, session consolidation behavior, tool/MCP guardrail behavior, proactive flow behavior, delegated workflow behavior, observer, storage, tool-boundary, vault repository, MCP test API, skills API, screen repository, and daily-briefing, activity-digest, plus evening-review degraded-input contracts
+- [x] deterministic eval harness coverage for core runtime, audit, REST and WebSocket chat behavior, guardian-state synthesis, observer refresh and delivery behavior, session consolidation behavior, tool/MCP guardrail behavior, proactive flow behavior, delegated workflow behavior, observer, storage, tool-boundary, vault repository, MCP test API, skills API, screen repository, and daily-briefing, activity-digest, plus evening-review degraded-input contracts
 
 ## Recommended Reading Order
 

--- a/docs/implementation/03-runtime-reliability.md
+++ b/docs/implementation/03-runtime-reliability.md
@@ -23,9 +23,9 @@
 
 ## Working On Now
 
-- [x] Runtime Reliability remains the repo-wide hardening track
+- [x] Runtime Reliability is no longer the repo-wide active focus after the first guardian behavior baseline shipped
 - [x] this workstream has shipped the first two items in the current repo-wide 10-PR horizon
-- [ ] richer provider policy and broader eval depth still remain after the current guardian-flow branch
+- [ ] richer provider policy and broader eval depth still remain in the queue after the current guardian-intelligence slice
 
 ## Still To Do On `develop`
 

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -12,16 +12,16 @@
 - [x] strategist agent with restricted guardian tool set
 - [x] daily briefing, evening review, activity digest, and weekly activity review foundations
 - [x] observer-driven user-state and attention-budget modeling
+- [x] explicit guardian-state synthesis that unifies observer context, memory, current session, recent sessions, and confidence for downstream agent paths
 
 ## Working On Now
 
-- [ ] this workstream is not the repo-wide active focus while Runtime Reliability is still being hardened
-- [x] this workstream owns `guardian-state-synthesis`, `intervention-policy-v1`, `guardian-feedback-loop`, and `observer-salience-and-confidence-model` in the master 10-PR queue
+- [x] this workstream is now the repo-wide active focus after the first runtime baseline shipped
+- [x] this workstream owns `intervention-policy-v1`, `guardian-feedback-loop`, and `observer-salience-and-confidence-model` in the master 10-PR queue
 
 ## Still To Do On `develop`
 
 - [ ] richer human world modeling that goes beyond current retrieval plus heuristics
-- [ ] explicit guardian-state synthesis that unifies memory, goals, observer state, recent sessions, and confidence
 - [ ] intervention policy that decides act, suggest, defer, bundle, request-approval, or stay-silent explicitly
 - [ ] stronger learning loops based on intervention outcomes
 - [ ] observer salience and confidence modeling for better prioritization and interruption quality
@@ -36,6 +36,6 @@
 
 - [x] Seraph can retain identity, memory, and goals across sessions
 - [x] Seraph can generate proactive guardian outputs from that context
-- [ ] Seraph has an explicit guardian-state object rather than spreading that reasoning across call sites
+- [x] Seraph has an explicit guardian-state object rather than spreading that reasoning across call sites
 - [ ] Seraph learns from intervention outcomes in a way that changes future policy
 - [ ] Seraph reliably models the human well enough to intervene at consistently high quality

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -22,8 +22,9 @@ title: Seraph Development Status
 
 ## Current Focus On `develop`
 
-- [x] Runtime Reliability is still the active hardening track.
-- [ ] Runtime Reliability is not complete yet.
+- [x] Guardian Intelligence is now the active implementation track.
+- [ ] Guardian Intelligence is not complete yet.
+- [x] Runtime Reliability now has a strong baseline on `develop`, but it is not fully complete.
 - [x] The repo-wide 10-PR horizon is tracked in `docs/implementation/00-master-roadmap.md`.
 - [x] The next strategic focus after the runtime baseline is guardian-state quality, intervention quality, operator cockpit quality, workflow composition, and native reach.
 - [x] The published 10-PR horizon should be refreshed whenever landed PR count from that queue is divisible by 5.
@@ -81,6 +82,7 @@ title: Seraph Development Status
 - [x] soul-backed persistent identity
 - [x] vector memory retrieval and consolidation
 - [x] hierarchical goals and progress APIs
+- [x] explicit guardian-state synthesis for chat, WebSocket, and strategist paths
 - [x] strategist agent and strategist scheduler tick
 - [x] daily briefing, evening review, activity digest, and weekly review surfaces
 - [x] observer refresh across time, calendar, git, goals, and screen context
@@ -108,7 +110,6 @@ title: Seraph Development Status
 
 ### Guardian intelligence
 
-- [ ] explicit guardian-state synthesis that unifies observer context, memory, goals, and recent sessions for downstream decision-making
 - [ ] stronger intervention selection and feedback loops so proactive behavior improves over time instead of staying heuristic-only
 - [ ] deeper guardian world modeling, learning loops, and stronger intervention quality
 - [ ] observer salience and confidence modeling for better strategy and delivery


### PR DESCRIPTION
## Done on develop
- [x] provider policy scoring, routing decision audit, and guardian-flow behavioral evals are already shipped on develop
- [x] the source-of-truth docs already publish the rolling 10-PR queue and guardian-intelligence direction

## Working in this PR
- [ ] add an explicit GuardianState object that unifies observer context, soul, memory recall, current session history, recent sessions, and confidence labels
- [ ] route REST chat, WebSocket chat, and strategist assembly through that shared guardian-state input
- [ ] cover guardian-state synthesis with dedicated tests, a deterministic eval scenario, and source-of-truth doc updates

## Still to do after this PR
- [ ] intervention-policy-v1
- [ ] guardian-feedback-loop
- [ ] observer-salience-and-confidence-model

## Validation
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_guardian_state.py tests/test_eval_harness.py tests/test_chat_api.py tests/test_websocket.py tests/test_strategist_tick.py tests/test_agent.py tests/test_strategist.py tests/test_delegation.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario guardian_state_synthesis --indent 2
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build
- git diff --check
