### PR TITLE
Rebuild the active cockpit workspace shell

### DIFF
--- a/backend/src/api/ws.py
+++ b/backend/src/api/ws.py
@@ -339,3 +339,9 @@ async def websocket_chat(websocket: WebSocket):
     except WebSocketDisconnect:
         ws_manager.disconnect(websocket)
         logger.info("WebSocket client disconnected")
+    except RuntimeError as exc:
+        ws_manager.disconnect(websocket)
+        if "WebSocket is not connected" in str(exc):
+            logger.info("WebSocket client disconnected before next receive")
+            return
+        raise

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -48,7 +48,7 @@ Legend for the checklist column:
 | 03. Runtime Reliability | `[ ]` | Fallback chains, routing rules, local runtime paths, provider scoring, broad audit visibility, and guardian-behavior runtime evals are shipped; richer provider policy and still broader eval depth are still left |
 | 04. Presence And Reach | `[ ]` | Browser UI, WebSocket chat, proactive delivery, observer refresh, native daemon foundations, a first coherent desktop presence surface, and a unified browser/native continuity snapshot are shipped; broader channel reach and deeper cross-surface continuity are still left |
 | 05. Guardian Intelligence | `[ ]` | Soul, memory, goals, strategist, briefings, reviews, observer-driven state, observer salience/confidence scoring, explicit guardian state, intervention policy, and feedback capture are shipped foundations; stronger learning loops are still left |
-| 06. Embodied Interface | `[ ]` | A first guardian cockpit shell with linked evidence, saved layouts, keyboard workspace control, and legacy village fallback is shipped, but denser workflow-operating surfaces are still left |
+| 06. Embodied Interface | `[ ]` | The guardian cockpit is now the active browser shell, with a pane workspace, drag/resize plus grid snap, packed layout presets, linked evidence, and keyboard workspace control shipped; denser workflow-operating surfaces are still left |
 | 07. Ecosystem And Delegation | `[ ]` | Skills, MCP, catalog/install surfaces, delegation foundations, and reusable workflow composition are shipped; stronger extension ergonomics and clearer workflow control are still left |
 
 ## Progress Summary
@@ -56,7 +56,7 @@ Legend for the checklist column:
 - [x] Seraph is already a real local guardian prototype with observer, memory, goals, tools, approvals, MCP, and proactive scheduling.
 - [x] Trust Boundaries, Execution Plane, and Runtime Reliability are the strongest shipped foundations on `develop`.
 - [x] The research tree now defines Seraph as a power-user guardian cockpit, not a village-first product.
-- [x] The first guardian cockpit shell is now shipped, with the village retained as a legacy mode rather than the default workflow.
+- [x] The guardian cockpit is now the active interface path, with the village retained only as a legacy fallback rather than a parallel active shell.
 - [ ] Seraph is still behind the strongest reference systems on workflow-operating density, deeper salience/intervention quality, native reach, deeper execution hardening, and operator workflow control.
 - [ ] No workstream is complete yet.
 
@@ -171,13 +171,13 @@ Implementation docs `08` through `10` are supporting mirror layers for this road
 ## Current Shipped Slice On `develop`
 
 - [x] local guardian stack with browser UI, backend APIs, WebSocket chat, scheduler, observer loop, and native macOS daemon
-- [x] guardian cockpit as the default browser shell, with the Phaser village kept as an explicit legacy mode
+- [x] guardian cockpit as the active browser shell, with the Phaser village kept only as an explicit legacy fallback path
 - [x] first coherent desktop presence surface built on daemon status, capture-mode visibility, pending native-notification state, a safe test-notification path, desktop-notification fallback when browser delivery is unavailable, and a first actionable desktop control shell inside the cockpit
 - [x] browser-side continuity controls for native notifications, including pending notification inspection, per-notification dismiss, bulk clear, cockpit-to-settings linkage for queued desktop state, and desktop-shell draft/continue actions over pending notifications, queued bundle items, and recent interventions
 - [x] a unified continuity snapshot now ties daemon state, pending native notifications, deferred bundle items, and recent interventions into one browser-readable model across cockpit and settings surfaces
 - [x] recent negative feedback on the same intervention type can now reduce interruption eagerness for similar future advisory nudges
 - [x] aligned active-work signals now calibrate observer salience upward, and grounded high-salience nudges can cut through high interruption cost outside focus mode
-- [x] the cockpit now supports persisted `default` / `focus` / `review` workspace presets, inspector visibility persistence, and layout switching from both the header and keyboard shortcuts
+- [x] the cockpit now supports a pane workspace with drag/resize, grid snap, packed `default` / `focus` / `review` layout presets, inspector visibility persistence, and layout switching from both the header and keyboard shortcuts
 - [x] 17 built-in tool capabilities exposed through the registry, with native and MCP-backed execution surfaces
 - [x] first-class reusable workflow definitions loaded from defaults and workspace files, exposed through a workflows API, workflow metadata registry, and a dedicated `workflow_runner` specialist
 - [x] first privileged-workflow hardening pass, including explicit workflow/tool execution-boundary metadata, richer approval behavior in tools/workflows APIs, and forced approval wrapping for approval-mode MCP workflow execution
@@ -198,7 +198,7 @@ Implementation docs `08` through `10` are supporting mirror layers for this road
 - [x] deeper guardian behavioral proof now also covers strategist tick learning its way into native-notification delivery and continuity-surface presence when high-signal learned nudges should bypass the browser
 - [x] runtime audit visibility across chat, session-bound helper and agent LLM traces, scheduler including daily-briefing, activity-digest, and evening-review degraded-input fallbacks, observer, screen observation summary/cleanup, proactive delivery transport, MCP lifecycle and manual test API flows, skills toggle/reload flows, embedding, vector store, soul file, vault repository, filesystem, browser, sandbox, and web search paths
 - [x] deterministic eval harness coverage for core runtime, audit, REST and WebSocket chat behavior, guardian-state synthesis, guardian world-model behavior, guardian feedback loop behavior, calibrated salience/confidence delivery behavior, intervention policy behavior, observer refresh and delivery behavior, native desktop presence status plus the test-notification path, session consolidation behavior, tool/MCP guardrail behavior, proactive flow behavior, delegated workflow behavior, workflow composition behavior, observer, storage, tool-boundary, vault repository, MCP test API, skills API, screen repository, and daily-briefing, activity-digest, plus evening-review degraded-input contracts
-- [x] denser guardian cockpit evidence surfaces with pending approvals, recent outputs, selectable intervention/audit/trace rows, an operations inspector that exposes linked details from the audit stream, and persisted layout presets with keyboard switching
+- [x] denser guardian cockpit evidence surfaces with pending approvals, recent outputs, selectable intervention/audit/trace rows, an operations inspector that exposes linked details from the audit stream, and a pane workspace with packed layout presets, drag/resize, grid snap, and keyboard switching
 
 ## Recommended Reading Order
 

--- a/docs/implementation/06-embodied-ux.md
+++ b/docs/implementation/06-embodied-ux.md
@@ -10,17 +10,19 @@
 
 ## Shipped On `develop`
 
-- [x] browser guardian cockpit shell with dense multi-pane layout, fixed composer, session rail, guardian-state panel, intervention feedback, audit surface, live trace, pending approvals, recent outputs, and an operations inspector
+- [x] browser guardian cockpit shell with dense multi-pane operator surfaces, fixed composer, sessions, goals, recent outputs, pending approvals, latest response, guardian state, workflow runs, interventions, audit surface, live trace, desktop continuity, operator controls, and an operations inspector
 - [x] dedicated cockpit workflow-run views with richer workflow inspector actions and artifact-lineage links
 - [x] cockpit artifact and workflow inspectors can now draft compatible follow-on workflows directly from selected artifact paths
-- [x] persisted cockpit workspace presets for `default`, `focus`, and `review`, with inspector visibility persistence and keyboard switching
+- [x] first-class draggable and resizable cockpit panes with persisted positions and z-order
+- [x] cockpit panes now snap to a shared 16px grid during drag, resize, and packed layout reset
+- [x] persisted cockpit workspace presets for `default`, `focus`, and `review`, now implemented as function-based packed pane layouts with inspector visibility persistence and keyboard switching
 - [x] cockpit-native bridge cues through live desktop status, pending native-notification state, deferred bundle visibility, recent intervention continuity, and browser-side native-presence controls in the operator surfaces
 - [x] cockpit-native operator surface for workflow availability, skills, MCP servers, and live policy state with direct reload controls
-- [x] cockpit-first default browser mode with explicit fallback to the legacy village shell
+- [x] cockpit is now the active browser shell on load rather than merely the default mode
 - [x] retro village UI with Phaser-based world rendering
 - [x] animated avatar states with visible casting behavior during tool use
 - [x] RPG-style dialog presentation for chat
-- [x] quest and settings surfaces in the current UI
+- [x] quest and settings overlays now use cockpit modal styling rather than legacy overlay frames
 - [x] standalone village editor support
 
 ## Working On Now
@@ -35,25 +37,27 @@
 
 ## Still To Do On `develop`
 
-- [ ] richer workflow history, broader keyboard/operator control, and more flexible workspace ergonomics inside the cockpit beyond the first dedicated workflow-run layer, direct artifact/workflow draft handoff, and first operator surface
+- [ ] richer workflow history, broader keyboard/operator control, and more flexible workspace ergonomics inside the cockpit beyond the first dedicated workflow-run layer, pane model, direct artifact/workflow draft handoff, and first operator surface
 - [ ] richer ambient indicators and any surviving embodiment strictly subordinate to the cockpit
 - [ ] stronger mobile and cross-surface UX coherence
 
 ## Non-Goals
 
 - cosmetic polish detached from guardian value
-- treating the current village shell as the long-term primary interface
+- treating the legacy village shell as the active or long-term primary interface
 - game aesthetics without meaningful life-state reflection
 
 ## Acceptance Checklist
 
 - [x] the interface feels intentionally different from a generic chatbot shell
 - [x] tool use and agent activity are visible in the world
-- [x] the primary workflow surface is now a guardian cockpit instead of defaulting to the village
+- [x] the primary workflow surface is now a guardian cockpit and the browser no longer boots into the village shell
 - [x] the cockpit now has linked evidence, artifact, and approval density beyond the first shell
 - [x] cockpit artifacts can now round-trip back into the command bar for the next operator step
 - [x] cockpit artifacts can now also seed compatible follow-on workflow drafts directly from the inspector
-- [x] the cockpit now supports persisted workspace presets and keyboard switching for core navigation
+- [x] the cockpit now supports draggable/resizable panes with 16px grid snapping
+- [x] the cockpit now supports persisted packed `default`, `focus`, and `review` layouts plus keyboard switching for core navigation
 - [x] the cockpit now exposes first-class operator visibility for workflows, skills, MCP servers, and live policy state
+- [x] settings and goals now present as cockpit-styled modal overlays instead of legacy shell overlays
 - [ ] the cockpit still needs broader workflow history, denser workflow control, and more flexible workspace ergonomics
 - [ ] the environment reflects the human’s life state and Seraph’s guidance with much higher fidelity

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -33,12 +33,12 @@ title: Seraph Development Status
 
 ## Current Focus On `develop`
 
-- [x] The repo-wide active delivery batch now returns to safer leverage, deeper workflow control, stronger world modeling, and broader cross-surface continuity after the last operator/guardian batch completed.
+- [x] The repo-wide active delivery batch now builds on a cockpit-first live-ops shell with broader cross-surface continuity, denser workflow control, and stronger world modeling after the last operator/guardian batch completed.
 - [ ] That refreshed batch is not complete yet.
 - [x] Guardian Intelligence remains central inside the current batch, but it is no longer the only active workstream.
 - [x] Runtime Reliability now has a strong baseline on `develop`, but it is not fully complete.
 - [x] The repo-wide 10-PR horizon is tracked in `docs/implementation/00-master-roadmap.md`.
-- [x] The next strategic focus is now `execution-safety-hardening-v3` on top of the newly shipped continuity, world-model, workflow-run, artifact-roundtrip, provider-safeguard, desktop-shell, and operator-surface foundations.
+- [x] The next strategic focus is now `execution-safety-hardening-v3` on top of the newly shipped cockpit-first shell, continuity, world-model, workflow-run, artifact-roundtrip, provider-safeguard, desktop-shell, and operator-surface foundations.
 - [x] The first three items in that refreshed batch, `execution-safety-hardening-v2`, `cockpit-workflow-views-v1`, and `guardian-learning-loop-v2`, are now shipped on this branch.
 - [x] `cross-surface-continuity-v2` is now shipped on this branch.
 - [x] `provider-policy-safeguards-v2` is now shipped on this branch.
@@ -127,11 +127,12 @@ title: Seraph Development Status
 
 ### Current interface surface
 
-- [x] browser-based guardian cockpit with session rail, guardian-state panel, dedicated workflow-run views, interventions feed, audit surface, trace view, pending approvals, recent outputs, operations inspector, artifact round-trip into the command bar, fixed composer, and persisted layout presets with keyboard switching
+- [x] cockpit-first browser guardian shell with session rail, guardian-state panel, workflow-run views, interventions feed, audit surface, trace view, pending approvals, recent outputs, operations inspector, artifact round-trip into the command bar, a fixed composer, and live send fallback
 - [x] cockpit workflow and artifact inspectors can now draft compatible follow-on workflows directly from existing artifact paths instead of only inserting generic file-context commands
-- [x] the cockpit now includes a first desktop-shell rail for pending native notifications, queued bundle items, and recent interventions with direct follow-up and dismiss controls
+- [x] grid-snapped draggable panes plus packed persisted `default` / `focus` / `review` layouts with keyboard switching now define the main cockpit workspace
+- [x] the cockpit now includes a first desktop-shell rail for pending native notifications, queued bundle items, and recent interventions with direct follow-up, continue, and dismiss controls
 - [x] the cockpit now includes a first operator surface for tool/MCP policy state, workflow availability, skills, and MCP server visibility with direct reload controls
-- [x] legacy Phaser village mode with chat, quest, and settings overlays
+- [x] larger more readable settings and goals overlays now support the cockpit-first shell without removing the legacy Phaser village fallback
 - [x] visible tool use and agent activity in the current world surface
 - [x] settings and management surfaces for tools, MCP, and system state
 - [x] macOS daemon-backed desktop presence card plus browser-side inspect/dismiss controls for native notifications and notification fallback for non-browser proactive reach

--- a/docs/research/07-embodied-interface.md
+++ b/docs/research/07-embodied-interface.md
@@ -6,9 +6,9 @@ Seraph should feel like a living guardian system with legible state, not a chat 
 
 ## Locked Direction
 
-The current village and avatar shell is **not** the future primary interface direction.
+The primary interface direction is a cockpit/terminal operator surface.
 
-It is a shipped surface on `develop`, but it is the wrong default operating surface for an information-heavy guardian product. The future primary interface is a dense guardian cockpit with a command layer, linked evidence views, and explicit intervention controls.
+The village and avatar shell can remain as a secondary or optional presence surface, but it is not the active shell for the current product direction. The main surface should optimize for command throughput, operator visibility, auditability, and fast intervention across multiple live threads.
 
 ## Why The Village Direction Falls Short
 
@@ -21,7 +21,9 @@ The village can be emotionally distinctive, but distinctiveness is not enough. T
 
 ## Primary Interface Shape
 
-### Top rail
+The near-term shape is a packed pane workspace, not a scenic dashboard. It should behave more like a dense operator desk: snap-aligned panes, a persistent command layer, and enough visible state that the user can steer the guardian without opening stacks of overlays.
+
+### Workspace frame
 
 A persistent guardian status rail showing:
 
@@ -30,49 +32,40 @@ A persistent guardian status rail showing:
 - queue size, urgent alerts, and degraded-state warnings
 - tool activity and intervention mode
 
-### Left rail
+### Packed panes
 
-Navigation and triage:
+The core workspace should support snap-aligned panes for:
 
-- sessions
-- today / timeline
-- goals and projects
-- proactive queue
-- alerts and pending approvals
-- saved workspaces
-
-### Center canvas
-
-A linked widget grid that can show:
-
-- current plan
-- observer signals
-- guardian-state summary
+- sessions and active threads
+- command/composer
+- workflow runs and operator controls
+- approvals and intervention queues
+- audit and live trace
+- artifacts, notes, and files
 - memory evidence
-- artifacts and notes
-- files, web findings, and workflow state
+- goals, projects, and saved workspaces
 
-### Right rail
+These panes should stay useful in compact form, be easy to rearrange, and hold a denser working set than the village-overlay model.
 
-Copilot and trace:
+### Command layer
 
-- conversation
-- current task/workflow trace
-- tool feed
-- citations and rationale
-- approval and interrupt controls
+A persistent command surface should stay available for:
 
-### Bottom composer
-
-A fixed command bar for chat, slash commands, structured actions, and quick redirection.
+- chat and redirection
+- slash-style operator commands
+- workflow launch and replay
+- artifact round-tripping
+- quick approvals and interrupt handling
 
 ## Interface Principles
 
 - keyboard-first by default
-- dense but legible
+- dense enough for continuous operator use
+- legible under high information load
 - provenance visible near every important claim
 - urgent interrupts clearly separated from queued suggestions
-- saved layouts and linked widgets instead of one giant scene
+- snap-aligned panes and saved layouts instead of one giant scene
+- controls should favor fast steering over decorative motion
 - human override and mixed-initiative control must stay explicit
 
 ## Embodiment After The Pivot
@@ -82,6 +75,7 @@ If any embodiment remains, it should be subordinate to the cockpit:
 - ambient status and mood cues
 - optional motivational reflection
 - lightweight ritual or home-state affordances
+- an occasional distinct village or presence surface when the user explicitly wants it
 
 It should not gate core workflows or consume the main screen real estate.
 
@@ -97,7 +91,8 @@ The strongest verified interface references for this direction are:
 
 ## Research Questions
 
-- which widgets belong in the default cockpit versus saved secondary layouts?
-- how much of the guardian trace should stay visible by default?
+- which panes belong in the default operator workspace versus saved secondary layouts?
+- what is the right snapping model for dense panes without creating layout thrash?
+- how much of the guardian trace should stay visible by default in a packed workspace?
 - what is the right split between urgent interrupts, queued suggestions, and ambient state?
 - which parts of the current embodiment survive as optional secondary surfaces?

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,5 @@
-import { useRef, useEffect } from "react";
-import { PhaserGame, type IRefPhaserGame } from "./game/PhaserGame";
-import { ChatPanel } from "./components/chat/ChatPanel";
+import { useEffect } from "react";
 import { QuestPanel } from "./components/quest/QuestPanel";
-import { HudButtons } from "./components/HudButtons";
 import { SettingsPanel } from "./components/SettingsPanel";
 import { useWebSocket } from "./hooks/useWebSocket";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
