### PR TITLE
Align research and implementation docs parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Start with:
 
 - [docs/implementation/00-master-roadmap.md](docs/implementation/00-master-roadmap.md)
 - [docs/implementation/STATUS.md](docs/implementation/STATUS.md)
+- [docs/implementation/08-docs-contract.md](docs/implementation/08-docs-contract.md)
+- [docs/implementation/09-benchmark-status.md](docs/implementation/09-benchmark-status.md)
+- [docs/implementation/10-superiority-delivery.md](docs/implementation/10-superiority-delivery.md)
 - [docs/research/00-synthesis.md](docs/research/00-synthesis.md)
 - [docs/research/10-competitive-benchmark.md](docs/research/10-competitive-benchmark.md)
 - [docs/research/11-superiority-program.md](docs/research/11-superiority-program.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,21 @@ Seraph now uses a three-part docs layout:
 - `docs/research/` is the canonical design and product-thesis surface
 - `docs/docs/` is retained as legacy/reference material
 
+The trees are meant to mirror each other:
+
+- research owns target shape, benchmark logic, and superiority logic
+- implementation owns shipped truth, benchmark-status translation, superiority delivery, and the live PR queue
+- `docs/implementation/01-07` are workstreams; `08-10` are cross-cutting mirror docs
+
+Start with:
+
+- `docs/implementation/00-master-roadmap.md`
+- `docs/implementation/STATUS.md`
+- `docs/implementation/08-docs-contract.md`
+- `docs/implementation/09-benchmark-status.md`
+- `docs/implementation/10-superiority-delivery.md`
+- `docs/research/00-synthesis.md`
+
 The Docusaurus site now serves:
 
 - `/` from `docs/implementation/`

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -16,13 +16,25 @@ Seraph uses the same high-level documentation split as `maas`:
 This implementation tree is the canonical answer to four questions:
 
 1. What is shipped on `develop`?
-2. What is the target product shape?
-3. What is still left before Seraph gets there?
+2. How does the target product shape translate into delivery on `develop`?
+3. What is still left before Seraph reaches that target?
 4. What are the next most valuable PRs?
+
+## Docs Contract
+
+- `docs/research/` defines target product shape, evidence rules, benchmark logic, and superiority program logic.
+- `docs/implementation/STATUS.md` is the fastest shipped-state snapshot.
+- this roadmap owns the live 10-PR queue and queue refresh rule.
+- `docs/implementation/08-docs-contract.md` explains the boundary between research truth and implementation truth.
+- `docs/implementation/09-benchmark-status.md` mirrors the benchmark axes from research as shipped implementation status.
+- `docs/implementation/10-superiority-delivery.md` mirrors the superiority program from research as delivery ownership and implementation translation.
+- `docs/implementation/01` through `07` are the only workstream docs; `08` through `10` are cross-cutting implementation mirrors, not extra workstreams.
+- if research adds a new benchmark/program layer without an implementation mirror, the docs are incomplete.
 
 ## Current Status
 
 Read this roadmap together with [Development Status](./STATUS.md).
+For the implementation-side mirrors of the evidence, benchmark, and superiority layers, also read [08. Docs Contract](./08-docs-contract.md), [09. Benchmark Status](./09-benchmark-status.md), and [10. Superiority Delivery](./10-superiority-delivery.md).
 
 Legend for the checklist column:
 
@@ -36,8 +48,8 @@ Legend for the checklist column:
 | 03. Runtime Reliability | `[ ]` | Fallback chains, routing rules, local runtime paths, provider scoring, broad audit visibility, and guardian-behavior runtime evals are shipped; richer provider policy and still broader eval depth are still left |
 | 04. Presence And Reach | `[ ]` | Browser UI, WebSocket chat, proactive delivery, observer refresh, native daemon foundations, and first native notifications are shipped; broader channel reach and a richer desktop shell are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, goals, strategist, briefings, reviews, observer-driven state, explicit guardian state, and intervention policy are shipped foundations; salience modeling and feedback loops are still left |
-| 06. Embodied UX | `[ ]` | The current village UI is shipped, but the target interface is now a dense guardian cockpit rather than a village-first shell |
-| 07. Ecosystem And Leverage | `[ ]` | Skills, MCP, catalog/install surfaces, and delegation foundations are shipped; workflow composition and stronger extension ergonomics are still left |
+| 06. Embodied Interface | `[ ]` | The current village UI is shipped, but the target interface is now a dense guardian cockpit rather than a village-first shell |
+| 07. Ecosystem And Delegation | `[ ]` | Skills, MCP, catalog/install surfaces, and delegation foundations are shipped; workflow composition and stronger extension ergonomics are still left |
 
 ## Progress Summary
 
@@ -85,8 +97,10 @@ This is the rolling execution queue. It should always show the next 10 most valu
 3. Runtime Reliability
 4. Presence And Reach
 5. Guardian Intelligence
-6. Embodied UX
-7. Ecosystem And Leverage
+6. Embodied Interface
+7. Ecosystem And Delegation
+
+Implementation docs `08` through `10` are supporting mirror layers for this roadmap, not additional workstreams.
 
 ## Stable Interfaces
 
@@ -113,6 +127,7 @@ This is the rolling execution queue. It should always show the next 10 most valu
 
 1. Read [Development Status](./STATUS.md) for the live shipped vs unfinished view.
 2. Read this file for workstream ordering and current scope.
-3. Read `01` through `07` for detailed per-workstream checklists.
-4. Read the research docs for the benchmark and superiority target.
-5. Treat `/legacy` docs as supporting history, not the live source of truth.
+3. Read [08. Docs Contract](./08-docs-contract.md), [09. Benchmark Status](./09-benchmark-status.md), and [10. Superiority Delivery](./10-superiority-delivery.md) for the implementation-side mirrors of the research benchmark/program docs.
+4. Read `01` through `07` for detailed per-workstream checklists.
+5. Read the research docs for the benchmark and superiority target.
+6. Treat `/legacy` docs as supporting history, not the live source of truth.

--- a/docs/implementation/01-trust-boundaries.md
+++ b/docs/implementation/01-trust-boundaries.md
@@ -4,6 +4,10 @@
 
 - [ ] Workstream 01 is only partially shipped on `develop`.
 
+## Paired Research
+
+- primary design doc: [04. Trust And Governance](/research/trust-and-governance)
+
 ## Shipped On `develop`
 
 - [x] tool policy modes for `safe`, `balanced`, and `full`
@@ -16,7 +20,7 @@
 
 ## Working On Now
 
-- [ ] this workstream is not the repo-wide active focus while Runtime Reliability is still being hardened
+- [ ] this workstream is not the repo-wide active focus while Guardian Intelligence leads the current 10-PR horizon
 - [x] this workstream owns `execution-safety-hardening-v1` in the master 10-PR queue
 - [ ] reduce reliance on raw secret retrieval in favor of narrower secret-injection paths
 

--- a/docs/implementation/02-execution-plane.md
+++ b/docs/implementation/02-execution-plane.md
@@ -4,6 +4,10 @@
 
 - [ ] Workstream 02 is only partially shipped on `develop`.
 
+## Paired Research
+
+- primary design doc: [05. Execution Plane](/research/execution-plane)
+
 ## Shipped On `develop`
 
 - [x] 17 built-in tool capabilities registered through the native tool registry
@@ -18,7 +22,7 @@
 
 ## Working On Now
 
-- [ ] this workstream is not the repo-wide active focus while Runtime Reliability is still being hardened
+- [ ] this workstream is not the repo-wide active focus while Guardian Intelligence leads the current 10-PR horizon
 - [x] this workstream owns `workflow-composition-v1` and shares `execution-safety-hardening-v1` in the master 10-PR queue
 
 ## Still To Do On `develop`

--- a/docs/implementation/03-runtime-reliability.md
+++ b/docs/implementation/03-runtime-reliability.md
@@ -4,6 +4,10 @@
 
 - [ ] Workstream 03 is only partially shipped on `develop`.
 
+## Paired Research
+
+- primary design doc: [03. Runtime And Reliability](/research/runtime-and-reliability)
+
 ## Shipped On `develop`
 
 - [x] degraded-mode fallback in the context window when `tiktoken` cannot load offline

--- a/docs/implementation/04-presence-and-reach.md
+++ b/docs/implementation/04-presence-and-reach.md
@@ -4,6 +4,10 @@
 
 - [ ] Workstream 04 is only partially shipped on `develop`.
 
+## Paired Research
+
+- primary design doc: [06. Presence And Reach](/research/presence-and-reach)
+
 ## Shipped On `develop`
 
 - [x] browser-based village and chat surface
@@ -15,7 +19,7 @@
 
 ## Working On Now
 
-- [ ] this workstream is not the repo-wide active focus while Runtime Reliability is still being hardened
+- [ ] this workstream is not the repo-wide active focus while Guardian Intelligence leads the current 10-PR horizon
 - [x] this workstream lands `native-presence-notifications` in the master 10-PR queue on this branch
 
 ## Still To Do On `develop`

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -4,6 +4,10 @@
 
 - [ ] Workstream 05 is only partially shipped on `develop`.
 
+## Paired Research
+
+- primary design docs: [01. Guardian Thesis](/research/guardian-thesis) and [02. Human Model And Memory](/research/human-model-and-memory)
+
 ## Shipped On `develop`
 
 - [x] soul-backed persistent identity

--- a/docs/implementation/06-embodied-ux.md
+++ b/docs/implementation/06-embodied-ux.md
@@ -1,8 +1,12 @@
-# Workstream 06: Embodied UX
+# Workstream 06: Embodied Interface
 
 ## Status On `develop`
 
 - [ ] Workstream 06 is only partially shipped on `develop`.
+
+## Paired Research
+
+- primary design doc: [07. Embodied Interface](/research/embodied-interface)
 
 ## Shipped On `develop`
 
@@ -14,7 +18,7 @@
 
 ## Working On Now
 
-- [ ] this workstream is not the repo-wide active focus while Runtime Reliability is still being hardened
+- [ ] this workstream is not the repo-wide active focus while Guardian Intelligence leads the current 10-PR horizon
 - [x] this workstream owns `operator-cockpit-v1` in the master 10-PR queue
 
 ## Still To Do On `develop`

--- a/docs/implementation/07-ecosystem-and-leverage.md
+++ b/docs/implementation/07-ecosystem-and-leverage.md
@@ -1,8 +1,12 @@
-# Workstream 07: Ecosystem And Leverage
+# Workstream 07: Ecosystem And Delegation
 
 ## Status On `develop`
 
 - [ ] Workstream 07 is only partially shipped on `develop`.
+
+## Paired Research
+
+- primary design doc: [08. Ecosystem And Delegation](/research/ecosystem-and-delegation)
 
 ## Shipped On `develop`
 
@@ -15,7 +19,7 @@
 
 ## Working On Now
 
-- [ ] this workstream is not the repo-wide active focus while Runtime Reliability is still being hardened
+- [ ] this workstream is not the repo-wide active focus while Guardian Intelligence leads the current 10-PR horizon
 - [x] this workstream owns `workflow-composition-v1` in the master 10-PR queue
 
 ## Still To Do On `develop`

--- a/docs/implementation/08-docs-contract.md
+++ b/docs/implementation/08-docs-contract.md
@@ -1,0 +1,57 @@
+---
+title: 08. Docs Contract
+---
+
+# 08. Docs Contract
+
+## Status On `develop`
+
+- [x] Seraph now has an explicit docs contract, but it still depends on contributors following it consistently.
+
+## Paired Research
+
+- evidence and comparison rules: [09. Reference Systems And Evidence](/research/reference-systems-and-evidence)
+
+## Purpose
+
+This file explains how research claims become implementation truth.
+
+It is a cross-cutting implementation mirror, not a workstream doc.
+
+Research and implementation should not compete with each other:
+
+- research owns target product shape, evidence rules, benchmark logic, and superiority logic
+- implementation owns shipped truth on `develop`, delivery ownership, and the live 10-PR queue
+
+If a major concept appears in research but not implementation, or vice versa, the docs are incomplete.
+
+## Ownership Rules
+
+- [x] `docs/research/00-synthesis.md` owns the target-product synthesis
+- [x] `docs/research/10-competitive-benchmark.md` owns the comparative judgment
+- [x] `docs/research/11-superiority-program.md` owns the design-level superiority program
+- [x] `docs/implementation/STATUS.md` owns the fastest shipped snapshot
+- [x] `docs/implementation/00-master-roadmap.md` owns the live 10-PR queue and refresh rule
+- [x] `docs/implementation/09-benchmark-status.md` mirrors the benchmark on shipped implementation terms
+- [x] `docs/implementation/10-superiority-delivery.md` mirrors the superiority program on delivery terms
+
+## Update Rules
+
+- [x] If research adds a new benchmark or program layer, implementation needs a mirror doc in the same PR.
+- [x] If implementation changes shipped truth, update `STATUS.md`, the owning workstream file, and any affected mirror docs in the same PR.
+- [x] If the live queue changes, update the roadmap first, then any docs that summarize or justify that queue.
+- [x] Open PRs and stacked branch state belong in PR bodies, not in docs that claim to describe `develop`.
+
+## Parity Rules
+
+- [x] Every implementation workstream should link to its paired research doc or docs.
+- [x] Research should not carry a stale duplicate of the live PR queue.
+- [x] Implementation should not make benchmark or superiority claims without a research-side source.
+- [ ] The trees are only “in parity” when a reader can move from synthesis -> benchmark/program -> shipped implementation without guessing which file owns what.
+
+## Acceptance Checklist
+
+- [x] The docs now explain where research truth ends and implementation truth begins.
+- [x] The benchmark/program layers have explicit implementation mirrors.
+- [x] The entry-point docs can link a reader to the right owner instead of repeating stale fragments.
+- [ ] Future PRs still need to follow this contract for the parity fix to hold.

--- a/docs/implementation/09-benchmark-status.md
+++ b/docs/implementation/09-benchmark-status.md
@@ -1,0 +1,52 @@
+---
+title: 09. Benchmark Status
+---
+
+# 09. Benchmark Status
+
+## Status On `develop`
+
+- [ ] The benchmark program is only partially implemented on `develop`.
+
+## Paired Research
+
+- benchmark source of truth: [10. Competitive Benchmark](/research/competitive-benchmark)
+- evidence rules: [09. Reference Systems And Evidence](/research/reference-systems-and-evidence)
+
+## Purpose
+
+This file is the implementation-side mirror of the competitive benchmark.
+
+Research owns the comparison against OpenClaw, Hermes, and IronClaw.
+This file owns three implementation questions:
+
+1. what is already shipped on `develop` for each benchmark axis?
+2. what is still missing before Seraph can credibly claim `Ahead` on that axis?
+3. which implementation workstreams own that gap?
+
+## Axis Status On `develop`
+
+| Axis | Checklist | Shipped On `develop` | Biggest Missing Piece | Owning Workstreams |
+|---|---|---|---|---|
+| Operator visibility and legibility | `[ ]` | audit trails, visible tool streaming, session traces, and current settings/state surfaces | dense cockpit with linked state, evidence, traces, and approvals in one operator view | 06, 03 |
+| Longitudinal memory and human modeling | `[ ]` | soul, vector memory, consolidation, goals, observer context, and explicit guardian state | better salience, confidence, and world-model quality over time | 05 |
+| Intervention quality and timing | `[ ]` | strategist, proactive scheduler surfaces, explicit intervention policy, and native-notification fallback | learning from outcomes plus stronger salience/confidence-aware timing | 05, 04 |
+| Safe real-world execution | `[ ]` | approvals, policy modes, sandboxed shell path, audit logging, and secret handling | stronger privileged-path isolation and clearer execution-hardening boundaries | 01, 02 |
+| Runtime reliability and eval rigor | `[ ]` | fallback chains, routing policy, structured runtime audit, and broad deterministic eval harness coverage | richer behavioral eval depth and broader provider-policy sophistication | 03 |
+| Workflow composition and delegation | `[ ]` | specialists, MCP, skills, and delegation foundations | first-class reusable workflows and clearer artifact round-tripping | 07, 02 |
+| Dense interface efficiency | `[ ]` | current village UI, settings, and visible agent/tool activity | dense guardian cockpit as the primary operator surface | 06 |
+| Presence and reach across surfaces | `[ ]` | browser delivery, proactive queue/bundle delivery, native daemon, and first desktop-notification fallback | richer desktop shell, stronger cross-surface continuity, and broader channels | 04, 06 |
+
+## What This Means On `develop`
+
+- [x] Seraph already has real foundations on every benchmark axis.
+- [x] Guardian memory, proactive scaffolding, and runtime legibility are stronger than a prototype-only baseline.
+- [ ] Seraph is not yet in a position to claim broad benchmark superiority from shipped implementation alone.
+- [ ] The biggest implementation gaps still cluster around cockpit density, workflow composition, execution hardening, and richer native reach.
+
+## Acceptance Checklist
+
+- [x] Every benchmark axis from research has an explicit implementation owner.
+- [x] Every benchmark axis says what is shipped on `develop` and what is still missing.
+- [ ] No axis should be called effectively “won” in implementation docs without shipped proof on `develop`.
+- [ ] The roadmap queue should continue to map directly back to the gaps named here.

--- a/docs/implementation/10-superiority-delivery.md
+++ b/docs/implementation/10-superiority-delivery.md
@@ -1,0 +1,94 @@
+---
+title: 10. Superiority Delivery
+---
+
+# 10. Superiority Delivery
+
+## Status On `develop`
+
+- [ ] The superiority program is only partially translated into shipped implementation on `develop`.
+
+## Paired Research
+
+- design source of truth: [11. Superiority Program](/research/superiority-program)
+- benchmark input: [10. Competitive Benchmark](/research/competitive-benchmark)
+- synthesis context: [00. Research Synthesis](/research)
+
+## Purpose
+
+This file is the implementation-side mirror of the superiority program.
+
+Research explains why Seraph should win and what “superior” means.
+This file explains:
+
+1. what parts of that program are already shipped on `develop`
+2. what still needs to be built
+3. which workstreams own each remaining gap
+4. where the live 10-PR queue is maintained
+
+## Docs Contract
+
+- [x] `docs/research/00-synthesis.md` defines the target product shape.
+- [x] `docs/research/10-competitive-benchmark.md` owns the evidence-backed comparison.
+- [x] `docs/research/11-superiority-program.md` owns the design-level program of work.
+- [x] `docs/implementation/STATUS.md` owns the fastest shipped snapshot.
+- [x] `docs/implementation/00-master-roadmap.md` owns the rolling 10-PR queue and queue refresh rule.
+- [x] This file owns the translation from benchmark/program gaps into implementation workstreams and delivery ownership.
+
+## Translation On `develop`
+
+### 1. Guardian state and human model
+
+- [x] shipped foundations: soul, vector memory, goals, observer context, and explicit guardian-state synthesis
+- [ ] still missing: stronger human/world modeling quality, salience, and confidence modeling
+- owners: Workstream 05
+
+### 2. Intervention quality and timing
+
+- [x] shipped foundations: strategist, proactive scheduler surfaces, explicit intervention policy, queued bundles, and first native notification fallback
+- [ ] still missing: feedback loops, outcome learning, and stronger timing quality
+- owners: Workstream 05, Workstream 04
+
+### 3. Reliability and legibility
+
+- [x] shipped foundations: runtime routing, fallbacks, scoring, structured audit visibility, and deterministic eval harness coverage
+- [ ] still missing: broader behavioral eval depth and richer provider policy beyond the current weighted router
+- owners: Workstream 03
+
+### 4. Presence and reach
+
+- [x] shipped foundations: browser delivery, WebSocket chat, native daemon ingest, and first desktop-notification fallback path
+- [ ] still missing: richer desktop shell, stronger non-browser continuity, and broader reach channels
+- owners: Workstream 04, Workstream 06
+
+### 5. Operator cockpit
+
+- [x] shipped foundations: distinct visual surface, current world UI, visible tool/activity feedback
+- [ ] still missing: dense multi-pane guardian cockpit with linked evidence, traceability, and control surfaces
+- owners: Workstream 06
+
+### 6. Workflow leverage
+
+- [x] shipped foundations: specialists, skills, MCP, and delegation primitives
+- [ ] still missing: first-class workflows, reusable multi-step compositions, and stronger artifact round-tripping
+- owners: Workstream 07, Workstream 02
+
+### 7. Execution hardening
+
+- [x] shipped foundations: approvals, policy modes, secret redaction, sandbox path, and audit logging
+- [ ] still missing: stronger privileged execution isolation and clearer hardening boundaries
+- owners: Workstream 01, Workstream 02
+
+## Queue Ownership
+
+- [x] The live rolling 10-PR queue stays in [00-master-roadmap.md](./00-master-roadmap.md).
+- [x] This file should explain why the queue exists in its current order.
+- [x] The current next unchecked items are workflow composition, guardian feedback loop, operator cockpit, salience/confidence modeling, and execution hardening.
+- [ ] If benchmark research materially changes priority, update this file and the roadmap in the same PR.
+
+## Acceptance Checklist
+
+- [x] Every superiority-program area has explicit implementation ownership.
+- [x] The docs now say where research truth ends and implementation truth begins.
+- [x] The master roadmap, status page, and synthesis can point to this file instead of duplicating the whole translation layer.
+- [ ] The implementation queue should continue to stay justified by the benchmark and superiority gaps named here.

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -20,6 +20,16 @@ title: Seraph Development Status
 - [ ] No workstream is complete yet.
 - [ ] Seraph is not yet the finished guardian product described in the research docs.
 
+## Docs Contract
+
+- [x] `docs/research/00-synthesis.md` defines what Seraph is trying to become.
+- [x] `docs/research/10-competitive-benchmark.md` owns the comparative judgment.
+- [x] `docs/research/11-superiority-program.md` owns the design-level superiority program.
+- [x] this file owns the fastest shipped snapshot on `develop`.
+- [x] `docs/implementation/00-master-roadmap.md` owns the live 10-PR queue.
+- [x] `docs/implementation/08-docs-contract.md`, `docs/implementation/09-benchmark-status.md`, and `docs/implementation/10-superiority-delivery.md` are the implementation-side mirrors of the research evidence/benchmark/program docs.
+- [x] `docs/implementation/01` through `07` remain the workstream docs; `08` through `10` are meta mirrors, not extra workstreams.
+
 ## Current Focus On `develop`
 
 - [x] Guardian Intelligence is now the active implementation track.
@@ -142,5 +152,5 @@ title: Seraph Development Status
 - [ ] Workstream 03: Runtime Reliability is only partially complete
 - [ ] Workstream 04: Presence And Reach is only partially complete
 - [ ] Workstream 05: Guardian Intelligence is only partially complete
-- [ ] Workstream 06: Embodied UX is only partially complete
-- [ ] Workstream 07: Ecosystem And Leverage is only partially complete
+- [ ] Workstream 06: Embodied Interface is only partially complete
+- [ ] Workstream 07: Ecosystem And Delegation is only partially complete

--- a/docs/research/00-synthesis.md
+++ b/docs/research/00-synthesis.md
@@ -15,6 +15,7 @@ The working model is:
 
 - `docs/research/` answers: what should Seraph become?
 - `docs/implementation/` answers: what is true on `develop` right now?
+- the trees should mirror each other closely enough that no major program layer exists only on one side
 
 This tree now has a narrower standard than before: every major product claim should either be grounded in direct Seraph repo evidence, official reference-system docs, or primary research. If that evidence is missing, the claim should be marked `Unknown`, not rounded into confidence.
 
@@ -94,13 +95,23 @@ Seraph should be judged against OpenClaw, Hermes, and IronClaw on explicit axes:
 
 ## Implementation Mapping
 
-- Workstream 01 maps to trust and governance
-- Workstream 02 maps to execution plane
-- Workstream 03 maps to runtime and reliability
-- Workstream 04 maps to presence and reach
-- Workstream 05 maps to human model and guardian intelligence
-- Workstream 06 maps to embodied interface
-- Workstream 07 maps to ecosystem and delegation
+- Research 01 and 02 map to Workstream 05 in `docs/implementation/05-guardian-intelligence.md`
+- Research 03 maps to Workstream 03 in `docs/implementation/03-runtime-reliability.md`
+- Research 04 maps to Workstream 01 in `docs/implementation/01-trust-boundaries.md`
+- Research 05 maps to Workstream 02 in `docs/implementation/02-execution-plane.md`
+- Research 06 maps to Workstream 04 in `docs/implementation/04-presence-and-reach.md`
+- Research 07 maps to Workstream 06 in `docs/implementation/06-embodied-ux.md`
+- Research 08 maps to Workstream 07 in `docs/implementation/07-ecosystem-and-leverage.md`
+- Research 09 is mirrored by `docs/implementation/08-docs-contract.md`
+- Research 10 is mirrored by `docs/implementation/09-benchmark-status.md`
+- Research 11 is mirrored by `docs/implementation/10-superiority-delivery.md`
+
+## Docs Contract
+
+- research docs define the target shape, evidence rules, and benchmark/program logic
+- implementation docs define shipped truth on `develop`, delivery ownership, and the live PR queue
+- if a new benchmark or program layer appears in research, implementation needs a mirror doc in the same PR
+- if implementation changes the live queue or shipped-state translation, research should not keep a stale competing version
 
 ## What “Superior” Means Here
 

--- a/docs/research/09-reference-systems-and-evidence.md
+++ b/docs/research/09-reference-systems-and-evidence.md
@@ -92,3 +92,10 @@ The research tree should now do two things at once:
 - show exactly where that target comes from and where the evidence is still thin
 
 That keeps the roadmap anchored to verifiable gaps rather than taste alone.
+
+The implementation tree should mirror that work explicitly:
+
+- research evidence rules should have an implementation-side docs contract mirror
+- benchmark logic in research should have a benchmark-status mirror in implementation
+- superiority-program logic in research should have a delivery mirror in implementation
+- the live PR queue should live only in implementation, not as a stale duplicate in research

--- a/docs/research/10-competitive-benchmark.md
+++ b/docs/research/10-competitive-benchmark.md
@@ -10,6 +10,10 @@ This file records the current evidence-backed comparison between Seraph on `deve
 
 The goal is not to win every category on paper. The goal is to identify exactly where Seraph is ahead, behind, or still unknown, then tie that to implementation work.
 
+Implementation mirror:
+
+- `docs/implementation/09-benchmark-status.md` owns the shipped-on-`develop` translation of these axes
+
 ## How To Read This
 
 - `Ahead` means Seraph’s currently shipped repo surface is stronger on the reviewed evidence.

--- a/docs/research/11-superiority-program.md
+++ b/docs/research/11-superiority-program.md
@@ -8,6 +8,11 @@ title: 11. Superiority Program
 
 Make Seraph superior for a power-user guardian use case, not merely “more capable” in the abstract.
 
+Implementation mirror:
+
+- `docs/implementation/10-superiority-delivery.md` owns the shipped-on-`develop` translation of this program
+- `docs/implementation/00-master-roadmap.md` owns the live 10-PR queue
+
 That means winning on:
 
 - durable human modeling
@@ -21,11 +26,11 @@ That means winning on:
 
 ### 1. Guardian state, not just session state
 
-Seraph already has the right foundations: soul, goals, vector memory, observer inputs, strategist, and proactive delivery. The next step is to turn those into one explicit guardian state instead of spreading the logic across isolated call sites.
+Seraph already has the right foundations: soul, goals, vector memory, observer inputs, strategist, proactive delivery, and a first explicit guardian-state layer. The next step is to deepen its quality, confidence, and reuse so the guardian state becomes the default backbone rather than a thin synthesis pass.
 
 ### 2. Intervention quality, not just proactive activity
 
-The product should win by deciding better when to act, defer, bundle, or stay silent. That means explicit policy, confidence, interruption cost, and a real feedback loop.
+Seraph already ships an explicit intervention-policy baseline. The product should win by deciding better when to act, defer, bundle, or stay silent through stronger confidence, interruption cost, outcome learning, and a real feedback loop.
 
 ### 3. Reliability that is visible and testable
 
@@ -59,8 +64,8 @@ Seraph has a browser surface, WebSocket path, and native daemon foundation, but 
 
 ### Guardian intelligence
 
-- build explicit guardian-state synthesis
-- build intervention policy as a first-class decision layer
+- deepen guardian-state synthesis into a richer salience- and confidence-aware backbone
+- evolve intervention policy from a first shipped baseline into a stronger adaptive decision layer
 - capture intervention outcomes and user feedback
 - add observer salience and confidence modeling
 
@@ -71,7 +76,7 @@ Seraph has a browser surface, WebSocket path, and native daemon foundation, but 
 
 ### Presence and leverage
 
-- add native notifications and non-browser reach
+- extend the first native-notification baseline into broader non-browser reach
 - add first-class workflow composition on top of tools, skills, MCP, and specialists
 
 ## Proof Of Superiority
@@ -84,15 +89,9 @@ Seraph should only claim superiority on an axis when all three are true:
 
 ## Translation To Delivery
 
-This research program maps directly to the implementation queue:
+This research program maps directly to the implementation tree, but the live queue should not be duplicated here.
 
-1. provider policy scoring
-2. guardian behavioral evals
-3. guardian-state synthesis
-4. intervention policy
-5. native presence and notifications
-6. workflow composition
-7. guardian feedback loop
-8. operator cockpit
-9. observer salience and confidence
-10. execution safety hardening
+Use:
+
+- `docs/implementation/10-superiority-delivery.md` for the current implementation translation
+- `docs/implementation/00-master-roadmap.md` for the live rolling 10-PR sequence

--- a/docs/sidebars.implementation.ts
+++ b/docs/sidebars.implementation.ts
@@ -2,15 +2,30 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 
 const sidebars: SidebarsConfig = {
   implementationSidebar: [
-    'master-roadmap',
-    'STATUS',
-    'trust-boundaries',
-    'execution-plane',
-    'runtime-reliability',
-    'presence-and-reach',
-    'guardian-intelligence',
-    'embodied-ux',
-    'ecosystem-and-leverage',
+    {
+      type: 'category',
+      label: 'Core',
+      items: [
+        'master-roadmap',
+        'STATUS',
+        'docs-contract',
+        'benchmark-status',
+        'superiority-delivery',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Workstreams',
+      items: [
+        'trust-boundaries',
+        'execution-plane',
+        'runtime-reliability',
+        'presence-and-reach',
+        'guardian-intelligence',
+        'embodied-ux',
+        'ecosystem-and-leverage',
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
Stacked on #186 (`feat/native-presence-notifications`).

## Done on develop
- [x] Seraph already has the MAAS-style split between `docs/research/` and `docs/implementation/`
- [x] research-side benchmark and superiority docs exist in `docs/research/09-11`
- [x] implementation-side roadmap, status, and workstream docs exist in `docs/implementation/00`, `STATUS`, and `01-07`

## Working in this PR
- [ ] add implementation mirror docs for the evidence, benchmark-status, and superiority-delivery layers
- [ ] clarify ownership boundaries so roadmap, status, synthesis, and superiority docs no longer disagree about what research owns vs what implementation owns
- [ ] make navigation less confusing by separating core/meta docs from the seven workstreams and wiring paired research references into each implementation workstream

## Still to do after this PR
- [ ] keep future research PRs adding benchmark/program layers paired with implementation mirror docs in the same changeset
- [ ] continue the queued delivery work after the stacked docs parity pass, starting with `workflow-composition-v1`
- [ ] refresh the rolling 10-PR horizon again when the landed-count modulo-5 rule triggers

## Validation
- `git diff --check`
- `cd docs && npm run build`
