### PR TITLE
Add explicit intervention policy

### DIFF
--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -56,6 +56,7 @@ from src.memory.vector_store import _reset_vector_store_state, add_memory, searc
 from src.observer.context import CurrentContext
 from src.observer.manager import ContextManager
 from src.observer.delivery import deliver_or_queue, deliver_queued_bundle
+from src.observer.intervention_policy import decide_intervention
 from src.observer.user_state import DeliveryDecision
 from src.scheduler.jobs.activity_digest import run_activity_digest
 from src.scheduler.jobs.daily_briefing import run_daily_briefing
@@ -3217,12 +3218,76 @@ async def _eval_observer_delivery_decision_behavior() -> dict[str, Any]:
         tool_name="observer_delivery_gate",
     )
     return {
-        "delivered_decision": delivered.value,
-        "queued_decision": queued.value,
+        "delivered_decision": delivered.delivery_decision.value if delivered.delivery_decision else None,
+        "delivered_action": delivered.action.value,
+        "queued_decision": queued.delivery_decision.value if queued.delivery_decision else None,
+        "queued_action": queued.action.value,
         "budget_decremented": mock_context_manager.decrement_attention_budget.call_count == 1,
         "queued_content_matches": mock_insight_queue.enqueue.await_args.kwargs["content"] == message.content,
         "delivered_connections": delivered_event["details"]["delivered_connections"],
         "queued_user_state": queued_event["details"]["user_state"],
+    }
+
+
+def _eval_intervention_policy_behavior() -> dict[str, Any]:
+    act = decide_intervention(
+        message_type="proactive",
+        intervention_type="advisory",
+        content="Act now",
+        urgency=3,
+        user_state="available",
+        interruption_mode="balanced",
+        attention_budget_remaining=2,
+    )
+    bundle = decide_intervention(
+        message_type="proactive",
+        intervention_type="advisory",
+        content="Bundle later",
+        urgency=3,
+        user_state="deep_work",
+        interruption_mode="balanced",
+        attention_budget_remaining=2,
+    )
+    defer = decide_intervention(
+        message_type="proactive",
+        intervention_type="advisory",
+        content="Too uncertain",
+        urgency=3,
+        user_state="available",
+        interruption_mode="balanced",
+        attention_budget_remaining=2,
+        guardian_confidence="partial",
+    )
+    request_approval = decide_intervention(
+        message_type="proactive",
+        intervention_type="alert",
+        content="Need confirmation",
+        urgency=4,
+        user_state="available",
+        interruption_mode="balanced",
+        attention_budget_remaining=2,
+        requires_approval=True,
+    )
+    stay_silent = decide_intervention(
+        message_type="proactive",
+        intervention_type="advisory",
+        content="",
+        urgency=2,
+        user_state="available",
+        interruption_mode="balanced",
+        attention_budget_remaining=2,
+    )
+    return {
+        "act_action": act.action.value,
+        "act_reason": act.reason,
+        "bundle_action": bundle.action.value,
+        "bundle_reason": bundle.reason,
+        "defer_action": defer.action.value,
+        "defer_reason": defer.reason,
+        "approval_action": request_approval.action.value,
+        "approval_reason": request_approval.reason,
+        "silent_action": stay_silent.action.value,
+        "silent_reason": stay_silent.reason,
     }
 
 
@@ -3775,6 +3840,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="behavior",
         description="Proactive delivery delivers while available, queues while blocked, and decrements budget only for delivered guardian nudges.",
         runner=_eval_observer_delivery_decision_behavior,
