### PR TITLE
Polish docs layout and navigation styling

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1,26 +1,28 @@
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Manrope:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;700&display=swap');
 
 /**
- * Seraph docs theme synced to the cockpit UI surface.
- * The docs keep the app's dark panel system, cyan/teal accents,
- * mono body copy, and condensed display headings.
+ * Seraph docs theme.
+ * Keep the cockpit color system, but render the docs as a readable,
+ * deliberate documentation surface rather than a terminal panel.
  */
 
 :root {
   --seraph-bg: #071019;
   --seraph-bg-deep: #05101a;
   --seraph-bg-soft: #091722;
-  --seraph-panel: rgba(9, 25, 39, 0.92);
-  --seraph-panel-soft: rgba(13, 33, 52, 0.82);
-  --seraph-panel-strong: rgba(11, 29, 45, 0.97);
-  --seraph-border: rgba(110, 177, 214, 0.22);
-  --seraph-border-strong: rgba(129, 213, 255, 0.46);
-  --seraph-text: #d7e7f5;
-  --seraph-muted: #7e9ab0;
+  --seraph-panel: rgba(8, 22, 34, 0.9);
+  --seraph-panel-soft: rgba(10, 28, 43, 0.82);
+  --seraph-panel-strong: rgba(8, 22, 34, 0.97);
+  --seraph-border: rgba(110, 177, 214, 0.18);
+  --seraph-border-strong: rgba(129, 213, 255, 0.34);
+  --seraph-text: #dbeaf6;
+  --seraph-text-strong: #f4fbff;
+  --seraph-muted: #8aa4b8;
   --seraph-accent: #8de2ff;
   --seraph-accent-strong: #6ef4c3;
   --seraph-warning: #ffcf70;
   --seraph-danger: #ff7d79;
+  --seraph-shadow: 0 28px 80px rgba(2, 8, 14, 0.34);
 
   --ifm-color-primary: #8de2ff;
   --ifm-color-primary-dark: #71dafd;
@@ -33,67 +35,69 @@
   --ifm-color-warning: #ffcf70;
   --ifm-color-danger: #ff7d79;
   --ifm-background-color: var(--seraph-bg);
-  --ifm-background-surface-color: var(--seraph-panel);
-  --ifm-navbar-background-color: rgba(7, 18, 27, 0.94);
-  --ifm-footer-background-color: rgba(7, 18, 27, 0.98);
+  --ifm-background-surface-color: transparent;
+  --ifm-navbar-background-color: rgba(7, 18, 27, 0.9);
+  --ifm-footer-background-color: rgba(7, 18, 27, 0.94);
   --ifm-font-family-base:
-    "IBM Plex Mono", "Iosevka", "SFMono-Regular", Menlo, Consolas, monospace;
+    "Manrope", "Segoe UI", "Helvetica Neue", sans-serif;
   --ifm-heading-font-family:
     "Space Grotesk", "Avenir Next Condensed", "Arial Narrow", sans-serif;
-  --ifm-code-font-size: 0.92rem;
+  --ifm-font-family-monospace:
+    "IBM Plex Mono", "Iosevka", "SFMono-Regular", Menlo, Consolas, monospace;
   --ifm-font-color-base: var(--seraph-text);
   --ifm-font-color-secondary: var(--seraph-muted);
-  --ifm-heading-color: #f2fbff;
+  --ifm-heading-color: var(--seraph-text-strong);
   --ifm-link-color: var(--seraph-accent);
-  --ifm-link-hover-color: #c4f4ff;
-  --ifm-menu-color: var(--seraph-muted);
-  --ifm-menu-color-active: var(--seraph-text);
-  --ifm-menu-color-background-active: rgba(141, 226, 255, 0.12);
-  --ifm-menu-color-background-hover: rgba(141, 226, 255, 0.08);
-  --ifm-breadcrumb-color-active: var(--seraph-text);
-  --ifm-breadcrumb-item-background-active: rgba(141, 226, 255, 0.12);
-  --ifm-toc-border-color: var(--seraph-border);
-  --ifm-global-radius: 18px;
-  --ifm-card-border-radius: 18px;
+  --ifm-link-hover-color: #c7f4ff;
+  --ifm-line-height-base: 1.72;
+  --ifm-code-font-size: 0.92rem;
+  --ifm-global-radius: 20px;
+  --ifm-card-border-radius: 22px;
   --ifm-button-border-radius: 999px;
-  --ifm-table-border-color: rgba(126, 154, 176, 0.22);
+  --ifm-table-border-color: rgba(126, 154, 176, 0.2);
   --ifm-table-head-background: rgba(141, 226, 255, 0.08);
-  --ifm-hover-overlay: rgba(141, 226, 255, 0.05);
   --ifm-code-background: rgba(110, 177, 214, 0.08);
-  --ifm-pre-background: rgba(4, 13, 20, 0.92);
+  --ifm-pre-background: rgba(4, 13, 20, 0.9);
   --ifm-pre-color: var(--seraph-text);
-  --ifm-blockquote-color: #c7dceb;
+  --ifm-blockquote-color: #c9dceb;
   --ifm-blockquote-border-color: var(--seraph-accent-strong);
-  --ifm-hr-border-color: rgba(126, 154, 176, 0.18);
+  --ifm-breadcrumb-color-active: var(--seraph-text);
+  --ifm-breadcrumb-item-background-active: rgba(141, 226, 255, 0.08);
   --ifm-color-emphasis-100: rgba(141, 226, 255, 0.04);
   --ifm-color-emphasis-200: rgba(141, 226, 255, 0.08);
   --ifm-color-emphasis-300: rgba(141, 226, 255, 0.14);
-  --ifm-color-emphasis-600: rgba(215, 231, 245, 0.72);
-  --ifm-color-emphasis-700: rgba(215, 231, 245, 0.82);
-  --ifm-color-emphasis-800: rgba(230, 242, 250, 0.92);
-  --ifm-color-emphasis-900: #f2fbff;
+  --ifm-color-emphasis-600: rgba(219, 234, 246, 0.72);
+  --ifm-color-emphasis-700: rgba(219, 234, 246, 0.84);
+  --ifm-color-emphasis-800: rgba(235, 245, 251, 0.92);
+  --ifm-color-emphasis-900: var(--seraph-text-strong);
   --docusaurus-highlighted-code-line-bg: rgba(141, 226, 255, 0.12);
   --docsearch-text-color: var(--seraph-text);
   --docsearch-muted-color: var(--seraph-muted);
+  --doc-sidebar-width: 320px;
+  --ifm-container-width-xl: 1500px;
+  --ifm-navbar-height: 4.4rem;
 }
 
 [data-theme='dark'] {
   --ifm-background-color: var(--seraph-bg);
-  --ifm-background-surface-color: var(--seraph-panel);
-  --ifm-navbar-background-color: rgba(7, 18, 27, 0.94);
-  --ifm-footer-background-color: rgba(7, 18, 27, 0.98);
-  --docusaurus-highlighted-code-line-bg: rgba(141, 226, 255, 0.12);
+  --ifm-background-surface-color: transparent;
+  --ifm-navbar-background-color: rgba(7, 18, 27, 0.9);
+  --ifm-footer-background-color: rgba(7, 18, 27, 0.94);
 }
 
 html {
-  background: linear-gradient(180deg, #05101a 0%, #07131d 42%, #091722 100%);
+  background:
+    radial-gradient(circle at top right, rgba(110, 244, 195, 0.07), transparent 28%),
+    radial-gradient(circle at top left, rgba(141, 226, 255, 0.08), transparent 32%),
+    linear-gradient(180deg, #05101a 0%, #07131d 42%, #091722 100%);
 }
 
 body {
   color: var(--seraph-text);
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 24%),
-    linear-gradient(180deg, #05101a 0%, #07131d 42%, #091722 100%);
+  font-family: var(--ifm-font-family-base);
+  font-size: 16.5px;
+  line-height: 1.72;
+  background: transparent;
 }
 
 body::before {
@@ -103,21 +107,15 @@ body::before {
   z-index: 0;
   pointer-events: none;
   background:
-    repeating-linear-gradient(
-      0deg,
-      rgba(141, 226, 255, 0.028) 0,
-      rgba(141, 226, 255, 0.028) 1px,
-      transparent 1px,
-      transparent 28px
-    ),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent 24%),
     repeating-linear-gradient(
       90deg,
-      rgba(141, 226, 255, 0.022) 0,
-      rgba(141, 226, 255, 0.022) 1px,
+      rgba(141, 226, 255, 0.014) 0,
+      rgba(141, 226, 255, 0.014) 1px,
       transparent 1px,
-      transparent 28px
+      transparent 32px
     );
-  opacity: 0.48;
+  opacity: 0.34;
 }
 
 #__docusaurus,
@@ -137,169 +135,364 @@ h6,
 .hero__title,
 .navbar__title {
   font-family: var(--ifm-heading-font-family);
-  letter-spacing: 0.04em;
+  letter-spacing: -0.02em;
 }
 
 h1 {
-  font-size: clamp(2.4rem, 4vw, 3.6rem);
-  line-height: 0.96;
+  font-size: clamp(2.5rem, 4vw, 3.8rem);
+  line-height: 0.98;
+  margin-bottom: 1.1rem;
 }
 
 h2 {
-  font-size: clamp(1.65rem, 2.6vw, 2.2rem);
+  font-size: clamp(1.7rem, 2.4vw, 2.25rem);
+  margin-top: 3rem;
+  padding-top: 1.05rem;
+  border-top: 1px solid rgba(129, 213, 255, 0.14);
 }
 
-h2,
 h3 {
-  color: #f2fbff;
+  font-size: clamp(1.22rem, 1.7vw, 1.5rem);
+  margin-top: 2.15rem;
+}
+
+p,
+li {
+  color: rgba(219, 234, 246, 0.92);
+}
+
+p,
+ul,
+ol,
+table,
+blockquote {
+  max-width: 78ch;
 }
 
 .navbar {
-  border-bottom: 1px solid rgba(138, 207, 255, 0.18);
+  border-bottom: 1px solid rgba(138, 207, 255, 0.14);
   background:
-    linear-gradient(180deg, rgba(7, 18, 27, 0.98), rgba(7, 18, 27, 0.94)),
+    linear-gradient(180deg, rgba(7, 18, 27, 0.96), rgba(7, 18, 27, 0.88)),
     repeating-linear-gradient(
       90deg,
-      rgba(141, 226, 255, 0.026) 0,
-      rgba(141, 226, 255, 0.026) 1px,
+      rgba(141, 226, 255, 0.018) 0,
+      rgba(141, 226, 255, 0.018) 1px,
       transparent 1px,
-      transparent 14px
+      transparent 16px
     );
+  backdrop-filter: blur(18px);
   box-shadow:
     inset 0 -1px 0 rgba(255, 255, 255, 0.02),
-    0 18px 60px rgba(2, 8, 14, 0.28);
-  backdrop-filter: blur(18px);
+    0 18px 48px rgba(2, 8, 14, 0.22);
+}
+
+.navbar__brand {
+  gap: 0.7rem;
 }
 
 .navbar__title {
-  color: var(--seraph-text);
+  font-size: 1rem;
   font-weight: 700;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: var(--seraph-text-strong);
 }
 
-.navbar__link,
-.footer__link-item {
+.navbar__link {
+  font-size: 0.93rem;
+  font-weight: 650;
   color: var(--seraph-muted);
 }
 
 .navbar__link:hover,
-.navbar__link--active,
-.footer__link-item:hover {
+.navbar__link--active {
   color: var(--seraph-accent);
 }
 
-.navbar__brand:hover {
-  color: var(--seraph-text);
-}
-
-.theme-doc-sidebar-container,
-.table-of-contents,
-.pagination-nav__link,
-.card,
-.theme-admonition,
-.theme-code-block,
-.menu,
-.footer {
-  background: var(--seraph-panel);
-  border: 1px solid var(--seraph-border);
-  box-shadow:
-    0 24px 80px rgba(1, 8, 13, 0.28),
-    inset 0 1px 0 rgba(255, 255, 255, 0.02);
-  backdrop-filter: blur(18px);
-}
-
 .theme-doc-sidebar-container {
+  background:
+    linear-gradient(180deg, rgba(10, 23, 35, 0.88), rgba(7, 19, 29, 0.94));
   border-left: 0;
   border-right: 1px solid var(--seraph-border);
+  box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.02);
 }
 
 .menu {
-  padding: 0.5rem;
+  padding: 1.35rem 1rem 1.65rem;
   background: transparent;
-  border: 0;
-  box-shadow: none;
-  backdrop-filter: none;
+}
+
+.menu__list-item {
+  margin: 0.14rem 0;
+}
+
+.menu__list .menu__list {
+  margin: 0.18rem 0 0.8rem;
+  padding-left: 0;
+  border-left: 0;
 }
 
 .menu__link,
 .table-of-contents__link {
+  display: block;
+  padding: 0.56rem 0.78rem;
   border: 1px solid transparent;
-  border-radius: 999px;
+  border-radius: 12px;
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.92rem;
+  font-weight: 600;
+  line-height: 1.42;
   color: var(--seraph-muted);
   transition:
-    color 120ms ease,
-    border-color 120ms ease,
-    background-color 120ms ease;
+    color 140ms ease,
+    border-color 140ms ease,
+    background-color 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease;
 }
 
 .menu__link:hover,
 .table-of-contents__link:hover {
   color: var(--seraph-text);
-  border-color: rgba(141, 226, 255, 0.18);
-  background: rgba(141, 226, 255, 0.08);
+  border-color: rgba(141, 226, 255, 0.1);
+  background: rgba(141, 226, 255, 0.05);
 }
 
 .menu__link--active,
 .table-of-contents__link--active {
+  color: var(--seraph-text-strong);
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+}
+
+.theme-doc-sidebar-item-category-level-1 {
+  margin-bottom: 0.8rem;
+}
+
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible {
+  margin-bottom: 0.28rem;
+}
+
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link {
+  padding: 0.25rem 0.1rem 0.5rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #b9d1e2;
+}
+
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link:hover,
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link.menu__link--active {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--seraph-text-strong);
+}
+
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link::after {
+  content: "";
+  display: block;
+  margin-top: 0.55rem;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(141, 226, 255, 0.22), rgba(141, 226, 255, 0));
+}
+
+.theme-doc-sidebar-item-category-level-1 > .menu__list {
+  position: relative;
+  margin-left: 0.1rem;
+  padding-left: 0.9rem;
+}
+
+.theme-doc-sidebar-item-category-level-1 > .menu__list::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.15rem;
+  bottom: 0.25rem;
+  width: 1px;
+  background: linear-gradient(180deg, rgba(141, 226, 255, 0.18), rgba(141, 226, 255, 0.04));
+}
+
+.theme-doc-sidebar-item-link-level-2 > .menu__link,
+.theme-doc-sidebar-item-category-level-2 > .menu__list-item-collapsible > .menu__link {
+  position: relative;
+  padding: 0.62rem 0.75rem 0.62rem 1rem;
+  border-radius: 0;
+  font-size: 0.96rem;
+  font-weight: 650;
+  color: #b6cbda;
+}
+
+.theme-doc-sidebar-item-link-level-2 > .menu__link:hover,
+.theme-doc-sidebar-item-category-level-2 > .menu__list-item-collapsible > .menu__link:hover {
   color: var(--seraph-text);
-  border-color: var(--seraph-border-strong);
-  background: rgba(141, 226, 255, 0.12);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  background: linear-gradient(90deg, rgba(141, 226, 255, 0.035), transparent 78%);
+}
+
+.theme-doc-sidebar-item-link-level-2 > .menu__link.menu__link--active,
+.theme-doc-sidebar-item-category-level-2 > .menu__list-item-collapsible > .menu__link.menu__link--active {
+  border-color: transparent;
+  background: transparent;
+  color: var(--seraph-text-strong);
+  box-shadow: none;
+}
+
+.theme-doc-sidebar-item-link-level-2 > .menu__link.menu__link--active::before,
+.theme-doc-sidebar-item-category-level-2 > .menu__list-item-collapsible > .menu__link.menu__link--active::before {
+  content: "";
+  position: absolute;
+  left: 0.1rem;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  width: 2px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--seraph-accent), #b8f3ff);
+  box-shadow: 0 0 18px rgba(141, 226, 255, 0.24);
+}
+
+.theme-doc-sidebar-item-link-level-3 > .menu__link,
+.theme-doc-sidebar-item-category-level-3 > .menu__list-item-collapsible > .menu__link {
+  padding-left: 0.9rem;
+  font-size: 0.9rem;
+  color: #9eb8cb;
+}
+
+.menu__caret::before {
+  opacity: 0.72;
+}
+
+.menu__caret:hover::before,
+.menu__list-item-collapsible:hover .menu__caret::before {
+  opacity: 1;
+}
+
+.theme-doc-breadcrumbs {
+  margin-bottom: 1.15rem;
+}
+
+.breadcrumbs__link {
+  border-radius: 999px;
+  padding: 0.28rem 0.65rem;
+}
+
+.breadcrumbs__item--active .breadcrumbs__link {
+  border: 1px solid rgba(141, 226, 255, 0.16);
+  background: rgba(141, 226, 255, 0.06);
+}
+
+.theme-doc-markdown {
+  position: relative;
+  max-width: 900px;
+  padding: clamp(1.5rem, 2.8vw, 2.65rem);
+  border: 1px solid var(--seraph-border);
+  border-radius: 28px;
+  background:
+    linear-gradient(180deg, rgba(10, 24, 37, 0.8), rgba(7, 19, 29, 0.94));
+  box-shadow: var(--seraph-shadow);
+  backdrop-filter: blur(18px);
+  overflow: hidden;
+}
+
+.theme-doc-markdown::before {
+  content: "";
+  position: absolute;
+  left: 0.9rem;
+  top: 1.4rem;
+  bottom: 1.4rem;
+  width: 2px;
+  border-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(141, 226, 255, 0.95),
+    rgba(110, 244, 195, 0.35)
+  );
+  box-shadow: 0 0 24px rgba(141, 226, 255, 0.16);
+  pointer-events: none;
+}
+
+.theme-doc-markdown > :first-child {
+  margin-top: 0;
+}
+
+.theme-doc-markdown a:not(.pagination-nav__link):not(.menu__link) {
+  text-decoration-color: rgba(141, 226, 255, 0.38);
+  text-underline-offset: 0.22em;
+}
+
+.theme-doc-markdown a:hover {
+  text-decoration-color: rgba(141, 226, 255, 0.9);
+}
+
+.table-of-contents,
+.pagination-nav__link,
+.theme-admonition,
+.card,
+.footer,
+.theme-doc-toc-mobile {
+  border: 1px solid var(--seraph-border);
+  border-radius: 22px;
+  background:
+    linear-gradient(180deg, rgba(10, 24, 37, 0.76), rgba(7, 19, 29, 0.92));
+  box-shadow: var(--seraph-shadow);
+  backdrop-filter: blur(18px);
 }
 
 .table-of-contents {
   padding: 1rem;
 }
 
