### PR TITLE
Harden wave 1 follow-up path and workflow fixes

### DIFF
--- a/backend/src/tools/process_tools.py
+++ b/backend/src/tools/process_tools.py
@@ -286,9 +286,41 @@ def _validate_workspace_scoped_args(executable: str, args: list[str], cwd: Path)
                 pattern_consumed = True
                 index += 2
                 continue
+            if arg.startswith("-f") and arg != "-f" and not arg.startswith("--"):
+                _ensure_workspace_scoped_path(arg[2:], cwd, label="-f path")
+                pattern_consumed = True
+                index += 1
+                continue
+            if arg.startswith("-") and not arg.startswith("--"):
+                short_flag_operand_index = arg.find("f", 1)
+                if 1 <= short_flag_operand_index < len(arg) - 1:
+                    _ensure_workspace_scoped_path(arg[short_flag_operand_index + 1 :], cwd, label="-f path")
+                    pattern_consumed = True
+                    index += 1
+                    continue
             if arg.startswith("--file="):
                 _ensure_workspace_scoped_path(arg.split("=", 1)[1], cwd, label="--file path")
                 pattern_consumed = True
+                index += 1
+                continue
+            if command_name == "grep" and arg in {"--exclude-from"}:
+                if index + 1 >= len(args):
+                    raise ValueError(f"{arg} requires a path argument.")
+                _ensure_workspace_scoped_path(args[index + 1], cwd, label=f"{arg} path")
+                index += 2
+                continue
+            if command_name == "grep" and arg.startswith("--exclude-from="):
+                _ensure_workspace_scoped_path(arg.split("=", 1)[1], cwd, label="--exclude-from path")
+                index += 1
+                continue
+            if command_name == "rg" and arg in {"--ignore-file"}:
+                if index + 1 >= len(args):
+                    raise ValueError(f"{arg} requires a path argument.")
+                _ensure_workspace_scoped_path(args[index + 1], cwd, label=f"{arg} path")
+                index += 2
+                continue
+            if command_name == "rg" and arg.startswith("--ignore-file="):
+                _ensure_workspace_scoped_path(arg.split("=", 1)[1], cwd, label="--ignore-file path")
                 index += 1
                 continue
             if arg.startswith("-"):