@@ -13,9 +10,15 @@ import { CockpitView } from "./components/cockpit/CockpitView";
 export default function App() {
   const { sendMessage, skipOnboarding } = useWebSocket();
   useKeyboardShortcuts();
-  const phaserRef = useRef<IRefPhaserGame>(null);
   const interfaceMode = useChatStore((s) => s.interfaceMode);
+  const setInterfaceMode = useChatStore((s) => s.setInterfaceMode);
   // Bridge Phaser EventBus → React panel toggles
+  useEffect(() => {
+    if (interfaceMode !== "cockpit") {
+      setInterfaceMode("cockpit");
+    }
+  }, [interfaceMode, setInterfaceMode]);
+
   useEffect(() => {
     const toggleChat = () => {
       const s = useChatStore.getState();
@@ -37,24 +40,9 @@ export default function App() {
 
   return (
     <>
-      {interfaceMode === "cockpit" ? (
-        <>
-          <CockpitView onSend={sendMessage} onSkipOnboarding={skipOnboarding} />
-          <QuestPanel />
-          <SettingsPanel />
-        </>
-      ) : (
-        <>
-          <div id="game-viewport" className="fixed inset-0 z-0">
-            <PhaserGame ref={phaserRef} />
-          </div>
-          <ChatPanel onSend={sendMessage} onSkipOnboarding={skipOnboarding} />
-          <QuestPanel />
-          <SettingsPanel />
-          <HudButtons />
-          <div className="crt-overlay" />
-        </>
-      )}
+      <CockpitView onSend={sendMessage} onSkipOnboarding={skipOnboarding} />
+      <QuestPanel />
+      <SettingsPanel />
     </>
   );
 }

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1,10 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { API_URL } from "../config/constants";
 import { useChatStore } from "../stores/chatStore";
-import { useDragResize } from "../hooks/useDragResize";
-import { ResizeHandles } from "./ResizeHandles";
 import { EventBus } from "../game/EventBus";
-import { DialogFrame } from "./chat/DialogFrame";
 import { InterruptionModeToggle } from "./settings/InterruptionModeToggle";
 import { DaemonStatus } from "./settings/DaemonStatus";
 import { CaptureModeToggle } from "./settings/CaptureModeToggle";
@@ -410,11 +407,6 @@ export function SettingsPanel() {
   const [installing, setInstalling] = useState<string | null>(null);
   const [configuringServer, setConfiguringServer] = useState<McpServer | null>(null);
 
-  const { panelRef, dragHandleProps, resizeHandleProps, style, bringToFront } = useDragResize("settings", {
-    minWidth: 240,
-    minHeight: 200,
-  });
-
   const fetchSkills = useCallback(async () => {
     try {
       const res = await fetch(`${API_URL}/api/skills`);
@@ -546,20 +538,28 @@ export function SettingsPanel() {
   if (!settingsPanelOpen) return null;
 
   return (
-    <div
-      ref={panelRef}
-      className="settings-overlay"
-      style={style}
-      onPointerDown={bringToFront}
-    >
-      <ResizeHandles resizeHandleProps={resizeHandleProps} />
-      <DialogFrame
-        title="Settings"
-        className="flex-1 min-h-0 flex flex-col"
-        onClose={() => setSettingsPanelOpen(false)}
-        dragHandleProps={dragHandleProps}
-      >
-        <div className="flex-1 min-h-0 overflow-y-auto retro-scrollbar flex flex-col gap-2 pb-1">
+    <div className="cockpit-modal-shell">
+      <button
+        type="button"
+        className="cockpit-modal-backdrop"
+        onClick={() => setSettingsPanelOpen(false)}
+        aria-label="Close settings"
+      />
+      <section className="cockpit-modal-card cockpit-modal-card--settings">
+        <div className="cockpit-modal-header">
+          <div>
+            <div className="cockpit-card-title">Settings</div>
+            <div className="cockpit-card-meta">system controls</div>
+          </div>
+          <button
+            type="button"
+            className="cockpit-modal-close"
+            onClick={() => setSettingsPanelOpen(false)}
+          >
+            Close
+          </button>
+        </div>
+        <div className="cockpit-modal-body cockpit-tone-scope cockpit-settings-scope flex flex-col gap-4">
           <div className="px-1">
             <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-2">
               General
@@ -702,7 +702,7 @@ export function SettingsPanel() {
             Seraph v0.1
           </div>
         </div>
-      </DialogFrame>
+      </section>
     </div>
   );
 }

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,19 +1,21 @@
 import { useState, type FormEvent, type KeyboardEvent } from "react";
 
 interface ChatInputProps {
-  onSend: (message: string) => void;
+  onSend: (message: string) => boolean | void | Promise<boolean | void>;
   disabled: boolean;
 }
 
 export function ChatInput({ onSend, disabled }: ChatInputProps) {
   const [value, setValue] = useState("");
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     const trimmed = value.trim();
     if (!trimmed || disabled) return;
-    onSend(trimmed);
-    setValue("");
+    const sent = await onSend(trimmed);
+    if (sent !== false) {
+      setValue("");
+    }
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -8,7 +8,7 @@ import { ThinkingIndicator } from "./ThinkingIndicator";
 import { ChatSidebar } from "./ChatSidebar";
 
 interface ChatPanelProps {
-  onSend: (message: string) => void;
+  onSend: (message: string) => boolean | void | Promise<boolean | void>;
   onSkipOnboarding?: () => void;
 }
 
@@ -20,8 +20,6 @@ export function ChatPanel({ onSend, onSkipOnboarding }: ChatPanelProps) {
   const toggleChatMaximized = useChatStore((s) => s.toggleChatMaximized);
   const setChatPanelOpen = useChatStore((s) => s.setChatPanelOpen);
   const onboardingCompleted = useChatStore((s) => s.onboardingCompleted);
-  const isConnected = connectionStatus === "connected";
-
   const { panelRef, dragHandleProps, resizeHandleProps, style, bringToFront } = useDragResize("chat", {
     minWidth: 400,
     minHeight: 200,
@@ -59,9 +57,9 @@ export function ChatPanel({ onSend, onSkipOnboarding }: ChatPanelProps) {
             <MessageList />
             {isAgentBusy && <ThinkingIndicator />}
           </div>
-          <ChatInput onSend={onSend} disabled={!isConnected || isAgentBusy} />
+          <ChatInput onSend={onSend} disabled={isAgentBusy} />
         </div>
-        {!isConnected && (
+        {connectionStatus !== "connected" && (
           <div className="absolute top-2 right-4 text-[9px] text-retro-error uppercase animate-blink">
             Disconnected
           </div>

--- a/frontend/src/components/cockpit/CockpitOverlays.test.tsx
+++ b/frontend/src/components/cockpit/CockpitOverlays.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../game/EventBus", () => ({
+  EventBus: {
+    emit: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+}));
+
+import { SettingsPanel } from "../SettingsPanel";
+import { QuestPanel } from "../quest/QuestPanel";
+import { GoalForm } from "../quest/GoalForm";
+import { useChatStore } from "../../stores/chatStore";
+import { useQuestStore } from "../../stores/questStore";
+
+function mockResponse(data: unknown, ok = true) {
+  return {
+    ok,
+    json: async () => data,
+  };
+}
+
+describe("cockpit overlays", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+    useChatStore.setState({
+      settingsPanelOpen: false,
+      questPanelOpen: false,
+      onboardingCompleted: true,
+      debugWalkability: false,
+      interfaceMode: "cockpit",
+      sessions: [],
+      sessionId: null,
+      messages: [],
+      toolRegistry: [],
+    });
+    useQuestStore.setState({
+      goalTree: [],
+      dashboard: { domains: {}, active_count: 0, completed_count: 0, total_count: 0 },
+      loading: false,
+      refresh: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders settings in a cockpit modal instead of a legacy frame", async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/skills")) return Promise.resolve(mockResponse({ skills: [] }));
+      if (url.includes("/api/mcp/servers")) return Promise.resolve(mockResponse({ servers: [] }));
+      if (url.includes("/api/catalog")) return Promise.resolve(mockResponse({ items: [] }));
+      if (url.includes("/api/settings/")) return Promise.resolve(mockResponse({ mode: "balanced" }));
+      if (url.includes("/api/audit/log")) return Promise.resolve(mockResponse({ entries: [] }));
+      if (url.includes("/api/workflows")) return Promise.resolve(mockResponse({ workflows: [] }));
+      return Promise.resolve(mockResponse({}));
+    });
+
+    useChatStore.setState({ settingsPanelOpen: true });
+    const { container } = render(<SettingsPanel />);
+
+    expect(await screen.findByText("Settings")).toBeInTheDocument();
+    expect(container.querySelector(".cockpit-modal-card")).not.toBeNull();
+    expect(container.querySelector(".rpg-frame")).toBeNull();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+
+  it("renders goals and goal editor in cockpit modals", async () => {
+    useChatStore.setState({ questPanelOpen: true });
+    const { container, rerender } = render(<QuestPanel />);
+
+    expect(screen.getByText("Goals")).toBeInTheDocument();
+    expect(container.querySelector(".cockpit-modal-card")).not.toBeNull();
+    expect(container.querySelector(".quest-overlay")).toBeNull();
+
+    rerender(<GoalForm onClose={vi.fn()} />);
+    expect(screen.getByText("New Goal")).toBeInTheDocument();
+    expect(container.querySelector(".rpg-frame")).toBeNull();
+  });
+});

--- a/frontend/src/components/cockpit/CockpitView.test.tsx
+++ b/frontend/src/components/cockpit/CockpitView.test.tsx
@@ -294,7 +294,6 @@ describe("CockpitView", () => {
     expect(screen.getByText("blocked web-brief-to-file · tools write_file")).toBeInTheDocument();
     expect(screen.getByText("bundle 1 queued")).toBeInTheDocument();
     expect(screen.getByText("Guardian nudge")).toBeInTheDocument();
-    expect(screen.getAllByText("Hold this until the browser is back.").length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: "Test browser" }));
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
@@ -343,6 +342,61 @@ describe("CockpitView", () => {
     expect(screen.getAllByText("web-brief-to-file").length).toBeGreaterThan(0);
   }, 15000);
 
+  it("surfaces the latest assistant response in the main cockpit column", async () => {
+    useChatStore.setState({
+      messages: [
+        {
+          id: "user-1",
+          role: "user",
+          content: "What changed today?",
+          timestamp: Date.now() - 1000,
+        },
+        {
+          id: "agent-1",
+          role: "agent",
+          content: "You completed the workflow batch and refreshed the roadmap queue.",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/sessions")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/goals/tree")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/goals/dashboard")) {
+        return Promise.resolve(mockResponse({ domains: {}, active_count: 0, completed_count: 0, total_count: 0 }));
+      }
+      if (url.includes("/api/observer/state")) return Promise.resolve(mockResponse({}));
+      if (url.includes("/api/audit/events")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/approvals/pending")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/observer/continuity")) {
+        return Promise.resolve(mockResponse({
+          daemon: { connected: false, pending_notification_count: 0, capture_mode: "balanced" },
+          notifications: [],
+          queued_insights: [],
+          queued_insight_count: 0,
+          recent_interventions: [],
+        }));
+      }
+      if (url.includes("/api/workflows")) return Promise.resolve(mockResponse({ workflows: [] }));
+      if (url.includes("/api/skills")) return Promise.resolve(mockResponse({ skills: [] }));
+      if (url.includes("/api/mcp/servers")) return Promise.resolve(mockResponse({ servers: [] }));
+      if (url.includes("/api/settings/tool-policy-mode")) return Promise.resolve(mockResponse({ mode: "balanced" }));
+      if (url.includes("/api/settings/mcp-policy-mode")) return Promise.resolve(mockResponse({ mode: "approval" }));
+      if (url.includes("/api/settings/approval-mode")) return Promise.resolve(mockResponse({ mode: "high_risk" }));
+      if (url.includes("/api/tools")) return Promise.resolve(mockResponse([]));
+      return Promise.resolve(mockResponse({}));
+    });
+
+    render(<CockpitView onSend={() => {}} />);
+
+    await waitFor(() => expect(screen.getByText("Latest response")).toBeInTheDocument());
+    expect(
+      screen.getAllByText("You completed the workflow batch and refreshed the roadmap queue.").length,
+    ).toBeGreaterThan(1);
+  });
+
   it("does not process refresh payloads after the cockpit unmounts", async () => {
     const deferredResponses = Array.from({ length: 11 }, () => {
       let resolve!: (value: { ok: boolean; json: () => Promise<unknown> }) => void;
@@ -385,5 +439,44 @@ describe("CockpitView", () => {
 
     expect(jsonSpies.every((spy) => spy.mock.calls.length === 0)).toBe(true);
     expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("keeps the composer text when send fails", async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/sessions")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/goals/tree")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/goals/dashboard")) {
+        return Promise.resolve(mockResponse({ domains: {}, active_count: 0, completed_count: 0, total_count: 0 }));
+      }
+      if (url.includes("/api/observer/state")) return Promise.resolve(mockResponse({}));
+      if (url.includes("/api/audit/events")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/approvals/pending")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/observer/continuity")) {
+        return Promise.resolve(mockResponse({
+          daemon: { connected: false, pending_notification_count: 0, capture_mode: "balanced" },
+          notifications: [],
+          queued_insights: [],
+          queued_insight_count: 0,
+          recent_interventions: [],
+        }));
+      }
+      if (url.includes("/api/workflows")) return Promise.resolve(mockResponse({ workflows: [] }));
+      if (url.includes("/api/skills")) return Promise.resolve(mockResponse({ skills: [] }));
+      if (url.includes("/api/mcp/servers")) return Promise.resolve(mockResponse({ servers: [] }));
+      if (url.includes("/api/settings/tool-policy-mode")) return Promise.resolve(mockResponse({ mode: "balanced" }));
+      if (url.includes("/api/settings/mcp-policy-mode")) return Promise.resolve(mockResponse({ mode: "approval" }));
+      if (url.includes("/api/settings/approval-mode")) return Promise.resolve(mockResponse({ mode: "high_risk" }));
+      if (url.includes("/api/tools")) return Promise.resolve(mockResponse([]));
+      return Promise.resolve(mockResponse({}));
+    });
+
+    render(<CockpitView onSend={vi.fn(async () => false)} />);
+
+    const composer = await screen.findByPlaceholderText(/Ask Seraph/i);
+    fireEvent.change(composer, { target: { value: "keep me" } });
+    fireEvent.submit(composer.closest("form")!);
+
+    await waitFor(() => expect(screen.getByDisplayValue("keep me")).toBeInTheDocument());
   });
 });

--- a/frontend/src/components/cockpit/CockpitView.tsx
+++ b/frontend/src/components/cockpit/CockpitView.tsx
@@ -1,12 +1,15 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from "react";
 
 import { EventBus } from "../../game/EventBus";
 import { API_URL } from "../../config/constants";
 import { useChatStore } from "../../stores/chatStore";
 import { useQuestStore } from "../../stores/questStore";
 import { useCockpitLayoutStore } from "../../stores/cockpitLayoutStore";
+import { usePanelLayoutStore } from "../../stores/panelLayoutStore";
 import type { ChatMessage, GoalInfo } from "../../types";
 import { buildWorkflowDraft, type WorkflowInfo } from "../settings/workflowDraft";
+import { useDragResize } from "../../hooks/useDragResize";
+import { ResizeHandles } from "../ResizeHandles";
 import {
   collectArtifacts,
   collectWorkflowRuns,
@@ -18,7 +21,7 @@ import {
 import { COCKPIT_LAYOUTS, getCockpitLayout } from "./layouts";
 
 interface CockpitViewProps {
-  onSend: (message: string) => void;
+  onSend: (message: string) => boolean | void | Promise<boolean | void>;
   onSkipOnboarding?: () => void;
 }
 
@@ -185,6 +188,46 @@ function supportsArtifactRoundtrip(workflow: WorkflowInfo): boolean {
   return Object.prototype.hasOwnProperty.call(workflow.inputs, "file_path");
 }
 
+function CockpitWorkspaceWindow({
+  panelId,
+  title,
+  meta,
+  minWidth,
+  minHeight,
+  children,
+}: {
+  panelId: string;
+  title: string;
+  meta: string;
+  minWidth: number;
+  minHeight: number;
+  children: ReactNode;
+}) {
+  const { panelRef, dragHandleProps, resizeHandleProps, style, bringToFront } = useDragResize(panelId, {
+    minWidth,
+    minHeight,
+  });
+
+  return (
+    <section
+      ref={panelRef}
+      className="cockpit-window"
+      style={style}
+      onPointerDown={bringToFront}
+    >
+      <ResizeHandles resizeHandleProps={resizeHandleProps} />
+      <div className="cockpit-window-header" {...dragHandleProps}>
+        <div>
+          <div className="cockpit-window-title">{title}</div>
+          <div className="cockpit-window-meta">{meta}</div>
+        </div>
+        <div className="cockpit-window-grip">drag / resize</div>
+      </div>
+      <div className="cockpit-window-body">{children}</div>
+    </section>
+  );
+}
+
 export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [composer, setComposer] = useState("");
@@ -210,7 +253,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
   const activeLayoutId = useCockpitLayoutStore((s) => s.activeLayoutId);
   const inspectorVisible = useCockpitLayoutStore((s) => s.inspectorVisible);
   const setLayout = useCockpitLayoutStore((s) => s.setLayout);
-  const resetLayout = useCockpitLayoutStore((s) => s.resetLayout);
+  const applyCockpitLayout = usePanelLayoutStore((s) => s.applyCockpitLayout);
 
   const messages = useChatStore((s) => s.messages);
   const sessions = useChatStore((s) => s.sessions);
@@ -225,12 +268,23 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
   const newSession = useChatStore((s) => s.newSession);
   const setQuestPanelOpen = useChatStore((s) => s.setQuestPanelOpen);
   const setSettingsPanelOpen = useChatStore((s) => s.setSettingsPanelOpen);
-  const setInterfaceMode = useChatStore((s) => s.setInterfaceMode);
 
   const dashboard = useQuestStore((s) => s.dashboard);
   const goalTree = useQuestStore((s) => s.goalTree);
   const loadingGoals = useQuestStore((s) => s.loading);
   const refreshGoals = useQuestStore((s) => s.refresh);
+
+  const handleResetWorkspace = useCallback(() => {
+    applyCockpitLayout(activeLayoutId, inspectorVisible);
+  }, [activeLayoutId, applyCockpitLayout, inspectorVisible]);
+
+  const handleSelectLayout = useCallback(
+    (layoutId: (typeof COCKPIT_LAYOUTS)[keyof typeof COCKPIT_LAYOUTS]["id"]) => {
+      setLayout(layoutId);
+      applyCockpitLayout(layoutId, inspectorVisible);
+    },
+    [applyCockpitLayout, inspectorVisible, setLayout],
+  );
 
   useEffect(() => {
     loadSessions();
@@ -380,6 +434,18 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
   const activeSession = sessions.find((item) => item.id === sessionId) ?? null;
   const activeLayout = getCockpitLayout(activeLayoutId);
   const recentConversation = messages.slice(-18);
+  const latestResponse = useMemo(
+    () =>
+      [...messages]
+        .reverse()
+        .find((message) =>
+          message.role === "agent"
+          || message.role === "error"
+          || message.role === "approval"
+          || message.role === "proactive",
+        ) ?? null,
+    [messages],
+  );
   const artifacts = useMemo(() => collectArtifacts(auditEvents), [auditEvents]);
   const workflowRuns = useMemo(() => collectWorkflowRuns(auditEvents).slice(0, 6), [auditEvents]);
   const artifactRoundtripWorkflows = useMemo(
@@ -425,7 +491,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
     .reverse();
   const topGoals = collectGoalTitles(goalTree, 5);
   const connectionLabel = connectionStatus === "connected" ? "live" : connectionStatus;
-  const submitDisabled = connectionStatus !== "connected" || isAgentBusy || !composer.trim();
+  const submitDisabled = isAgentBusy || !composer.trim();
 
   function approvalForWorkflow(workflow: WorkflowRunRecord): PendingApproval | null {
     return pendingApprovals.find((approval) => approval.tool_name === workflow.toolName) ?? null;
@@ -484,12 +550,14 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
     }
   }
 
-  function handleSubmit(event: FormEvent) {
+  async function handleSubmit(event: FormEvent) {
     event.preventDefault();
     const message = composer.trim();
     if (!message || submitDisabled) return;
-    onSend(message);
-    setComposer("");
+    const sent = await onSend(message);
+    if (sent !== false) {
+      setComposer("");
+    }
   }
 
   function queueComposerDraft(message: string) {
@@ -828,7 +896,6 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
       <header className="cockpit-topbar">
         <div className="cockpit-brand">
           <div className="cockpit-eyebrow">Seraph</div>
-          <div className="cockpit-title">Guardian Cockpit</div>
           <div className="cockpit-subtitle">
             dense operator surface for state, evidence, interventions, and action
           </div>
@@ -888,12 +955,6 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
             >
               Settings
             </button>
-            <button
-              className="cockpit-action cockpit-action--primary"
-              onClick={() => setInterfaceMode("village")}
-            >
-              Legacy village
-            </button>
           </div>
 
           <div className="cockpit-layout-row">
@@ -903,751 +964,800 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                 className={`cockpit-action cockpit-action--ghost ${
                   activeLayoutId === layout.id ? "cockpit-action--active" : ""
                 }`}
-                onClick={() => setLayout(layout.id)}
+                onClick={() => handleSelectLayout(layout.id)}
                 title={layout.description}
               >
                 {layout.label}
               </button>
             ))}
-            <button className="cockpit-action cockpit-action--ghost" onClick={() => resetLayout()}>
+            <button className="cockpit-action cockpit-action--ghost" onClick={handleResetWorkspace}>
               Reset view
             </button>
           </div>
         </div>
       </header>
 
-      <div className={`cockpit-grid cockpit-grid--${activeLayoutId}`}>
+      <div className="cockpit-workspace">
         {activeLayout.sections.rail && (
-        <aside className="cockpit-rail">
-          <section className="cockpit-panel">
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Sessions</div>
-              <div className="cockpit-card-meta">
-                {activeSession ? activeSession.title : "new session"}
-              </div>
-            </div>
-            <div className="cockpit-list">
-              {sessions.slice(0, 8).map((session) => (
-                <button
-                  key={session.id}
-                  className={`cockpit-session ${session.id === sessionId ? "active" : ""}`}
-                  onClick={() => switchSession(session.id)}
-                >
-                  <span className="cockpit-session-title">{session.title}</span>
-                  <span className="cockpit-session-meta">{formatAge(session.updated_at)}</span>
-                </button>
-              ))}
-              {sessions.length === 0 && (
-                <div className="cockpit-empty">No saved sessions yet.</div>
-              )}
-            </div>
-          </section>
-
-          <section className="cockpit-panel">
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Goals</div>
-              <div className="cockpit-card-meta">
-                {loadingGoals ? "refreshing" : `${dashboard?.active_count ?? 0} active`}
-              </div>
-            </div>
-            {dashboard ? (
-              <div className="cockpit-domain-stack">
-                {Object.entries(dashboard.domains).map(([domain, stat]) => (
-                  <div key={domain} className="cockpit-domain-row">
-                    <div className="cockpit-domain-label">{domain.replace("_", " ")}</div>
-                    <div className="cockpit-domain-bar">
-                      <div
-                        className="cockpit-domain-fill"
-                        style={{ width: `${stat.progress}%` }}
-                      />
-                    </div>
-                    <div className="cockpit-domain-value">{stat.progress}%</div>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="cockpit-empty">Goal dashboard unavailable.</div>
-            )}
-            <div className="cockpit-sublist">
-              {topGoals.map((goal) => (
-                <div key={goal} className="cockpit-sublist-item">
-                  {goal}
-                </div>
-              ))}
-              {topGoals.length === 0 && <div className="cockpit-empty">No active goals yet.</div>}
-            </div>
-          </section>
-
-          <section className="cockpit-panel">
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Recent outputs</div>
-              <div className="cockpit-card-meta">{artifacts.length} files</div>
-            </div>
-            <div className="cockpit-sublist">
-              {artifacts.map((artifact) => (
-                <button
-                  key={artifact.id}
-                  className={`cockpit-sublist-button ${
-                    selectedInspector?.kind === "artifact" && selectedInspector.artifact.id === artifact.id
-                      ? "active"
-                      : ""
-                  }`}
-                  onClick={() => setSelectedInspector({ kind: "artifact", artifact })}
-                >
-                  <span>{artifact.filePath}</span>
-                  <span className="cockpit-row-age">{formatAge(artifact.createdAt)}</span>
-                </button>
-              ))}
-              {artifacts.length === 0 && (
-                <div className="cockpit-empty">No recent file outputs in the current audit window.</div>
-              )}
-            </div>
-          </section>
-
-          <section className="cockpit-panel">
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Pending approvals</div>
-              <div className="cockpit-card-meta">{pendingApprovals.length} waiting</div>
-            </div>
-            <div className="cockpit-list">
-              {pendingApprovals.map((approval) => (
-                <div key={approval.id} className="cockpit-row">
-                  <button
-                    className={`cockpit-row-button ${
-                      selectedInspector?.kind === "approval" && selectedInspector.approval.id === approval.id
-                        ? "active"
-                        : ""
-                    }`}
-                    onClick={() => setSelectedInspector({ kind: "approval", approval })}
-                  >
-                    <div className="cockpit-row-header">
-                      <span className="cockpit-role">{approval.tool_name}</span>
-                      <span className="cockpit-row-age">{formatAge(approval.created_at)}</span>
-                    </div>
-                    <div className="cockpit-row-body">{approval.summary}</div>
-                    <div className="cockpit-row-meta">{approval.risk_level} risk</div>
-                  </button>
-                  <div className="cockpit-feedback-row">
+          <>
+            <CockpitWorkspaceWindow
+              panelId="sessions_pane"
+              title="Sessions"
+              meta={activeSession ? activeSession.title : "new session"}
+              minWidth={260}
+              minHeight={180}
+            >
+              <section className="cockpit-panel cockpit-panel--embedded">
+                <div className="cockpit-list">
+                  {sessions.slice(0, 8).map((session) => (
                     <button
-                      className="cockpit-feedback-button"
-                      onClick={() => void handleApprovalDecision(approval, "approve")}
+                      key={session.id}
+                      className={`cockpit-session ${session.id === sessionId ? "active" : ""}`}
+                      onClick={() => switchSession(session.id)}
                     >
-                      Approve
+                      <span className="cockpit-session-title">{session.title}</span>
+                      <span className="cockpit-session-meta">{formatAge(session.updated_at)}</span>
                     </button>
-                    <button
-                      className="cockpit-feedback-button"
-                      onClick={() => void handleApprovalDecision(approval, "deny")}
-                    >
-                      Deny
-                    </button>
-                    <span className="cockpit-feedback-status">
-                      {approvalState[approval.id] ?? "pending"}
-                    </span>
-                  </div>
-                </div>
-              ))}
-              {pendingApprovals.length === 0 && (
-                <div className="cockpit-empty">No pending approvals.</div>
-              )}
-            </div>
-          </section>
-        </aside>
-        )}
-
-        <main className={`cockpit-center ${activeLayout.centerSingleColumn ? "cockpit-center--single" : ""}`}>
-          {activeLayout.sections.guardianState && (
-          <section className="cockpit-panel">
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Guardian state</div>
-              <div className="cockpit-card-meta">
-                {observerState?.time_of_day ?? "pending"} · {observerState?.day_of_week ?? "today"}
-              </div>
-            </div>
-            <div className="cockpit-state-grid">
-              <div>
-                <div className="cockpit-key">user state</div>
-                <div className="cockpit-value">{observerState?.user_state ?? "unknown"}</div>
-              </div>
-              <div>
-                <div className="cockpit-key">interrupt mode</div>
-                <div className="cockpit-value">{observerState?.interruption_mode ?? "unknown"}</div>
-              </div>
-              <div>
-                <div className="cockpit-key">active window</div>
-                <div className="cockpit-value">{observerState?.active_window ?? "not observed"}</div>
-              </div>
-              <div>
-                <div className="cockpit-key">work hours</div>
-                <div className="cockpit-value">
-                  {observerState?.is_working_hours ? "within window" : "outside window"}
-                </div>
-              </div>
-            </div>
-            <div className="cockpit-context-block">
-              <div className="cockpit-key">screen context</div>
-              <div className="cockpit-value cockpit-value--multiline">
-                {observerState?.screen_context ?? "No screen context ingested yet."}
-              </div>
-            </div>
-            <div className="cockpit-context-block">
-              <div className="cockpit-key">active goals</div>
-              <div className="cockpit-value cockpit-value--multiline">
-                {observerState?.active_goals_summary ?? "Goal summary unavailable."}
-              </div>
-            </div>
-            <div className="cockpit-context-block">
-              <div className="cockpit-key">upcoming events</div>
-              <div className="cockpit-value cockpit-value--multiline">
-                {observerState?.upcoming_events?.length
-                  ? observerState.upcoming_events
-                    .slice(0, 3)
-                    .map((event) => event.summary || "Untitled event")
-                    .join(" • ")
-                  : "No upcoming events loaded."}
-              </div>
-            </div>
-          </section>
-          )}
-
-          {activeLayout.sections.workflows && (
-          <section className="cockpit-panel">
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Workflow runs</div>
-              <div className="cockpit-card-meta">{workflowRuns.length} recent</div>
-            </div>
-            <div className="cockpit-list">
-              {workflowRuns.map((workflow) => {
-                const approval = approvalForWorkflow(workflow);
-                const linkedInterventions = interventionsForWorkflow(workflow);
-                return (
-                  <button
-                    key={workflow.id}
-                    className={`cockpit-row-button ${
-                      selectedInspector?.kind === "workflow" && selectedInspector.workflow.id === workflow.id
-                        ? "active"
-                        : ""
-                    }`}
-                    onClick={() => setSelectedInspector({ kind: "workflow", workflow })}
-                  >
-                    <div className="cockpit-row-header">
-                      <span className="cockpit-role">{workflow.workflowName}</span>
-                      <span className="cockpit-row-age">{formatAge(workflow.updatedAt)}</span>
-                    </div>
-                    <div className="cockpit-row-body">{workflow.summary}</div>
-                    <div className="cockpit-row-meta">
-                      {workflow.status} · {workflow.artifactPaths.length} artifacts ·{" "}
-                      {approval ? "approval waiting" : "no approval"} · {linkedInterventions.length} interventions
-                    </div>
-                  </button>
-                );
-              })}
-              {workflowRuns.length === 0 && (
-                <div className="cockpit-empty">No recent workflow executions in the current audit window.</div>
-              )}
-            </div>
-          </section>
-          )}
-
-          {activeLayout.sections.interventions && (
-          <section className="cockpit-panel">
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Interventions</div>
-              <div className="cockpit-card-meta">{recentInterventions.length} recent</div>
-            </div>
-            <div className="cockpit-list">
-              {recentInterventions.map((message) => (
-                <div key={message.id} className="cockpit-row">
-                  <button
-                    className={`cockpit-row-button ${
-                      selectedInspector?.kind === "intervention" && selectedInspector.intervention.id === message.id
-                        ? "active"
-                        : ""
-                    }`}
-                    onClick={() => setSelectedInspector({ kind: "intervention", intervention: message })}
-                  >
-                    <div className="cockpit-row-header">
-                      <span className="cockpit-role">{message.intervention_type}</span>
-                      <span className="cockpit-row-age">{formatAge(message.updated_at)}</span>
-                    </div>
-                    <div className="cockpit-row-body">{message.content_excerpt}</div>
-                    <div className="cockpit-row-meta">
-                      {formatContinuityLabel(message.continuity_surface)} · {formatContinuityLabel(message.latest_outcome)}
-                    </div>
-                  </button>
-                  {message.id && (
-                    <div className="cockpit-feedback-row">
-                      <button
-                        className="cockpit-feedback-button"
-                        onClick={() => sendFeedback(message.id, "helpful")}
-                      >
-                        Helpful
-                      </button>
-                      <button
-                        className="cockpit-feedback-button"
-                        onClick={() => sendFeedback(message.id, "not_helpful")}
-                      >
-                        Not helpful
-                      </button>
-                      <span className="cockpit-feedback-status">
-                        {feedbackState[message.id] ?? message.feedback_type ?? "unrated"}
-                      </span>
-                    </div>
+                  ))}
+                  {sessions.length === 0 && (
+                    <div className="cockpit-empty">No saved sessions yet.</div>
                   )}
                 </div>
-              ))}
-              {recentInterventions.length === 0 && (
-                <div className="cockpit-empty">No proactive interventions yet.</div>
-              )}
-            </div>
-          </section>
-          )}
+              </section>
+            </CockpitWorkspaceWindow>
 
-          {activeLayout.sections.audit && (
-          <section className="cockpit-panel">
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Audit surface</div>
-              <div className="cockpit-card-meta">{auditEvents.length} events</div>
-            </div>
-            <div className="cockpit-list">
-              {auditEvents.map((event) => (
-                <button
-                  key={event.id}
-                  className={`cockpit-row-button ${
-                    selectedInspector?.kind === "audit" && selectedInspector.event.id === event.id
-                      ? "active"
-                      : ""
-                  }`}
-                  onClick={() => setSelectedInspector({ kind: "audit", event })}
-                >
-                  <div className="cockpit-row-header">
-                    <span className="cockpit-role">{event.tool_name ?? event.event_type}</span>
-                    <span className="cockpit-row-age">{formatAge(event.created_at)}</span>
+            <CockpitWorkspaceWindow
+              panelId="goals_pane"
+              title="Goals"
+              meta={loadingGoals ? "refreshing" : `${dashboard?.active_count ?? 0} active`}
+              minWidth={280}
+              minHeight={220}
+            >
+              <section className="cockpit-panel cockpit-panel--embedded">
+                {dashboard ? (
+                  <div className="cockpit-domain-stack">
+                    {Object.entries(dashboard.domains).map(([domain, stat]) => (
+                      <div key={domain} className="cockpit-domain-row">
+                        <div className="cockpit-domain-label">{domain.replace("_", " ")}</div>
+                        <div className="cockpit-domain-bar">
+                          <div
+                            className="cockpit-domain-fill"
+                            style={{ width: `${stat.progress}%` }}
+                          />
+                        </div>
+                        <div className="cockpit-domain-value">{stat.progress}%</div>
+                      </div>
+                    ))}
                   </div>
-                  <div className="cockpit-row-body">{event.summary}</div>
-                  <div className="cockpit-row-meta">
-                    {event.event_type} · {event.risk_level} · {event.policy_mode}
-                  </div>
-                </button>
-              ))}
-              {auditEvents.length === 0 && (
-                <div className="cockpit-empty">No audit events available.</div>
-              )}
-            </div>
-          </section>
-          )}
+                ) : (
+                  <div className="cockpit-empty">Goal dashboard unavailable.</div>
+                )}
+                <div className="cockpit-sublist">
+                  {topGoals.map((goal) => (
+                    <div key={goal} className="cockpit-sublist-item">
+                      {goal}
+                    </div>
+                  ))}
+                  {topGoals.length === 0 && <div className="cockpit-empty">No active goals yet.</div>}
+                </div>
+              </section>
+            </CockpitWorkspaceWindow>
 
-          {activeLayout.sections.trace && (
-          <section className="cockpit-panel">
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Live trace</div>
-              <div className="cockpit-card-meta">{isAgentBusy ? "agent active" : "idle"}</div>
-            </div>
-            <div className="cockpit-list">
-              {recentTrace.map((message) => (
-                <button
-                  key={message.id}
-                  className={`cockpit-row-button ${
-                    selectedInspector?.kind === "trace" && selectedInspector.message.id === message.id
-                      ? "active"
-                      : ""
-                  }`}
-                  onClick={() => setSelectedInspector({ kind: "trace", message })}
-                >
-                  <div className="cockpit-row-header">
-                    <span className="cockpit-role">{labelForRole(message)}</span>
-                    <span className="cockpit-row-age">{formatAge(message.timestamp)}</span>
-                  </div>
-                  <div className="cockpit-row-body">{message.content}</div>
-                </button>
-              ))}
-              {recentTrace.length === 0 && (
-                <div className="cockpit-empty">No live tool or error trace yet.</div>
-              )}
-            </div>
-          </section>
-          )}
+            <CockpitWorkspaceWindow
+              panelId="outputs_pane"
+              title="Recent outputs"
+              meta={`${artifacts.length} files`}
+              minWidth={280}
+              minHeight={180}
+            >
+              <section className="cockpit-panel cockpit-panel--embedded">
+                <div className="cockpit-sublist">
+                  {artifacts.map((artifact) => (
+                    <button
+                      key={artifact.id}
+                      className={`cockpit-sublist-button ${
+                        selectedInspector?.kind === "artifact" && selectedInspector.artifact.id === artifact.id
+                          ? "active"
+                          : ""
+                      }`}
+                      onClick={() => setSelectedInspector({ kind: "artifact", artifact })}
+                    >
+                      <span>{artifact.filePath}</span>
+                      <span className="cockpit-row-age">{formatAge(artifact.createdAt)}</span>
+                    </button>
+                  ))}
+                  {artifacts.length === 0 && (
+                    <div className="cockpit-empty">No recent file outputs in the current audit window.</div>
+                  )}
+                </div>
+              </section>
+            </CockpitWorkspaceWindow>
 
-          {activeLayout.sections.inspector && inspectorVisible && (
-          <section
-            className={`cockpit-panel ${activeLayout.centerSingleColumn ? "" : "cockpit-panel--span-2"}`}
+            <CockpitWorkspaceWindow
+              panelId="approvals_pane"
+              title="Pending approvals"
+              meta={`${pendingApprovals.length} waiting`}
+              minWidth={300}
+              minHeight={220}
+            >
+              <section className="cockpit-panel cockpit-panel--embedded">
+                <div className="cockpit-list">
+                  {pendingApprovals.map((approval) => (
+                    <div key={approval.id} className="cockpit-row">
+                      <button
+                        className={`cockpit-row-button ${
+                          selectedInspector?.kind === "approval" && selectedInspector.approval.id === approval.id
+                            ? "active"
+                            : ""
+                        }`}
+                        onClick={() => setSelectedInspector({ kind: "approval", approval })}
+                      >
+                        <div className="cockpit-row-header">
+                          <span className="cockpit-role">{approval.tool_name}</span>
+                          <span className="cockpit-row-age">{formatAge(approval.created_at)}</span>
+                        </div>
+                        <div className="cockpit-row-body">{approval.summary}</div>
+                        <div className="cockpit-row-meta">{approval.risk_level} risk</div>
+                      </button>
+                      <div className="cockpit-feedback-row">
+                        <button
+                          className="cockpit-feedback-button"
+                          onClick={() => void handleApprovalDecision(approval, "approve")}
+                        >
+                          Approve
+                        </button>
+                        <button
+                          className="cockpit-feedback-button"
+                          onClick={() => void handleApprovalDecision(approval, "deny")}
+                        >
+                          Deny
+                        </button>
+                        <span className="cockpit-feedback-status">
+                          {approvalState[approval.id] ?? "pending"}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                  {pendingApprovals.length === 0 && (
+                    <div className="cockpit-empty">No pending approvals.</div>
+                  )}
+                </div>
+              </section>
+            </CockpitWorkspaceWindow>
+          </>
+        )}
+
+        {latestResponse && (
+          <CockpitWorkspaceWindow
+            panelId="response_pane"
+            title="Latest response"
+            meta={`${labelForRole(latestResponse)} · ${formatAge(latestResponse.timestamp)}`}
+            minWidth={420}
+            minHeight={160}
           >
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Operations inspector</div>
-              <div className="cockpit-card-meta">
-                {selectedInspector ? selectedInspector.kind : "nothing selected"}
+            <section className="cockpit-panel cockpit-panel--embedded cockpit-panel--response">
+              <div className="cockpit-response-body">{latestResponse.content}</div>
+            </section>
+          </CockpitWorkspaceWindow>
+        )}
+
+        {activeLayout.sections.guardianState && (
+          <CockpitWorkspaceWindow
+            panelId="guardian_state_pane"
+            title="Guardian state"
+            meta={`${observerState?.time_of_day ?? "pending"} · ${observerState?.day_of_week ?? "today"}`}
+            minWidth={420}
+            minHeight={260}
+          >
+            <section className="cockpit-panel cockpit-panel--embedded">
+              <div className="cockpit-state-grid">
+                <div>
+                  <div className="cockpit-key">user state</div>
+                  <div className="cockpit-value">{observerState?.user_state ?? "unknown"}</div>
+                </div>
+                <div>
+                  <div className="cockpit-key">interrupt mode</div>
+                  <div className="cockpit-value">{observerState?.interruption_mode ?? "unknown"}</div>
+                </div>
+                <div>
+                  <div className="cockpit-key">active window</div>
+                  <div className="cockpit-value">{observerState?.active_window ?? "not observed"}</div>
+                </div>
+                <div>
+                  <div className="cockpit-key">work hours</div>
+                  <div className="cockpit-value">
+                    {observerState?.is_working_hours ? "within window" : "outside window"}
+                  </div>
+                </div>
               </div>
-            </div>
-            <div className="cockpit-feed">{renderInspector()}</div>
-          </section>
-          )}
-        </main>
+              <div className="cockpit-context-block">
+                <div className="cockpit-key">screen context</div>
+                <div className="cockpit-value cockpit-value--multiline">
+                  {observerState?.screen_context ?? "No screen context ingested yet."}
+                </div>
+              </div>
+              <div className="cockpit-context-block">
+                <div className="cockpit-key">active goals</div>
+                <div className="cockpit-value cockpit-value--multiline">
+                  {observerState?.active_goals_summary ?? "Goal summary unavailable."}
+                </div>
+              </div>
+              <div className="cockpit-context-block">
+                <div className="cockpit-key">upcoming events</div>
+                <div className="cockpit-value cockpit-value--multiline">
+                  {observerState?.upcoming_events?.length
+                    ? observerState.upcoming_events
+                      .slice(0, 3)
+                      .map((event) => event.summary || "Untitled event")
+                      .join(" • ")
+                    : "No upcoming events loaded."}
+                </div>
+              </div>
+            </section>
+          </CockpitWorkspaceWindow>
+        )}
+
+        {activeLayout.sections.workflows && (
+          <CockpitWorkspaceWindow
+            panelId="workflows_pane"
+            title="Workflow runs"
+            meta={`${workflowRuns.length} recent`}
+            minWidth={380}
+            minHeight={220}
+          >
+            <section className="cockpit-panel cockpit-panel--embedded">
+              <div className="cockpit-list">
+                {workflowRuns.map((workflow) => {
+                  const approval = approvalForWorkflow(workflow);
+                  const linkedInterventions = interventionsForWorkflow(workflow);
+                  return (
+                    <button
+                      key={workflow.id}
+                      className={`cockpit-row-button ${
+                        selectedInspector?.kind === "workflow" && selectedInspector.workflow.id === workflow.id
+                          ? "active"
+                          : ""
+                      }`}
+                      onClick={() => setSelectedInspector({ kind: "workflow", workflow })}
+                    >
+                      <div className="cockpit-row-header">
+                        <span className="cockpit-role">{workflow.workflowName}</span>
+                        <span className="cockpit-row-age">{formatAge(workflow.updatedAt)}</span>
+                      </div>
+                      <div className="cockpit-row-body">{workflow.summary}</div>
+                      <div className="cockpit-row-meta">
+                        {workflow.status} · {workflow.artifactPaths.length} artifacts ·{" "}
+                        {approval ? "approval waiting" : "no approval"} · {linkedInterventions.length} interventions
+                      </div>
+                    </button>
+                  );
+                })}
+                {workflowRuns.length === 0 && (
+                  <div className="cockpit-empty">No recent workflow executions in the current audit window.</div>
+                )}
+              </div>
+            </section>
+          </CockpitWorkspaceWindow>
+        )}
+
+        {activeLayout.sections.interventions && (
+          <CockpitWorkspaceWindow
+            panelId="interventions_pane"
+            title="Interventions"
+            meta={`${recentInterventions.length} recent`}
+            minWidth={380}
+            minHeight={220}
+          >
+            <section className="cockpit-panel cockpit-panel--embedded">
+              <div className="cockpit-list">
+                {recentInterventions.map((message) => (
+                  <div key={message.id} className="cockpit-row">
+                    <button
+                      className={`cockpit-row-button ${
+                        selectedInspector?.kind === "intervention" && selectedInspector.intervention.id === message.id
+                          ? "active"
+                          : ""
+                      }`}
+                      onClick={() => setSelectedInspector({ kind: "intervention", intervention: message })}
+                    >
+                      <div className="cockpit-row-header">
+                        <span className="cockpit-role">{message.intervention_type}</span>
+                        <span className="cockpit-row-age">{formatAge(message.updated_at)}</span>
+                      </div>
+                      <div className="cockpit-row-body">{message.content_excerpt}</div>
+                      <div className="cockpit-row-meta">
+                        {formatContinuityLabel(message.continuity_surface)} · {formatContinuityLabel(message.latest_outcome)}
+                      </div>
+                    </button>
+                    {message.id && (
+                      <div className="cockpit-feedback-row">
+                        <button
+                          className="cockpit-feedback-button"
+                          onClick={() => sendFeedback(message.id, "helpful")}
+                        >
+                          Helpful
+                        </button>
+                        <button
+                          className="cockpit-feedback-button"
+                          onClick={() => sendFeedback(message.id, "not_helpful")}
+                        >
+                          Not helpful
+                        </button>
+                        <span className="cockpit-feedback-status">
+                          {feedbackState[message.id] ?? message.feedback_type ?? "unrated"}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                ))}
+                {recentInterventions.length === 0 && (
+                  <div className="cockpit-empty">No proactive interventions yet.</div>
+                )}
+              </div>
+            </section>
+          </CockpitWorkspaceWindow>
+        )}
+
+        {activeLayout.sections.audit && (
+          <CockpitWorkspaceWindow
+            panelId="audit_pane"
+            title="Audit surface"
+            meta={`${auditEvents.length} events`}
+            minWidth={340}
+            minHeight={220}
+          >
+            <section className="cockpit-panel cockpit-panel--embedded">
+              <div className="cockpit-list">
+                {auditEvents.map((event) => (
+                  <button
+                    key={event.id}
+                    className={`cockpit-row-button ${
+                      selectedInspector?.kind === "audit" && selectedInspector.event.id === event.id
+                        ? "active"
+                        : ""
+                    }`}
+                    onClick={() => setSelectedInspector({ kind: "audit", event })}
+                  >
+                    <div className="cockpit-row-header">
+                      <span className="cockpit-role">{event.tool_name ?? event.event_type}</span>
+                      <span className="cockpit-row-age">{formatAge(event.created_at)}</span>
+                    </div>
+                    <div className="cockpit-row-body">{event.summary}</div>
+                    <div className="cockpit-row-meta">
+                      {event.event_type} · {event.risk_level} · {event.policy_mode}
+                    </div>
+                  </button>
+                ))}
+                {auditEvents.length === 0 && (
+                  <div className="cockpit-empty">No audit events available.</div>
+                )}
+              </div>
+            </section>
+          </CockpitWorkspaceWindow>
+        )}
+
+        {activeLayout.sections.trace && (
+          <CockpitWorkspaceWindow
+            panelId="trace_pane"
+            title="Live trace"
+            meta={isAgentBusy ? "agent active" : "idle"}
+            minWidth={320}
+            minHeight={180}
+          >
+            <section className="cockpit-panel cockpit-panel--embedded">
+              <div className="cockpit-list">
+                {recentTrace.map((message) => (
+                  <button
+                    key={message.id}
+                    className={`cockpit-row-button ${
+                      selectedInspector?.kind === "trace" && selectedInspector.message.id === message.id
+                        ? "active"
+                        : ""
+                    }`}
+                    onClick={() => setSelectedInspector({ kind: "trace", message })}
+                  >
+                    <div className="cockpit-row-header">
+                      <span className="cockpit-role">{labelForRole(message)}</span>
+                      <span className="cockpit-row-age">{formatAge(message.timestamp)}</span>
+                    </div>
+                    <div className="cockpit-row-body">{message.content}</div>
+                  </button>
+                ))}
+                {recentTrace.length === 0 && (
+                  <div className="cockpit-empty">No live tool or error trace yet.</div>
+                )}
+              </div>
+            </section>
+          </CockpitWorkspaceWindow>
+        )}
+
+        {activeLayout.sections.inspector && inspectorVisible && (
+          <CockpitWorkspaceWindow
+            panelId="inspector_pane"
+            title="Operations inspector"
+            meta={selectedInspector ? selectedInspector.kind : "nothing selected"}
+            minWidth={480}
+            minHeight={240}
+          >
+            <section className="cockpit-panel cockpit-panel--embedded">
+              <div className="cockpit-feed">{renderInspector()}</div>
+            </section>
+          </CockpitWorkspaceWindow>
+        )}
 
         {activeLayout.sections.conversation && (
-        <aside className="cockpit-chatrail">
-          <section className="cockpit-panel cockpit-chat-panel">
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Conversation</div>
-              <div className="cockpit-card-meta">
-                {activeSession?.title ?? "new session"}
-              </div>
-            </div>
-            <div className="cockpit-feed">
-              {recentConversation.map((message) => (
-                <div key={message.id} className={`cockpit-message cockpit-message--${message.role}`}>
-                  <div className="cockpit-row-header">
-                    <span className="cockpit-role">{labelForRole(message)}</span>
-                    <span className="cockpit-row-age">{formatAge(message.timestamp)}</span>
-                  </div>
-                  <div className="cockpit-message-body">{message.content}</div>
-                </div>
-              ))}
-              {recentConversation.length === 0 && (
-                <div className="cockpit-empty">No conversation yet. Use the command bar below.</div>
-              )}
-            </div>
-          </section>
-
-          <section className="cockpit-panel">
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Desktop shell</div>
-              <div className="cockpit-card-meta">
-                {daemonPresence?.connected ? "linked" : "offline"} · {desktopNotifications.length} alerts
-              </div>
-            </div>
-            <div className="cockpit-sublist">
-              <div className="cockpit-sublist-item">
-                capture {daemonPresence?.capture_mode ?? "unknown"} · bundle {queuedInsights.length} · recent {recentInterventions.length}
-              </div>
-            </div>
-            <div className="cockpit-list">
-              {desktopNotifications.slice(0, 3).map((notification) => (
-                <div key={notification.id} className="cockpit-row">
-                  <div className="cockpit-row-header">
-                    <span className="cockpit-role">{notification.title}</span>
-                    <span className="cockpit-row-age">{formatAge(notification.created_at)}</span>
-                  </div>
-                  <div className="cockpit-row-body">{notification.body}</div>
-                  <div className="cockpit-feedback-row">
-                    <button
-                      className="cockpit-feedback-button"
-                      onClick={() => queueComposerDraft(`Follow up on this desktop alert: ${notification.body}`)}
-                    >
-                      Draft Follow-up
-                    </button>
-                    <button
-                      className="cockpit-feedback-button"
-                      onClick={() => void dismissDesktopNotification(notification.id)}
-                    >
-                      Dismiss
-                    </button>
-                  </div>
-                </div>
-              ))}
-              {desktopNotifications.length > 1 && (
-                <button className="cockpit-feedback-button" onClick={() => void dismissAllDesktopNotifications()}>
-                  Dismiss All Alerts
-                </button>
-              )}
-              {queuedInsights.slice(0, 2).map((item) => (
-                <div key={item.id} className="cockpit-row">
-                  <div className="cockpit-row-header">
-                    <span className="cockpit-role">{item.intervention_type}</span>
-                    <span className="cockpit-row-age">{formatAge(item.created_at)}</span>
-                  </div>
-                  <div className="cockpit-row-body">{item.content_excerpt}</div>
-                  <div className="cockpit-feedback-row">
-                    <button
-                      className="cockpit-feedback-button"
-                      onClick={() => queueComposerDraft(`Follow up on this deferred guardian item: ${item.content_excerpt}`)}
-                    >
-                      Draft Follow-up
-                    </button>
-                  </div>
-                </div>
-              ))}
-              {recentInterventions.slice(0, 2).map((item) => (
-                <div key={`desktop-${item.id}`} className="cockpit-row">
-                  <div className="cockpit-row-header">
-                    <span className="cockpit-role">{item.intervention_type}</span>
-                    <span className="cockpit-row-age">{formatAge(item.updated_at)}</span>
-                  </div>
-                  <div className="cockpit-row-body">{item.content_excerpt}</div>
-                  <div className="cockpit-row-meta">
-                    {formatContinuityLabel(item.continuity_surface)} · {formatContinuityLabel(item.latest_outcome)}
-                  </div>
-                  <div className="cockpit-feedback-row">
-                    <button
-                      className="cockpit-feedback-button"
-                      onClick={() => queueComposerDraft(`Continue from this guardian intervention: ${item.content_excerpt}`)}
-                    >
-                      Continue
-                    </button>
-                    <button
-                      className="cockpit-feedback-button"
-                      onClick={() => sendFeedback(item.id, "helpful")}
-                    >
-                      Helpful
-                    </button>
-                  </div>
-                </div>
-              ))}
-              {desktopNotifications.length === 0 && queuedInsights.length === 0 && recentInterventions.length === 0 && (
-                <div className="cockpit-empty">No desktop continuity items yet.</div>
-              )}
-            </div>
-          </section>
-
-          <section className="cockpit-panel">
-            <div className="cockpit-card-header">
-              <div className="cockpit-card-title">Operator surface</div>
-              <div className="cockpit-card-meta">
-                tool {toolPolicyMode} · mcp {mcpPolicyMode}
-              </div>
-            </div>
-            <div className="cockpit-state-grid">
-              <div>
-                <div className="cockpit-key">approval</div>
-                <div className="cockpit-value">{approvalMode}</div>
-              </div>
-              <div>
-                <div className="cockpit-key">visible tools</div>
-                <div className="cockpit-value">
-                  {tools.length} total · {highRiskTools.length} high risk
-                </div>
-              </div>
-              <div>
-                <div className="cockpit-key">skills</div>
-                <div className="cockpit-value">
-                  {enabledSkills.length}/{skills.length} enabled
-                </div>
-              </div>
-              <div>
-                <div className="cockpit-key">mcp</div>
-                <div className="cockpit-value">
-                  {enabledMcpServers.length}/{mcpServers.length} servers · {mcpTools.length} tools
-                </div>
-              </div>
-              <div>
-                <div className="cockpit-key">workflows</div>
-                <div className="cockpit-value">
-                  {availableWorkflows.length}/{workflows.length} available
-                </div>
-              </div>
-            </div>
-            <div className="cockpit-sublist">
-              <div className="cockpit-operator-section">
-                <div className="cockpit-key">policy state</div>
-                <div className="cockpit-operator-row">
-                  <span className="cockpit-operator-label">tools</span>
-                  <div className="cockpit-operator-actions">
-                    {(["safe", "balanced", "full"] as const).map((mode) => (
-                      <button
-                        key={mode}
-                        type="button"
-                        aria-label={`Set tool policy to ${mode}`}
-                        aria-pressed={toolPolicyMode === mode}
-                        className={`cockpit-operator-button ${toolPolicyMode === mode ? "cockpit-operator-button--active" : ""}`}
-                        onClick={() => void updateToolPolicy(mode)}
-                      >
-                        {mode}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-                <div className="cockpit-operator-row">
-                  <span className="cockpit-operator-label">mcp</span>
-                  <div className="cockpit-operator-actions">
-                    {([
-                      { value: "disabled", label: "off" },
-                      { value: "approval", label: "ask" },
-                      { value: "full", label: "full" },
-                    ] as const).map((mode) => (
-                      <button
-                        key={mode.value}
-                        type="button"
-                        aria-label={`Set MCP policy to ${mode.value}`}
-                        aria-pressed={mcpPolicyMode === mode.value}
-                        className={`cockpit-operator-button ${mcpPolicyMode === mode.value ? "cockpit-operator-button--active" : ""}`}
-                        onClick={() => void updateMcpPolicy(mode.value)}
-                      >
-                        {mode.label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-                <div className="cockpit-operator-row">
-                  <span className="cockpit-operator-label">approval</span>
-                  <div className="cockpit-operator-actions">
-                    {([
-                      { value: "high_risk", label: "high risk" },
-                      { value: "off", label: "off" },
-                    ] as const).map((mode) => (
-                      <button
-                        key={mode.value}
-                        type="button"
-                        aria-label={`Set approval mode to ${mode.value}`}
-                        aria-pressed={approvalMode === mode.value}
-                        className={`cockpit-operator-button ${approvalMode === mode.value ? "cockpit-operator-button--active" : ""}`}
-                        onClick={() => void updateApprovalPolicy(mode.value)}
-                      >
-                        {mode.label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              </div>
-
-              <div className="cockpit-operator-section">
-                <div className="cockpit-operator-row">
-                  <span className="cockpit-key">mcp servers</span>
-                  <button
-                    type="button"
-                    className="cockpit-operator-link"
-                    onClick={() => setSettingsPanelOpen(true)}
-                  >
-                    full settings
-                  </button>
-                </div>
-                {mcpServers.slice(0, 3).map((server) => (
-                  <div key={server.name} className="cockpit-operator-row">
-                    <div className="cockpit-operator-details">
-                      <div className="cockpit-value">{server.name}</div>
-                      <div className="cockpit-operator-note">
-                        {server.status === "connected"
-                          ? `${server.tool_count ?? 0} tools live`
-                          : server.status === "auth_required"
-                            ? "auth required"
-                            : server.status === "error"
-                              ? server.status_message || "error"
-                              : server.enabled
-                                ? "disconnected"
-                                : "disabled"}
+          <>
+            <CockpitWorkspaceWindow
+              panelId="conversation_pane"
+              title="Conversation"
+              meta={activeSession?.title ?? "new session"}
+              minWidth={360}
+              minHeight={260}
+            >
+              <section className="cockpit-panel cockpit-panel--embedded cockpit-chat-panel">
+                <div className="cockpit-feed">
+                  {recentConversation.map((message) => (
+                    <div key={message.id} className={`cockpit-message cockpit-message--${message.role}`}>
+                      <div className="cockpit-row-header">
+                        <span className="cockpit-role">{labelForRole(message)}</span>
+                        <span className="cockpit-row-age">{formatAge(message.timestamp)}</span>
                       </div>
+                      <div className="cockpit-message-body">{message.content}</div>
                     </div>
-                    <div className="cockpit-operator-actions">
-                      <button
-                        type="button"
-                        aria-label={`Test ${server.name}`}
-                        className="cockpit-operator-button"
-                        onClick={() => void testMcpServer(server)}
-                      >
-                        test
-                      </button>
-                      <button
-                        type="button"
-                        aria-label={`${server.enabled ? "Turn off" : "Turn on"} ${server.name}`}
-                        className={`cockpit-operator-button ${server.enabled ? "cockpit-operator-button--active" : ""}`}
-                        onClick={() => void toggleMcpServer(server)}
-                      >
-                        {server.enabled ? "on" : "off"}
-                      </button>
-                      {(server.status === "auth_required" || server.has_headers) && (
+                  ))}
+                  {recentConversation.length === 0 && (
+                    <div className="cockpit-empty">No conversation yet. Use the command bar below.</div>
+                  )}
+                </div>
+              </section>
+            </CockpitWorkspaceWindow>
+
+            <CockpitWorkspaceWindow
+              panelId="desktop_shell_pane"
+              title="Desktop shell"
+              meta={`${daemonPresence?.connected ? "linked" : "offline"} · ${desktopNotifications.length} alerts`}
+              minWidth={340}
+              minHeight={220}
+            >
+              <section className="cockpit-panel cockpit-panel--embedded">
+                <div className="cockpit-sublist">
+                  <div className="cockpit-sublist-item">
+                    capture {daemonPresence?.capture_mode ?? "unknown"} · bundle {queuedInsights.length} · recent {recentInterventions.length}
+                  </div>
+                </div>
+                <div className="cockpit-list">
+                  {desktopNotifications.slice(0, 3).map((notification) => (
+                    <div key={notification.id} className="cockpit-row">
+                      <div className="cockpit-row-header">
+                        <span className="cockpit-role">{notification.title}</span>
+                        <span className="cockpit-row-age">{formatAge(notification.created_at)}</span>
+                      </div>
+                      <div className="cockpit-row-body">{notification.body}</div>
+                      <div className="cockpit-feedback-row">
                         <button
-                          type="button"
-                          aria-label={`Open settings for ${server.name}`}
-                          className="cockpit-operator-button"
-                          onClick={() => setSettingsPanelOpen(true)}
+                          className="cockpit-feedback-button"
+                          onClick={() => queueComposerDraft(`Follow up on this desktop alert: ${notification.body}`)}
                         >
-                          setup
+                          Draft Follow-up
                         </button>
-                      )}
-                    </div>
-                  </div>
-                ))}
-                {mcpServers.length === 0 && (
-                  <div className="cockpit-empty">No MCP servers configured.</div>
-                )}
-              </div>
-
-              <div className="cockpit-operator-section">
-                <div className="cockpit-operator-row">
-                  <span className="cockpit-key">skills</span>
-                  <button
-                    type="button"
-                    className="cockpit-operator-link"
-                    onClick={() => void reloadOperatorSurface("skills")}
-                  >
-                    reload
-                  </button>
-                </div>
-                {skills.slice(0, 4).map((skill) => (
-                  <div key={skill.name} className="cockpit-operator-row">
-                    <div className="cockpit-operator-details">
-                      <div className="cockpit-value">{skill.name}</div>
-                      <div className="cockpit-operator-note">
-                        {skill.user_invocable ? "invocable" : "runtime"}{skill.requires_tools?.length ? ` · ${skill.requires_tools.join(", ")}` : ""}
+                        <button
+                          className="cockpit-feedback-button"
+                          onClick={() => void dismissDesktopNotification(notification.id)}
+                        >
+                          Dismiss
+                        </button>
                       </div>
                     </div>
-                    <div className="cockpit-operator-actions">
-                      <button
-                        type="button"
-                        aria-label={`${skill.enabled ? "Turn off" : "Turn on"} ${skill.name}`}
-                        className={`cockpit-operator-button ${skill.enabled ? "cockpit-operator-button--active" : ""}`}
-                        onClick={() => void toggleSkill(skill)}
-                      >
-                        {skill.enabled ? "on" : "off"}
-                      </button>
+                  ))}
+                  {desktopNotifications.length > 1 && (
+                    <button className="cockpit-feedback-button" onClick={() => void dismissAllDesktopNotifications()}>
+                      Dismiss All Alerts
+                    </button>
+                  )}
+                  {queuedInsights.slice(0, 2).map((item) => (
+                    <div key={item.id} className="cockpit-row">
+                      <div className="cockpit-row-header">
+                        <span className="cockpit-role">{item.intervention_type}</span>
+                        <span className="cockpit-row-age">{formatAge(item.created_at)}</span>
+                      </div>
+                      <div className="cockpit-row-body">{item.content_excerpt}</div>
+                      <div className="cockpit-feedback-row">
+                        <button
+                          className="cockpit-feedback-button"
+                          onClick={() => queueComposerDraft(`Follow up on this deferred guardian item: ${item.content_excerpt}`)}
+                        >
+                          Draft Follow-up
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                  {recentInterventions.slice(0, 2).map((item) => (
+                    <div key={`desktop-${item.id}`} className="cockpit-row">
+                      <div className="cockpit-row-header">
+                        <span className="cockpit-role">{item.intervention_type}</span>
+                        <span className="cockpit-row-age">{formatAge(item.updated_at)}</span>
+                      </div>
+                      <div className="cockpit-row-body">{item.content_excerpt}</div>
+                      <div className="cockpit-row-meta">
+                        {formatContinuityLabel(item.continuity_surface)} · {formatContinuityLabel(item.latest_outcome)}
+                      </div>
+                      <div className="cockpit-feedback-row">
+                        <button
+                          className="cockpit-feedback-button"
+                          onClick={() => queueComposerDraft(`Continue from this guardian intervention: ${item.content_excerpt}`)}
+                        >
+                          Continue
+                        </button>
+                        <button
+                          className="cockpit-feedback-button"
+                          onClick={() => sendFeedback(item.id, "helpful")}
+                        >
+                          Helpful
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                  {desktopNotifications.length === 0 && queuedInsights.length === 0 && recentInterventions.length === 0 && (
+                    <div className="cockpit-empty">No desktop continuity items yet.</div>
+                  )}
+                </div>
+              </section>
+            </CockpitWorkspaceWindow>
+
+            <CockpitWorkspaceWindow
+              panelId="operator_surface_pane"
+              title="Operator surface"
+              meta={`tool ${toolPolicyMode} · mcp ${mcpPolicyMode}`}
+              minWidth={360}
+              minHeight={260}
+            >
+              <section className="cockpit-panel cockpit-panel--embedded">
+                <div className="cockpit-state-grid">
+                  <div>
+                    <div className="cockpit-key">approval</div>
+                    <div className="cockpit-value">{approvalMode}</div>
+                  </div>
+                  <div>
+                    <div className="cockpit-key">visible tools</div>
+                    <div className="cockpit-value">
+                      {tools.length} total · {highRiskTools.length} high risk
                     </div>
                   </div>
-                ))}
-                {skills.length === 0 && (
-                  <div className="cockpit-empty">No skills loaded.</div>
-                )}
-              </div>
-
-              <div className="cockpit-operator-section">
-                <div className="cockpit-operator-row">
-                  <span className="cockpit-key">workflow availability</span>
-                  <button
-                    type="button"
-                    className="cockpit-operator-link"
-                    onClick={() => void reloadOperatorSurface("workflows")}
-                  >
-                    reload
-                  </button>
-                </div>
-                <div className="cockpit-sublist-item">
-                  invocable {availableWorkflows.filter((workflow) => workflow.user_invocable).length}/{invocableWorkflows.length} available
-                </div>
-                <div className="cockpit-sublist-item">
-                  approval {approvalWorkflows.length} · blocked {blockedWorkflows.length}
-                </div>
-                {blockedWorkflows.slice(0, 2).map((workflow) => (
-                  <div key={workflow.name} className="cockpit-sublist-item">
-                    blocked {workflow.name}
-                    {workflow.missing_tools?.length ? ` · tools ${workflow.missing_tools.join(", ")}` : ""}
-                    {workflow.missing_skills?.length ? ` · skills ${workflow.missing_skills.join(", ")}` : ""}
+                  <div>
+                    <div className="cockpit-key">skills</div>
+                    <div className="cockpit-value">
+                      {enabledSkills.length}/{skills.length} enabled
+                    </div>
                   </div>
-                ))}
-                {workflows.length === 0 && (
-                  <div className="cockpit-empty">No workflows available.</div>
-                )}
-              </div>
-              {operatorStatus && (
-                <div className="cockpit-sublist-item">{operatorStatus}</div>
-              )}
-              <div className="cockpit-feedback-row">
-                <button
-                  className="cockpit-feedback-button"
-                  onClick={() => setSettingsPanelOpen(true)}
-                >
-                  Open Settings
-                </button>
-              </div>
-              {workflows.length === 0 && skills.length === 0 && mcpServers.length === 0 && tools.length === 0 && (
-                <div className="cockpit-empty">Operator surface unavailable.</div>
-              )}
-            </div>
-          </section>
-        </aside>
+                  <div>
+                    <div className="cockpit-key">mcp</div>
+                    <div className="cockpit-value">
+                      {enabledMcpServers.length}/{mcpServers.length} servers · {mcpTools.length} tools
+                    </div>
+                  </div>
+                  <div>
+                    <div className="cockpit-key">workflows</div>
+                    <div className="cockpit-value">
+                      {availableWorkflows.length}/{workflows.length} available
+                    </div>
+                  </div>
+                </div>
+                <div className="cockpit-sublist">
+                  <div className="cockpit-operator-section">
+                    <div className="cockpit-key">policy state</div>
+                    <div className="cockpit-operator-row">
+                      <span className="cockpit-operator-label">tools</span>
+                      <div className="cockpit-operator-actions">
+                        {(["safe", "balanced", "full"] as const).map((mode) => (
+                          <button
+                            key={mode}
+                            type="button"
+                            aria-label={`Set tool policy to ${mode}`}
+                            aria-pressed={toolPolicyMode === mode}
+                            className={`cockpit-operator-button ${toolPolicyMode === mode ? "cockpit-operator-button--active" : ""}`}
+                            onClick={() => void updateToolPolicy(mode)}
+                          >
+                            {mode}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="cockpit-operator-row">
+                      <span className="cockpit-operator-label">mcp</span>
+                      <div className="cockpit-operator-actions">
+                        {([
+                          { value: "disabled", label: "off" },
+                          { value: "approval", label: "ask" },
+                          { value: "full", label: "full" },
+                        ] as const).map((mode) => (
+                          <button
+                            key={mode.value}
+                            type="button"
+                            aria-label={`Set MCP policy to ${mode.value}`}
+                            aria-pressed={mcpPolicyMode === mode.value}
+                            className={`cockpit-operator-button ${mcpPolicyMode === mode.value ? "cockpit-operator-button--active" : ""}`}
+                            onClick={() => void updateMcpPolicy(mode.value)}
+                          >
+                            {mode.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="cockpit-operator-row">
+                      <span className="cockpit-operator-label">approval</span>
+                      <div className="cockpit-operator-actions">
+                        {([
+                          { value: "high_risk", label: "high risk" },
+                          { value: "off", label: "off" },
+                        ] as const).map((mode) => (
+                          <button
+                            key={mode.value}
+                            type="button"
+                            aria-label={`Set approval mode to ${mode.value}`}
+                            aria-pressed={approvalMode === mode.value}
+                            className={`cockpit-operator-button ${approvalMode === mode.value ? "cockpit-operator-button--active" : ""}`}
+                            onClick={() => void updateApprovalPolicy(mode.value)}
+                          >
+                            {mode.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="cockpit-operator-section">
+                    <div className="cockpit-operator-row">
+                      <span className="cockpit-key">mcp servers</span>
+                      <button
+                        type="button"
+                        className="cockpit-operator-link"
+                        onClick={() => setSettingsPanelOpen(true)}
+                      >
+                        full settings
+                      </button>
+                    </div>
+                    {mcpServers.slice(0, 3).map((server) => (
+                      <div key={server.name} className="cockpit-operator-row">
+                        <div className="cockpit-operator-details">
+                          <div className="cockpit-value">{server.name}</div>
+                          <div className="cockpit-operator-note">
+                            {server.status === "connected"
+                              ? `${server.tool_count ?? 0} tools live`
+                              : server.status === "auth_required"
+                                ? "auth required"
+                                : server.status === "error"
+                                  ? server.status_message || "error"
+                                  : server.enabled
+                                    ? "disconnected"
+                                    : "disabled"}
+                          </div>
+                        </div>
+                        <div className="cockpit-operator-actions">
+                          <button
+                            type="button"
+                            aria-label={`Test ${server.name}`}
+                            className="cockpit-operator-button"
+                            onClick={() => void testMcpServer(server)}
+                          >
+                            test
+                          </button>
+                          <button
+                            type="button"
+                            aria-label={`${server.enabled ? "Turn off" : "Turn on"} ${server.name}`}
+                            className={`cockpit-operator-button ${server.enabled ? "cockpit-operator-button--active" : ""}`}
+                            onClick={() => void toggleMcpServer(server)}
+                          >
+                            {server.enabled ? "on" : "off"}
+                          </button>
+                          {(server.status === "auth_required" || server.has_headers) && (
+                            <button
+                              type="button"
+                              aria-label={`Open settings for ${server.name}`}
+                              className="cockpit-operator-button"
+                              onClick={() => setSettingsPanelOpen(true)}
+                            >
+                              setup
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                    {mcpServers.length === 0 && (
+                      <div className="cockpit-empty">No MCP servers configured.</div>
+                    )}
+                  </div>
+
+                  <div className="cockpit-operator-section">
+                    <div className="cockpit-operator-row">
+                      <span className="cockpit-key">skills</span>
+                      <button
+                        type="button"
+                        className="cockpit-operator-link"
+                        onClick={() => void reloadOperatorSurface("skills")}
+                      >
+                        reload
+                      </button>
+                    </div>
+                    {skills.slice(0, 4).map((skill) => (
+                      <div key={skill.name} className="cockpit-operator-row">
+                        <div className="cockpit-operator-details">
+                          <div className="cockpit-value">{skill.name}</div>
+                          <div className="cockpit-operator-note">
+                            {skill.user_invocable ? "invocable" : "runtime"}
+                            {skill.requires_tools?.length ? ` · ${skill.requires_tools.join(", ")}` : ""}
+                          </div>
+                        </div>
+                        <div className="cockpit-operator-actions">
+                          <button
+                            type="button"
+                            aria-label={`${skill.enabled ? "Turn off" : "Turn on"} ${skill.name}`}
+                            className={`cockpit-operator-button ${skill.enabled ? "cockpit-operator-button--active" : ""}`}
+                            onClick={() => void toggleSkill(skill)}
+                          >
+                            {skill.enabled ? "on" : "off"}
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                    {skills.length === 0 && (
+                      <div className="cockpit-empty">No skills loaded.</div>
+                    )}
+                  </div>
+
+                  <div className="cockpit-operator-section">
+                    <div className="cockpit-operator-row">
+                      <span className="cockpit-key">workflow availability</span>
+                      <button
+                        type="button"
+                        className="cockpit-operator-link"
+                        onClick={() => void reloadOperatorSurface("workflows")}
+                      >
+                        reload
+                      </button>
+                    </div>
+                    <div className="cockpit-sublist-item">
+                      invocable {availableWorkflows.filter((workflow) => workflow.user_invocable).length}/{invocableWorkflows.length} available
+                    </div>
+                    <div className="cockpit-sublist-item">
+                      approval {approvalWorkflows.length} · blocked {blockedWorkflows.length}
+                    </div>
+                    {blockedWorkflows.slice(0, 2).map((workflow) => (
+                      <div key={workflow.name} className="cockpit-sublist-item">
+                        blocked {workflow.name}
+                        {workflow.missing_tools?.length ? ` · tools ${workflow.missing_tools.join(", ")}` : ""}
+                        {workflow.missing_skills?.length ? ` · skills ${workflow.missing_skills.join(", ")}` : ""}
+                      </div>
+                    ))}
+                    {workflows.length === 0 && (
+                      <div className="cockpit-empty">No workflows available.</div>
+                    )}
+                  </div>
+                  {operatorStatus && (
+                    <div className="cockpit-sublist-item">{operatorStatus}</div>
+                  )}
+                  <div className="cockpit-feedback-row">
+                    <button
+                      className="cockpit-feedback-button"
+                      onClick={() => setSettingsPanelOpen(true)}
+                    >
+                      Open Settings
+                    </button>
+                  </div>
+                  {workflows.length === 0 && skills.length === 0 && mcpServers.length === 0 && tools.length === 0 && (
+                    <div className="cockpit-empty">Operator surface unavailable.</div>
+                  )}
+                </div>
+              </section>
+            </CockpitWorkspaceWindow>
+          </>
         )}
       </div>
 
       <form className="cockpit-composer" onSubmit={handleSubmit}>
         <div className="cockpit-composer-meta">
           <span>command bar</span>
-          <span>
-            {activeLayout.label} · Shift+1/2/3 layouts · Shift+I inspector · Shift+C composer
+          <span className="cockpit-composer-meta-center">
+            {activeLayout.label} · drag panes on 16px grid · resize edges · Shift+1/2/3 when not typing
           </span>
           <span>{isAgentBusy ? "agent busy" : "ready"}</span>
         </div>
@@ -1660,10 +1770,10 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
             placeholder={
               connectionStatus === "connected"
                 ? "Ask Seraph, redirect a workflow, or steer the guardian."
-                : "Waiting for WebSocket connection..."
+                : "WebSocket offline. Message will fall back to direct chat."
             }
             className="cockpit-input"
-            disabled={connectionStatus !== "connected" || isAgentBusy}
+            disabled={isAgentBusy}
           />
           <button type="submit" className="cockpit-send" disabled={submitDisabled}>
             Send

--- a/frontend/src/components/quest/GoalForm.tsx
+++ b/frontend/src/components/quest/GoalForm.tsx
@@ -57,85 +57,99 @@ export function GoalForm({ goal, onClose }: Props) {
   };
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
-      <div className="rpg-frame p-3 w-[280px] max-w-[90vw] relative z-10 space-y-2">
-        <div className="text-[11px] uppercase tracking-wider text-retro-highlight font-bold mb-2">
-          {isEdit ? "Edit Quest" : "New Quest"}
-        </div>
-
-        <input
-          type="text"
-          placeholder="Quest title"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          className="w-full bg-transparent text-[10px] text-retro-text border-b border-retro-text/20 px-0.5 py-1 outline-none focus:border-retro-highlight"
-          autoFocus
-        />
-
-        <div className="flex gap-2">
-          <div className="flex-1">
-            <div className="text-[9px] text-retro-text/40 mb-0.5">Level</div>
-            <select
-              value={level}
-              onChange={(e) => setLevel(e.target.value)}
-              className="w-full bg-retro-bg text-[10px] text-retro-text border border-retro-text/20 rounded-sm px-0.5 py-0.5 outline-none focus:border-retro-highlight"
-            >
-              {LEVELS.map((l) => (
-                <option key={l} value={l}>{l}</option>
-              ))}
-            </select>
+    <div className="cockpit-modal-shell cockpit-modal-shell--raised">
+      <button
+        type="button"
+        className="cockpit-modal-backdrop"
+        onClick={onClose}
+        aria-label="Close goal editor"
+      />
+      <section className="cockpit-modal-card cockpit-modal-card--goal-editor">
+        <div className="cockpit-modal-header">
+          <div>
+            <div className="cockpit-card-title">{isEdit ? "Edit Goal" : "New Goal"}</div>
+            <div className="cockpit-card-meta">guardian planning</div>
           </div>
-          <div className="flex-1">
-            <div className="text-[9px] text-retro-text/40 mb-0.5">Domain</div>
-            <select
-              value={domain}
-              onChange={(e) => setDomain(e.target.value)}
-              className="w-full bg-retro-bg text-[10px] text-retro-text border border-retro-text/20 rounded-sm px-0.5 py-0.5 outline-none focus:border-retro-highlight"
-            >
-              {DOMAINS.map((d) => (
-                <option key={d} value={d}>{d}</option>
-              ))}
-            </select>
-          </div>
+          <button type="button" className="cockpit-modal-close" onClick={onClose}>
+            Close
+          </button>
         </div>
-
-        <textarea
-          placeholder="Description (optional)"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          rows={2}
-          className="w-full bg-transparent text-[10px] text-retro-text border border-retro-text/20 rounded-sm px-1 py-1 outline-none focus:border-retro-highlight resize-none"
-        />
-
-        <div>
-          <div className="text-[9px] text-retro-text/40 mb-0.5">Due date (optional)</div>
+        <div className="cockpit-modal-body cockpit-modal-form cockpit-tone-scope cockpit-goals-scope">
           <input
-            type="date"
-            value={dueDate}
-            onChange={(e) => setDueDate(e.target.value)}
-            className="bg-retro-bg text-[10px] text-retro-text border border-retro-text/20 rounded-sm px-1 py-0.5 outline-none focus:border-retro-highlight"
+            type="text"
+            placeholder="Goal title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="w-full bg-transparent text-[11px] text-slate-100 border-b border-white/10 px-0.5 py-1 outline-none focus:border-cyan-300 placeholder:text-slate-500"
+            autoFocus
           />
-        </div>
 
-        {error && <div className="text-[9px] text-red-400">{error}</div>}
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <div className="text-[10px] text-slate-400 mb-1 uppercase tracking-[0.16em]">Level</div>
+              <select
+                value={level}
+                onChange={(e) => setLevel(e.target.value)}
+                className="w-full bg-slate-950/70 text-[11px] text-slate-100 border border-white/10 rounded-md px-2 py-1.5 outline-none focus:border-cyan-300"
+              >
+                {LEVELS.map((l) => (
+                  <option key={l} value={l}>{l}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex-1">
+              <div className="text-[10px] text-slate-400 mb-1 uppercase tracking-[0.16em]">Domain</div>
+              <select
+                value={domain}
+                onChange={(e) => setDomain(e.target.value)}
+                className="w-full bg-slate-950/70 text-[11px] text-slate-100 border border-white/10 rounded-md px-2 py-1.5 outline-none focus:border-cyan-300"
+              >
+                {DOMAINS.map((d) => (
+                  <option key={d} value={d}>{d}</option>
+                ))}
+              </select>
+            </div>
+          </div>
 
-        <div className="flex gap-2 pt-1">
-          <button
-            onClick={handleSubmit}
-            disabled={saving}
-            className="text-[10px] text-retro-highlight hover:text-retro-text uppercase tracking-wider font-bold"
-          >
-            {saving ? "Saving..." : isEdit ? "Update" : "Create"}
-          </button>
-          <button
-            onClick={onClose}
-            className="text-[10px] text-retro-text/40 hover:text-retro-text uppercase tracking-wider"
-          >
-            Cancel
-          </button>
+          <textarea
+            placeholder="Description (optional)"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="w-full bg-slate-950/70 text-[11px] text-slate-100 border border-white/10 rounded-md px-2 py-2 outline-none focus:border-cyan-300 resize-none placeholder:text-slate-500"
+          />
+
+          <div>
+            <div className="text-[10px] text-slate-400 mb-1 uppercase tracking-[0.16em]">
+              Due date (optional)
+            </div>
+            <input
+              type="date"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
+              className="bg-slate-950/70 text-[11px] text-slate-100 border border-white/10 rounded-md px-2 py-1.5 outline-none focus:border-cyan-300"
+            />
+          </div>
+
+          {error && <div className="text-[10px] text-rose-400">{error}</div>}
+
+          <div className="flex gap-2 pt-1">
+            <button
+              onClick={handleSubmit}
+              disabled={saving}
+              className="cockpit-action cockpit-action--primary disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {saving ? "Saving..." : isEdit ? "Update" : "Create"}
+            </button>
+            <button
+              onClick={onClose}
+              className="cockpit-action cockpit-action--ghost"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
-      </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/components/quest/QuestPanel.tsx
+++ b/frontend/src/components/quest/QuestPanel.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { useChatStore } from "../../stores/chatStore";
 import { useQuestStore } from "../../stores/questStore";
-import { useDragResize } from "../../hooks/useDragResize";
-import { ResizeHandles } from "../ResizeHandles";
-import { DialogFrame } from "../chat/DialogFrame";
+import { useChatStore } from "../../stores/chatStore";
 import { DomainStats } from "./DomainStats";
 import { GoalTree } from "./GoalTree";
 import { GoalForm } from "./GoalForm";
@@ -48,11 +45,6 @@ export function QuestPanel() {
   const [filterLevel, setFilterLevel] = useState("");
   const [filterDomain, setFilterDomain] = useState("");
 
-  const { panelRef, dragHandleProps, resizeHandleProps, style, bringToFront } = useDragResize("quest", {
-    minWidth: 240,
-    minHeight: 200,
-  });
-
   useEffect(() => {
     if (questPanelOpen) refresh();
   }, [questPanelOpen, refresh]);
@@ -69,96 +61,109 @@ export function QuestPanel() {
 
   if (!questPanelOpen) return null;
 
-  return (
-    <div
-      ref={panelRef}
-      className="quest-overlay"
-      style={style}
-      onPointerDown={bringToFront}
-    >
-      <ResizeHandles resizeHandleProps={resizeHandleProps} />
-      <DialogFrame
-        title="Quest Log"
-        className="flex-1 min-h-0 flex flex-col"
-        onClose={() => setQuestPanelOpen(false)}
-        dragHandleProps={dragHandleProps}
-      >
-        <div className="flex-1 min-h-0 overflow-y-auto retro-scrollbar flex flex-col gap-2 pb-1">
-          {dashboard && <DomainStats dashboard={dashboard} />}
+  const content = (
+    <div className="cockpit-tone-scope cockpit-goals-scope flex-1 min-h-0 overflow-y-auto retro-scrollbar flex flex-col gap-3 pb-2">
+      {dashboard && <DomainStats dashboard={dashboard} />}
 
-          <div className="border-t border-retro-border/20 my-1" />
+      <div className="border-t border-retro-border/20 my-1" />
 
-          <div className="px-1">
-            <div className="flex items-center justify-between mb-2">
-              <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold">
-                Active Quests
-              </div>
-              <button
-                onClick={() => setEditingGoal("new")}
-                className="text-[11px] text-retro-text/40 hover:text-retro-highlight px-1"
-                title="Add new quest"
-              >
-                +
-              </button>
-            </div>
+      <div className="px-1">
+        <div className="flex items-center justify-between mb-2">
+          <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold">
+            Active Quests
+          </div>
+          <button
+            onClick={() => setEditingGoal("new")}
+            className="text-[11px] text-retro-text/40 hover:text-retro-highlight px-1"
+            title="Add new quest"
+          >
+            +
+          </button>
+        </div>
 
-            <div className="flex flex-col gap-1 mb-2">
-              <input
-                type="text"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search quests..."
-                className="w-full bg-transparent text-[10px] text-retro-text border border-retro-text/20 rounded-sm px-1.5 py-0.5 outline-none focus:border-retro-highlight placeholder:text-retro-text/30"
-              />
-              <div className="flex gap-1">
-                <select
-                  value={filterLevel}
-                  onChange={(e) => setFilterLevel(e.target.value)}
-                  className="flex-1 bg-retro-bg text-[9px] text-retro-text border border-retro-text/20 rounded-sm px-0.5 py-0.5 outline-none focus:border-retro-highlight"
-                >
-                  <option value="">All levels</option>
-                  {LEVELS.map((l) => (
-                    <option key={l} value={l}>{l}</option>
-                  ))}
-                </select>
-                <select
-                  value={filterDomain}
-                  onChange={(e) => setFilterDomain(e.target.value)}
-                  className="flex-1 bg-retro-bg text-[9px] text-retro-text border border-retro-text/20 rounded-sm px-0.5 py-0.5 outline-none focus:border-retro-highlight"
-                >
-                  <option value="">All domains</option>
-                  {DOMAINS.map((d) => (
-                    <option key={d} value={d}>{d}</option>
-                  ))}
-                </select>
-              </div>
-            </div>
-
-            {loading ? (
-              <div className="text-[10px] text-retro-text/40 italic">Loading...</div>
-            ) : filteredTree.length === 0 ? (
-              <div className="text-[10px] text-retro-text/40 italic">
-                {hasFilters
-                  ? "No quests match filters."
-                  : "No quests yet. Chat with Seraph to set goals!"}
-              </div>
-            ) : (
-              <GoalTree
-                goals={filteredTree}
-                depth={0}
-                onEdit={(goal) => setEditingGoal(goal)}
-              />
-            )}
+        <div className="flex flex-col gap-1 mb-2">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search quests..."
+            className="w-full bg-transparent text-[10px] text-retro-text border border-retro-text/20 rounded-sm px-1.5 py-0.5 outline-none focus:border-retro-highlight placeholder:text-retro-text/30"
+          />
+          <div className="flex gap-1">
+            <select
+              value={filterLevel}
+              onChange={(e) => setFilterLevel(e.target.value)}
+              className="flex-1 bg-retro-bg text-[9px] text-retro-text border border-retro-text/20 rounded-sm px-0.5 py-0.5 outline-none focus:border-retro-highlight"
+            >
+              <option value="">All levels</option>
+              {LEVELS.map((l) => (
+                <option key={l} value={l}>{l}</option>
+              ))}
+            </select>
+            <select
+              value={filterDomain}
+              onChange={(e) => setFilterDomain(e.target.value)}
+              className="flex-1 bg-retro-bg text-[9px] text-retro-text border border-retro-text/20 rounded-sm px-0.5 py-0.5 outline-none focus:border-retro-highlight"
+            >
+              <option value="">All domains</option>
+              {DOMAINS.map((d) => (
+                <option key={d} value={d}>{d}</option>
+              ))}
+            </select>
           </div>
         </div>
-      </DialogFrame>
 
+        {loading ? (
+          <div className="text-[10px] text-retro-text/40 italic">Loading...</div>
+        ) : filteredTree.length === 0 ? (
+          <div className="text-[10px] text-retro-text/40 italic">
+            {hasFilters
+              ? "No quests match filters."
+              : "No quests yet. Chat with Seraph to set goals!"}
+          </div>
+        ) : (
+          <GoalTree
+            goals={filteredTree}
+            depth={0}
+            onEdit={(goal) => setEditingGoal(goal)}
+          />
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      <div className="cockpit-modal-shell">
+        <button
+          type="button"
+          className="cockpit-modal-backdrop"
+          onClick={() => setQuestPanelOpen(false)}
+          aria-label="Close goals"
+        />
+      <section className="cockpit-modal-card cockpit-modal-card--goals">
+          <div className="cockpit-modal-header">
+            <div>
+              <div className="cockpit-card-title">Goals</div>
+              <div className="cockpit-card-meta">cockpit view</div>
+            </div>
+            <button
+              type="button"
+              className="cockpit-modal-close"
+              onClick={() => setQuestPanelOpen(false)}
+            >
+              Close
+            </button>
+          </div>
+          <div className="cockpit-modal-body">{content}</div>
+        </section>
+      </div>
       {editingGoal !== null && (
         <GoalForm
           goal={editingGoal === "new" ? undefined : editingGoal}
           onClose={() => setEditingGoal(null)}
         />
       )}
-    </div>
+    </>
   );
 }

--- a/frontend/src/hooks/useDragResize.test.ts
+++ b/frontend/src/hooks/useDragResize.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PANEL_GRID_SIZE, clampRect, snapRectToGrid } from "./useDragResize";
+
+describe("useDragResize snap helpers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("snaps pane coordinates and sizes to the shared grid", () => {
+    expect(
+      snapRectToGrid(
+        { x: 23, y: 41, width: 317, height: 205 },
+        200,
+        160,
+      ),
+    ).toEqual({
+      x: 16,
+      y: 48,
+      width: 320,
+      height: 208,
+    });
+  });
+
+  it("preserves minimum sizes while snapping", () => {
+    expect(
+      snapRectToGrid(
+        { x: 7, y: 9, width: 100, height: 110 },
+        240,
+        180,
+      ),
+    ).toEqual({
+      x: 0,
+      y: 16,
+      width: 240,
+      height: 180,
+    });
+  });
+
+  it("clamps snapped panes to the visible viewport", () => {
+    vi.stubGlobal("window", { innerWidth: 1280, innerHeight: 720 });
+
+    expect(clampRect(1277, 719, 317, 205, 200, 160)).toEqual({
+      x: 1200,
+      y: 640,
+      width: 320,
+      height: 208,
+    });
+  });
+
+  it("uses the shared 16px grid", () => {
+    expect(PANEL_GRID_SIZE).toBe(16);
+  });
+});

--- a/frontend/src/hooks/useDragResize.ts
+++ b/frontend/src/hooks/useDragResize.ts
@@ -4,6 +4,7 @@ import { usePanelLayoutStore, PANEL_MIN_SIZES } from "../stores/panelLayoutStore
 export type ResizeEdge = "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw";
 
 const VISIBLE_MIN = 80;
+export const PANEL_GRID_SIZE = 16;
 
 interface Rect {
   x: number;
@@ -12,7 +13,20 @@ interface Rect {
   height: number;
 }
 
-function clampRect(
+function snapToGrid(value: number): number {
+  return Math.round(value / PANEL_GRID_SIZE) * PANEL_GRID_SIZE;
+}
+
+export function snapRectToGrid(rect: Rect, minW: number, minH: number): Rect {
+  return {
+    x: snapToGrid(rect.x),
+    y: snapToGrid(rect.y),
+    width: Math.max(minW, snapToGrid(rect.width)),
+    height: Math.max(minH, snapToGrid(rect.height)),
+  };
+}
+
+export function clampRect(
   x: number,
   y: number,
   width: number,
@@ -22,11 +36,14 @@ function clampRect(
 ): Rect {
   const vw = window.innerWidth;
   const vh = window.innerHeight;
-  const w = Math.max(width, minW);
-  const h = Math.max(height, minH);
-  const cx = Math.max(-(w - VISIBLE_MIN), Math.min(x, vw - VISIBLE_MIN));
+  const snapped = snapRectToGrid({ x, y, width, height }, minW, minH);
+  const w = snapped.width;
+  const h = snapped.height;
+  const sx = snapped.x;
+  const sy = snapped.y;
+  const cx = Math.max(-(w - VISIBLE_MIN), Math.min(sx, vw - VISIBLE_MIN));
   // Top: keep drag bar on screen (y >= 0); bottom/sides: keep 80px visible
-  const cy = Math.max(0, Math.min(y, vh - VISIBLE_MIN));
+  const cy = Math.max(0, Math.min(sy, vh - VISIBLE_MIN));
   return { x: cx, y: cy, width: w, height: h };
 }
 

--- a/frontend/src/hooks/useKeyboardShortcuts.test.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.test.ts
@@ -39,10 +39,11 @@ function resetStores() {
 
 function makeEvent(
   key: string,
-  options?: { target?: Partial<HTMLElement>; shiftKey?: boolean },
+  options?: { target?: Partial<HTMLElement>; shiftKey?: boolean; code?: string },
 ): KeyboardEvent {
   const event = new KeyboardEvent("keydown", {
     key,
+    code: options?.code,
     shiftKey: options?.shiftKey ?? false,
     bubbles: true,
   });
@@ -73,23 +74,23 @@ describe("handleGlobalKeyboardShortcut", () => {
   it("Shift+1/2/3 switch cockpit layouts", () => {
     useChatStore.setState({ interfaceMode: "cockpit" });
 
-    handleGlobalKeyboardShortcut(makeEvent("2", { shiftKey: true }));
+    handleGlobalKeyboardShortcut(makeEvent("@", { shiftKey: true, code: "Digit2" }));
     expect(useCockpitLayoutStore.getState().activeLayoutId).toBe("focus");
 
-    handleGlobalKeyboardShortcut(makeEvent("3", { shiftKey: true }));
+    handleGlobalKeyboardShortcut(makeEvent("#", { shiftKey: true, code: "Digit3" }));
     expect(useCockpitLayoutStore.getState().activeLayoutId).toBe("review");
 
-    handleGlobalKeyboardShortcut(makeEvent("1", { shiftKey: true }));
+    handleGlobalKeyboardShortcut(makeEvent("!", { shiftKey: true, code: "Digit1" }));
     expect(useCockpitLayoutStore.getState().activeLayoutId).toBe("default");
   });
 
   it("Shift+I toggles inspector visibility in cockpit mode", () => {
     useChatStore.setState({ interfaceMode: "cockpit" });
 
-    handleGlobalKeyboardShortcut(makeEvent("i", { shiftKey: true }));
+    handleGlobalKeyboardShortcut(makeEvent("I", { shiftKey: true, code: "KeyI" }));
     expect(useCockpitLayoutStore.getState().inspectorVisible).toBe(false);
 
-    handleGlobalKeyboardShortcut(makeEvent("i", { shiftKey: true }));
+    handleGlobalKeyboardShortcut(makeEvent("I", { shiftKey: true, code: "KeyI" }));
     expect(useCockpitLayoutStore.getState().inspectorVisible).toBe(true);
   });
 

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -5,6 +5,7 @@ import { usePanelLayoutStore } from "../stores/panelLayoutStore";
 
 export function handleGlobalKeyboardShortcut(event: KeyboardEvent) {
   const tag = (event.target as HTMLElement)?.tagName;
+  const code = event.code;
   if (tag === "INPUT" || tag === "TEXTAREA") return;
 
   const s = useChatStore.getState();
@@ -12,26 +13,27 @@ export function handleGlobalKeyboardShortcut(event: KeyboardEvent) {
   const cockpitLayout = useCockpitLayoutStore.getState();
 
   if (s.interfaceMode === "cockpit") {
+    if (event.shiftKey && code === "Digit1") {
+      cockpitLayout.setLayout("default");
+      return;
+    }
+    if (event.shiftKey && code === "Digit2") {
+      cockpitLayout.setLayout("focus");
+      return;
+    }
+    if (event.shiftKey && code === "Digit3") {
+      cockpitLayout.setLayout("review");
+      return;
+    }
+    if (event.shiftKey && code === "KeyI") {
+      cockpitLayout.toggleInspector();
+      return;
+    }
+
     switch (event.key.toLowerCase()) {
       case "c":
         if (!event.shiftKey) return;
         window.dispatchEvent(new CustomEvent("seraph-cockpit-focus-composer"));
-        return;
-      case "1":
-        if (!event.shiftKey) return;
-        cockpitLayout.setLayout("default");
-        return;
-      case "2":
-        if (!event.shiftKey) return;
-        cockpitLayout.setLayout("focus");
-        return;
-      case "3":
-        if (!event.shiftKey) return;
-        cockpitLayout.setLayout("review");
-        return;
-      case "i":
-        if (!event.shiftKey) return;
-        cockpitLayout.toggleInspector();
         return;
       default:
         break;

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback } from "react";
-import { WS_URL, WS_RECONNECT_DELAY_MS, WS_PING_INTERVAL_MS } from "../config/constants";
+import { API_URL, WS_URL, WS_RECONNECT_DELAY_MS, WS_PING_INTERVAL_MS } from "../config/constants";
 import { useChatStore } from "../stores/chatStore";
 import { detectToolFromStep } from "../lib/toolParser";
 import { useAgentAnimation } from "./useAgentAnimation";
@@ -35,6 +35,20 @@ export function useWebSocket() {
   onToolDetectedRef.current = onToolDetected;
   onFinalAnswerRef.current = onFinalAnswer;
 
+  const buildUserMessage = useCallback((message: string): ChatMessage => ({
+    id: makeId(),
+    role: "user",
+    content: message,
+    timestamp: Date.now(),
+  }), []);
+
+  const buildErrorMessage = useCallback((message: string): ChatMessage => ({
+    id: makeId(),
+    role: "error",
+    content: message,
+    timestamp: Date.now(),
+  }), []);
+
   const sendSocketMessage = useCallback(
     (
       message: string,
@@ -44,30 +58,105 @@ export function useWebSocket() {
     ) => {
       if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return false;
 
-      setAgentBusy(true);
-      onThinking();
+      try {
+        setAgentBusy(true);
+        onThinking();
 
-      if (echoUser) {
-        const userMsg: ChatMessage = {
-          id: makeId(),
-          role: "user",
-          content: message,
-          timestamp: Date.now(),
-        };
-        addMessage(userMsg);
+        if (echoUser) {
+          addMessage(buildUserMessage(message));
+        }
+
+        wsRef.current.send(
+          JSON.stringify({
+            type: messageType,
+            message,
+            session_id: sessionId,
+          })
+        );
+        return true;
+      } catch {
+        setAgentBusy(false);
+        addMessage(buildErrorMessage("Message delivery failed."));
+        return false;
       }
+    },
+    [addMessage, buildErrorMessage, buildUserMessage, setAgentBusy, onThinking]
+  );
 
-      wsRef.current.send(
-        JSON.stringify({
-          type: messageType,
+  const sendRestMessage = useCallback(async (message: string, sessionId: string | null) => {
+    setAgentBusy(true);
+    onThinking();
+    addMessage(buildUserMessage(message));
+
+    try {
+      const response = await fetch(`${API_URL}/api/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
           message,
           session_id: sessionId,
-        })
-      );
+        }),
+      });
+
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        const detail = payload?.detail ?? payload;
+
+        if (response.status === 409 && detail?.type === "approval_required") {
+          const approvalMsg: ChatMessage = {
+            id: makeId(),
+            role: "approval",
+            content: detail.message ?? "Approval required before continuing.",
+            timestamp: Date.now(),
+            approvalId: detail.approval_id,
+            toolUsed: detail.tool_name,
+            riskLevel: detail.risk_level,
+            approvalStatus: "pending",
+          };
+          addMessage(approvalMsg);
+          return false;
+        }
+
+        const messageText =
+          (typeof detail === "string" && detail)
+          || detail?.message
+          || "Message delivery failed.";
+        addMessage(buildErrorMessage(messageText));
+        return false;
+      }
+
+      const nextSessionId = typeof payload?.session_id === "string" ? payload.session_id : sessionId;
+      if (nextSessionId) {
+        setSessionId(nextSessionId);
+      }
+
+      const responseText = typeof payload?.response === "string" ? payload.response : "";
+      onFinalAnswerRef.current(responseText);
+      addMessage({
+        id: makeId(),
+        role: "agent",
+        content: responseText,
+        timestamp: Date.now(),
+      });
+
+      await useChatStore.getState().fetchProfile();
+      await useChatStore.getState().loadSessions();
+      if (nextSessionId) {
+        const updated = useChatStore.getState();
+        const session = updated.sessions.find((item) => item.id === nextSessionId);
+        if (session && session.title === "New Conversation") {
+          await updated.generateSessionTitle(nextSessionId);
+        }
+      }
+
       return true;
-    },
-    [addMessage, setAgentBusy, onThinking]
-  );
+    } catch {
+      addMessage(buildErrorMessage("Message delivery failed."));
+      return false;
+    } finally {
+      setAgentBusy(false);
+    }
+  }, [addMessage, buildErrorMessage, buildUserMessage, onThinking, setAgentBusy, setSessionId]);
 
   const connect = useCallback(() => {
     if (wsRef.current?.readyState === WebSocket.OPEN) return;
@@ -217,6 +306,7 @@ export function useWebSocket() {
     };
 
     ws.onclose = () => {
+      setAgentBusy(false);
       setConnectionStatus("disconnected");
       if (pingRef.current) clearInterval(pingRef.current);
       reconnectRef.current = setTimeout(connect, backoffRef.current);
@@ -224,6 +314,7 @@ export function useWebSocket() {
     };
 
     ws.onerror = () => {
+      setAgentBusy(false);
       setConnectionStatus("error");
       ws.close();
     };
@@ -236,11 +327,15 @@ export function useWebSocket() {
   }, []);
 
   const sendMessage = useCallback(
-    (message: string) => {
+    async (message: string) => {
       const sessionId = useChatStore.getState().sessionId;
-      sendSocketMessage(message, sessionId, true);
+      if (sendSocketMessage(message, sessionId, true)) {
+        return true;
+      }
+
+      return sendRestMessage(message, sessionId);
     },
-    [sendSocketMessage]
+    [sendRestMessage, sendSocketMessage]
   );
 
   useEffect(() => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -43,7 +43,12 @@ body {
   --cockpit-warning: #ffcf70;
   --cockpit-danger: #ff7d79;
   font-family: "IBM Plex Mono", "Iosevka", "SFMono-Regular", Menlo, Consolas, monospace;
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
+  min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
   color: var(--cockpit-text);
   background:
     radial-gradient(circle at top left, rgba(88, 163, 214, 0.22), transparent 28%),
@@ -183,7 +188,97 @@ body {
   grid-template-columns: 280px minmax(0, 1fr) 420px;
   gap: 16px;
   padding: 16px 20px;
-  min-height: calc(100vh - 184px);
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.cockpit-workspace {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.cockpit-window {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--cockpit-border-strong);
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(7, 20, 31, 0.98), rgba(9, 24, 37, 0.96)),
+    radial-gradient(circle at top right, rgba(141, 226, 255, 0.08), transparent 42%);
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  overflow: hidden;
+}
+
+.cockpit-window-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px 12px;
+  border-bottom: 1px solid rgba(141, 226, 255, 0.1);
+  background:
+    linear-gradient(180deg, rgba(12, 30, 44, 0.98), rgba(10, 26, 39, 0.94)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(141, 226, 255, 0.03) 0,
+      rgba(141, 226, 255, 0.03) 1px,
+      transparent 1px,
+      transparent 10px
+    );
+  cursor: grab;
+  user-select: none;
+}
+
+.cockpit-window-header:active {
+  cursor: grabbing;
+}
+
+.cockpit-window-title {
+  font-family: "Space Grotesk", "Avenir Next Condensed", "Arial Narrow", sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cockpit-text);
+}
+
+.cockpit-window-meta,
+.cockpit-window-grip {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--cockpit-muted);
+}
+
+.cockpit-window-grip {
+  align-self: center;
+}
+
+.cockpit-window-body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
+.cockpit-window-body > .cockpit-rail,
+.cockpit-window-body > .cockpit-chatrail,
+.cockpit-window-body > .cockpit-center {
+  height: 100%;
+}
+
+.cockpit-window-body > .cockpit-panel--embedded {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  scrollbar-gutter: stable;
 }
 
 .cockpit-grid--focus {
@@ -236,6 +331,328 @@ body {
 
 .cockpit-panel--span-2 {
   grid-column: span 2;
+}
+
+.cockpit-panel--response {
+  border-color: rgba(141, 226, 255, 0.18);
+  background:
+    radial-gradient(circle at top right, rgba(141, 226, 255, 0.12), transparent 45%),
+    linear-gradient(180deg, rgba(14, 36, 58, 0.96), rgba(8, 20, 34, 0.94));
+}
+
+.cockpit-panel--embedded {
+  border: 0;
+  border-radius: 0;
+  background:
+    linear-gradient(180deg, rgba(7, 20, 31, 0.78), rgba(8, 22, 34, 0.82)),
+    repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.012) 0,
+      rgba(255, 255, 255, 0.012) 1px,
+      transparent 1px,
+      transparent 18px
+    );
+  box-shadow: none;
+}
+
+.cockpit-window-body > .cockpit-panel--embedded,
+.cockpit-list,
+.cockpit-feed,
+.cockpit-modal-body,
+.cockpit-shell .retro-scrollbar,
+.cockpit-modal-shell .retro-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(136, 214, 255, 0.7) rgba(10, 24, 36, 0.94);
+}
+
+.cockpit-window-body > .cockpit-panel--embedded::-webkit-scrollbar,
+.cockpit-list::-webkit-scrollbar,
+.cockpit-feed::-webkit-scrollbar,
+.cockpit-modal-body::-webkit-scrollbar,
+.cockpit-shell .retro-scrollbar::-webkit-scrollbar,
+.cockpit-modal-shell .retro-scrollbar::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+.cockpit-window-body > .cockpit-panel--embedded::-webkit-scrollbar-track,
+.cockpit-list::-webkit-scrollbar-track,
+.cockpit-feed::-webkit-scrollbar-track,
+.cockpit-modal-body::-webkit-scrollbar-track,
+.cockpit-shell .retro-scrollbar::-webkit-scrollbar-track,
+.cockpit-modal-shell .retro-scrollbar::-webkit-scrollbar-track {
+  background:
+    linear-gradient(180deg, rgba(6, 18, 28, 0.98), rgba(9, 23, 35, 0.98));
+  border-left: 1px solid rgba(141, 226, 255, 0.1);
+}
+
+.cockpit-window-body > .cockpit-panel--embedded::-webkit-scrollbar-thumb,
+.cockpit-list::-webkit-scrollbar-thumb,
+.cockpit-feed::-webkit-scrollbar-thumb,
+.cockpit-modal-body::-webkit-scrollbar-thumb,
+.cockpit-shell .retro-scrollbar::-webkit-scrollbar-thumb,
+.cockpit-modal-shell .retro-scrollbar::-webkit-scrollbar-thumb {
+  background:
+    linear-gradient(180deg, rgba(130, 209, 247, 0.92), rgba(89, 171, 215, 0.9));
+  border: 2px solid rgba(8, 22, 34, 0.94);
+  border-radius: 999px;
+  box-shadow:
+    inset 0 0 0 1px rgba(216, 243, 255, 0.12),
+    0 0 0 1px rgba(141, 226, 255, 0.12);
+}
+
+.cockpit-window-body > .cockpit-panel--embedded::-webkit-scrollbar-thumb:hover,
+.cockpit-list::-webkit-scrollbar-thumb:hover,
+.cockpit-feed::-webkit-scrollbar-thumb:hover,
+.cockpit-modal-body::-webkit-scrollbar-thumb:hover,
+.cockpit-shell .retro-scrollbar::-webkit-scrollbar-thumb:hover,
+.cockpit-modal-shell .retro-scrollbar::-webkit-scrollbar-thumb:hover {
+  background:
+    linear-gradient(180deg, rgba(164, 229, 255, 0.98), rgba(110, 244, 195, 0.9));
+}
+
+.cockpit-window-body > .cockpit-panel--embedded::-webkit-scrollbar-corner,
+.cockpit-list::-webkit-scrollbar-corner,
+.cockpit-feed::-webkit-scrollbar-corner,
+.cockpit-modal-body::-webkit-scrollbar-corner,
+.cockpit-shell .retro-scrollbar::-webkit-scrollbar-corner,
+.cockpit-modal-shell .retro-scrollbar::-webkit-scrollbar-corner {
+  background: rgba(7, 20, 31, 0.98);
+}
+
+.cockpit-modal-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  font-family: "IBM Plex Mono", "Iosevka", "SFMono-Regular", Menlo, Consolas, monospace;
+  color: var(--cockpit-text);
+}
+
+.cockpit-modal-shell * {
+  image-rendering: auto;
+}
+
+.cockpit-modal-shell--raised {
+  z-index: 90;
+}
+
+.cockpit-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background:
+    linear-gradient(180deg, rgba(2, 8, 15, 0.72), rgba(3, 8, 15, 0.86)),
+    radial-gradient(circle at top, rgba(141, 226, 255, 0.08), transparent 34%);
+  backdrop-filter: blur(12px);
+  cursor: pointer;
+}
+
+.cockpit-modal-card {
+  position: relative;
+  z-index: 1;
+  width: min(820px, calc(100vw - 48px));
+  max-height: calc(100dvh - 48px);
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--cockpit-border-strong);
+  border-radius: 20px;
+  background:
+    linear-gradient(180deg, rgba(7, 21, 32, 0.98), rgba(8, 22, 34, 0.96)),
+    radial-gradient(circle at top right, rgba(141, 226, 255, 0.1), transparent 44%);
+  box-shadow: 0 24px 72px rgba(0, 0, 0, 0.46);
+  overflow: hidden;
+  line-height: 1.45;
+}
+
+.cockpit-modal-card--wide {
+  width: min(1040px, calc(100vw - 48px));
+}
+
+.cockpit-modal-card--compact {
+  width: min(560px, calc(100vw - 48px));
+}
+
+.cockpit-modal-card--settings {
+  width: min(1240px, calc(100vw - 40px));
+}
+
+.cockpit-modal-card--goals {
+  width: min(1120px, calc(100vw - 40px));
+}
+
+.cockpit-modal-card--goal-editor {
+  width: min(720px, calc(100vw - 40px));
+}
+
+.cockpit-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid rgba(141, 226, 255, 0.08);
+}
+
+.cockpit-modal-close {
+  border: 1px solid var(--cockpit-border);
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: rgba(11, 27, 40, 0.78);
+  color: var(--cockpit-muted);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.cockpit-modal-close:hover {
+  border-color: var(--cockpit-border-strong);
+  color: var(--cockpit-text);
+  background: rgba(141, 226, 255, 0.08);
+}
+
+.cockpit-modal-body {
+  min-height: 0;
+  overflow: auto;
+  padding: 16px 20px 20px;
+}
+
+.cockpit-settings-scope,
+.cockpit-goals-scope {
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.cockpit-settings-scope .text-\[9px\],
+.cockpit-goals-scope .text-\[9px\] {
+  font-size: 12px;
+}
+
+.cockpit-settings-scope .text-\[10px\],
+.cockpit-goals-scope .text-\[10px\] {
+  font-size: 13px;
+}
+
+.cockpit-settings-scope .text-\[11px\],
+.cockpit-goals-scope .text-\[11px\] {
+  font-size: 14px;
+}
+
+.cockpit-settings-scope input,
+.cockpit-settings-scope select,
+.cockpit-settings-scope textarea,
+.cockpit-goals-scope input,
+.cockpit-goals-scope select,
+.cockpit-goals-scope textarea {
+  min-height: 38px;
+}
+
+.cockpit-goals-scope textarea,
+.cockpit-settings-scope textarea {
+  min-height: 96px;
+}
+
+.cockpit-settings-scope button,
+.cockpit-goals-scope button {
+  min-height: 32px;
+}
+
+.cockpit-modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.cockpit-tone-scope [class~="text-retro-border"] {
+  color: var(--cockpit-accent);
+}
+
+.cockpit-tone-scope [class*="text-retro-highlight"] {
+  color: var(--cockpit-accent-strong);
+}
+
+.cockpit-tone-scope [class~="text-retro-text"],
+.cockpit-tone-scope [class*="text-retro-text/70"],
+.cockpit-tone-scope [class*="text-retro-text/80"] {
+  color: var(--cockpit-text);
+}
+
+.cockpit-tone-scope [class*="text-retro-text/20"] {
+  color: rgba(126, 154, 176, 0.46);
+}
+
+.cockpit-tone-scope [class*="text-retro-text/30"] {
+  color: rgba(126, 154, 176, 0.58);
+}
+
+.cockpit-tone-scope [class*="text-retro-text/40"] {
+  color: rgba(126, 154, 176, 0.72);
+}
+
+.cockpit-tone-scope [class*="text-retro-text/50"],
+.cockpit-tone-scope [class*="text-retro-text/60"] {
+  color: rgba(152, 180, 201, 0.84);
+}
+
+.cockpit-tone-scope [class*="border-retro-text/10"] {
+  border-color: rgba(141, 226, 255, 0.12);
+}
+
+.cockpit-tone-scope [class*="border-retro-text/20"],
+.cockpit-tone-scope [class*="border-retro-border/20"] {
+  border-color: rgba(141, 226, 255, 0.18);
+}
+
+.cockpit-tone-scope [class*="border-retro-text/40"] {
+  border-color: rgba(141, 226, 255, 0.28);
+}
+
+.cockpit-tone-scope [class*="bg-retro-bg"] {
+  background: rgba(7, 20, 31, 0.74);
+}
+
+.cockpit-tone-scope .pixel-border-thin {
+  border-color: rgba(141, 226, 255, 0.18);
+  box-shadow:
+    inset 0 0 0 1px rgba(7, 16, 25, 0.92),
+    0 0 0 1px rgba(141, 226, 255, 0.1);
+}
+
+.cockpit-tone-scope input,
+.cockpit-tone-scope select,
+.cockpit-tone-scope textarea {
+  color: var(--cockpit-text);
+  background-color: rgba(7, 20, 31, 0.74);
+  border-radius: 8px;
+}
+
+.cockpit-tone-scope input::placeholder,
+.cockpit-tone-scope textarea::placeholder {
+  color: rgba(126, 154, 176, 0.56);
+}
+
+.cockpit-tone-scope button {
+  transition:
+    color 120ms ease,
+    border-color 120ms ease,
+    background 120ms ease,
+    opacity 120ms ease;
+}
+
+.cockpit-tone-scope [class*="hover:text-retro-highlight"]:hover {
+  color: var(--cockpit-accent-strong);
+}
+
+.cockpit-tone-scope [class*="hover:text-retro-text"]:hover {
+  color: var(--cockpit-text);
+}
+
+.cockpit-tone-scope [class*="hover:border-retro-highlight"]:hover {
+  border-color: var(--cockpit-accent-strong);
 }
 
 .cockpit-chat-panel {
@@ -400,6 +817,14 @@ body {
 .cockpit-message-body {
   font-size: 12px;
   line-height: 1.6;
+}
+
+.cockpit-response-body {
+  padding: 18px 20px 20px;
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--cockpit-text);
+  white-space: pre-wrap;
 }
 
 .cockpit-sublist-button,
@@ -617,7 +1042,8 @@ body {
 }
 
 .cockpit-composer {
-  padding: 0 20px 20px;
+  padding: 0 20px calc(20px + env(safe-area-inset-bottom, 0px));
+  background: linear-gradient(180deg, rgba(7, 16, 25, 0), rgba(7, 16, 25, 0.92) 22%, rgba(7, 16, 25, 1) 100%);
 }
 
 .cockpit-composer-meta {
@@ -629,6 +1055,10 @@ body {
   font-size: 10px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
+}
+
+.cockpit-composer-meta-center {
+  text-align: center;
 }
 
 .cockpit-composer-row {

--- a/frontend/src/stores/panelLayoutStore.test.ts
+++ b/frontend/src/stores/panelLayoutStore.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getPackedCockpitPanels } from "./panelLayoutStore";
+
+describe("panelLayoutStore packed cockpit layouts", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("packs the default layout across the workspace with no bottom gaps per column", () => {
+    vi.stubGlobal("window", { innerWidth: 1600, innerHeight: 980 });
+
+    const panels = getPackedCockpitPanels("default", true);
+    const columns = new Map<number, Array<{ y: number; height: number }>>();
+
+    for (const panel of Object.values(panels)) {
+      const items = columns.get(panel.x) ?? [];
+      items.push({ y: panel.y, height: panel.height });
+      columns.set(panel.x, items);
+    }
+
+    const bottoms = [...columns.values()].map((items) => {
+      const sorted = items.sort((left, right) => left.y - right.y);
+      const last = sorted[sorted.length - 1];
+      return last ? last.y + last.height : 0;
+    });
+
+    expect(new Set(bottoms).size).toBe(1);
+  });
+
+  it("focus layout keeps a denser three-column arrangement without the hidden inspector", () => {
+    vi.stubGlobal("window", { innerWidth: 1600, innerHeight: 980 });
+
+    const panels = getPackedCockpitPanels("focus", false);
+    const xs = new Set(Object.values(panels).map((panel) => panel.x));
+
+    expect(xs.size).toBe(3);
+    expect(panels.inspector_pane).toBeUndefined();
+    expect(panels.response_pane).toBeDefined();
+    expect(panels.conversation_pane).toBeDefined();
+  });
+
+  it("gives the default layout more width to the main guardian surfaces than to inventory panes", () => {
+    vi.stubGlobal("window", { innerWidth: 1600, innerHeight: 980 });
+
+    const panels = getPackedCockpitPanels("default", true);
+
+    expect(panels.response_pane.width).toBeGreaterThan(panels.sessions_pane.width);
+    expect(panels.guardian_state_pane.width).toBeGreaterThan(panels.goals_pane.width);
+    expect(panels.conversation_pane.width).toBeGreaterThan(panels.audit_pane.width);
+  });
+
+  it("keeps focus and review layouts functionally distinct", () => {
+    vi.stubGlobal("window", { innerWidth: 1600, innerHeight: 980 });
+
+    const focusPanels = getPackedCockpitPanels("focus", true);
+    const reviewPanels = getPackedCockpitPanels("review", true);
+
+    expect(focusPanels.response_pane.width).toBeGreaterThan(focusPanels.workflows_pane.width);
+    expect(reviewPanels.audit_pane.width).toBeGreaterThan(reviewPanels.sessions_pane.width);
+    expect(reviewPanels.trace_pane.width).toBeGreaterThan(reviewPanels.sessions_pane.width);
+  });
+});

--- a/frontend/src/stores/panelLayoutStore.ts
+++ b/frontend/src/stores/panelLayoutStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { CockpitLayoutId } from "../components/cockpit/layouts";
 
 export interface PanelRect {
   x: number;
@@ -12,7 +13,183 @@ export const PANEL_MIN_SIZES: Record<string, { width: number; height: number }> 
   chat: { width: 400, height: 200 },
   quest: { width: 240, height: 200 },
   settings: { width: 240, height: 200 },
+  sessions_pane: { width: 224, height: 96 },
+  goals_pane: { width: 224, height: 112 },
+  outputs_pane: { width: 224, height: 96 },
+  approvals_pane: { width: 224, height: 112 },
+  response_pane: { width: 224, height: 112 },
+  guardian_state_pane: { width: 240, height: 144 },
+  workflows_pane: { width: 224, height: 112 },
+  interventions_pane: { width: 224, height: 112 },
+  audit_pane: { width: 224, height: 112 },
+  trace_pane: { width: 224, height: 96 },
+  inspector_pane: { width: 240, height: 144 },
+  conversation_pane: { width: 240, height: 144 },
+  desktop_shell_pane: { width: 224, height: 112 },
+  operator_surface_pane: { width: 240, height: 144 },
 };
+
+const WORKSPACE_GAP = 16;
+const WORKSPACE_LEFT = 16;
+const WORKSPACE_TOP = 124;
+const WORKSPACE_RIGHT = 16;
+const WORKSPACE_BOTTOM = 140;
+const PANEL_GRID_SIZE = 16;
+const COCKPIT_PANE_IDS = [
+  "sessions_pane",
+  "goals_pane",
+  "outputs_pane",
+  "approvals_pane",
+  "response_pane",
+  "guardian_state_pane",
+  "workflows_pane",
+  "interventions_pane",
+  "audit_pane",
+  "trace_pane",
+  "inspector_pane",
+  "conversation_pane",
+  "desktop_shell_pane",
+  "operator_surface_pane",
+] as const;
+
+interface LayoutColumn {
+  weight: number;
+  panes: string[];
+}
+
+const LAYOUT_COLUMNS: Record<CockpitLayoutId, LayoutColumn[]> = {
+  default: [
+    { weight: 0.92, panes: ["sessions_pane", "goals_pane", "outputs_pane"] },
+    { weight: 1.38, panes: ["response_pane", "guardian_state_pane", "interventions_pane"] },
+    { weight: 1.02, panes: ["approvals_pane", "workflows_pane", "audit_pane", "trace_pane", "inspector_pane"] },
+    { weight: 1.18, panes: ["conversation_pane", "desktop_shell_pane", "operator_surface_pane"] },
+  ],
+  focus: [
+    { weight: 1.28, panes: ["response_pane", "guardian_state_pane", "interventions_pane"] },
+    { weight: 1.02, panes: ["workflows_pane", "inspector_pane"] },
+    { weight: 1.16, panes: ["conversation_pane", "desktop_shell_pane", "operator_surface_pane"] },
+  ],
+  review: [
+    { weight: 0.86, panes: ["sessions_pane", "approvals_pane"] },
+    { weight: 1.1, panes: ["response_pane", "workflows_pane", "interventions_pane"] },
+    { weight: 1.08, panes: ["audit_pane", "trace_pane", "inspector_pane"] },
+    { weight: 1.12, panes: ["conversation_pane", "desktop_shell_pane", "operator_surface_pane"] },
+  ],
+};
+
+function snap(value: number): number {
+  return Math.round(value / PANEL_GRID_SIZE) * PANEL_GRID_SIZE;
+}
+
+function getWorkspaceFrame() {
+  const width = typeof window !== "undefined" ? window.innerWidth : 1440;
+  const height = typeof window !== "undefined" ? window.innerHeight : 900;
+  return {
+    x: WORKSPACE_LEFT,
+    y: WORKSPACE_TOP,
+    width: width - WORKSPACE_LEFT - WORKSPACE_RIGHT,
+    height: height - WORKSPACE_TOP - WORKSPACE_BOTTOM,
+  };
+}
+
+function distributeHeights(
+  ids: string[],
+  availableHeight: number,
+): number[] {
+  if (ids.length === 0) return [];
+
+  const gaps = WORKSPACE_GAP * (ids.length - 1);
+  const usable = Math.max(0, availableHeight - gaps);
+  const mins = ids.map((id) => PANEL_MIN_SIZES[id]?.height ?? 96);
+  const minTotal = mins.reduce((sum, value) => sum + value, 0);
+
+  if (usable <= minTotal) {
+    const compact = snap(usable / ids.length);
+    const heights = ids.map((id) => Math.max(PANEL_MIN_SIZES[id]?.height ?? 96, compact));
+    return heights;
+  }
+
+  const base = mins.slice();
+  let remaining = usable - minTotal;
+  const growthWeights = ids.map((id) => {
+    if (id === "guardian_state_pane" || id === "inspector_pane" || id === "conversation_pane") return 2;
+    if (id === "operator_surface_pane" || id === "response_pane") return 1.5;
+    return 1;
+  });
+  const totalWeight = growthWeights.reduce((sum, value) => sum + value, 0);
+
+  const heights = base.map((value, index) => {
+    if (index === ids.length - 1) return value;
+    const extra = snap((remaining * growthWeights[index]) / totalWeight);
+    remaining -= extra;
+    return value + extra;
+  });
+  heights[heights.length - 1] += remaining;
+
+  return heights;
+}
+
+export function getPackedCockpitPanels(
+  layoutId: CockpitLayoutId,
+  inspectorVisible = true,
+): Record<string, PanelRect> {
+  const frame = getWorkspaceFrame();
+  const columns = LAYOUT_COLUMNS[layoutId]
+    .map((column) => ({
+      weight: column.weight,
+      panes: column.panes.filter((id) => inspectorVisible || id !== "inspector_pane"),
+    }))
+    .filter((column) => column.panes.length > 0);
+  const columnCount = columns.length;
+  const totalGap = WORKSPACE_GAP * (columnCount - 1);
+  const availableWidth = frame.width - totalGap;
+  const totalWeight = columns.reduce((sum, column) => sum + column.weight, 0);
+  const columnWidths: number[] = [];
+  let assignedWidth = 0;
+  columns.forEach((column, index) => {
+    if (index === columnCount - 1) {
+      const minWidth = Math.max(...column.panes.map((id) => PANEL_MIN_SIZES[id]?.width ?? 224));
+      columnWidths.push(snap(Math.max(minWidth, availableWidth - assignedWidth)));
+      return;
+    }
+    const rawWidth = (availableWidth * column.weight) / totalWeight;
+    const minWidth = Math.max(...column.panes.map((id) => PANEL_MIN_SIZES[id]?.width ?? 224));
+    const width = snap(Math.max(minWidth, rawWidth));
+    columnWidths.push(width);
+    assignedWidth += width;
+  });
+  const panels: Record<string, PanelRect> = {};
+
+  columns.forEach((column, columnIndex) => {
+    const x = snap(
+      frame.x +
+        columnWidths.slice(0, columnIndex).reduce((sum, width) => sum + width, 0) +
+        WORKSPACE_GAP * columnIndex,
+    );
+    const heights = distributeHeights(column.panes, frame.height);
+    let y = snap(frame.y);
+
+    column.panes.forEach((id, rowIndex) => {
+      const width =
+        columnIndex === columnCount - 1
+          ? snap(frame.x + frame.width - x)
+          : columnWidths[columnIndex];
+      const height =
+        rowIndex === column.panes.length - 1
+          ? snap(frame.y + frame.height - y)
+          : heights[rowIndex];
+      panels[id] = {
+        x,
+        y,
+        width: Math.max(PANEL_MIN_SIZES[id]?.width ?? 224, width),
+        height: Math.max(PANEL_MIN_SIZES[id]?.height ?? 96, height),
+      };
+      y = snap(y + height + WORKSPACE_GAP);
+    });
+  });
+
+  return panels;
+}
 
 function defaultPanels(): Record<string, PanelRect> {
   const w = typeof window !== "undefined" ? window.innerWidth : 1280;
@@ -36,7 +213,30 @@ function defaultPanels(): Record<string, PanelRect> {
       width: 280,
       height: 340,
     },
+    ...getPackedCockpitPanels("default", true),
   };
+}
+
+function defaultZStack(): string[] {
+  return [
+    "chat",
+    "quest",
+    "settings",
+    "sessions_pane",
+    "goals_pane",
+    "outputs_pane",
+    "approvals_pane",
+    "response_pane",
+    "guardian_state_pane",
+    "workflows_pane",
+    "interventions_pane",
+    "audit_pane",
+    "trace_pane",
+    "inspector_pane",
+    "conversation_pane",
+    "desktop_shell_pane",
+    "operator_surface_pane",
+  ];
 }
 
 interface PanelLayoutStore {
@@ -46,6 +246,7 @@ interface PanelLayoutStore {
   setRect: (id: string, rect: Partial<PanelRect>) => void;
   bringToFront: (id: string) => void;
   resetPanel: (id: string) => void;
+  applyCockpitLayout: (layoutId: CockpitLayoutId, inspectorVisible?: boolean) => void;
   getZIndex: (id: string) => number;
 }
 
@@ -53,7 +254,7 @@ export const usePanelLayoutStore = create<PanelLayoutStore>()(
   persist(
     (set, get) => ({
       panels: defaultPanels(),
-      zStack: ["chat", "quest", "settings"],
+      zStack: defaultZStack(),
 
       setRect: (id, rect) =>
         set((state) => ({
@@ -78,6 +279,15 @@ export const usePanelLayoutStore = create<PanelLayoutStore>()(
           },
         })),
 
+      applyCockpitLayout: (layoutId, inspectorVisible = true) =>
+        set((state) => ({
+          panels: {
+            ...state.panels,
+            ...getPackedCockpitPanels(layoutId, inspectorVisible),
+          },
+          zStack: [...state.zStack.filter((id) => !COCKPIT_PANE_IDS.includes(id as (typeof COCKPIT_PANE_IDS)[number])), ...COCKPIT_PANE_IDS],
+        })),
+
       getZIndex: (id) => {
         const idx = get().zStack.indexOf(id);
         return 50 + (idx === -1 ? 0 : idx);
@@ -89,6 +299,25 @@ export const usePanelLayoutStore = create<PanelLayoutStore>()(
         panels: state.panels,
         zStack: state.zStack,
       }),
+      merge: (persisted, current) => {
+        const persistedState = (persisted ?? {}) as Partial<PanelLayoutStore>;
+        const mergedPanels = {
+          ...current.panels,
+          ...(persistedState.panels ?? {}),
+        };
+        const mergedZStack = [...(persistedState.zStack ?? [])];
+        for (const panelId of defaultZStack()) {
+          if (!mergedZStack.includes(panelId)) {
+            mergedZStack.push(panelId);
+          }
+        }
+        return {
+          ...current,
+          ...persistedState,
+          panels: mergedPanels,
+          zStack: mergedZStack,
+        };
+      },
     },
   ),
 );


### PR DESCRIPTION
## Done on develop
- [x] guardian-state, intervention-policy, native presence, workflow composition, operator surface, and cockpit-first research/implementation docs are already shipped foundations
- [x] runtime reliability, provider policy routing, and guardian behavioral eval foundations are already in place on `develop`

## Working in this PR
- [ ] rebuild the active browser shell around a real pane workspace instead of three movable buckets
- [ ] make live send resilient with REST fallback when WebSocket is unavailable and keep the latest response visible in the main surface
- [ ] add draggable/resizable panes with 16px grid snap plus packed `default`, `focus`, and `review` layouts
- [ ] remove the active legacy village framing from settings/goals overlays and restyle them as larger cockpit modals
- [ ] update implementation and research docs so the source of truth matches the shipped cockpit-first direction

## Still to do after this PR
- [ ] docking, pane add/remove management, and saved custom operator workspaces
- [ ] denser workflow-operating surfaces beyond the first packed pane workspace
- [ ] execution-safety-hardening-v3 and the rest of the current rolling roadmap batch

## Validation
- `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`
- `cd frontend && npm test`
- `cd frontend && npm run build`
- `cd docs && npm run build`