-.theme-doc-markdown,
-.theme-doc-markdown article {
-  color: var(--seraph-text);
+.table-of-contents__link {
+  position: relative;
+  padding-left: 0.95rem;
 }
 
-.theme-doc-markdown a:not(.pagination-nav__link):not(.menu__link) {
-  text-decoration-color: rgba(141, 226, 255, 0.4);
-  text-underline-offset: 0.22em;
+.table-of-contents__link--active {
+  color: var(--seraph-text-strong);
 }
 
-.theme-doc-markdown a:hover {
-  text-decoration-color: rgba(141, 226, 255, 0.82);
-}
-
-.theme-doc-breadcrumbs {
-  margin-bottom: 1rem;
-}
-
-.breadcrumbs__item--active .breadcrumbs__link {
-  border: 1px solid rgba(141, 226, 255, 0.18);
-  background: rgba(141, 226, 255, 0.08);
-}
-
-.breadcrumbs__link {
+.table-of-contents__link--active::before {
+  content: "";
+  position: absolute;
+  left: 0.18rem;
+  top: 0.42rem;
+  bottom: 0.42rem;
+  width: 2px;
   border-radius: 999px;
+  background: linear-gradient(180deg, var(--seraph-accent), #b8f3ff);
+  box-shadow: 0 0 14px rgba(141, 226, 255, 0.18);
+  pointer-events: none;
 }
 
 .pagination-nav__link {
-  border-radius: 18px;
+  padding: 1rem 1.15rem;
 }
 
 .pagination-nav__label {
   font-family: var(--ifm-heading-font-family);
-  letter-spacing: 0.03em;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
 }
 
 pre,
 code,
 kbd,
 samp {
-  font-family: var(--ifm-font-family-base);
+  font-family: var(--ifm-font-family-monospace);
 }
 
 pre {
-  border: 1px solid rgba(141, 226, 255, 0.16);
+  border: 1px solid rgba(141, 226, 255, 0.15);
+  border-radius: 20px;
 }
 
 code {
-  border: 1px solid rgba(141, 226, 255, 0.1);
+  border: 1px solid rgba(141, 226, 255, 0.09);
   border-radius: 10px;
 }
 
@@ -308,13 +501,14 @@ code {
 }
 
 blockquote {
-  background: rgba(110, 244, 195, 0.06);
-  border-radius: 0 16px 16px 0;
+  padding: 0.9rem 1.1rem;
+  border-radius: 0 18px 18px 0;
+  background: rgba(110, 244, 195, 0.05);
 }
 
 table {
   overflow: hidden;
-  border-radius: 16px;
+  border-radius: 18px;
 }
 
 thead tr {
@@ -322,15 +516,14 @@ thead tr {
 }
 
 .alert {
-  border: 1px solid var(--seraph-border);
   border-radius: 18px;
+  border-color: var(--seraph-border);
 }
 
 .button {
-  border-color: rgba(141, 226, 255, 0.28);
+  border-color: rgba(141, 226, 255, 0.24);
   font-family: var(--ifm-heading-font-family);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .button--primary {
@@ -346,35 +539,65 @@ thead tr {
 
 .footer {
   margin-top: 4rem;
-  border-bottom: 0;
   border-left: 0;
   border-right: 0;
+  border-bottom: 0;
 }
 
 .footer__title {
-  color: #f2fbff;
+  color: var(--seraph-text-strong);
   font-family: var(--ifm-heading-font-family);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  letter-spacing: 0.01em;
+}
+
+.footer__link-item {
+  color: var(--seraph-muted);
+}
+
+.footer__link-item:hover {
+  color: var(--seraph-accent);
 }
 
 .footer__copyright {
   color: var(--seraph-muted);
 }
 
-.theme-doc-toc-mobile {
-  border: 1px solid var(--seraph-border);
-  border-radius: 18px;
-  background: var(--seraph-panel);
+@media (min-width: 997px) {
+  .theme-doc-sidebar-container {
+    width: var(--doc-sidebar-width) !important;
+  }
+
+  .theme-doc-markdown {
+    margin-right: auto;
+  }
 }
 
 @media (max-width: 996px) {
   body::before {
-    opacity: 0.32;
+    opacity: 0.24;
   }
 
   h1 {
-    font-size: clamp(2rem, 9vw, 2.8rem);
+    font-size: clamp(2.1rem, 8vw, 3rem);
+  }
+
+  .theme-doc-markdown {
+    padding: 1.2rem 1rem 1.5rem;
+    border-radius: 22px;
+  }
+
+  .theme-doc-markdown::before {
+    left: 0.72rem;
+    top: 1rem;
+    bottom: 1rem;
+  }
+
+  .table-of-contents {
+    padding-left: 1rem;
+  }
+
+  .menu {
+    padding-inline: 0.7rem;
   }
 
   .table-of-contents,


### PR DESCRIPTION
## Done on develop
- [x] the docs already use the Seraph color palette and dark-only theme
- [x] the docs entry-point copy already matches the current product positioning

## Working in this PR
- [ ] replace the mono-heavy docs styling with readable documentation typography and spacing
- [ ] redesign the sidebar and right-hand table of contents around cleaner left-rail selection states
- [ ] keep the Seraph visual system while making the docs feel like a proper documentation surface

## Still to do after this PR
- [ ] broader docs IA and content revisions beyond this visual polish pass

## Validation
- 
> docs@0.0.0 build
> docusaurus build

[INFO] [en] Creating an optimized production build...
[webpackbar] ℹ Compiling Client
[webpackbar] ℹ Compiling Server
[webpackbar] ✔ Server: Compiled successfully in 2.65s
[webpackbar] ✔ Client: Compiled successfully in 3.70s
[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.