+    ),
+    EvalScenario(
+        name="intervention_policy_behavior",
+        category="guardian",
+        description="Intervention policy explicitly distinguishes act, bundle, defer, request_approval, and stay_silent outcomes.",
+        runner=_eval_intervention_policy_behavior,
     ),
     EvalScenario(
         name="daily_briefing_fallback",

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -37,6 +37,7 @@ class WSResponse(BaseModel):
     urgency: int | None = None
     intervention_type: str | None = None
     reasoning: str | None = None
+    requires_approval: bool | None = None
     # Phase 3 — Ambient state
     state: str | None = None
     tooltip: str | None = None

--- a/backend/src/observer/delivery.py
+++ b/backend/src/observer/delivery.py
@@ -4,7 +4,7 @@ import logging
 
 from src.audit.runtime import log_observer_delivery_event
 from src.models.schemas import WSResponse
-from src.observer.user_state import DeliveryDecision, user_state_machine
+from src.observer.intervention_policy import InterventionDecision, decide_intervention
 
 logger = logging.getLogger(__name__)
 
@@ -20,11 +20,13 @@ def _transport_failure_reason(*, attempted_connections: int, failed_connections:
 async def deliver_or_queue(
     message: WSResponse,
     is_scheduled: bool = False,
-) -> DeliveryDecision:
+    *,
+    guardian_confidence: str | None = None,
+) -> InterventionDecision:
     """Route a proactive message through the delivery gate.
 
-    Reads current context, decides deliver/queue/drop, and acts accordingly.
-    Returns the decision for callers that need to know.
+    Reads current context, makes an explicit intervention-policy decision,
+    and executes the resulting delivery/bundle/silence path.
     """
     from src.observer.manager import context_manager
     from src.observer.insight_queue import insight_queue
@@ -33,25 +35,34 @@ async def deliver_or_queue(
     ctx = context_manager.get_context()
     intervention_type = message.intervention_type or message.type
     urgency = message.urgency or 0
-    decision: DeliveryDecision | None = None
+    policy_decision: InterventionDecision | None = None
 
     try:
-        decision = user_state_machine.should_deliver(
+        policy_decision = decide_intervention(
+            message_type=message.type,
+            intervention_type=intervention_type,
+            content=message.content,
+            urgency=urgency,
             user_state=ctx.user_state,
             interruption_mode=ctx.interruption_mode,
             attention_budget_remaining=ctx.attention_budget_remaining,
-            urgency=urgency,
-            intervention_type=intervention_type,
             is_scheduled=is_scheduled,
+            data_quality=ctx.data_quality,
+            guardian_confidence=guardian_confidence,
+            requires_approval=bool(message.requires_approval),
         )
 
         event_details = {
             "user_state": ctx.user_state,
             "interruption_mode": ctx.interruption_mode,
             "attention_budget_remaining": ctx.attention_budget_remaining,
+            "data_quality": ctx.data_quality,
+            "guardian_confidence": guardian_confidence,
+            "policy_action": policy_decision.action.value,
+            "policy_reason": policy_decision.reason,
         }
 
-        if decision == DeliveryDecision.deliver:
+        if policy_decision.action.value == "act":
             broadcast_result = await ws_manager.broadcast(message)
             event_details.update(
                 {
@@ -74,20 +85,18 @@ async def deliver_or_queue(
                     is_scheduled=is_scheduled,
                     details={
                         **event_details,
-                        "delivery_decision": decision.value,
+                        "delivery_decision": policy_decision.delivery_decision.value
+                        if policy_decision.delivery_decision is not None
+                        else None,
                         "error": _transport_failure_reason(
                             attempted_connections=broadcast_result.attempted_connections,
                             failed_connections=broadcast_result.failed_connections,
                         ),
                     },
                 )
-                return decision
+                return policy_decision
             # Decrement budget if this delivery costs budget
-            if user_state_machine.should_cost_budget(
-                intervention_type=intervention_type,
-                is_scheduled=is_scheduled,
-                urgency=urgency,
-            ):
+            if policy_decision.should_cost_budget:
                 context_manager.decrement_attention_budget()
             logger.info("Delivered proactive message (type=%s)", message.type)
             await log_observer_delivery_event(
@@ -99,7 +108,7 @@ async def deliver_or_queue(
                 details=event_details,
             )
 
-        elif decision == DeliveryDecision.queue:
+        elif policy_decision.action.value == "bundle":
             await insight_queue.enqueue(
                 content=message.content,
                 intervention_type=intervention_type,
@@ -117,9 +126,14 @@ async def deliver_or_queue(
             )
 
         else:
-            logger.info("Dropped proactive message (type=%s)", message.type)
+            logger.info(
+                "Suppressed proactive message (type=%s, action=%s, reason=%s)",
+                message.type,
+                policy_decision.action.value,
+                policy_decision.reason,
+            )
             await log_observer_delivery_event(
-                decision="dropped",
+                decision=policy_decision.audit_decision,
                 message_type=message.type,
                 intervention_type=intervention_type,
                 urgency=urgency,
@@ -127,7 +141,7 @@ async def deliver_or_queue(
                 details=event_details,
             )
 
-        return decision
+        return policy_decision
     except Exception as exc:
         await log_observer_delivery_event(
             decision="failed",
@@ -139,7 +153,15 @@ async def deliver_or_queue(
                 "user_state": ctx.user_state,
                 "interruption_mode": ctx.interruption_mode,
                 "attention_budget_remaining": ctx.attention_budget_remaining,
-                "delivery_decision": decision.value if decision is not None else None,
+                "data_quality": ctx.data_quality,
+                "guardian_confidence": guardian_confidence,
+                "policy_action": policy_decision.action.value if policy_decision is not None else None,
+                "policy_reason": policy_decision.reason if policy_decision is not None else None,
+                "delivery_decision": (
+                    policy_decision.delivery_decision.value
+                    if policy_decision is not None and policy_decision.delivery_decision is not None
+                    else None
+                ),
                 "error": str(exc),
             },
         )

--- a/backend/src/observer/intervention_policy.py
+++ b/backend/src/observer/intervention_policy.py
@@ -1,0 +1,153 @@
+"""Explicit intervention policy for proactive guardian outputs."""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+from src.observer.user_state import DeliveryDecision, InterruptionMode, UserState, user_state_machine
+
+
+class InterventionAction(str, enum.Enum):
+    act = "act"
+    defer = "defer"
+    bundle = "bundle"
+    request_approval = "request_approval"
+    stay_silent = "stay_silent"
+
+
+@dataclass(frozen=True)
+class InterventionDecision:
+    action: InterventionAction
+    reason: str
+    delivery_decision: DeliveryDecision | None
+    should_cost_budget: bool
+
+    @property
+    def audit_decision(self) -> str:
+        match self.action:
+            case InterventionAction.act:
+                return "delivered"
+            case InterventionAction.bundle:
+                return "queued"
+            case InterventionAction.defer:
+                return "deferred"
+            case InterventionAction.request_approval:
+                return "approval_requested"
+            case InterventionAction.stay_silent:
+                return "silenced"
+
+
+def _has_meaningful_payload(*, message_type: str, content: str) -> bool:
+    if message_type == "ambient":
+        return True
+    return bool(content.strip())
+
+
+def decide_intervention(
+    *,
+    message_type: str,
+    intervention_type: str,
+    content: str,
+    urgency: int,
+    user_state: str,
+    interruption_mode: str,
+    attention_budget_remaining: int,
+    is_scheduled: bool = False,
+    data_quality: str = "good",
+    guardian_confidence: str | None = None,
+    requires_approval: bool = False,
+) -> InterventionDecision:
+    """Make the explicit policy decision for a proactive intervention candidate."""
+    should_cost_budget = user_state_machine.should_cost_budget(
+        intervention_type=intervention_type,
+        is_scheduled=is_scheduled,
+        urgency=urgency,
+    )
+
+    if not _has_meaningful_payload(message_type=message_type, content=content):
+        return InterventionDecision(
+            action=InterventionAction.stay_silent,
+            reason="empty_content",
+            delivery_decision=None,
+            should_cost_budget=should_cost_budget,
+        )
+
+    if requires_approval:
+        return InterventionDecision(
+            action=InterventionAction.request_approval,
+            reason="requires_approval",
+            delivery_decision=None,
+            should_cost_budget=should_cost_budget,
+        )
+
+    if guardian_confidence in {"degraded", "partial", "empty"} and urgency < 4 and not is_scheduled:
+        return InterventionDecision(
+            action=InterventionAction.defer,
+            reason="low_guardian_confidence",
+            delivery_decision=None,
+            should_cost_budget=should_cost_budget,
+        )
+
+    if data_quality in {"degraded", "stale"} and urgency < 4 and not is_scheduled:
+        return InterventionDecision(
+            action=InterventionAction.defer,
+            reason="degraded_observer_state",
+            delivery_decision=None,
+            should_cost_budget=should_cost_budget,
+        )
+
+    if urgency >= 5:
+        return InterventionDecision(
+            action=InterventionAction.act,
+            reason="urgent",
+            delivery_decision=DeliveryDecision.deliver,
+            should_cost_budget=should_cost_budget,
+        )
+
+    if is_scheduled:
+        return InterventionDecision(
+            action=InterventionAction.act,
+            reason="scheduled",
+            delivery_decision=DeliveryDecision.deliver,
+            should_cost_budget=should_cost_budget,
+        )
+
+    if user_state in {UserState.deep_work.value, UserState.in_meeting.value, UserState.away.value}:
+        return InterventionDecision(
+            action=InterventionAction.bundle,
+            reason="blocked_state",
+            delivery_decision=DeliveryDecision.queue,
+            should_cost_budget=should_cost_budget,
+        )
+
+    if interruption_mode == InterruptionMode.focus.value:
+        return InterventionDecision(
+            action=InterventionAction.bundle,
+            reason="focus_mode",
+            delivery_decision=DeliveryDecision.queue,
+            should_cost_budget=should_cost_budget,
+        )
+
+    if user_state == UserState.winding_down.value and intervention_type != "alert":
+        return InterventionDecision(
+            action=InterventionAction.defer,
+            reason="winding_down_quiet_hours",
+            delivery_decision=None,
+            should_cost_budget=should_cost_budget,
+        )
+
+    if should_cost_budget and attention_budget_remaining <= 0:
+        return InterventionDecision(
+            action=InterventionAction.bundle,
+            reason="attention_budget_exhausted",
+            delivery_decision=DeliveryDecision.queue,
+            should_cost_budget=should_cost_budget,
+        )
+
+    return InterventionDecision(
+        action=InterventionAction.act,
+        reason="available_capacity",
+        delivery_decision=DeliveryDecision.deliver,
+        should_cost_budget=should_cost_budget,
+    )

--- a/backend/src/scheduler/jobs/calendar_scan.py
+++ b/backend/src/scheduler/jobs/calendar_scan.py
@@ -8,6 +8,20 @@ from src.models.schemas import WSResponse
 logger = logging.getLogger(__name__)
 
 
+def _delivery_value(result) -> str | None:
+    delivery_decision = getattr(result, "delivery_decision", None)
+    if delivery_decision is not None:
+        return delivery_decision.value
+    return getattr(result, "value", None)
+
+
+def _policy_action_value(result) -> str | None:
+    action = getattr(result, "action", None)
+    if action is not None:
+        return action.value
+    return None
+
+
 async def run_calendar_scan() -> None:
     """Scan upcoming calendar events and alert user about imminent ones."""
     logger.info("calendar_scan started")
@@ -75,7 +89,8 @@ async def run_calendar_scan() -> None:
             details={
                 "duration_ms": int((perf_counter() - started_at) * 1000),
                 "alert_count": len(alerts),
-                "delivery": result.value,
+                "delivery": _delivery_value(result),
+                "policy_action": _policy_action_value(result),
             },
         )
         logger.info("calendar_scan: alerted for %d event(s)", len(alerts))

--- a/backend/src/scheduler/jobs/goal_check.py
+++ b/backend/src/scheduler/jobs/goal_check.py
@@ -7,6 +7,20 @@ from src.models.schemas import WSResponse
 logger = logging.getLogger(__name__)
 
 
+def _delivery_value(result) -> str | None:
+    delivery_decision = getattr(result, "delivery_decision", None)
+    if delivery_decision is not None:
+        return delivery_decision.value
+    return getattr(result, "value", None)
+
+
+def _policy_action_value(result) -> str | None:
+    action = getattr(result, "action", None)
+    if action is not None:
+        return action.value
+    return None
+
+
 async def run_goal_check() -> None:
     """Check goal progress and broadcast ambient state."""
     logger.info("goal_check started")
@@ -59,7 +73,8 @@ async def run_goal_check() -> None:
                 "duration_ms": int((perf_counter() - started_at) * 1000),
                 "state": state,
                 "completion_rate": completion_rate,
-                "delivery": result.value,
+                "delivery": _delivery_value(result),
+                "policy_action": _policy_action_value(result),
             },
         )
         logger.info("goal_check: broadcast state=%s (%.0f%% complete)", state, completion_rate * 100)

--- a/backend/src/scheduler/jobs/strategist_tick.py
+++ b/backend/src/scheduler/jobs/strategist_tick.py
@@ -23,6 +23,20 @@ logger = logging.getLogger(__name__)
 _STRATEGIST_RUNTIME_SESSION_ID = "scheduler:strategist_tick"
 
 
+def _delivery_value(result) -> str | None:
+    delivery_decision = getattr(result, "delivery_decision", None)
+    if delivery_decision is not None:
+        return delivery_decision.value
+    return getattr(result, "value", None)
+
+
+def _policy_action_value(result) -> str | None:
+    action = getattr(result, "action", None)
+    if action is not None:
+        return action.value
+    return None
+
+
 async def run_strategist_tick() -> None:
     """Review context and decide if proactive intervention is warranted."""
     started_at = perf_counter()
@@ -71,7 +85,10 @@ async def run_strategist_tick() -> None:
             urgency=decision.urgency,
             reasoning=decision.reasoning,
         )
-        result = await deliver_or_queue(message)
+        result = await deliver_or_queue(
+            message,
+            guardian_confidence=guardian_state.confidence.overall,
+        )
         await log_scheduler_job_event(
             job_name="strategist_tick",
             outcome="succeeded",
@@ -79,14 +96,16 @@ async def run_strategist_tick() -> None:
                 "duration_ms": int((perf_counter() - started_at) * 1000),
                 "intervention_type": decision.intervention_type,
                 "urgency": decision.urgency,
-                "delivery": result.value,
+                "delivery": _delivery_value(result),
+                "policy_action": _policy_action_value(result),
             },
         )
         logger.info(
-            "strategist_tick: intervention sent (type=%s, urgency=%d, delivery=%s)",
+            "strategist_tick: intervention handled (type=%s, urgency=%d, delivery=%s, action=%s)",
             decision.intervention_type,
             decision.urgency,
-            result.value,
+            _delivery_value(result),
+            _policy_action_value(result),
         )
 
     except asyncio.TimeoutError:

--- a/backend/src/scheduler/jobs/weekly_activity_review.py
+++ b/backend/src/scheduler/jobs/weekly_activity_review.py
@@ -12,6 +12,20 @@ from src.models.schemas import WSResponse
 
 logger = logging.getLogger(__name__)
 
+
+def _delivery_value(result) -> str | None:
+    delivery_decision = getattr(result, "delivery_decision", None)
+    if delivery_decision is not None:
+        return delivery_decision.value
+    return getattr(result, "value", None)
+
+
+def _policy_action_value(result) -> str | None:
+    action = getattr(result, "action", None)
+    if action is not None:
+        return action.value
+    return None
+
 _WEEKLY_PROMPT = """\
 You are Seraph, a guardian intelligence. Generate a weekly activity review for your human.
 
@@ -134,7 +148,8 @@ async def run_weekly_activity_review() -> None:
             outcome="succeeded",
             details={
                 "duration_ms": int((perf_counter() - started_at) * 1000),
-                "delivery": result.value,
+                "delivery": _delivery_value(result),
+                "policy_action": _policy_action_value(result),
                 "total_observations": summary.get("total_observations", 0),
                 "total_tracked_minutes": summary.get("total_tracked_minutes", 0),
             },

--- a/backend/tests/test_delivery.py
+++ b/backend/tests/test_delivery.py
@@ -8,7 +8,7 @@ from src.audit.repository import audit_repository
 from src.models.schemas import WSResponse
 from src.observer.context import CurrentContext
 from src.observer.delivery import deliver_or_queue, deliver_queued_bundle
-from src.observer.user_state import DeliveryDecision
+from src.observer.intervention_policy import InterventionAction
 from src.scheduler.connection_manager import BroadcastResult
 
 
@@ -54,7 +54,9 @@ async def test_deliver_broadcasts():
         msg = WSResponse(type="proactive", content="Test", intervention_type="advisory", urgency=3)
         decision = await deliver_or_queue(msg)
 
-        assert decision == DeliveryDecision.deliver
+        assert decision.action == InterventionAction.act
+        assert decision.delivery_decision is not None
+        assert decision.delivery_decision.value == "deliver"
         mock_ws.broadcast.assert_called_once_with(msg)
         mock_iq.enqueue.assert_not_called()
     finally:
@@ -78,6 +80,8 @@ async def test_deliver_logs_runtime_audit(async_db):
             and event["tool_name"] == "observer_delivery_gate"
             and event["details"]["intervention_type"] == "advisory"
             and event["details"]["user_state"] == "available"
+            and event["details"]["policy_action"] == "act"
+            and event["details"]["policy_reason"] == "available_capacity"
             and event["details"]["delivered_connections"] == 1
             for event in events
         )
@@ -110,8 +114,9 @@ async def test_deliver_ambient_no_budget_decrement():
         p.start()
     try:
         msg = WSResponse(type="ambient", content="", intervention_type="ambient", state="on_track")
-        await deliver_or_queue(msg)
+        decision = await deliver_or_queue(msg)
 
+        assert decision.action == InterventionAction.act
         mock_cm.decrement_attention_budget.assert_not_called()
     finally:
         for p in patches:
@@ -128,7 +133,9 @@ async def test_queue_when_blocked():
         msg = WSResponse(type="proactive", content="Queued msg", intervention_type="advisory", urgency=3)
         decision = await deliver_or_queue(msg)
 
-        assert decision == DeliveryDecision.queue
+        assert decision.action == InterventionAction.bundle
+        assert decision.delivery_decision is not None
+        assert decision.delivery_decision.value == "queue"
         mock_ws.broadcast.assert_not_called()
         mock_iq.enqueue.assert_called_once_with(
             content="Queued msg",
@@ -157,6 +164,8 @@ async def test_queue_logs_runtime_audit(async_db):
             and event["tool_name"] == "observer_delivery_gate"
             and event["details"]["user_state"] == "deep_work"
             and event["details"]["interruption_mode"] == "balanced"
+            and event["details"]["policy_action"] == "bundle"
+            and event["details"]["policy_reason"] == "blocked_state"
             for event in events
         )
     finally:
@@ -174,7 +183,8 @@ async def test_queue_when_no_budget():
         msg = WSResponse(type="proactive", content="Budget depleted", intervention_type="advisory", urgency=3)
         decision = await deliver_or_queue(msg)
 
-        assert decision == DeliveryDecision.queue
+        assert decision.action == InterventionAction.bundle
+        assert decision.reason == "attention_budget_exhausted"
         mock_ws.broadcast.assert_not_called()
     finally:
         for p in patches:
@@ -191,7 +201,8 @@ async def test_urgent_delivers_through_blocked():
         msg = WSResponse(type="proactive", content="Urgent!", intervention_type="alert", urgency=5)
         decision = await deliver_or_queue(msg)
 
-        assert decision == DeliveryDecision.deliver
+        assert decision.action == InterventionAction.act
+        assert decision.reason == "urgent"
         mock_ws.broadcast.assert_called_once()
     finally:
         for p in patches:
@@ -238,7 +249,7 @@ async def test_delivery_transport_failure_logs_runtime_audit(async_db):
         msg = WSResponse(type="proactive", content="Test", intervention_type="advisory", urgency=3)
         decision = await deliver_or_queue(msg)
 
-        assert decision == DeliveryDecision.deliver
+        assert decision.action == InterventionAction.act
         mock_cm.decrement_attention_budget.assert_not_called()
 
         events = await audit_repository.list_events(limit=10)
@@ -267,8 +278,97 @@ async def test_delivery_audit_fails_open():
         with patch("src.audit.runtime.audit_repository.log_event", new_callable=AsyncMock, side_effect=RuntimeError("audit down")):
             decision = await deliver_or_queue(msg)
 
-        assert decision == DeliveryDecision.deliver
+        assert decision.action == InterventionAction.act
         mock_ws.broadcast.assert_called_once_with(msg)
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_defer_when_winding_down(async_db):
+    ctx = _make_context(user_state="winding_down")
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    for p in patches:
+        p.start()
+    try:
+        msg = WSResponse(type="proactive", content="Wrap up the inbox.", intervention_type="advisory", urgency=3)
+        decision = await deliver_or_queue(msg)
+
+        assert decision.action == InterventionAction.defer
+        assert decision.reason == "winding_down_quiet_hours"
+        mock_ws.broadcast.assert_not_called()
+        mock_iq.enqueue.assert_not_called()
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "observer_delivery_deferred"
+            and event["tool_name"] == "observer_delivery_gate"
+            and event["details"]["policy_action"] == "defer"
+            and event["details"]["policy_reason"] == "winding_down_quiet_hours"
+            for event in events
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_stay_silent_for_empty_proactive_message(async_db):
+    ctx = _make_context()
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    for p in patches:
+        p.start()
+    try:
+        msg = WSResponse(type="proactive", content="", intervention_type="advisory", urgency=2)
+        decision = await deliver_or_queue(msg)
+
+        assert decision.action == InterventionAction.stay_silent
+        assert decision.reason == "empty_content"
+        mock_ws.broadcast.assert_not_called()
+        mock_iq.enqueue.assert_not_called()
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "observer_delivery_silenced"
+            and event["tool_name"] == "observer_delivery_gate"
+            and event["details"]["policy_action"] == "stay_silent"
+            for event in events
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_request_approval_policy_action_is_logged(async_db):
+    ctx = _make_context()
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    for p in patches:
+        p.start()
+    try:
+        msg = WSResponse(
+            type="proactive",
+            content="Open a high-risk action suggestion.",
+            intervention_type="alert",
+            urgency=4,
+            reasoning="Needs confirmation",
+            requires_approval=True,
+        )
+        decision = await deliver_or_queue(msg)
+
+        assert decision.action == InterventionAction.request_approval
+        assert decision.reason == "requires_approval"
+        mock_ws.broadcast.assert_not_called()
+        mock_iq.enqueue.assert_not_called()
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "observer_delivery_approval_requested"
+            and event["tool_name"] == "observer_delivery_gate"
+            and event["details"]["policy_action"] == "request_approval"
+            for event in events
+        )
     finally:
         for p in patches:
             p.stop()

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -54,6 +54,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "guardian_state_synthesis" in captured.out
     assert "observer_refresh_behavior" in captured.out
     assert "observer_delivery_decision_behavior" in captured.out
+    assert "intervention_policy_behavior" in captured.out
     assert "provider_fallback_chain" in captured.out
     assert "provider_health_reroute" in captured.out
     assert "local_runtime_profile" in captured.out
@@ -142,6 +143,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "guardian_state_synthesis",
                 "observer_refresh_behavior",
                 "observer_delivery_decision_behavior",
+                "intervention_policy_behavior",
                 "agent_local_runtime_profile",
                 "delegation_local_runtime_profile",
                 "delegated_tool_workflow_behavior",
@@ -266,11 +268,23 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["observer_refresh_behavior"]["triggered_bundle_delivery"] is True
     assert details_by_name["observer_refresh_behavior"]["bundle_task_scheduled"] is True
     assert details_by_name["observer_delivery_decision_behavior"]["delivered_decision"] == "deliver"
+    assert details_by_name["observer_delivery_decision_behavior"]["delivered_action"] == "act"
     assert details_by_name["observer_delivery_decision_behavior"]["queued_decision"] == "queue"
+    assert details_by_name["observer_delivery_decision_behavior"]["queued_action"] == "bundle"
     assert details_by_name["observer_delivery_decision_behavior"]["budget_decremented"] is True
     assert details_by_name["observer_delivery_decision_behavior"]["queued_content_matches"] is True
     assert details_by_name["observer_delivery_decision_behavior"]["delivered_connections"] == 1
     assert details_by_name["observer_delivery_decision_behavior"]["queued_user_state"] == "deep_work"
+    assert details_by_name["intervention_policy_behavior"]["act_action"] == "act"
+    assert details_by_name["intervention_policy_behavior"]["act_reason"] == "available_capacity"
+    assert details_by_name["intervention_policy_behavior"]["bundle_action"] == "bundle"
+    assert details_by_name["intervention_policy_behavior"]["bundle_reason"] == "blocked_state"
+    assert details_by_name["intervention_policy_behavior"]["defer_action"] == "defer"
+    assert details_by_name["intervention_policy_behavior"]["defer_reason"] == "low_guardian_confidence"
+    assert details_by_name["intervention_policy_behavior"]["approval_action"] == "request_approval"
+    assert details_by_name["intervention_policy_behavior"]["approval_reason"] == "requires_approval"
+    assert details_by_name["intervention_policy_behavior"]["silent_action"] == "stay_silent"
+    assert details_by_name["intervention_policy_behavior"]["silent_reason"] == "empty_content"
     assert details_by_name["agent_local_runtime_profile"]["routed_models"]["chat_agent"] == "ollama/llama3.2"
     assert details_by_name["agent_local_runtime_profile"]["routed_models"]["onboarding_agent"] == "ollama/llama3.2"
     assert details_by_name["agent_local_runtime_profile"]["routed_models"]["strategist_agent"] == "ollama/llama3.2"

--- a/backend/tests/test_intervention_policy.py
+++ b/backend/tests/test_intervention_policy.py
@@ -1,0 +1,90 @@
+"""Tests for explicit intervention-policy decisions."""
+
+from src.observer.intervention_policy import (
+    InterventionAction,
+    decide_intervention,
+)
+
+
+def test_decide_intervention_acts_when_capacity_is_available():
+    decision = decide_intervention(
+        message_type="proactive",
+        intervention_type="advisory",
+        content="Guardian note",
+        urgency=3,
+        user_state="available",
+        interruption_mode="balanced",
+        attention_budget_remaining=3,
+    )
+
+    assert decision.action == InterventionAction.act
+    assert decision.reason == "available_capacity"
+    assert decision.delivery_decision is not None
+    assert decision.delivery_decision.value == "deliver"
+
+
+def test_decide_intervention_bundles_when_blocked():
+    decision = decide_intervention(
+        message_type="proactive",
+        intervention_type="advisory",
+        content="Guardian note",
+        urgency=3,
+        user_state="deep_work",
+        interruption_mode="balanced",
+        attention_budget_remaining=3,
+    )
+
+    assert decision.action == InterventionAction.bundle
+    assert decision.reason == "blocked_state"
+    assert decision.delivery_decision is not None
+    assert decision.delivery_decision.value == "queue"
+
+
+def test_decide_intervention_defers_on_low_guardian_confidence():
+    decision = decide_intervention(
+        message_type="proactive",
+        intervention_type="advisory",
+        content="Guardian note",
+        urgency=3,
+        user_state="available",
+        interruption_mode="balanced",
+        attention_budget_remaining=3,
+        guardian_confidence="partial",
+    )
+
+    assert decision.action == InterventionAction.defer
+    assert decision.reason == "low_guardian_confidence"
+    assert decision.delivery_decision is None
+
+
+def test_decide_intervention_requests_approval_when_flagged():
+    decision = decide_intervention(
+        message_type="proactive",
+        intervention_type="alert",
+        content="Guardian note",
+        urgency=4,
+        user_state="available",
+        interruption_mode="balanced",
+        attention_budget_remaining=3,
+        requires_approval=True,
+    )
+
+    assert decision.action == InterventionAction.request_approval
+    assert decision.reason == "requires_approval"
+    assert decision.delivery_decision is None
+
+
+def test_decide_intervention_stays_silent_for_empty_non_ambient_payload():
+    decision = decide_intervention(
+        message_type="proactive",
+        intervention_type="advisory",
+        content="",
+        urgency=2,
+        user_state="available",
+        interruption_mode="balanced",
+        attention_budget_remaining=3,
+    )
+
+    assert decision.action == InterventionAction.stay_silent
+    assert decision.reason == "empty_content"
+    assert decision.delivery_decision is None

--- a/backend/tests/test_strategist_tick.py
+++ b/backend/tests/test_strategist_tick.py
@@ -95,10 +95,12 @@ async def test_strategist_tick_logs_success(async_db):
         await run_strategist_tick()
 
     events = await audit_repository.list_events(limit=10)
+    assert mock_deliver.await_args.kwargs["guardian_confidence"] == "grounded"
     assert any(
         event["event_type"] == "scheduler_job_succeeded"
         and event["tool_name"] == "strategist_tick"
         and event["details"]["delivery"] == "deliver"
+        and event["details"]["policy_action"] is None
         for event in events
     )
 

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -45,6 +45,7 @@ uv run python -m src.evals.harness --scenario strategist_tick_behavior
 uv run python -m src.evals.harness --scenario guardian_state_synthesis
 uv run python -m src.evals.harness --scenario observer_refresh_behavior
 uv run python -m src.evals.harness --scenario observer_delivery_decision_behavior
+uv run python -m src.evals.harness --scenario intervention_policy_behavior
 uv run python -m src.evals.harness --scenario provider_fallback_chain
 uv run python -m src.evals.harness --scenario provider_health_reroute
 uv run python -m src.evals.harness --scenario local_runtime_profile
@@ -94,7 +95,7 @@ uv run python -m src.evals.harness --scenario evening_review_degraded_delivery_b
 uv run python -m src.evals.harness --scenario evening_review_degraded_inputs_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so REST and WebSocket chat behavior, guardian-state synthesis, observer refresh and delivery behavior, session consolidation behavior, strategist and scheduled proactive flow behavior, delegated tool-heavy workflow behavior, ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, capability-aware runtime policy intents, weighted provider policy scoring, structured routing decision auditing, session-bound helper LLM trace visibility, runtime-path primary and fallback overrides, local helper/agent/all current scheduled-job/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, vault-repository, and filesystem boundary failures, context-window degradation, daily-briefing, activity-digest, and evening-review degraded-input fallback auditing, tool/MCP policy guardrails, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, screen observation summary/cleanup boundary behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so REST and WebSocket chat behavior, guardian-state synthesis, intervention policy behavior, observer refresh and delivery behavior, session consolidation behavior, strategist and scheduled proactive flow behavior, delegated tool-heavy workflow behavior, ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, capability-aware runtime policy intents, weighted provider policy scoring, structured routing decision auditing, session-bound helper LLM trace visibility, runtime-path primary and fallback overrides, local helper/agent/all current scheduled-job/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, vault-repository, and filesystem boundary failures, context-window degradation, daily-briefing, activity-digest, and evening-review degraded-input fallback auditing, tool/MCP policy guardrails, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, screen observation summary/cleanup boundary behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -132,6 +133,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_goals_api.py` | 10 | Goals HTTP endpoints — create, list, filter, tree, dashboard, update, delete |
 | `test_goals_repository.py` | 21 | GoalRepository — CRUD, tree building, dashboard stats, cascading deletes |
 | `test_guardian_state.py` | 4 | Guardian-state synthesis — state assembly, confidence labels, agent injection, strategist context |
+| `test_intervention_policy.py` | 5 | Intervention policy — explicit act, bundle, defer, request-approval, and stay-silent decisions |
 | `test_http_mcp_server.py` | 16 | HTTP MCP server — request handling, internal URL blocking, timeout, truncation |
 | `test_insight_queue.py` | 12 | Insight queue — enqueue, drain, peek, ordering, expiry |
 | `test_insight_queue_expiry.py` | 8 | Insight queue expiry — TTL, cleanup, edge cases |

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -35,7 +35,7 @@ Legend for the checklist column:
 | 02. Execution Plane | `[ ]` | Real tools, MCP, browser, shell, filesystem, goals, vault, and web search are shipped; richer workflow execution and stronger execution safety are still left |
 | 03. Runtime Reliability | `[ ]` | Fallback chains, routing rules, local runtime paths, provider scoring, broad audit visibility, and guardian-behavior runtime evals are shipped; richer provider policy and still broader eval depth are still left |
 | 04. Presence And Reach | `[ ]` | Browser UI, WebSocket chat, proactive delivery, observer refresh, and native daemon foundations are shipped; native notifications and broader channel reach are still left |
-| 05. Guardian Intelligence | `[ ]` | Soul, memory, goals, strategist, briefings, reviews, observer-driven state, and explicit guardian state are shipped foundations; intervention policy, salience modeling, and feedback loops are still left |
+| 05. Guardian Intelligence | `[ ]` | Soul, memory, goals, strategist, briefings, reviews, observer-driven state, explicit guardian state, and intervention policy are shipped foundations; salience modeling and feedback loops are still left |
 | 06. Embodied UX | `[ ]` | The current village UI is shipped, but the target interface is now a dense guardian cockpit rather than a village-first shell |
 | 07. Ecosystem And Leverage | `[ ]` | Skills, MCP, catalog/install surfaces, and delegation foundations are shipped; workflow composition and stronger extension ergonomics are still left |
 
@@ -57,7 +57,7 @@ This is the rolling execution queue. It should always show the next 10 most valu
    extend behavioral evals into observer refresh, consolidation, proactive delivery, and guardrail-sensitive guardian flows
 3. [x] `guardian-state-synthesis`:
    merge observer signals, memory, goals, sessions, and confidence into one structured guardian-state input
-4. [ ] `intervention-policy-v1`:
+4. [x] `intervention-policy-v1`:
    make intervene, defer, bundle, request-approval, and stay-silent decisions explicit and state-aware
 5. [ ] `native-presence-notifications`:
    add the first real non-browser presence path with desktop notifications and interrupt-aware reach
@@ -104,8 +104,9 @@ This is the rolling execution queue. It should always show the next 10 most valu
 - [x] 9 scheduler jobs and 5 observer source boundaries wired into the current product
 - [x] provider-agnostic LLM runtime with ordered fallback chains, health-aware rerouting, runtime-path profile preferences, wildcard path rules, runtime-path model overrides, runtime-path fallback overrides, and local-runtime routing across helper, scheduled, agent, delegation, and MCP-specialist paths
 - [x] explicit guardian-state synthesis across chat, WebSocket, and strategist paths, combining observer context, memory recall, session history, recent sessions, and confidence into one structured downstream input
+- [x] explicit intervention policy at the proactive delivery boundary, with first-class act, bundle, defer, request-approval, and stay-silent classifications plus policy audit reasons
 - [x] runtime audit visibility across chat, session-bound helper and agent LLM traces, scheduler including daily-briefing, activity-digest, and evening-review degraded-input fallbacks, observer, screen observation summary/cleanup, proactive delivery transport, MCP lifecycle and manual test API flows, skills toggle/reload flows, embedding, vector store, soul file, vault repository, filesystem, browser, sandbox, and web search paths
-- [x] deterministic eval harness coverage for core runtime, audit, REST and WebSocket chat behavior, guardian-state synthesis, observer refresh and delivery behavior, session consolidation behavior, tool/MCP guardrail behavior, proactive flow behavior, delegated workflow behavior, observer, storage, tool-boundary, vault repository, MCP test API, skills API, screen repository, and daily-briefing, activity-digest, plus evening-review degraded-input contracts
+- [x] deterministic eval harness coverage for core runtime, audit, REST and WebSocket chat behavior, guardian-state synthesis, intervention policy behavior, observer refresh and delivery behavior, session consolidation behavior, tool/MCP guardrail behavior, proactive flow behavior, delegated workflow behavior, observer, storage, tool-boundary, vault repository, MCP test API, skills API, screen repository, and daily-briefing, activity-digest, plus evening-review degraded-input contracts
 
 ## Recommended Reading Order
 

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -13,16 +13,16 @@
 - [x] daily briefing, evening review, activity digest, and weekly activity review foundations
 - [x] observer-driven user-state and attention-budget modeling
 - [x] explicit guardian-state synthesis that unifies observer context, memory, current session, recent sessions, and confidence for downstream agent paths
+- [x] explicit intervention policy that distinguishes act, bundle, defer, request-approval, and stay-silent outcomes for proactive guardian messages
 
 ## Working On Now
 
 - [x] this workstream is now the repo-wide active focus after the first runtime baseline shipped
-- [x] this workstream owns `intervention-policy-v1`, `guardian-feedback-loop`, and `observer-salience-and-confidence-model` in the master 10-PR queue
+- [x] this workstream owns `guardian-feedback-loop` and `observer-salience-and-confidence-model` in the master 10-PR queue
 
 ## Still To Do On `develop`
 
 - [ ] richer human world modeling that goes beyond current retrieval plus heuristics
-- [ ] intervention policy that decides act, suggest, defer, bundle, request-approval, or stay-silent explicitly
 - [ ] stronger learning loops based on intervention outcomes
 - [ ] observer salience and confidence modeling for better prioritization and interruption quality
 - [ ] stronger linkage between guardian state, execution choices, and feedback
@@ -37,5 +37,6 @@
 - [x] Seraph can retain identity, memory, and goals across sessions
 - [x] Seraph can generate proactive guardian outputs from that context
 - [x] Seraph has an explicit guardian-state object rather than spreading that reasoning across call sites
+- [x] Seraph has an explicit intervention policy rather than only deliver-versus-queue heuristics
 - [ ] Seraph learns from intervention outcomes in a way that changes future policy
 - [ ] Seraph reliably models the human well enough to intervene at consistently high quality

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -83,6 +83,7 @@ title: Seraph Development Status
 - [x] vector memory retrieval and consolidation
 - [x] hierarchical goals and progress APIs
 - [x] explicit guardian-state synthesis for chat, WebSocket, and strategist paths
+- [x] explicit intervention-policy decisions for proactive delivery, including act / bundle / defer / request-approval / stay-silent classifications
 - [x] strategist agent and strategist scheduler tick
 - [x] daily briefing, evening review, activity digest, and weekly review surfaces
 - [x] observer refresh across time, calendar, git, goals, and screen context
@@ -110,7 +111,7 @@ title: Seraph Development Status
 
 ### Guardian intelligence
 
-- [ ] stronger intervention selection and feedback loops so proactive behavior improves over time instead of staying heuristic-only
+- [ ] stronger learning and feedback loops so proactive behavior improves over time instead of staying policy-only
 - [ ] deeper guardian world modeling, learning loops, and stronger intervention quality
 - [ ] observer salience and confidence modeling for better strategy and delivery
 


### PR DESCRIPTION
## Done on develop
- [x] guardian-state synthesis is shipped across chat, websocket, and strategist paths
- [x] guardian behavioral evals cover observer refresh, delivery decisions, consolidation, and tool policy guardrails
- [x] proactive delivery transport/runtime audit is already in place

## Working in this PR
- [x] add an explicit intervention policy at the proactive delivery boundary with act, bundle, defer, request-approval, and stay-silent outcomes
- [x] thread policy action/reason metadata into delivery audit events and scheduler job audit details
- [x] add deterministic eval coverage and focused backend tests for the new guardian policy contract

## Still to do after this PR
- [ ] native-presence-notifications
- [ ] workflow-composition-v1
- [ ] guardian-feedback-loop

## Validation
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_intervention_policy.py tests/test_delivery.py tests/test_strategist_tick.py tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_scheduler_job_audit.py tests/test_scheduler.py tests/test_activity_digest.py tests/test_daily_briefing.py tests/test_evening_review.py tests/test_delivery.py tests/test_intervention_policy.py tests/test_strategist_tick.py tests/test_eval_harness.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario observer_delivery_decision_behavior --scenario intervention_policy_behavior --indent 2
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m py_compile src/observer/intervention_policy.py src/observer/delivery.py src/scheduler/jobs/strategist_tick.py src/scheduler/jobs/goal_check.py src/scheduler/jobs/calendar_scan.py src/scheduler/jobs/weekly_activity_review.py src/evals/harness.py tests/test_intervention_policy.py tests/test_delivery.py tests/test_strategist_tick.py tests/test_eval_harness.py
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build
- git diff --check
