### PR TITLE
Add native presence notifications

### DIFF
--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -1,7 +1,6 @@
 """Observer API — context state and daemon integration endpoints."""
 
 import logging
-import time
 from datetime import date, datetime, timezone
 
 from fastapi import APIRouter
@@ -9,6 +8,7 @@ from pydantic import BaseModel
 
 from src.audit.runtime import log_integration_event
 from src.observer.manager import context_manager
+from src.observer.native_notification_queue import native_notification_queue
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +30,23 @@ class ScreenContextRequest(BaseModel):
     screen_context: str | None = None
     observation: ScreenObservationData | None = None
     switch_timestamp: float | None = None
+
+
+class NativeNotificationResponse(BaseModel):
+    id: str
+    title: str
+    body: str
+    intervention_type: str | None = None
+    urgency: int | None = None
+    created_at: str
+
+
+class NativeNotificationPollResponse(BaseModel):
+    notification: NativeNotificationResponse | None = None
+
+
+class NotificationAckResponse(BaseModel):
+    acked: bool
 
 
 @router.get("/observer/state")
@@ -108,16 +125,54 @@ async def post_screen_context(body: ScreenContextRequest):
 async def daemon_status():
     """Return daemon connectivity status based on heartbeat timestamp."""
     ctx = context_manager.get_context()
-    connected = (
-        ctx.last_daemon_post is not None
-        and (time.time() - ctx.last_daemon_post) < 30
-    )
+    connected = context_manager.is_daemon_connected()
     return {
         "connected": connected,
         "last_post": ctx.last_daemon_post,
         "active_window": ctx.active_window,
         "has_screen_context": bool(ctx.screen_context),
     }
+
+
+@router.get("/observer/notifications/next", response_model=NativeNotificationPollResponse)
+async def get_next_native_notification():
+    """Return the next pending native notification for the daemon, if any."""
+    notification = await native_notification_queue.peek()
+    if notification is None:
+        await log_integration_event(
+            integration_type="observer_daemon",
+            name="notifications",
+            outcome="empty_result",
+            details={"pending_count": 0},
+        )
+        return {"notification": None}
+
+    pending_count = await native_notification_queue.count()
+    await log_integration_event(
+        integration_type="observer_daemon",
+        name="notifications",
+        outcome="succeeded",
+        details={
+            "notification_id": notification.id,
+            "pending_count": pending_count,
+            "intervention_type": notification.intervention_type,
+            "urgency": notification.urgency,
+        },
+    )
+    return {"notification": notification.to_dict()}
+
+
+@router.post("/observer/notifications/{notification_id}/ack", response_model=NotificationAckResponse)
+async def ack_native_notification(notification_id: str):
+    """Acknowledge and remove a native notification after the daemon displays it."""
+    acked = await native_notification_queue.ack(notification_id)
+    await log_integration_event(
+        integration_type="observer_daemon",
+        name="notifications",
+        outcome="acked" if acked else "ack_missing",
+        details={"notification_id": notification_id},
+    )
+    return {"acked": acked}
 
 
 @router.get("/observer/activity/today")

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -39,7 +39,13 @@ from src.agent.specialists import create_mcp_specialist, create_specialist, mcp_
 from src.agent.strategist import create_strategist_agent
 from src.guardian.state import build_guardian_state
 from src.api.mcp import test_server as test_mcp_server
-from src.api.observer import ScreenContextRequest, ScreenObservationData, post_screen_context
+from src.api.observer import (
+    ScreenContextRequest,
+    ScreenObservationData,
+    ack_native_notification,
+    get_next_native_notification,
+    post_screen_context,
+)
 from src.api.skills import UpdateSkillRequest, reload_skills as reload_skill_api, update_skill as update_skill_api
 from src.audit.repository import audit_repository
 from src.app import create_app
@@ -57,6 +63,7 @@ from src.observer.context import CurrentContext
 from src.observer.manager import ContextManager
 from src.observer.delivery import deliver_or_queue, deliver_queued_bundle
 from src.observer.intervention_policy import decide_intervention
+from src.observer.native_notification_queue import native_notification_queue
 from src.observer.user_state import DeliveryDecision
 from src.scheduler.jobs.activity_digest import run_activity_digest
 from src.scheduler.jobs.daily_briefing import run_daily_briefing
@@ -3229,6 +3236,71 @@ async def _eval_observer_delivery_decision_behavior() -> dict[str, Any]:
     }
 
 