--- a/backend/src/workflows/manager.py
+++ b/backend/src/workflows/manager.py
@@ -69,7 +69,7 @@ def _summarize_workflow_result(workflow: Workflow, step_results: dict[str, dict[
         result = str(step_state.get("result", ""))
         if len(result) > 240:
             result = result[:237] + "..."
-        lines.append(f"- {step.id} ({step.tool}): {result}")
+        lines.append(f"- {step.id} ({canonical_tool_name(step.tool)}): {result}")
     return "\n".join(lines)
 
 
@@ -160,11 +160,12 @@ class WorkflowTool(Tool):
         continued_error_steps: list[str] = []
         artifact_paths = _collect_artifact_paths(workflow_inputs)
         step_records: list[dict[str, Any]] = []
+        canonical_step_tools = [canonical_tool_name(step.tool) for step in self.workflow.steps]
 
-        for step in self.workflow.steps:
+        for step, canonical_step_tool in zip(self.workflow.steps, canonical_step_tools, strict=False):
             tool = self.tools_by_name.get(step.tool)
             if tool is None:
-                tool = self.tools_by_name.get(canonical_tool_name(step.tool))
+                tool = self.tools_by_name.get(canonical_step_tool)
             if tool is None:
                 raise RuntimeError(
                     f"Workflow '{self.workflow.name}' requires unavailable tool '{step.tool}'"
@@ -192,7 +193,7 @@ class WorkflowTool(Tool):
             step_completed_at = _utc_now_iso()
             duration_ms = int((time.perf_counter() - started) * 1000)
             context["steps"][step.id] = {
-                "tool": step.tool,
+                "tool": canonical_step_tool,
                 "arguments": rendered_arguments,
                 "result": result,
             }
@@ -203,7 +204,7 @@ class WorkflowTool(Tool):
             step_records.append({
                 "id": step.id,
                 "index": len(step_records) + 1,
-                "tool": step.tool,
+                "tool": canonical_step_tool,
                 "status": step_status,
                 "argument_keys": (
                     sorted(str(key) for key in rendered_arguments.keys())
@@ -238,7 +239,7 @@ class WorkflowTool(Tool):
                 "workflow_name": self.workflow.name,
                 "run_fingerprint": run_fingerprint,
                 "step_count": len(self.workflow.steps),
-                "step_tools": [step.tool for step in self.workflow.steps],
+                "step_tools": canonical_step_tools,
                 "step_records": step_records,
                 "checkpoint_step_ids": [str(step["id"]) for step in step_records if step.get("id")],
                 "last_completed_step_id": (

--- a/backend/tests/test_process_tools.py
+++ b/backend/tests/test_process_tools.py
@@ -78,6 +78,41 @@ def test_run_command_rejects_grep_file_argument_outside_workspace():
     assert result == "Error: path argument must stay within the workspace."
 
 
+def test_run_command_rejects_grep_exclude_from_outside_workspace():
+    result = run_command(command="grep", args_json='["--exclude-from","/etc/hosts","localhost","hosts.txt"]')
+    assert result == "Error: --exclude-from path must stay within the workspace."
+
+
+def test_run_command_rejects_rg_ignore_file_outside_workspace():
+    result = run_command(command="rg", args_json='["--ignore-file","/etc/hosts","localhost","hosts.txt"]')
+    assert result == "Error: --ignore-file path must stay within the workspace."
+
+
+def test_run_command_rejects_grep_attached_file_flag_outside_workspace():
+    result = run_command(command="grep", args_json='["-f/etc/hosts","localhost","hosts.txt"]')
+    assert result == "Error: -f path must stay within the workspace."
+
+
+def test_run_command_rejects_rg_attached_file_flag_outside_workspace():
+    result = run_command(command="rg", args_json='["-f/etc/hosts","localhost","hosts.txt"]')
+    assert result == "Error: -f path must stay within the workspace."
+
+
+def test_run_command_rejects_sed_attached_file_flag_outside_workspace():
+    result = run_command(command="sed", args_json='["-f/etc/hosts","hosts.txt"]')
+    assert result == "Error: -f path must stay within the workspace."
+
+
+def test_run_command_rejects_grep_clustered_file_flag_outside_workspace():
+    result = run_command(command="grep", args_json='["-rf/etc/hosts","localhost","hosts.txt"]')
+    assert result == "Error: -f path must stay within the workspace."
+
+
+def test_run_command_rejects_sed_clustered_file_flag_outside_workspace():
+    result = run_command(command="sed", args_json='["-nf/etc/hosts","hosts.txt"]')
+    assert result == "Error: -f path must stay within the workspace."
+
+
 def test_start_process_rejects_absolute_script_path_outside_workspace():
     result = start_process(command="python3", args_json='["/tmp/outside.py"]')
     assert result == "Error: script path must stay within the workspace."

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -255,8 +255,15 @@ class TestWorkflowManager:
         execute_code = DummyTool("execute_code", lambda code: f"ran {code}")
         workflow_tool = WorkflowTool(workflow, {"execute_code": execute_code})
 
-        assert "ran print('hello')" in workflow_tool()
+        result = workflow_tool()
+        assert "ran print('hello')" in result
+        assert "shell_execute" not in result
+        assert "execute_code" in result
         assert execute_code.calls == [{"code": "print('hello')"}]
+        audit_payload = workflow_tool.get_audit_result_payload({}, "ignored")
+        assert audit_payload is not None
+        assert audit_payload[1]["step_tools"] == ["execute_code"]
+        assert audit_payload[1]["step_records"][0]["tool"] == "execute_code"
 
         mgr = WorkflowManager()
         mgr._workflows = [workflow]


### PR DESCRIPTION
## Done on develop
- [x] Wave 1 Hermes runtime parity merged in #222
- [x] Websocket clarification payloads now preserve live `content` text
- [x] Legacy `shell_execute` workflow execution resolves to `execute_code`

## Working in this PR
- [x] Block additional `grep` / `rg` / `sed` file-list path escapes, including attached and clustered `-f` forms
- [x] Canonicalize fallback workflow summaries so legacy `shell_execute` no longer leaks in user or audit-visible output
- [x] Add backend regressions for the new path-validation and summary edge cases

## Still to do after this PR
- [ ] None for this follow-up; merge to land the remaining Wave 1 hardening fixes

## Validation
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_process_tools.py tests/test_workflows.py tests/test_tools_api.py tests/test_eval_harness.py -q`
- `git diff --check`
- Subagent review: concrete findings on attached and clustered `-f` path escapes plus legacy `shell_execute` summary leakage were fixed; final re-review timed out without new findings