+async def _eval_native_presence_notification_behavior() -> dict[str, Any]:
+    await native_notification_queue.clear()
+    available_ctx = _make_context(
+        user_state="available",
+        interruption_mode="balanced",
+        attention_budget_remaining=3,
+        last_daemon_post=time.time(),
+    )
+    mock_context_manager = MagicMock()
+    mock_context_manager.get_context.return_value = available_ctx
+    mock_context_manager.decrement_attention_budget = MagicMock()
+    mock_context_manager.is_daemon_connected.return_value = True
+    mock_ws_manager = MagicMock()
+    mock_ws_manager.broadcast = AsyncMock(return_value=BroadcastResult(0, 0, 0))
+    mock_log_event = AsyncMock()
+    message = WSResponse(
+        type="proactive",
+        content="Guardian fallback through native notifications.",
+        intervention_type="alert",
+        urgency=5,
+        reasoning="Browser is not connected",
+    )
+
+    with (
+        patch("src.observer.manager.context_manager", mock_context_manager),
+        patch("src.api.observer.context_manager", mock_context_manager),
+        patch("src.scheduler.connection_manager.ws_manager", mock_ws_manager),
+        patch.object(audit_repository, "log_event", mock_log_event),
+    ):
+        decision = await deliver_or_queue(message)
+        polled = await get_next_native_notification()
+        notification = polled["notification"]
+        acked = await ack_native_notification(notification["id"])
+
+    delivered_event = _find_audit_call(
+        mock_log_event,
+        event_type="observer_delivery_delivered",
+        tool_name="observer_delivery_gate",
+    )
+    integration_event = _find_audit_call(
+        mock_log_event,
+        event_type="integration_succeeded",
+        tool_name="observer_daemon:notifications",
+    )
+    ack_event = _find_audit_call(
+        mock_log_event,
+        event_type="integration_acked",
+        tool_name="observer_daemon:notifications",
+    )
+    remaining = await native_notification_queue.count()
+    await native_notification_queue.clear()
+
+    return {
+        "action": decision.action.value,
+        "delivery_decision": decision.delivery_decision.value if decision.delivery_decision else None,
+        "transport": delivered_event["details"]["transport"],
+        "notification_title": notification["title"],
+        "notification_body_matches": notification["body"] == message.content,
+        "integration_pending_count": integration_event["details"]["pending_count"],
+        "acked": acked["acked"],
+        "ack_event_matches": ack_event["details"]["notification_id"] == notification["id"],
+        "remaining_notifications": remaining,
+    }
+
+
 def _eval_intervention_policy_behavior() -> dict[str, Any]:
     act = decide_intervention(
         message_type="proactive",
@@ -3840,6 +3912,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="behavior",
         description="Proactive delivery delivers while available, queues while blocked, and decrements budget only for delivered guardian nudges.",
         runner=_eval_observer_delivery_decision_behavior,
+    ),
+    EvalScenario(
+        name="native_presence_notification_behavior",
+        category="presence",
+        description="When browser delivery is unavailable but the daemon is connected, proactive messages reroute through native notifications.",
+        runner=_eval_native_presence_notification_behavior,
     ),
     EvalScenario(
         name="intervention_policy_behavior",

--- a/backend/src/observer/delivery.py
+++ b/backend/src/observer/delivery.py
@@ -5,6 +5,7 @@ import logging
 from src.audit.runtime import log_observer_delivery_event
 from src.models.schemas import WSResponse
 from src.observer.intervention_policy import InterventionDecision, decide_intervention
+from src.observer.native_notification_queue import native_notification_queue
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +16,28 @@ def _transport_failure_reason(*, attempted_connections: int, failed_connections:
     if failed_connections >= attempted_connections:
         return "all_connections_failed"
     return "unknown_transport_failure"
+
+
+def _should_offer_native_notification(message: WSResponse, *, is_scheduled: bool) -> bool:
+    if message.type != "proactive":
+        return False
+    if bool(message.requires_approval):
+        return False
+    if not message.content.strip():
+        return False
+    if is_scheduled:
+        return True
+    if message.intervention_type == "alert":
+        return True
+    return (message.urgency or 0) >= 3
+
+
+def _native_notification_title(message: WSResponse, *, is_scheduled: bool) -> str:
+    if message.intervention_type == "alert":
+        return "Seraph alert"
+    if is_scheduled:
+        return "Seraph update"
+    return "Seraph"
 
 
 async def deliver_or_queue(
@@ -72,6 +95,38 @@ async def deliver_or_queue(
                 }
             )
             if broadcast_result.delivered_connections <= 0:
+                if (
+                    context_manager.is_daemon_connected()
+                    and _should_offer_native_notification(message, is_scheduled=is_scheduled)
+                ):
+                    notification = await native_notification_queue.enqueue(
+                        title=_native_notification_title(message, is_scheduled=is_scheduled),
+                        body=message.content,
+                        intervention_type=intervention_type,
+                        urgency=urgency,
+                    )
+                    logger.info(
+                        "Rerouted proactive message to native notification (type=%s, notification_id=%s)",
+                        message.type,
+                        notification.id,
+                    )
+                    await log_observer_delivery_event(
+                        decision="delivered",
+                        message_type=message.type,
+                        intervention_type=intervention_type,
+                        urgency=urgency,
+                        is_scheduled=is_scheduled,
+                        details={
+                            **event_details,
+                            "transport": "native_notification",
+                            "notification_id": notification.id,
+                            "delivery_decision": policy_decision.delivery_decision.value
+                            if policy_decision.delivery_decision is not None
+                            else None,
+                        },
+                    )
+                    return policy_decision
+
                 logger.warning(
                     "Failed to deliver proactive message over WebSocket transport (attempted=%d failed=%d)",
                     broadcast_result.attempted_connections,
@@ -85,6 +140,7 @@ async def deliver_or_queue(
                     is_scheduled=is_scheduled,
                     details={
                         **event_details,
+                        "transport": "websocket",
                         "delivery_decision": policy_decision.delivery_decision.value
                         if policy_decision.delivery_decision is not None
                         else None,
@@ -105,7 +161,7 @@ async def deliver_or_queue(
                 intervention_type=intervention_type,
                 urgency=urgency,
                 is_scheduled=is_scheduled,
-                details=event_details,
+                details={**event_details, "transport": "websocket"},
             )
 
         elif policy_decision.action.value == "bundle":

--- a/backend/src/observer/manager.py
+++ b/backend/src/observer/manager.py
@@ -26,6 +26,13 @@ class ContextManager:
         """Return current snapshot (sync, non-blocking)."""
         return self._context
 
+    def is_daemon_connected(self, max_age_seconds: float = 30) -> bool:
+        """Return whether the native daemon has posted recently."""
+        last_post = self._context.last_daemon_post
+        if last_post is None:
+            return False
+        return (time.time() - last_post) < max_age_seconds
+
     async def refresh(self) -> CurrentContext:
         """Gather all sources and merge into a new context snapshot.
 

--- a/backend/src/observer/native_notification_queue.py
+++ b/backend/src/observer/native_notification_queue.py
@@ -1,0 +1,74 @@
+"""In-memory queue for native desktop notifications consumed by the daemon."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from uuid import uuid4
+
+
+@dataclass
+class NativeNotification:
+    id: str
+    title: str
+    body: str
+    intervention_type: str | None
+    urgency: int | None
+    created_at: str
+
+    def to_dict(self) -> dict[str, str | int | None]:
+        return asdict(self)
+
+
+class NativeNotificationQueue:
+    """Small fail-open queue for daemon-delivered desktop notifications."""
+
+    def __init__(self) -> None:
+        self._items: list[NativeNotification] = []
+        self._lock = asyncio.Lock()
+
+    async def enqueue(
+        self,
+        *,
+        title: str,
+        body: str,
+        intervention_type: str | None,
+        urgency: int | None,
+    ) -> NativeNotification:
+        notification = NativeNotification(
+            id=str(uuid4()),
+            title=title,
+            body=body,
+            intervention_type=intervention_type,
+            urgency=urgency,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+        async with self._lock:
+            self._items.append(notification)
+        return notification
+
+    async def peek(self) -> NativeNotification | None:
+        async with self._lock:
+            if not self._items:
+                return None
+            return self._items[0]
+
+    async def ack(self, notification_id: str) -> bool:
+        async with self._lock:
+            for idx, item in enumerate(self._items):
+                if item.id == notification_id:
+                    self._items.pop(idx)
+                    return True
+        return False
+
+    async def count(self) -> int:
+        async with self._lock:
+            return len(self._items)
+
+    async def clear(self) -> None:
+        async with self._lock:
+            self._items.clear()
+
+
+native_notification_queue = NativeNotificationQueue()

--- a/backend/tests/test_delivery.py
+++ b/backend/tests/test_delivery.py
@@ -9,6 +9,7 @@ from src.models.schemas import WSResponse
 from src.observer.context import CurrentContext
 from src.observer.delivery import deliver_or_queue, deliver_queued_bundle
 from src.observer.intervention_policy import InterventionAction
+from src.observer.native_notification_queue import native_notification_queue
 from src.scheduler.connection_manager import BroadcastResult
 
 
@@ -26,6 +27,7 @@ def _patch_deps(ctx):
     """Patch the lazy-imported singletons at their source modules."""
     mock_cm = MagicMock()
     mock_cm.get_context.return_value = ctx
+    mock_cm.is_daemon_connected.return_value = False
     mock_ws = MagicMock()
     mock_ws.broadcast = AsyncMock(return_value=BroadcastResult(
         attempted_connections=1,
@@ -263,6 +265,41 @@ async def test_delivery_transport_failure_logs_runtime_audit(async_db):
             for event in events
         )
     finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_delivery_reroutes_to_native_notification_when_daemon_connected(async_db):
+    await native_notification_queue.clear()
+    ctx = _make_context()
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    mock_cm.is_daemon_connected.return_value = True
+    mock_ws.broadcast = AsyncMock(return_value=BroadcastResult(
+        attempted_connections=0,
+        delivered_connections=0,
+        failed_connections=0,
+    ))
+    for p in patches:
+        p.start()
+    try:
+        msg = WSResponse(type="proactive", content="Native fallback", intervention_type="alert", urgency=5)
+        decision = await deliver_or_queue(msg)
+
+        assert decision.action == InterventionAction.act
+        assert await native_notification_queue.count() == 1
+        mock_iq.enqueue.assert_not_called()
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "observer_delivery_delivered"
+            and event["tool_name"] == "observer_delivery_gate"
+            and event["details"]["transport"] == "native_notification"
+            and event["details"]["notification_id"] is not None
+            for event in events
+        )
+    finally:
+        await native_notification_queue.clear()
         for p in patches:
             p.stop()
 

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -54,6 +54,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "guardian_state_synthesis" in captured.out
     assert "observer_refresh_behavior" in captured.out
     assert "observer_delivery_decision_behavior" in captured.out
+    assert "native_presence_notification_behavior" in captured.out
     assert "intervention_policy_behavior" in captured.out
     assert "provider_fallback_chain" in captured.out
     assert "provider_health_reroute" in captured.out
@@ -143,6 +144,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "guardian_state_synthesis",
                 "observer_refresh_behavior",
                 "observer_delivery_decision_behavior",
+                "native_presence_notification_behavior",
                 "intervention_policy_behavior",
                 "agent_local_runtime_profile",
                 "delegation_local_runtime_profile",
@@ -258,6 +260,13 @@ def test_runtime_eval_scenarios_expose_expected_details():
     assert details_by_name["guardian_state_synthesis"]["recent_sessions_contains_title"] is True
     assert details_by_name["guardian_state_synthesis"]["current_history_mentions_guardian_state"] is True
     assert details_by_name["guardian_state_synthesis"]["instructions_include_guardian_state"] is True
+    assert details_by_name["native_presence_notification_behavior"]["action"] == "act"
+    assert details_by_name["native_presence_notification_behavior"]["delivery_decision"] == "deliver"
+    assert details_by_name["native_presence_notification_behavior"]["transport"] == "native_notification"
+    assert details_by_name["native_presence_notification_behavior"]["notification_title"] == "Seraph alert"
+    assert details_by_name["native_presence_notification_behavior"]["notification_body_matches"] is True
+    assert details_by_name["native_presence_notification_behavior"]["acked"] is True
+    assert details_by_name["native_presence_notification_behavior"]["remaining_notifications"] == 0
     assert details_by_name["guardian_state_synthesis"]["instructions_include_recent_sessions"] is True
     assert details_by_name["observer_refresh_behavior"]["new_user_state"] == "transitioning"
     assert details_by_name["observer_refresh_behavior"]["data_quality"] == "good"

--- a/backend/tests/test_observer_api.py
+++ b/backend/tests/test_observer_api.py
@@ -7,6 +7,7 @@ import pytest_asyncio
 from src.audit.repository import audit_repository
 from src.observer.context import CurrentContext
 from src.observer.manager import ContextManager
+from src.observer.native_notification_queue import native_notification_queue
 from src.observer.screen_repository import ScreenObservationRepository
 
 
@@ -237,6 +238,74 @@ class TestObserverAPI:
         assert resp.status_code == 200
         assert mgr.get_context().active_window == "Terminal"
         assert mgr.get_context().screen_context == "Running tests"
+
+    @pytest.mark.asyncio
+    async def test_get_next_native_notification(self, async_db, client):
+        await native_notification_queue.clear()
+        notification = await native_notification_queue.enqueue(
+            title="Seraph alert",
+            body="Browser is closed; use the daemon path.",
+            intervention_type="alert",
+            urgency=5,
+        )
+
+        resp = await client.get("/api/observer/notifications/next")
+
+        assert resp.status_code == 200
+        payload = resp.json()["notification"]
+        assert payload["id"] == notification.id
+        assert payload["title"] == "Seraph alert"
+        assert await native_notification_queue.count() == 1
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_succeeded"
+            and event["tool_name"] == "observer_daemon:notifications"
+            and event["details"]["notification_id"] == notification.id
+            for event in events
+        )
+
+        await native_notification_queue.clear()
+
+    @pytest.mark.asyncio
+    async def test_get_next_native_notification_empty(self, async_db, client):
+        await native_notification_queue.clear()
+
+        resp = await client.get("/api/observer/notifications/next")
+
+        assert resp.status_code == 200
+        assert resp.json()["notification"] is None
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_empty_result"
+            and event["tool_name"] == "observer_daemon:notifications"
+            for event in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_ack_native_notification(self, async_db, client):
+        await native_notification_queue.clear()
+        notification = await native_notification_queue.enqueue(
+            title="Seraph",
+            body="Ack me",
+            intervention_type="advisory",
+            urgency=3,
+        )
+
+        resp = await client.post(f"/api/observer/notifications/{notification.id}/ack")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"acked": True}
+        assert await native_notification_queue.count() == 0
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "integration_acked"
+            and event["tool_name"] == "observer_daemon:notifications"
+            and event["details"]["notification_id"] == notification.id
+            for event in events
+        )
 
     @pytest.mark.asyncio
     async def test_get_activity_today(self, async_db, client):

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -39,6 +39,7 @@ This starts three containers:
 ```
 
 The daemon runs outside Docker and posts active window context to the backend every few seconds.
+It also polls for pending native Seraph notifications and displays them through macOS Notification Center when the browser surface is unavailable.
 
 ### Optional: Things3 MCP integration
 
@@ -206,6 +207,15 @@ Without `--ocr`, the payload is simpler (no `observation` field):
   "active_window": "VS Code — main.py"
 }
 ```
+
+## Native Notifications
+
+When the browser is not connected but the daemon is alive, Seraph can now fall back to native macOS notifications for selected proactive messages. The daemon polls the backend for one pending notification, shows it with `osascript`, then acknowledges it so it is not repeated.
+
+This is a first presence path, not a full desktop shell:
+- notification delivery is best-effort
+- pending notifications are currently in-memory on the backend
+- broader channel controls and richer desktop presence are still future work
 
 ## How It Works
 

--- a/daemon/seraph_daemon.py
+++ b/daemon/seraph_daemon.py
@@ -98,6 +98,32 @@ def format_active_window(app_name: str | None, window_title: str | None) -> str 
     return app_name
 
 
+def _escape_applescript(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def show_notification(title: str, body: str) -> bool:
+    """Display a macOS notification via AppleScript."""
+    try:
+        result = subprocess.run(
+            [
+                "osascript",
+                "-e",
+                f'display notification "{_escape_applescript(body)}" with title "{_escape_applescript(title)}"',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+    except Exception:
+        logger.debug("Failed to display native notification", exc_info=True)
+        return False
+
+
 # ─── Capture mode helper ─────────────────────────────────
 
 
@@ -110,6 +136,28 @@ async def fetch_capture_mode(client: httpx.AsyncClient, url: str) -> str:
     except Exception:
         pass
     return "on_switch"
+
+
+async def fetch_next_notification(client: httpx.AsyncClient, url: str) -> dict | None:
+    """Fetch the next pending native notification from the backend."""
+    try:
+        r = await client.get(f"{url}/api/observer/notifications/next")
+        if r.status_code == 200:
+            return r.json().get("notification")
+    except Exception:
+        pass
+    return None
+
+
+async def ack_notification(client: httpx.AsyncClient, url: str, notification_id: str) -> bool:
+    """Acknowledge a displayed native notification."""
+    try:
+        r = await client.post(f"{url}/api/observer/notifications/{notification_id}/ack")
+        if r.status_code == 200:
+            return bool(r.json().get("acked"))
+    except Exception:
+        pass
+    return False
 
 
 # ─── Main loop ────────────────────────────────────────────
@@ -137,6 +185,19 @@ async def poll_loop(
     async with httpx.AsyncClient(timeout=10.0) as client:
         while True:
             try:
+                notification = await fetch_next_notification(client, url)
+                if notification is not None:
+                    displayed = await asyncio.to_thread(
+                        show_notification,
+                        notification.get("title", "Seraph"),
+                        notification.get("body", ""),
+                    )
+                    if displayed:
+                        await ack_notification(client, url, notification["id"])
+                        if verbose:
+                            ts = time.strftime("%H:%M:%S")
+                            logger.info("[%s] notification \u2192 %s", ts, notification.get("title", "Seraph"))
+
                 # Check idle state
                 idle_secs = get_idle_seconds()
                 is_idle = idle_secs > idle_timeout

--- a/daemon/tests/test_notifications.py
+++ b/daemon/tests/test_notifications.py
@@ -1,0 +1,121 @@
+"""Tests for native notification polling in the macOS daemon."""
+
+import asyncio
+import os
+import platform
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Darwin",
+    reason="Daemon tests require macOS (PyObjC, Quartz)",
+)
+
+httpx = pytest.importorskip("httpx")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from seraph_daemon import ack_notification, fetch_next_notification, poll_loop
+
+
+class TestNotificationPolling:
+    @pytest.mark.asyncio
+    async def test_fetch_next_notification_returns_none_on_error(self):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+        result = await fetch_next_notification(mock_client, "http://localhost:8004")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_next_notification_parses_payload(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "notification": {
+                "id": "notif-1",
+                "title": "Seraph alert",
+                "body": "Hello",
+            }
+        }
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=response)
+
+        result = await fetch_next_notification(mock_client, "http://localhost:8004")
+
+        assert result == {
+            "id": "notif-1",
+            "title": "Seraph alert",
+            "body": "Hello",
+        }
+
+    @pytest.mark.asyncio
+    async def test_ack_notification_returns_true_on_success(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"acked": True}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=response)
+
+        acked = await ack_notification(mock_client, "http://localhost:8004", "notif-1")
+
+        assert acked is True
+
+    @pytest.mark.asyncio
+    async def test_poll_loop_displays_and_acks_notification(self):
+        notification_payload = {
+            "id": "notif-1",
+            "title": "Seraph alert",
+            "body": "Native path online",
+        }
+        context_posts: list[dict] = []
+        ack_posts: list[str] = []
+        notifications = [notification_payload, None, None]
+
+        async def mock_get(url, **kwargs):
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {
+                "notification": notifications.pop(0) if notifications else None,
+            }
+            return response
+
+        async def mock_post(url, **kwargs):
+            if "/notifications/" in url:
+                ack_posts.append(url)
+                response = MagicMock()
+                response.status_code = 200
+                response.json.return_value = {"acked": True}
+                return response
+            context_posts.append(kwargs.get("json", {}))
+            return MagicMock(status_code=200)
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = mock_post
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("seraph_daemon.get_frontmost_app_name", return_value="VS Code"),
+            patch("seraph_daemon.get_window_title", return_value="main.py"),
+            patch("seraph_daemon.get_idle_seconds", return_value=0.0),
+            patch("seraph_daemon.show_notification", return_value=True) as mock_show,
+            patch("httpx.AsyncClient", return_value=mock_client),
+        ):
+            task = asyncio.create_task(
+                poll_loop("http://localhost:8004", interval=0.05, idle_timeout=300, verbose=False)
+            )
+            await asyncio.sleep(0.2)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        mock_show.assert_called_once_with("Seraph alert", "Native path online")
+        assert len(ack_posts) == 1
+        assert len(context_posts) >= 1

--- a/docs/docs/development/testing.md
+++ b/docs/docs/development/testing.md
@@ -45,6 +45,7 @@ uv run python -m src.evals.harness --scenario strategist_tick_behavior
 uv run python -m src.evals.harness --scenario guardian_state_synthesis
 uv run python -m src.evals.harness --scenario observer_refresh_behavior
 uv run python -m src.evals.harness --scenario observer_delivery_decision_behavior
+uv run python -m src.evals.harness --scenario native_presence_notification_behavior
 uv run python -m src.evals.harness --scenario intervention_policy_behavior
 uv run python -m src.evals.harness --scenario provider_fallback_chain
 uv run python -m src.evals.harness --scenario provider_health_reroute
@@ -95,7 +96,7 @@ uv run python -m src.evals.harness --scenario evening_review_degraded_delivery_b
 uv run python -m src.evals.harness --scenario evening_review_degraded_inputs_audit
 ```
 
-This runner does not call external providers. It exercises core seams with controlled mocks so REST and WebSocket chat behavior, guardian-state synthesis, intervention policy behavior, observer refresh and delivery behavior, session consolidation behavior, strategist and scheduled proactive flow behavior, delegated tool-heavy workflow behavior, ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, capability-aware runtime policy intents, weighted provider policy scoring, structured routing decision auditing, session-bound helper LLM trace visibility, runtime-path primary and fallback overrides, local helper/agent/all current scheduled-job/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, vault-repository, and filesystem boundary failures, context-window degradation, daily-briefing, activity-digest, and evening-review degraded-input fallback auditing, tool/MCP policy guardrails, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, screen observation summary/cleanup boundary behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
+This runner does not call external providers. It exercises core seams with controlled mocks so REST and WebSocket chat behavior, guardian-state synthesis, intervention policy behavior, observer refresh and delivery behavior, native notification fallback behavior, session consolidation behavior, strategist and scheduled proactive flow behavior, delegated tool-heavy workflow behavior, ordered fallback routing, health-aware provider rerouting, runtime-path profile preferences, wildcard runtime-path rules, capability-aware runtime policy intents, weighted provider policy scoring, structured routing decision auditing, session-bound helper LLM trace visibility, runtime-path primary and fallback overrides, local helper/agent/all current scheduled-job/delegation/MCP-specialist profile routing, embedding-model, vector-store, soul-file, vault-repository, and filesystem boundary failures, context-window degradation, daily-briefing, activity-digest, and evening-review degraded-input fallback auditing, tool/MCP policy guardrails, proactive delivery transport, daemon ingest, manual MCP test API auth-required/success/failure behavior, skills toggle/reload audit behavior, screen observation summary/cleanup boundary behavior, observer source availability and time/goal summaries, sandbox, browser, filesystem, and web-search timeout/empty-result auditing, tool degradation behavior, and audit visibility for strategist/helper paths stay easy to verify after reliability changes.
 
 ### Frontend
 
@@ -125,7 +126,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_activity_digest.py` | 6 | Activity digest — skip/no data, happy path, runtime path, timeout, degraded summary-input audit visibility |
 | `test_daily_briefing.py` | 8 | Daily briefing — happy path, context/LLM failure, empty data, events in prompt, degraded memory-input audit visibility |
 | `test_delegation.py` | 10 | Delegation architecture — orchestrator, specialist routing, depth limits |
-| `test_delivery.py` | 9 | Delivery coordinator — deliver/queue/drop routing, budget decrement, bundle formatting |
+| `test_delivery.py` | 10 | Delivery coordinator — deliver/queue/drop routing, native notification fallback, budget decrement, bundle formatting |
 | `test_embedder.py` | 3 | Embedding model boundary — load success, load failure, encode failure runtime audit logging |
 | `test_e2e_conversation.py` | 3 | End-to-end conversation flow — full agent interaction paths |
 | `test_evening_review.py` | 10 | Evening review — happy path, no goals/messages, DB/LLM failure, date filtering, degraded-input audit visibility |
@@ -139,7 +140,7 @@ Frontend tests use [Vitest](https://vitest.dev/) with jsdom, configured in `vite
 | `test_insight_queue_expiry.py` | 8 | Insight queue expiry — TTL, cleanup, edge cases |
 | `test_mcp_api.py` | 7 | MCP HTTP API endpoints — token update, manual server test auth/success/failure flows, and runtime audit logging |
 | `test_mcp_manager.py` | 31 | MCP server integration — connect, disconnect, failure handling, token auth, env var resolution |
-| `test_observer_api.py` | 7 | Observer API endpoints — state, context POST, daemon status |
+| `test_observer_api.py` | 10 | Observer API endpoints — state, context POST, daemon status, native notification poll/ack |
 | `test_observer_calendar.py` | 4 | Calendar observer source — event parsing, empty/failure handling, runtime audit logging |
 | `test_observer_git.py` | 7 | Git observer source — commit parsing, missing repo/reflog handling, runtime audit logging |
 | `test_observer_goals.py` | 4 | Goals observer source — active goals summary and runtime audit logging |

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -34,7 +34,7 @@ Legend for the checklist column:
 | 01. Trust Boundaries | `[ ]` | Policy modes, approvals, audit logging, and secret handling are shipped; deeper isolation and narrower privileged execution paths are still left |
 | 02. Execution Plane | `[ ]` | Real tools, MCP, browser, shell, filesystem, goals, vault, and web search are shipped; richer workflow execution and stronger execution safety are still left |
 | 03. Runtime Reliability | `[ ]` | Fallback chains, routing rules, local runtime paths, provider scoring, broad audit visibility, and guardian-behavior runtime evals are shipped; richer provider policy and still broader eval depth are still left |
-| 04. Presence And Reach | `[ ]` | Browser UI, WebSocket chat, proactive delivery, observer refresh, and native daemon foundations are shipped; native notifications and broader channel reach are still left |
+| 04. Presence And Reach | `[ ]` | Browser UI, WebSocket chat, proactive delivery, observer refresh, native daemon foundations, and first native notifications are shipped; broader channel reach and a richer desktop shell are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, goals, strategist, briefings, reviews, observer-driven state, explicit guardian state, and intervention policy are shipped foundations; salience modeling and feedback loops are still left |
 | 06. Embodied UX | `[ ]` | The current village UI is shipped, but the target interface is now a dense guardian cockpit rather than a village-first shell |
 | 07. Ecosystem And Leverage | `[ ]` | Skills, MCP, catalog/install surfaces, and delegation foundations are shipped; workflow composition and stronger extension ergonomics are still left |
@@ -59,7 +59,7 @@ This is the rolling execution queue. It should always show the next 10 most valu
    merge observer signals, memory, goals, sessions, and confidence into one structured guardian-state input
 4. [x] `intervention-policy-v1`:
    make intervene, defer, bundle, request-approval, and stay-silent decisions explicit and state-aware
-5. [ ] `native-presence-notifications`:
+5. [x] `native-presence-notifications`:
    add the first real non-browser presence path with desktop notifications and interrupt-aware reach
 6. [ ] `workflow-composition-v1`:
    add first-class reusable multi-step workflows across tools, specialists, skills, and MCP
@@ -100,6 +100,7 @@ This is the rolling execution queue. It should always show the next 10 most valu
 ## Current Shipped Slice On `develop`
 
 - [x] local guardian stack with browser UI, backend APIs, WebSocket chat, scheduler, observer loop, and native macOS daemon
+- [x] first native desktop-notification fallback path when browser delivery is unavailable but the daemon is connected
 - [x] 17 built-in tool capabilities exposed through the registry, with native and MCP-backed execution surfaces
 - [x] 9 scheduler jobs and 5 observer source boundaries wired into the current product
 - [x] provider-agnostic LLM runtime with ordered fallback chains, health-aware rerouting, runtime-path profile preferences, wildcard path rules, runtime-path model overrides, runtime-path fallback overrides, and local-runtime routing across helper, scheduled, agent, delegation, and MCP-specialist paths

--- a/docs/implementation/04-presence-and-reach.md
+++ b/docs/implementation/04-presence-and-reach.md
@@ -11,16 +11,17 @@
 - [x] native macOS observer daemon for screen and OCR ingest
 - [x] observer refresh pipeline across time, calendar, git, goals, and screen context
 - [x] proactive delivery gating and queued-bundle delivery inside the current product
+- [x] first native desktop-notification path when browser delivery is unavailable but the daemon is connected
 
 ## Working On Now
 
 - [ ] this workstream is not the repo-wide active focus while Runtime Reliability is still being hardened
-- [x] this workstream owns `native-presence-notifications` in the master 10-PR queue
+- [x] this workstream lands `native-presence-notifications` in the master 10-PR queue on this branch
 
 ## Still To Do On `develop`
 
 - [ ] native-feeling desktop shell beyond the current browser-plus-daemon split
-- [ ] notifications and interruption channels outside the current in-product delivery surface
+- [ ] richer notification controls and broader interruption channels outside the current in-product delivery surface
 - [ ] broader external communication channels
 - [ ] better cross-surface continuity between ambient observation and deliberate interaction
 
@@ -33,4 +34,5 @@
 
 - [x] Seraph can observe and update state outside the immediate chat loop
 - [x] Seraph can proactively surface output in the current product
-- [ ] Seraph feels present outside a browser tab
+- [x] Seraph has at least one real non-browser presence path outside the browser tab
+- [ ] Seraph feels like a coherent desktop presence rather than a browser app plus daemon

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -88,12 +88,14 @@ title: Seraph Development Status
 - [x] daily briefing, evening review, activity digest, and weekly review surfaces
 - [x] observer refresh across time, calendar, git, goals, and screen context
 - [x] proactive delivery gating and queued-bundle behavior
+- [x] native-notification fallback delivery when browser sockets are unavailable but the daemon is connected
 
 ### Current interface surface
 
 - [x] browser-based village UI with chat, quest, and settings overlays
 - [x] visible tool use and agent activity in the current world surface
 - [x] settings and management surfaces for tools, MCP, and system state
+- [x] macOS daemon notification fallback for non-browser proactive reach
 
 ### Ecosystem foundations
 
@@ -118,7 +120,7 @@ title: Seraph Development Status
 ### Interface and presence
 
 - [ ] primary dense guardian cockpit instead of the current village as the default workflow surface
-- [ ] native desktop shell, notifications, and non-browser presence
+- [ ] richer native desktop shell and broader non-browser presence beyond the first notification fallback path
 - [ ] stronger cross-surface continuity between ambient observation and deliberate interaction
 
 ### Workflow and leverage


### PR DESCRIPTION
Stacked on #185 (feat/intervention-policy-v1).

## Done on develop
- [x] native macOS observer daemon for screen and OCR ingest
- [x] proactive delivery gating and explicit intervention policy at the guardian boundary
- [x] browser and WebSocket proactive delivery transport

## Working in this PR
- [x] add a backend native-notification queue plus daemon poll/ack endpoints
- [x] reroute proactive act decisions to native notifications when browser delivery is unavailable but the daemon is connected
- [x] add backend tests, daemon tests, deterministic eval coverage, and docs updates for the first real non-browser presence path

## Still to do after this PR
- [ ] workflow-composition-v1
- [ ] guardian-feedback-loop
- [ ] operator-cockpit-v1

## Validation
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_delivery.py tests/test_observer_api.py tests/test_eval_harness.py
- cd daemon && UV_CACHE_DIR=/tmp/uv-cache uv run --with-requirements requirements.txt pytest tests/test_notifications.py tests/test_daemon_offline.py tests/test_periodic_capture.py
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python -m src.evals.harness --scenario observer_delivery_decision_behavior --scenario native_presence_notification_behavior --scenario intervention_policy_behavior --indent 2
- cd daemon && UV_CACHE_DIR=/tmp/uv-cache uv run --with-requirements requirements.txt python -m py_compile seraph_daemon.py tests/test_notifications.py tests/test_daemon_offline.py tests/test_periodic_capture.py
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- cd docs && npm run build
- git diff --check
