### PR TITLE
Add Wave 3 packaged capability imports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,8 @@ jobs:
         env:
           OPENROUTER_API_KEY: test-key
           WORKSPACE_DIR: /tmp/seraph-test
-        timeout-minutes: 10
-        run: uv run pytest -v
+        timeout-minutes: 20
+        run: uv run pytest -q
 
   frontend-tests:
     runs-on: ubuntu-latest

--- a/backend/src/agent/specialists.py
+++ b/backend/src/agent/specialists.py
@@ -39,6 +39,7 @@ TOOL_DOMAINS: dict[str, str] = {
     "get_goal_progress": "goals",
     "web_search": "research",
     "browse_webpage": "research",
+    "browser_session": "research",
     "read_file": "files",
     "write_file": "files",
     "fill_template": "files",

--- a/backend/src/api/browser.py
+++ b/backend/src/api/browser.py
@@ -1,0 +1,30 @@
+"""Structured browser session API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query
+
+from src.browser.sessions import browser_session_runtime
+
+router = APIRouter()
+
+
+@router.get("/browser/sessions")
+async def list_browser_sessions(session_id: str = Query(...)):
+    return {"sessions": browser_session_runtime.list_sessions(owner_session_id=session_id)}
+
+
+@router.get("/browser/sessions/{browser_session_id}")
+async def get_browser_session(browser_session_id: str, session_id: str = Query(...)):
+    session = browser_session_runtime.get_session(browser_session_id, owner_session_id=session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail=f"Browser session '{browser_session_id}' not found")
+    return {"session": session}
+
+
+@router.delete("/browser/sessions/{browser_session_id}")
+async def close_browser_session(browser_session_id: str, session_id: str = Query(...)):
+    session = browser_session_runtime.close_session(browser_session_id, owner_session_id=session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail=f"Browser session '{browser_session_id}' not found")
+    return {"status": "closed", "session": session}

--- a/backend/src/api/capabilities.py
+++ b/backend/src/api/capabilities.py
@@ -1,4 +1,4 @@
-"""Capability overview API — aggregated tools, skills, workflows, MCP, and starter packs."""
+"""Capability overview API — aggregated tools, skills, workflows, MCP, packs, and starter packs."""
 
 from __future__ import annotations
 
@@ -535,6 +535,54 @@ def _recommended_actions(
                 "description": server.get("description", ""),
                 "action": {"type": "install_catalog_item", "label": "Install MCP server", "name": name},
             })
+
+    for extension in catalog.get("extension_packages", []):
+        if not isinstance(extension, dict):
+            continue
+        catalog_id = str(extension.get("catalog_id") or "").strip()
+        display_name = str(extension.get("name") or catalog_id or "extension-pack").strip()
+        if not catalog_id:
+            continue
+        installed = bool(extension.get("installed"))
+        update_available = bool(extension.get("update_available"))
+        status = str(extension.get("status") or "ready")
+        action_label = "Update pack" if installed and update_available else "Install pack"
+        recommended_actions = (
+            []
+            if status != "ready" or (installed and not update_available)
+            else [{"type": "install_catalog_item", "label": action_label, "name": catalog_id}]
+        )
+        catalog_items.append({
+            "name": display_name,
+            "catalog_id": catalog_id,
+            "type": "extension_pack",
+            "description": extension.get("description", ""),
+            "category": extension.get("category", ""),
+            "bundled": bool(extension.get("bundled", False)),
+            "installed": installed,
+            "update_available": update_available,
+            "version": extension.get("version"),
+            "installed_version": extension.get("installed_version"),
+            "trust": extension.get("trust"),
+            "contribution_types": list(extension.get("contribution_types") or []),
+            "status": status,
+            "doctor_ok": bool(extension.get("doctor_ok", status == "ready")),
+            "issues": list(extension.get("issues") or []),
+            "load_errors": list(extension.get("load_errors") or []),
+            "recommended_actions": recommended_actions,
+        })
+        if status != "ready" or (installed and not update_available):
+            continue
+        add_recommendation({
+            "id": f"catalog-extension:{catalog_id}",
+            "label": f"{action_label} {display_name}",
+            "description": str(extension.get("description") or ""),
+            "action": {
+                "type": "install_catalog_item",
+                "label": action_label,
+                "name": catalog_id,
+            },
+        })
 
     for workflow_name, workflow in workflows_by_name.items():
         for missing_skill in workflow.get("missing_skills", []):
@@ -1181,6 +1229,38 @@ def _attach_mcp_actions(mcp_servers: list[dict[str, Any]], *, mcp_mode: str) -> 
         server["recommended_actions"] = actions
 
 
+def _mcp_toolset_preset_map() -> dict[str, list[dict[str, Any]]]:
+    registry = ExtensionRegistry(
+        manifest_roots=default_manifest_roots_for_workspace(settings.workspace_dir),
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    )
+    preset_map: dict[str, list[dict[str, Any]]] = {}
+    for extension in registry.snapshot().extensions:
+        for contribution in extension.contributions:
+            if contribution.contribution_type != "toolset_presets":
+                continue
+            preset_name = str(contribution.metadata.get("name") or "").strip()
+            servers = [
+                server_name
+                for server_name in contribution.metadata.get("include_mcp_servers", []) or []
+                if isinstance(server_name, str) and server_name.strip()
+            ]
+            if not preset_name or not servers:
+                continue
+            summary = {
+                "name": preset_name,
+                "description": str(contribution.metadata.get("description") or ""),
+                "reference": contribution.reference,
+                "extension_id": extension.id,
+                "extension_display_name": extension.display_name,
+            }
+            for server_name in servers:
+                preset_map.setdefault(server_name, []).append(summary)
+    return preset_map
+
+
 def _workflow_status_map(
     available_tool_names: list[str],
     active_skill_names: list[str],
@@ -1228,6 +1308,7 @@ def _tool_status_list(tool_mode: str) -> list[dict[str, Any]]:
 
 def _mcp_status_list(mcp_mode: str) -> list[dict[str, Any]]:
     servers = []
+    preset_map = _mcp_toolset_preset_map()
     for server in mcp_manager.get_config():
         status = server.get("status", "disconnected")
         enabled = bool(server.get("enabled", False))
@@ -1249,10 +1330,19 @@ def _mcp_status_list(mcp_mode: str) -> list[dict[str, Any]]:
         else:
             availability = "blocked"
             blocked_reason = "disconnected"
+        tool_names = sorted(
+            {
+                str(getattr(tool, "name", "")).strip()
+                for tool in mcp_manager.get_server_tools(str(server.get("name") or ""))
+                if str(getattr(tool, "name", "")).strip()
+            }
+        )
         servers.append({
             **server,
             "availability": availability,
             "blocked_reason": blocked_reason,
+            "tool_names": tool_names,
+            "toolset_presets": preset_map.get(str(server.get("name") or ""), []),
         })
     return servers
 

--- a/backend/src/api/catalog.py
+++ b/backend/src/api/catalog.py
@@ -1,21 +1,29 @@
-"""Discover catalog API — browse and install skills/MCP servers."""
+"""Discover catalog API — browse and install skills, MCP servers, and packages."""
 
 from __future__ import annotations
 
 import json
 import logging
 import os
+from dataclasses import asdict
 from pathlib import Path
 import tempfile
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from packaging.version import InvalidVersion, Version
 import yaml
 
 from config.settings import settings
-from src.extensions.lifecycle import install_extension_path
+from src.extensions.doctor import doctor_snapshot
+from src.extensions.lifecycle import install_extension_path, update_extension_path, validate_extension_path
 from src.extensions.permissions import evaluate_tool_permissions
-from src.extensions.registry import ExtensionRegistry, bundled_manifest_root
+from src.extensions.registry import (
+    ExtensionRecord,
+    ExtensionRegistry,
+    bundled_manifest_root,
+    default_manifest_roots_for_workspace,
+)
 from src.extensions.scaffold import validate_extension_package
 from src.skills.loader import parse_skill_content, scan_skill_paths
 from src.skills.manager import skill_manager
@@ -27,23 +35,158 @@ router = APIRouter()
 
 _DEFAULTS_DIR = os.path.join(os.path.dirname(__file__), "../defaults")
 _CATALOG_PATH = os.path.join(_DEFAULTS_DIR, "skill-catalog.json")
+_CATALOG_EXTENSION_ROOT = os.path.join(_DEFAULTS_DIR, "catalog-extensions")
 
 
 def load_catalog_items() -> dict[str, list[dict[str, Any]]]:
     """Load catalog JSON and normalize top-level collections."""
     path = os.path.normpath(_CATALOG_PATH)
     if not os.path.isfile(path):
-        return {"skills": [], "mcp_servers": []}
-    with open(path, "r", encoding="utf-8") as f:
-        payload = json.load(f)
+        payload: dict[str, Any] = {}
+    else:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
     return {
         "skills": payload.get("skills", []) if isinstance(payload.get("skills"), list) else [],
         "mcp_servers": payload.get("mcp_servers", []) if isinstance(payload.get("mcp_servers"), list) else [],
+        "extension_packages": _load_catalog_extension_packages(),
     }
 
 
 def _load_catalog() -> dict[str, list[dict[str, Any]]]:
     return load_catalog_items()
+
+
+def _catalog_extension_registry() -> ExtensionRegistry:
+    return ExtensionRegistry(
+        manifest_roots=[_CATALOG_EXTENSION_ROOT],
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    )
+
+
+def _runtime_extension_registry() -> ExtensionRegistry:
+    return ExtensionRegistry(
+        manifest_roots=default_manifest_roots_for_workspace(settings.workspace_dir),
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    )
+
+
+def _catalog_extension_records() -> list[ExtensionRecord]:
+    if not os.path.isdir(_CATALOG_EXTENSION_ROOT):
+        return []
+    return _catalog_extension_registry().snapshot().extensions
+
+
+def _contribution_types_for_extension(extension: ExtensionRecord) -> list[str]:
+    if extension.manifest is None:
+        return sorted({item.contribution_type for item in extension.contributions})
+    return sorted(extension.manifest.contributed_types())
+
+
+def _safe_version(value: str | None) -> Version | None:
+    if not value:
+        return None
+    try:
+        return Version(value)
+    except InvalidVersion:
+        return None
+
+
+def _extension_catalog_entry(
+    extension: ExtensionRecord,
+    *,
+    doctor_result: Any | None = None,
+    load_errors: list[Any] | None = None,
+) -> dict[str, Any]:
+    installed = _runtime_extension_registry().snapshot().get_extension(extension.id)
+    installed_version = (
+        installed.manifest.version
+        if installed is not None and installed.manifest is not None
+        else None
+    )
+    catalog_version = extension.manifest.version if extension.manifest is not None else None
+    update_available = False
+    if installed_version and catalog_version:
+        installed_parsed = _safe_version(installed_version)
+        catalog_parsed = _safe_version(catalog_version)
+        update_available = (
+            installed_parsed is not None
+            and catalog_parsed is not None
+            and catalog_parsed > installed_parsed
+        )
+
+    contribution_types = _contribution_types_for_extension(extension)
+    issues = [asdict(issue) for issue in getattr(doctor_result, "issues", [])] if doctor_result is not None else []
+    related_load_errors = [
+        {
+            "source": getattr(error, "source", ""),
+            "phase": getattr(error, "phase", ""),
+            "message": getattr(error, "message", ""),
+            "details": list(getattr(error, "details", []) or []),
+        }
+        for error in (load_errors or [])
+        if extension.root_path
+        and getattr(error, "source", None)
+        and (
+            str(getattr(error, "source", "")) == str(extension.manifest_path)
+            or (
+                os.path.commonpath([os.path.abspath(str(getattr(error, "source", ""))), os.path.abspath(extension.root_path)])
+                == os.path.abspath(extension.root_path)
+            )
+        )
+    ]
+    status = "ready" if not issues and not related_load_errors else "degraded"
+    return {
+        "name": extension.display_name,
+        "catalog_id": extension.id,
+        "type": "extension_pack",
+        "description": (
+            extension.manifest.summary
+            if extension.manifest is not None and extension.manifest.summary
+            else extension.manifest.description
+            if extension.manifest is not None and extension.manifest.description
+            else ""
+        ),
+        "category": extension.kind,
+        "requires_tools": [],
+        "installed": installed is not None,
+        "bundled": True,
+        "extension_id": extension.id,
+        "version": catalog_version,
+        "installed_version": installed_version,
+        "update_available": update_available,
+        "publisher": (
+            extension.manifest.publisher.name
+            if extension.manifest is not None
+            else ""
+        ),
+        "trust": extension.trust,
+        "contribution_types": contribution_types,
+        "kind": extension.kind,
+        "status": status,
+        "doctor_ok": status == "ready",
+        "issues": issues,
+        "load_errors": related_load_errors,
+    }
+
+
+def _load_catalog_extension_packages() -> list[dict[str, Any]]:
+    registry = _catalog_extension_registry()
+    snapshot = registry.snapshot()
+    doctor = doctor_snapshot(snapshot)
+    doctor_by_id = {result.extension_id: result for result in doctor.results}
+    return [
+        _extension_catalog_entry(
+            extension,
+            doctor_result=doctor_by_id.get(extension.id),
+            load_errors=snapshot.load_errors,
+        )
+        for extension in snapshot.extensions
+    ]
 
 
 def _skill_installed(name: str) -> bool:
@@ -106,6 +249,29 @@ def catalog_mcp_by_name() -> dict[str, dict[str, Any]]:
     }
 
 
+def catalog_extension_by_id() -> dict[str, dict[str, Any]]:
+    return {
+        str(item["catalog_id"]): item
+        for item in _load_catalog().get("extension_packages", [])
+        if isinstance(item, dict) and isinstance(item.get("catalog_id"), str)
+    }
+
+
+def _find_catalog_extension(identifier: str) -> dict[str, Any] | None:
+    candidate = identifier.strip()
+    if not candidate:
+        return None
+    by_id = catalog_extension_by_id()
+    if candidate in by_id:
+        return by_id[candidate]
+    lowered = candidate.casefold()
+    for item in by_id.values():
+        display_name = str(item.get("name") or "").strip()
+        if display_name and display_name.casefold() == lowered:
+            return item
+    return None
+
+
 def _slugify(value: str) -> str:
     return "".join(char.lower() if char.isalnum() else "-" for char in value).strip("-") or "connector"
 
@@ -116,6 +282,13 @@ def _catalog_mcp_extension_id(name: str) -> str:
 
 def _catalog_skill_extension_id(name: str) -> str:
     return f"seraph.catalog-skill-{_slugify(name)}"
+
+
+def _catalog_extension_source_path(extension_id: str) -> str | None:
+    for extension in _catalog_extension_records():
+        if extension.id == extension_id and extension.root_path:
+            return extension.root_path
+    return None
 
 
 def _write_catalog_skill_package(root: str, item: dict[str, Any], source_path: str) -> str:
@@ -210,6 +383,87 @@ def _validation_detail(report: Any) -> str:
 
 def install_catalog_item_by_name(name: str) -> dict[str, Any]:
     """Install a bundled skill or MCP server from the catalog."""
+    catalog_extension = _find_catalog_extension(name)
+    if catalog_extension is not None:
+        extension_id = str(catalog_extension.get("catalog_id") or name)
+        package_path = _catalog_extension_source_path(extension_id)
+        if not package_path:
+            return {
+                "ok": False,
+                "status": "missing_bundle",
+                "name": str(catalog_extension.get("name") or extension_id),
+                "type": "extension_pack",
+                "bundled": True,
+            }
+        installed = _runtime_extension_registry().snapshot().get_extension(extension_id)
+        try:
+            if installed is not None and installed.root_path and installed.source == "manifest":
+                catalog_version = _safe_version(str(catalog_extension.get("version") or ""))
+                installed_version = _safe_version(
+                    installed.manifest.version if installed.manifest is not None else None,
+                )
+                if (
+                    catalog_version is not None
+                    and installed_version is not None
+                    and catalog_version > installed_version
+                ):
+                    update_extension_path(package_path)
+                    return {
+                        "ok": True,
+                        "status": "updated",
+                        "name": str(catalog_extension.get("name") or extension_id),
+                        "type": "extension_pack",
+                        "extension_id": extension_id,
+                        "bundled": True,
+                    }
+                return {
+                    "ok": False,
+                    "status": "already_installed",
+                    "name": str(catalog_extension.get("name") or extension_id),
+                    "type": "extension_pack",
+                    "extension_id": extension_id,
+                    "bundled": True,
+                }
+            install_extension_path(package_path)
+            return {
+                "ok": True,
+                "status": "installed",
+                "name": str(catalog_extension.get("name") or extension_id),
+                "type": "extension_pack",
+                "extension_id": extension_id,
+                "bundled": True,
+            }
+        except FileExistsError:
+            return {
+                "ok": False,
+                "status": "already_installed",
+                "name": str(catalog_extension.get("name") or extension_id),
+                "type": "extension_pack",
+                "extension_id": extension_id,
+                "bundled": True,
+            }
+        except ValueError as exc:
+            return {
+                "ok": False,
+                "status": "validation_failed",
+                "name": str(catalog_extension.get("name") or extension_id),
+                "type": "extension_pack",
+                "extension_id": extension_id,
+                "bundled": True,
+                "detail": str(exc),
+            }
+        except OSError as exc:
+            logger.warning("Failed to install catalog extension '%s'", name, exc_info=True)
+            return {
+                "ok": False,
+                "status": "install_failed",
+                "name": str(catalog_extension.get("name") or extension_id),
+                "type": "extension_pack",
+                "extension_id": extension_id,
+                "bundled": True,
+                "detail": str(exc),
+            }
+
     catalog_skill = catalog_skill_by_name().get(name)
     if catalog_skill is not None:
         if _skill_loaded(name):
@@ -390,6 +644,29 @@ def install_catalog_item_by_name(name: str) -> dict[str, Any]:
     }
 
 
+def _catalog_extension_lifecycle_action(catalog_extension: dict[str, Any]) -> tuple[str, str] | None:
+    extension_id = str(catalog_extension.get("catalog_id") or catalog_extension.get("name") or "")
+    if not extension_id:
+        return None
+    package_path = _catalog_extension_source_path(extension_id)
+    if not package_path:
+        return None
+    installed = _runtime_extension_registry().snapshot().get_extension(extension_id)
+    if installed is not None and installed.root_path and installed.source == "manifest":
+        catalog_version = _safe_version(str(catalog_extension.get("version") or ""))
+        installed_version = _safe_version(
+            installed.manifest.version if installed.manifest is not None else None,
+        )
+        if (
+            catalog_version is not None
+            and installed_version is not None
+            and catalog_version > installed_version
+        ):
+            return "update", package_path
+        return None
+    return "install", package_path
+
+
 @router.get("/catalog")
 async def get_catalog():
     """Return catalog items enriched with install status."""
@@ -418,12 +695,25 @@ async def get_catalog():
             "bundled": server.get("bundled", False),
         })
 
+    for extension in catalog.get("extension_packages", []):
+        items.append(dict(extension))
+
     return {"items": items}
 
 
 @router.post("/catalog/install/{name}", status_code=201)
 async def install_item(name: str):
     """Install a skill or MCP server from the catalog."""
+    catalog_extension = _find_catalog_extension(name)
+    if catalog_extension is not None:
+        lifecycle_action = _catalog_extension_lifecycle_action(catalog_extension)
+        if lifecycle_action is not None:
+            action, package_path = lifecycle_action
+            preview = validate_extension_path(package_path)
+            if preview.get("ok"):
+                from src.api.extensions import _require_extension_lifecycle_approval
+
+                await _require_extension_lifecycle_approval(action, preview)
     result = install_catalog_item_by_name(name)
     if result["ok"]:
         payload = {"status": result["status"], "name": name, "type": result["type"]}
@@ -431,11 +721,12 @@ async def install_item(name: str):
             payload["extension_id"] = result["extension_id"]
         return payload
     if result["status"] == "already_installed":
-        detail = (
-            f"Skill '{name}' is already installed"
-            if result["type"] == "skill"
-            else f"MCP server '{name}' is already installed"
-        )
+        if result["type"] == "skill":
+            detail = f"Skill '{name}' is already installed"
+        elif result["type"] == "mcp_server":
+            detail = f"MCP server '{name}' is already installed"
+        else:
+            detail = f"Extension package '{name}' is already installed"
         raise HTTPException(status_code=409, detail=detail)
     if result["status"] == "not_bundled":
         raise HTTPException(
@@ -443,10 +734,14 @@ async def install_item(name: str):
             detail=f"Skill '{name}' is not bundled and cannot be auto-installed",
         )
     if result["status"] == "missing_bundle":
-        raise HTTPException(
-            status_code=404,
-            detail=f"Bundled skill file for '{name}' not found",
+        missing_label = (
+            "skill file"
+            if result["type"] == "skill"
+            else "extension package"
+            if result["type"] == "extension_pack"
+            else "connector package"
         )
+        raise HTTPException(status_code=404, detail=f"Bundled {missing_label} for '{name}' not found")
     if result["status"] == "installed_file_invalid":
         raise HTTPException(
             status_code=422,

--- a/backend/src/api/extensions.py
+++ b/backend/src/api/extensions.py
@@ -184,13 +184,14 @@ def _configure_request_uses_new_secret_values(
             key = field.get("key")
             if not isinstance(key, str) or not key:
                 continue
+            if key not in incoming_config:
+                continue
             value = incoming_config.get(key)
-            if (
-                isinstance(value, str)
-                and value.strip()
-                and value != _REDACTED_CONFIG_SENTINEL
-            ):
+            if isinstance(value, str):
+                if not value.strip() or value == _REDACTED_CONFIG_SENTINEL:
+                    continue
                 return True
+            return True
     return False
 
 

--- a/backend/src/api/extensions.py
+++ b/backend/src/api/extensions.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 from smolagents import MCPClient
 
+from config.settings import settings
 from src.approval.repository import approval_repository, fingerprint_tool_call
 from src.audit.runtime import log_integration_event
 from src.extensions.lifecycle import (
@@ -27,13 +29,23 @@ from src.extensions.lifecycle import (
     update_extension_path,
     validate_extension_path,
 )
+from src.extensions.scaffold import scaffold_extension_package
 from src.tools.mcp_manager import mcp_manager
 
 router = APIRouter()
+_REDACTED_CONFIG_SENTINEL = "__SERAPH_STORED_SECRET__"
 
 
 class ExtensionPathRequest(BaseModel):
     path: str
+
+
+class ExtensionScaffoldRequest(BaseModel):
+    package_name: str
+    display_name: str
+    extension_id: str | None = None
+    kind: str = "capability-pack"
+    contributions: list[str] = Field(default_factory=lambda: ["skills"])
 
 
 class ExtensionConfigRequest(BaseModel):
@@ -133,19 +145,78 @@ async def _log_extension_lifecycle_event(
     )
 
 
+def _scaffold_package_slug(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9-]+", "-", value.strip().lower()).strip("-")
+    if not normalized:
+        raise ValueError("package_name must contain at least one letter or number")
+    return normalized
+
+
+def _configure_request_uses_new_secret_values(
+    preview: dict[str, Any],
+    config: dict[str, Any],
+) -> bool:
+    contributions = preview.get("contributions")
+    if not isinstance(contributions, list) or not isinstance(config, dict):
+        return False
+
+    for contribution in contributions:
+        if not isinstance(contribution, dict):
+            continue
+        contribution_type = contribution.get("type")
+        contribution_name = contribution.get("name")
+        config_fields = contribution.get("config_fields")
+        if not isinstance(contribution_type, str) or not isinstance(contribution_name, str):
+            continue
+        if not isinstance(config_fields, list):
+            continue
+        contribution_configs = config.get(contribution_type)
+        if not isinstance(contribution_configs, dict):
+            continue
+        incoming_config = contribution_configs.get(contribution_name)
+        if not isinstance(incoming_config, dict):
+            continue
+        for field in config_fields:
+            if not isinstance(field, dict):
+                continue
+            if str(field.get("input") or "") != "password":
+                continue
+            key = field.get("key")
+            if not isinstance(key, str) or not key:
+                continue
+            value = incoming_config.get(key)
+            if (
+                isinstance(value, str)
+                and value.strip()
+                and value != _REDACTED_CONFIG_SENTINEL
+            ):
+                return True
+    return False
+
+
 async def _require_extension_lifecycle_approval(action: str, preview: dict[str, Any]) -> None:
     approval_profile = preview.get("approval_profile")
     if not isinstance(approval_profile, dict) or not approval_profile.get("requires_lifecycle_approval"):
         return
 
-    extension_id = str(preview.get("id") or preview.get("extension_id") or "")
-    display_name = str(preview.get("display_name") or extension_id or "extension")
-    tool_name = f"extension_{action}"
     lifecycle_boundaries = [
         str(boundary)
         for boundary in approval_profile.get("lifecycle_boundaries", [])
         if isinstance(boundary, str) and boundary.strip()
     ]
+    if action == "enable":
+        enable_boundaries = [
+            boundary
+            for boundary in lifecycle_boundaries
+            if boundary != "secret_management"
+        ]
+        if not enable_boundaries:
+            return
+        lifecycle_boundaries = enable_boundaries or lifecycle_boundaries
+
+    extension_id = str(preview.get("id") or preview.get("extension_id") or "")
+    display_name = str(preview.get("display_name") or extension_id or "extension")
+    tool_name = f"extension_{action}"
     arguments = {
         "extension_id": extension_id,
         "version": preview.get("version"),
@@ -301,6 +372,59 @@ async def _test_extension_mcp_connector(connector: dict[str, Any]) -> dict[str, 
         }
 
 
+@router.post("/extensions/scaffold", status_code=201)
+async def scaffold_extension_package_in_workspace(req: ExtensionScaffoldRequest):
+    preview: dict[str, Any] | None = None
+    display_name = req.display_name.strip()
+    if not display_name:
+        raise HTTPException(status_code=422, detail="display_name must be non-empty")
+    try:
+        slug = _scaffold_package_slug(req.package_name)
+        extension_id = req.extension_id.strip() if isinstance(req.extension_id, str) and req.extension_id.strip() else f"seraph.{slug}"
+        package_root = Path(settings.workspace_dir) / "extensions" / slug
+        scaffold = scaffold_extension_package(
+            package_root,
+            extension_id=extension_id,
+            display_name=display_name,
+            kind=req.kind,
+            contributions=req.contributions,
+        )
+        preview = validate_extension_path(str(package_root))
+    except FileExistsError as exc:
+        await _log_extension_lifecycle_event(
+            action="scaffold",
+            outcome="failed",
+            path=str(Path(settings.workspace_dir) / "extensions" / req.package_name.strip()),
+            error=str(exc),
+        )
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        await _log_extension_lifecycle_event(
+            action="scaffold",
+            outcome="failed",
+            path=req.package_name,
+            error=str(exc),
+        )
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    await _log_extension_lifecycle_event(
+        action="scaffold",
+        outcome="succeeded",
+        preview=preview,
+        path=str(scaffold.package_root),
+        extra_details={
+            "created_file_count": len(scaffold.created_files),
+            "created_files": [str(path.relative_to(scaffold.package_root)) for path in scaffold.created_files],
+        },
+    )
+    return {
+        "status": "scaffolded" if preview.get("ok") else "scaffolded_invalid",
+        "path": str(scaffold.package_root),
+        "created_files": [str(path.relative_to(scaffold.package_root)) for path in scaffold.created_files],
+        "preview": preview,
+    }
+
+
 @router.get("/extensions")
 async def list_extension_packages():
     return list_extensions()
@@ -367,7 +491,45 @@ async def set_extension_package_connector_enabled(extension_id: str, req: Extens
                 raise ValueError(
                     f"extension '{extension_id}' is degraded and cannot enable packaged connectors until validation issues are fixed"
                 )
-            await _require_extension_lifecycle_approval("enable", preview)
+            target_connector = next(
+                (
+                    contribution
+                    for contribution in preview.get("contributions", [])
+                    if isinstance(contribution, dict) and contribution.get("reference") == req.reference
+                ),
+                None,
+            )
+            if target_connector is None:
+                raise KeyError(req.reference)
+            permission_profile = target_connector.get("permission_profile")
+            connector_preview = {
+                **preview,
+                "approval_profile": {
+                    "requires_runtime_approval": bool(
+                        isinstance(permission_profile, dict) and permission_profile.get("requires_approval")
+                    ),
+                    "runtime_behavior": (
+                        str(permission_profile.get("approval_behavior") or "never")
+                        if isinstance(permission_profile, dict)
+                        else "never"
+                    ),
+                    "requires_lifecycle_approval": bool(
+                        isinstance(permission_profile, dict)
+                        and permission_profile.get("lifecycle_approval_boundaries")
+                    ),
+                    "lifecycle_boundaries": (
+                        list(permission_profile.get("lifecycle_approval_boundaries", []))
+                        if isinstance(permission_profile, dict)
+                        else []
+                    ),
+                    "risk_level": (
+                        str(permission_profile.get("risk_level") or "low")
+                        if isinstance(permission_profile, dict)
+                        else "low"
+                    ),
+                },
+            }
+            await _require_extension_lifecycle_approval("enable", connector_preview)
         result = set_extension_connector_enabled(extension_id, req.reference, enabled=req.enabled)
     except KeyError as exc:
         detail = (
@@ -633,7 +795,11 @@ async def disable_extension_package(extension_id: str):
 
 @router.post("/extensions/{extension_id}/configure")
 async def configure_extension_package(extension_id: str, req: ExtensionConfigRequest):
+    preview: dict[str, Any] | None = None
     try:
+        preview = get_extension(extension_id)
+        if _configure_request_uses_new_secret_values(preview, req.config):
+            await _require_extension_lifecycle_approval("configure", preview)
         extension = configure_extension(extension_id, req.config)
     except KeyError as exc:
         await _log_extension_lifecycle_event(
@@ -656,7 +822,7 @@ async def configure_extension_package(extension_id: str, req: ExtensionConfigReq
     await _log_extension_lifecycle_event(
         action="configure",
         outcome="succeeded",
-        preview=extension,
+        preview=extension or preview,
         path=extension_id,
         extra_details={"config_keys": sorted(req.config.keys())},
     )

--- a/backend/src/browser/__init__.py
+++ b/backend/src/browser/__init__.py
@@ -1,0 +1,1 @@
+"""Browser runtime helpers."""

--- a/backend/src/browser/sessions.py
+++ b/backend/src/browser/sessions.py
@@ -1,0 +1,206 @@
+"""In-memory browser session runtime for structured browsing workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import threading
+import uuid
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _excerpt(content: str, *, limit: int = 180) -> str:
+    collapsed = " ".join(str(content or "").split())
+    if len(collapsed) <= limit:
+        return collapsed
+    return f"{collapsed[:limit - 1]}…"
+
+
+@dataclass
+class BrowserSnapshot:
+    ref: str
+    capture: str
+    content: str
+    created_at: str
+    summary: str
+
+    def as_payload(self) -> dict[str, str]:
+        return {
+            "ref": self.ref,
+            "capture": self.capture,
+            "created_at": self.created_at,
+            "summary": self.summary,
+        }
+
+
+@dataclass
+class BrowserSession:
+    session_id: str
+    owner_session_id: str
+    url: str
+    provider_name: str
+    provider_kind: str
+    execution_mode: str
+    created_at: str
+    updated_at: str
+    snapshots: list[BrowserSnapshot] = field(default_factory=list)
+
+    def latest_snapshot(self) -> BrowserSnapshot | None:
+        return self.snapshots[-1] if self.snapshots else None
+
+    def as_summary(self) -> dict[str, object]:
+        latest = self.latest_snapshot()
+        return {
+            "session_id": self.session_id,
+            "owner_session_id": self.owner_session_id,
+            "url": self.url,
+            "provider_name": self.provider_name,
+            "provider_kind": self.provider_kind,
+            "execution_mode": self.execution_mode,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "snapshot_count": len(self.snapshots),
+            "latest_ref": latest.ref if latest is not None else None,
+            "latest_capture": latest.capture if latest is not None else None,
+            "latest_summary": latest.summary if latest is not None else "",
+        }
+
+
+class BrowserSessionRuntime:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sessions: dict[str, BrowserSession] = {}
+        self._refs: dict[str, tuple[str, int]] = {}
+
+    def reset_for_tests(self) -> None:
+        with self._lock:
+            self._sessions = {}
+            self._refs = {}
+
+    def list_sessions(self, *, owner_session_id: str) -> list[dict[str, object]]:
+        with self._lock:
+            sessions = [
+                session
+                for session in self._sessions.values()
+                if session.owner_session_id == owner_session_id
+            ]
+        sessions.sort(key=lambda item: item.updated_at, reverse=True)
+        return [item.as_summary() for item in sessions]
+
+    def open_session(
+        self,
+        *,
+        owner_session_id: str,
+        url: str,
+        provider_name: str,
+        provider_kind: str,
+        execution_mode: str,
+        capture: str,
+        content: str,
+    ) -> dict[str, object]:
+        created_at = _utc_now()
+        session_id = f"bs-{uuid.uuid4().hex[:10]}"
+        snapshot = BrowserSnapshot(
+            ref=f"{session_id}:1",
+            capture=capture,
+            content=content,
+            created_at=created_at,
+            summary=_excerpt(content),
+        )
+        session = BrowserSession(
+            session_id=session_id,
+            owner_session_id=owner_session_id,
+            url=url,
+            provider_name=provider_name,
+            provider_kind=provider_kind,
+            execution_mode=execution_mode,
+            created_at=created_at,
+            updated_at=created_at,
+            snapshots=[snapshot],
+        )
+        with self._lock:
+            self._sessions[session_id] = session
+            self._refs[snapshot.ref] = (session_id, 0)
+        payload = session.as_summary()
+        payload["content"] = content
+        return payload
+
+    def snapshot_session(
+        self,
+        *,
+        owner_session_id: str,
+        session_id: str,
+        capture: str,
+        content: str,
+    ) -> dict[str, object] | None:
+        with self._lock:
+            session = self._sessions.get(session_id)
+            if session is None or session.owner_session_id != owner_session_id:
+                return None
+            created_at = _utc_now()
+            snapshot = BrowserSnapshot(
+                ref=f"{session_id}:{len(session.snapshots) + 1}",
+                capture=capture,
+                content=content,
+                created_at=created_at,
+                summary=_excerpt(content),
+            )
+            session.snapshots.append(snapshot)
+            session.updated_at = created_at
+            self._refs[snapshot.ref] = (session_id, len(session.snapshots) - 1)
+            payload = session.as_summary()
+            payload["content"] = content
+            return payload
+
+    def get_session(self, session_id: str, *, owner_session_id: str) -> dict[str, object] | None:
+        with self._lock:
+            session = self._sessions.get(session_id)
+            if session is None or session.owner_session_id != owner_session_id:
+                return None
+            payload = session.as_summary()
+            payload["snapshots"] = [snapshot.as_payload() for snapshot in session.snapshots]
+            return payload
+
+    def read_ref(self, ref: str, *, owner_session_id: str) -> dict[str, object] | None:
+        with self._lock:
+            target = self._refs.get(ref)
+            if target is None:
+                return None
+            session_id, index = target
+            session = self._sessions.get(session_id)
+            if (
+                session is None
+                or session.owner_session_id != owner_session_id
+                or index >= len(session.snapshots)
+            ):
+                return None
+            snapshot = session.snapshots[index]
+            return {
+                "session_id": session_id,
+                "owner_session_id": session.owner_session_id,
+                "ref": snapshot.ref,
+                "capture": snapshot.capture,
+                "content": snapshot.content,
+                "summary": snapshot.summary,
+                "url": session.url,
+                "provider_name": session.provider_name,
+                "provider_kind": session.provider_kind,
+                "execution_mode": session.execution_mode,
+                "created_at": snapshot.created_at,
+            }
+
+    def close_session(self, session_id: str, *, owner_session_id: str) -> dict[str, object] | None:
+        with self._lock:
+            session = self._sessions.get(session_id)
+            if session is None or session.owner_session_id != owner_session_id:
+                return None
+            session = self._sessions.pop(session_id)
+            for snapshot in session.snapshots:
+                self._refs.pop(snapshot.ref, None)
+            return session.as_summary()
+
+
+browser_session_runtime = BrowserSessionRuntime()

--- a/backend/src/defaults/catalog-extensions/hermes-browser-ops/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-browser-ops/manifest.yaml
@@ -1,0 +1,23 @@
+id: seraph.hermes-browser-ops
+version: 2026.3.23
+display_name: Hermes Browser Ops
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Optional browser-session skills and presets for structured multi-step browsing.
+contributes:
+  skills:
+    - skills/browser-session-review.md
+    - skills/browser-snapshot.md
+  toolset_presets:
+    - presets/toolset/browser-session-ops.yaml
+permissions:
+  tools:
+    - browse_webpage
+    - browser_session
+  execution_boundaries:
+    - external_read
+  network: true

--- a/backend/src/defaults/catalog-extensions/hermes-browser-ops/presets/toolset/browser-session-ops.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-browser-ops/presets/toolset/browser-session-ops.yaml
@@ -1,0 +1,11 @@
+name: browser-session-ops
+description: Structured browsing preset with browser sessions, snapshots, and direct page reads.
+include_tools:
+  - browse_webpage
+  - browser_session
+capabilities:
+  - page_refs
+  - snapshots
+  - structured_browsing
+execution_boundaries:
+  - external_read

--- a/backend/src/defaults/catalog-extensions/hermes-browser-ops/skills/browser-session-review.md
+++ b/backend/src/defaults/catalog-extensions/hermes-browser-ops/skills/browser-session-review.md
@@ -1,0 +1,23 @@
+---
+name: browser-session-review
+description: Use structured browser sessions when Seraph needs to inspect one web target over multiple steps.
+requires:
+  tools: [browser_session]
+user_invocable: true
+---
+
+Use this skill when Seraph needs to open a page once, keep a stable session id,
+capture one or more follow-up snapshots, and refer back to those stored results
+by page ref while working through a multi-step browsing task.
+
+1. Open a session with `browser_session(action="open", url=...)`.
+2. If a follow-up capture is needed, call `browser_session(action="snapshot", session_id=...)`.
+3. Use `browser_session(action="read", ref=...)` when a later step needs the
+   exact captured content again.
+4. Close the session once the task is complete.
+
+Today, packaged remote browser providers may still run in `local_fallback`
+mode. Treat the session id and refs as handles to stored captures, not as proof
+that a live remote browser transport is active.
+
+Never claim a session exists unless `browser_session` returned a session id.

--- a/backend/src/defaults/catalog-extensions/hermes-browser-ops/skills/browser-snapshot.md
+++ b/backend/src/defaults/catalog-extensions/hermes-browser-ops/skills/browser-snapshot.md
@@ -1,0 +1,15 @@
+---
+name: browser-snapshot
+description: Capture a focused follow-up snapshot from an existing browser session.
+requires:
+  tools: [browser_session]
+user_invocable: false
+---
+
+Use this support skill when a running browser session needs one more structured
+capture before Seraph summarizes or writes the result elsewhere.
+
+1. Inspect the current session id and latest ref.
+2. Capture a follow-up snapshot with `browser_session(action="snapshot", ...)`.
+3. Read the new ref with `browser_session(action="read", ref=...)` if a later
+   step needs the exact capture payload.

--- a/backend/src/defaults/catalog-extensions/hermes-browserbase/connectors/browser/browserbase.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-browserbase/connectors/browser/browserbase.yaml
@@ -1,0 +1,18 @@
+name: browserbase
+description: Browserbase-style provider definition that currently stages credentials and uses the local browser runtime as fallback for browsing work.
+provider_kind: browserbase
+enabled: false
+capabilities:
+  - staged_remote_provider
+  - local_fallback
+  - snapshots
+  - page_refs
+config_fields:
+  - key: api_key
+    label: Browserbase API Key
+    input: password
+    required: true
+  - key: project_id
+    label: Project ID
+    input: text
+    required: false

--- a/backend/src/defaults/catalog-extensions/hermes-browserbase/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-browserbase/manifest.yaml
@@ -1,0 +1,22 @@
+id: seraph.hermes-browserbase
+version: 2026.3.23
+display_name: Hermes Browserbase
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Managed Browserbase-style browser provider package with local-fallback browsing until remote transport lands.
+contributes:
+  browser_providers:
+    - connectors/browser/browserbase.yaml
+  toolset_presets:
+    - presets/toolset/browserbase-ops.yaml
+permissions:
+  tools:
+    - browse_webpage
+    - browser_session
+  execution_boundaries:
+    - external_read
+  network: true

--- a/backend/src/defaults/catalog-extensions/hermes-browserbase/presets/toolset/browserbase-ops.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-browserbase/presets/toolset/browserbase-ops.yaml
@@ -1,0 +1,11 @@
+name: browserbase-ops
+description: Operator preset for Browserbase-style provider setup plus local-fallback browser sessions and snapshots.
+include_tools:
+  - browse_webpage
+  - browser_session
+capabilities:
+  - staged_remote_provider
+  - local_fallback
+  - session_snapshots
+execution_boundaries:
+  - external_read

--- a/backend/src/defaults/catalog-extensions/hermes-discord-relay/connectors/messaging/discord.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-discord-relay/connectors/messaging/discord.yaml
@@ -1,0 +1,16 @@
+name: discord
+description: Planned Discord bot relay definition for channel and thread delivery.
+platform: discord
+enabled: false
+delivery_modes:
+  - channel
+  - thread
+config_fields:
+  - key: bot_token
+    label: Bot Token
+    input: password
+    required: true
+  - key: guild_id
+    label: Guild ID
+    input: text
+    required: false

--- a/backend/src/defaults/catalog-extensions/hermes-discord-relay/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-discord-relay/manifest.yaml
@@ -1,0 +1,16 @@
+id: seraph.hermes-discord-relay
+version: 2026.3.23
+display_name: Hermes Discord Relay
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Discord messaging connector definition for future Seraph operator notifications and continuations.
+description: Packages Discord relay metadata and configuration so Seraph can stage guarded delivery into Discord as the messaging runtime matures.
+permissions:
+  network: true
+contributes:
+  messaging_connectors:
+    - connectors/messaging/discord.yaml

--- a/backend/src/defaults/catalog-extensions/hermes-github-mcp/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-github-mcp/manifest.yaml
@@ -1,0 +1,18 @@
+id: seraph.hermes-github-mcp
+version: 2026.3.23
+display_name: Hermes GitHub MCP
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: GitHub MCP connector packaged with a matching operator toolset preset.
+description: Installs a packaged GitHub MCP connector and a toolset preset that makes the server easier to reason about in the operator surface.
+permissions:
+  network: true
+contributes:
+  mcp_servers:
+    - mcp/github.json
+  toolset_presets:
+    - presets/toolset/github-operator.yaml

--- a/backend/src/defaults/catalog-extensions/hermes-github-mcp/mcp/github.json
+++ b/backend/src/defaults/catalog-extensions/hermes-github-mcp/mcp/github.json
@@ -1,0 +1,11 @@
+{
+  "name": "github",
+  "url": "https://api.githubcopilot.com/mcp/",
+  "description": "GitHub MCP bridge for repository, issue, and pull request operations.",
+  "headers": {
+    "Authorization": "Bearer ${GITHUB_TOKEN}"
+  },
+  "auth_hint": "Set GITHUB_TOKEN before enabling the packaged GitHub MCP connector.",
+  "transport": "streamable-http",
+  "enabled": false
+}

--- a/backend/src/defaults/catalog-extensions/hermes-github-mcp/presets/toolset/github-operator.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-github-mcp/presets/toolset/github-operator.yaml
@@ -1,0 +1,12 @@
+name: github-operator
+description: Operator preset for the packaged GitHub MCP connector.
+mode: balanced
+include_mcp_servers:
+  - github
+capabilities:
+  - pull_requests
+  - issues
+  - repository_ops
+execution_boundaries:
+  - external_mcp
+enabled: true

--- a/backend/src/defaults/catalog-extensions/hermes-multimodal-review/context/multimodal-review.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-multimodal-review/context/multimodal-review.yaml
@@ -1,0 +1,7 @@
+name: multimodal-review
+description: Context pack for image, screenshot, and artifact analysis.
+instructions: Prefer concrete scene description, anomaly spotting, artifact labeling, and operator-safe summaries over aesthetic commentary.
+domains:
+  - research
+  - diagnostics
+  - review

--- a/backend/src/defaults/catalog-extensions/hermes-multimodal-review/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-multimodal-review/manifest.yaml
@@ -1,0 +1,20 @@
+id: seraph.hermes-multimodal-review
+version: 2026.3.23
+display_name: Hermes Multimodal Review
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Multimodal prompt and context assets for image, screenshot, and artifact review workflows.
+description: Packages multimodal review scaffolding so Seraph can carry explicit image and artifact-analysis guidance through the extension platform while the richer media runtime continues to evolve.
+permissions:
+  network: false
+contributes:
+  context_packs:
+    - context/multimodal-review.yaml
+  prompt_packs:
+    - prompts/vision-triage.md
+  provider_presets:
+    - presets/provider/multimodal-review.yaml

--- a/backend/src/defaults/catalog-extensions/hermes-multimodal-review/presets/provider/multimodal-review.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-multimodal-review/presets/provider/multimodal-review.yaml
@@ -1,0 +1,4 @@
+name: multimodal-review
+label: Multimodal Review
+default_model: multimodal-primary
+notes: Prefer a multimodal-capable runtime target for image, screenshot, or artifact analysis.

--- a/backend/src/defaults/catalog-extensions/hermes-multimodal-review/prompts/vision-triage.md
+++ b/backend/src/defaults/catalog-extensions/hermes-multimodal-review/prompts/vision-triage.md
@@ -1,0 +1,7 @@
+# Vision Triage
+
+Use this pack when Seraph is reviewing screenshots, generated images, UI captures, or rich artifacts.
+
+- Describe what is visible before inferring intent.
+- Call out uncertainty and missing context explicitly.
+- Prefer actionable operator summaries over stylistic critique.

--- a/backend/src/defaults/catalog-extensions/hermes-research-ops/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-research-ops/manifest.yaml
@@ -1,0 +1,23 @@
+id: seraph.hermes-research-ops
+version: 2026.3.23
+display_name: Hermes Research Ops
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Optional Hermes-style research and synthesis skills.
+description: Adds deeper multi-source research and synthesis helpers on top of Seraph's runtime tools.
+permissions:
+  tools:
+    - browse_webpage
+    - web_search
+    - write_file
+  network: true
+contributes:
+  skills:
+    - skills/deep-research.md
+    - skills/evidence-snapshot.md
+  toolset_presets:
+    - presets/toolset/research-ops.yaml

--- a/backend/src/defaults/catalog-extensions/hermes-research-ops/presets/toolset/research-ops.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-research-ops/presets/toolset/research-ops.yaml
@@ -1,0 +1,11 @@
+name: research-ops
+description: Research-oriented operator preset for search, browsing, and note capture.
+mode: balanced
+include_tools:
+  - web_search
+  - browse_webpage
+  - write_file
+capabilities:
+  - research
+  - synthesis
+enabled: true

--- a/backend/src/defaults/catalog-extensions/hermes-research-ops/skills/deep-research.md
+++ b/backend/src/defaults/catalog-extensions/hermes-research-ops/skills/deep-research.md
@@ -1,0 +1,22 @@
+---
+name: deep-research
+description: Search, inspect, and synthesize multiple sources into a concise operator brief
+requires:
+  tools: [web_search, browse_webpage, write_file]
+user_invocable: true
+---
+
+Use this skill when the user asks for a researched brief, comparison, or source-grounded summary.
+
+Process:
+
+1. Use `web_search` to discover candidate sources.
+2. Use `browse_webpage` to inspect the most relevant results, preferring primary sources.
+3. Synthesize findings into:
+   - a short summary
+   - key findings
+   - open questions or uncertainty
+   - cited source URLs
+4. If the user asks to save the result, write a concise workspace note with `write_file`.
+
+Keep the brief compact and evidence-led.

--- a/backend/src/defaults/catalog-extensions/hermes-research-ops/skills/evidence-snapshot.md
+++ b/backend/src/defaults/catalog-extensions/hermes-research-ops/skills/evidence-snapshot.md
@@ -1,0 +1,16 @@
+---
+name: evidence-snapshot
+description: Turn gathered sources into a short saved evidence note
+requires:
+  tools: [write_file]
+user_invocable: true
+---
+
+Use this skill to persist a short research snapshot into the workspace after Seraph has already gathered sources and conclusions.
+
+Write only the final brief:
+
+- summary
+- source list
+- open questions
+- next action

--- a/backend/src/defaults/catalog-extensions/hermes-session-memory/context/session-memory.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-session-memory/context/session-memory.yaml
@@ -1,0 +1,12 @@
+name: session-memory
+description: Bias guardian context toward recent session history and active checklist state.
+instructions: |
+  Prefer bounded session recall and current todo state before broader long-horizon memory when a request is clearly about ongoing thread continuity.
+domains:
+  - continuity
+  - operator
+memory_tags:
+  - active-thread
+  - checklist
+prompt_refs:
+  - guardian_state

--- a/backend/src/defaults/catalog-extensions/hermes-session-memory/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-session-memory/manifest.yaml
@@ -1,0 +1,23 @@
+id: seraph.hermes-session-memory
+version: 2026.3.23
+display_name: Hermes Session Memory
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Optional Hermes-style session recall and checklist skills.
+description: Adds bounded session recall, handoff, and checklist-oriented working-memory helpers.
+permissions:
+  tools:
+    - clarify
+    - session_search
+    - todo
+  network: false
+contributes:
+  skills:
+    - skills/session-recall.md
+    - skills/session-checklist.md
+  context_packs:
+    - context/session-memory.yaml

--- a/backend/src/defaults/catalog-extensions/hermes-session-memory/skills/session-checklist.md
+++ b/backend/src/defaults/catalog-extensions/hermes-session-memory/skills/session-checklist.md
@@ -1,0 +1,18 @@
+---
+name: session-checklist
+description: Convert active work into a maintained session-local checklist
+requires:
+  tools: [todo]
+user_invocable: true
+---
+
+Use this skill when the user needs a compact working checklist for the current thread.
+
+Process:
+
+1. Inspect the current list with `todo(action="list")`.
+2. If no structured list exists, propose or apply a short checklist through `todo(action="set")`.
+3. Keep items concrete and execution-oriented.
+4. When the user finishes work, reopen, complete, or remove items instead of rewriting the whole list.
+
+Prefer a short, stable checklist over verbose planning text.

--- a/backend/src/defaults/catalog-extensions/hermes-session-memory/skills/session-recall.md
+++ b/backend/src/defaults/catalog-extensions/hermes-session-memory/skills/session-recall.md
@@ -1,0 +1,21 @@
+---
+name: session-recall
+description: Recover the most relevant prior thread context before continuing
+requires:
+  tools: [session_search, clarify]
+user_invocable: true
+---
+
+Use this skill when the user asks Seraph to resume a topic, recover prior context, or continue work across older threads.
+
+Process:
+
+1. Use `session_search` with a short topic query taken from the user's request.
+2. Prefer the smallest useful recall set rather than dumping every matching snippet.
+3. If the request is ambiguous, use `clarify` to ask what thread, project, or time window the user means.
+4. Return:
+   - the most relevant thread or threads
+   - the key commitments or open questions
+   - the next recommended continuation step
+
+Never pretend recall happened if `session_search` returned nothing.

--- a/backend/src/defaults/catalog-extensions/hermes-slack-relay/connectors/messaging/slack.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-slack-relay/connectors/messaging/slack.yaml
@@ -1,0 +1,17 @@
+name: slack
+description: Planned Slack bot relay definition for channels, direct messages, and thread delivery.
+platform: slack
+enabled: false
+delivery_modes:
+  - dm
+  - channel
+  - thread
+config_fields:
+  - key: bot_token
+    label: Bot Token
+    input: password
+    required: true
+  - key: app_token
+    label: App Token
+    input: password
+    required: false

--- a/backend/src/defaults/catalog-extensions/hermes-slack-relay/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-slack-relay/manifest.yaml
@@ -1,0 +1,16 @@
+id: seraph.hermes-slack-relay
+version: 2026.3.23
+display_name: Hermes Slack Relay
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Slack messaging connector definition for future Seraph channel and direct operator updates.
+description: Packages Slack relay metadata and configuration so Seraph can stage guarded updates and thread continuations into Slack as the messaging runtime matures.
+permissions:
+  network: true
+contributes:
+  messaging_connectors:
+    - connectors/messaging/slack.yaml

--- a/backend/src/defaults/catalog-extensions/hermes-speech-ops/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-speech-ops/manifest.yaml
@@ -1,0 +1,18 @@
+id: seraph.hermes-speech-ops
+version: 2026.3.23
+display_name: Hermes Speech Ops
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Speech profiles and operator guidance for future TTS and STT delivery paths.
+description: Packages voice-facing operator assets so Seraph can carry explicit speech profiles, wake-word guidance, and delivery prompts even before the full voice runtime arrives.
+permissions:
+  network: true
+contributes:
+  speech_profiles:
+    - speech/openai-realtime-voice.yaml
+  prompt_packs:
+    - prompts/voice-relay.md

--- a/backend/src/defaults/catalog-extensions/hermes-speech-ops/prompts/voice-relay.md
+++ b/backend/src/defaults/catalog-extensions/hermes-speech-ops/prompts/voice-relay.md
@@ -1,0 +1,7 @@
+# Voice Relay
+
+Use this pack when Seraph needs to prepare concise spoken output, guarded voice confirmations, or later talk-mode prompts.
+
+- Keep phrasing short and unambiguous.
+- Prefer confirmations over long monologues.
+- Surface approval-sensitive actions explicitly before assuming execution.

--- a/backend/src/defaults/catalog-extensions/hermes-speech-ops/speech/openai-realtime-voice.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-speech-ops/speech/openai-realtime-voice.yaml
@@ -1,0 +1,7 @@
+name: openai-realtime-voice
+description: Duplex speech profile for guarded voice delivery and future live talk mode.
+provider: openai
+voice: alloy
+supports_tts: true
+supports_stt: true
+wake_word: seraph

--- a/backend/src/defaults/catalog-extensions/hermes-telegram-relay/connectors/messaging/telegram.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-telegram-relay/connectors/messaging/telegram.yaml
@@ -1,0 +1,16 @@
+name: telegram
+description: Planned Telegram bot relay definition for direct messages, summaries, and approvals.
+platform: telegram
+enabled: false
+delivery_modes:
+  - dm
+  - thread
+config_fields:
+  - key: bot_token
+    label: Bot Token
+    input: password
+    required: true
+  - key: default_chat_id
+    label: Default Chat ID
+    input: text
+    required: false

--- a/backend/src/defaults/catalog-extensions/hermes-telegram-relay/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-telegram-relay/manifest.yaml
@@ -1,0 +1,16 @@
+id: seraph.hermes-telegram-relay
+version: 2026.3.23
+display_name: Hermes Telegram Relay
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Telegram messaging connector definition for future Seraph reach beyond the browser workspace.
+description: Packages Telegram relay metadata and configuration so Seraph can stage guarded delivery into Telegram as the messaging runtime matures.
+permissions:
+  network: true
+contributes:
+  messaging_connectors:
+    - connectors/messaging/telegram.yaml

--- a/backend/src/extensions/browser_providers.py
+++ b/backend/src/extensions/browser_providers.py
@@ -1,0 +1,139 @@
+"""Active browser-provider selection for packaged browser reach."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.extensions.registry import ExtensionContributionRecord
+
+
+_PROVIDER_KIND_ORDER = {
+    "local": 0,
+    "browserbase": 1,
+    "remote_cdp": 2,
+    "extension_relay": 3,
+}
+
+
+@dataclass(frozen=True)
+class ActiveBrowserProvider:
+    extension_id: str
+    name: str
+    provider_kind: str
+    description: str
+    default_enabled: bool
+    reference: str
+    resolved_path: str | None
+    manifest_root_index: int
+    configured: bool
+    config_keys: tuple[str, ...]
+    requires_network: bool
+    requires_daemon: bool
+    capabilities: tuple[str, ...]
+
+
+def _required_config_missing(config_fields: list[dict[str, Any]], config_entry: dict[str, Any]) -> bool:
+    for field in config_fields:
+        if not isinstance(field, dict):
+            continue
+        key = field.get("key")
+        if not isinstance(key, str) or not key:
+            continue
+        if not bool(field.get("required", False)):
+            continue
+        value = config_entry.get(key)
+        if value is None:
+            return True
+        if isinstance(value, str) and not value.strip():
+            return True
+    return False
+
+
+def select_active_browser_provider(
+    contributions: list["ExtensionContributionRecord"],
+    *,
+    state_by_id: dict[str, Any] | None = None,
+    enabled_overrides: dict[tuple[str, str], bool] | None = None,
+    requested_name: str | None = None,
+) -> ActiveBrowserProvider | None:
+    selected: ActiveBrowserProvider | None = None
+    requested = requested_name.strip().casefold() if isinstance(requested_name, str) and requested_name.strip() else None
+
+    for contribution in contributions:
+        if contribution.contribution_type != "browser_providers":
+            continue
+        name = contribution.metadata.get("name")
+        provider_kind = contribution.metadata.get("provider_kind")
+        if not isinstance(name, str) or not name:
+            continue
+        if not isinstance(provider_kind, str) or not provider_kind:
+            continue
+        if requested is not None and name.casefold() != requested:
+            continue
+
+        default_enabled = bool(contribution.metadata.get("default_enabled", True))
+        enabled = enabled_overrides.get((contribution.extension_id, contribution.reference), default_enabled) if enabled_overrides else default_enabled
+        if not enabled:
+            continue
+
+        state_entry = state_by_id.get(contribution.extension_id, {}) if isinstance(state_by_id, dict) else {}
+        config_entry = {}
+        if isinstance(state_entry, dict):
+            raw_config = state_entry.get("config")
+            if isinstance(raw_config, dict):
+                provider_bucket = raw_config.get("browser_providers")
+                if isinstance(provider_bucket, dict):
+                    candidate_entry = provider_bucket.get(name)
+                    if isinstance(candidate_entry, dict):
+                        config_entry = candidate_entry
+
+        config_fields = contribution.metadata.get("config_fields")
+        config_field_list = config_fields if isinstance(config_fields, list) else []
+        configured = not _required_config_missing(config_field_list, config_entry)
+
+        candidate = ActiveBrowserProvider(
+            extension_id=contribution.extension_id,
+            name=name,
+            provider_kind=provider_kind,
+            description=str(contribution.metadata.get("description") or ""),
+            default_enabled=default_enabled,
+            reference=contribution.reference,
+            resolved_path=(
+                str(contribution.metadata.get("resolved_path"))
+                if isinstance(contribution.metadata.get("resolved_path"), str)
+                else None
+            ),
+            manifest_root_index=int(contribution.metadata.get("manifest_root_index", 999999)),
+            configured=configured,
+            config_keys=tuple(sorted(config_entry.keys())),
+            requires_network=bool(contribution.metadata.get("requires_network", provider_kind != "local")),
+            requires_daemon=bool(contribution.metadata.get("requires_daemon", provider_kind == "extension_relay")),
+            capabilities=tuple(
+                item
+                for item in contribution.metadata.get("capabilities", [])
+                if isinstance(item, str) and item.strip()
+            ) if isinstance(contribution.metadata.get("capabilities"), list) else (),
+        )
+        if not candidate.configured:
+            continue
+        if selected is None:
+            selected = candidate
+            continue
+        selected_priority = (
+            selected.manifest_root_index,
+            _PROVIDER_KIND_ORDER.get(selected.provider_kind, 999),
+            selected.extension_id,
+            selected.name,
+        )
+        candidate_priority = (
+            candidate.manifest_root_index,
+            _PROVIDER_KIND_ORDER.get(candidate.provider_kind, 999),
+            candidate.extension_id,
+            candidate.name,
+        )
+        if candidate_priority < selected_priority:
+            selected = candidate
+
+    return selected

--- a/backend/src/extensions/capability_contributions.py
+++ b/backend/src/extensions/capability_contributions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import re
 from typing import Any
 
 from src.extensions.connectors import ConnectorDefinitionError, load_connector_payload
@@ -100,6 +101,7 @@ class ToolsetPresetDefinition:
     description: str = ""
     mode: str = ""
     include_tools: tuple[str, ...] = ()
+    include_mcp_servers: tuple[str, ...] = ()
     exclude_tools: tuple[str, ...] = ()
     capabilities: tuple[str, ...] = ()
     execution_boundaries: tuple[str, ...] = ()
@@ -111,6 +113,7 @@ class ToolsetPresetDefinition:
             "description": self.description,
             "mode": self.mode,
             "include_tools": list(self.include_tools),
+            "include_mcp_servers": list(self.include_mcp_servers),
             "exclude_tools": list(self.exclude_tools),
             "capabilities": list(self.capabilities),
             "execution_boundaries": list(self.execution_boundaries),
@@ -137,6 +140,22 @@ class ContextPackDefinition:
             "profile_fields": list(self.profile_fields),
             "prompt_refs": list(self.prompt_refs),
             "domains": list(self.domains),
+        }
+
+
+@dataclass(frozen=True)
+class PromptPackDefinition:
+    name: str
+    title: str
+    description: str = ""
+    instructions: str = ""
+
+    def as_metadata(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "title": self.title,
+            "description": self.description,
+            "instructions": self.instructions,
         }
 
 
@@ -237,6 +256,22 @@ class SpeechProfileDefinition:
 
 
 @dataclass(frozen=True)
+class ProviderPresetDefinition:
+    name: str
+    label: str = ""
+    default_model: str = ""
+    notes: str = ""
+
+    def as_metadata(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "label": self.label,
+            "default_model": self.default_model,
+            "notes": self.notes,
+        }
+
+
+@dataclass(frozen=True)
 class NodeAdapterDefinition:
     name: str
     adapter_kind: str
@@ -272,6 +307,10 @@ def _parse_named_object(payload: Any, *, source: str, noun: str) -> tuple[str, s
     return raw_name.strip(), raw_description.strip() if isinstance(raw_description, str) else ""
 
 
+def _slugify_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") or "prompt-pack"
+
+
 def parse_toolset_preset_definition(payload: Any, *, source: str) -> ToolsetPresetDefinition:
     name, description = _parse_named_object(payload, source=source, noun="toolset preset")
     if not isinstance(payload, dict):
@@ -280,6 +319,11 @@ def parse_toolset_preset_definition(payload: Any, *, source: str) -> ToolsetPres
     if raw_mode is not None and not isinstance(raw_mode, str):
         raise ConnectorDefinitionError(f"{source}: toolset preset mode must be a string")
     include_tools = _parse_string_list(payload.get("include_tools"), source=source, field_name="include_tools")
+    include_mcp_servers = _parse_string_list(
+        payload.get("include_mcp_servers"),
+        source=source,
+        field_name="include_mcp_servers",
+    )
     exclude_tools = _parse_string_list(payload.get("exclude_tools"), source=source, field_name="exclude_tools")
     capabilities = _parse_string_list(payload.get("capabilities"), source=source, field_name="capabilities")
     execution_boundaries = _parse_string_list(
@@ -290,15 +334,16 @@ def parse_toolset_preset_definition(payload: Any, *, source: str) -> ToolsetPres
     raw_enabled = payload.get("enabled")
     if raw_enabled is not None and not isinstance(raw_enabled, bool):
         raise ConnectorDefinitionError(f"{source}: toolset preset enabled must be a boolean")
-    if not any((include_tools, exclude_tools, capabilities, execution_boundaries)):
+    if not any((include_tools, include_mcp_servers, exclude_tools, capabilities, execution_boundaries)):
         raise ConnectorDefinitionError(
-            f"{source}: toolset preset must declare tools, capabilities, or execution boundaries"
+            f"{source}: toolset preset must declare tools, MCP servers, capabilities, or execution boundaries"
         )
     return ToolsetPresetDefinition(
         name=name,
         description=description,
         mode=raw_mode.strip() if isinstance(raw_mode, str) and raw_mode.strip() else "",
         include_tools=include_tools,
+        include_mcp_servers=include_mcp_servers,
         exclude_tools=exclude_tools,
         capabilities=capabilities,
         execution_boundaries=execution_boundaries,
@@ -330,6 +375,41 @@ def parse_context_pack_definition(payload: Any, *, source: str) -> ContextPackDe
         profile_fields=profile_fields,
         prompt_refs=prompt_refs,
         domains=domains,
+    )
+
+
+def parse_prompt_pack_definition(content: str, *, source: str) -> PromptPackDefinition:
+    if not isinstance(content, str):
+        raise ConnectorDefinitionError(f"{source}: prompt pack must be UTF-8 text")
+    normalized = content.strip()
+    if not normalized:
+        raise ConnectorDefinitionError(f"{source}: prompt pack must not be empty")
+
+    title = ""
+    description = ""
+    for raw_line in normalized.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if not title and line.startswith("#"):
+            title = line.lstrip("#").strip()
+            continue
+        if not description and not line.startswith(("-", "*")):
+            description = line
+            break
+
+    fallback_name = Path(source).stem.replace("_", "-")
+    if title:
+        name = _slugify_name(title)
+    else:
+        name = _slugify_name(fallback_name)
+        title = fallback_name.replace("-", " ").title()
+
+    return PromptPackDefinition(
+        name=name,
+        title=title,
+        description=description,
+        instructions=normalized,
     )
 
 
@@ -454,6 +534,30 @@ def parse_speech_profile_definition(payload: Any, *, source: str) -> SpeechProfi
     )
 
 
+def parse_provider_preset_definition(payload: Any, *, source: str) -> ProviderPresetDefinition:
+    name, _description = _parse_named_object(payload, source=source, noun="provider preset")
+    if not isinstance(payload, dict):
+        raise ConnectorDefinitionError(f"{source}: provider preset definition must be an object")
+    raw_label = payload.get("label")
+    raw_default_model = payload.get("default_model")
+    raw_notes = payload.get("notes")
+    for field_name, value in {
+        "label": raw_label,
+        "default_model": raw_default_model,
+        "notes": raw_notes,
+    }.items():
+        if value is not None and not isinstance(value, str):
+            raise ConnectorDefinitionError(f"{source}: provider preset {field_name} must be a string")
+    if not isinstance(raw_default_model, str) or not raw_default_model.strip():
+        raise ConnectorDefinitionError(f"{source}: provider preset must include a non-empty default_model")
+    return ProviderPresetDefinition(
+        name=name,
+        label=raw_label.strip() if isinstance(raw_label, str) else "",
+        default_model=raw_default_model.strip(),
+        notes=raw_notes.strip() if isinstance(raw_notes, str) else "",
+    )
+
+
 def parse_node_adapter_definition(payload: Any, *, source: str) -> NodeAdapterDefinition:
     name, description = _parse_named_object(payload, source=source, noun="node adapter")
     if not isinstance(payload, dict):
@@ -489,6 +593,10 @@ def load_context_pack_definition(path: Path) -> ContextPackDefinition:
     return parse_context_pack_definition(load_connector_payload(path), source=str(path))
 
 
+def load_prompt_pack_definition(path: Path) -> PromptPackDefinition:
+    return parse_prompt_pack_definition(path.read_text(encoding="utf-8"), source=str(path))
+
+
 def load_automation_trigger_definition(path: Path) -> AutomationTriggerDefinition:
     return parse_automation_trigger_definition(load_connector_payload(path), source=str(path))
 
@@ -503,6 +611,10 @@ def load_messaging_connector_definition(path: Path) -> MessagingConnectorDefinit
 
 def load_speech_profile_definition(path: Path) -> SpeechProfileDefinition:
     return parse_speech_profile_definition(load_connector_payload(path), source=str(path))
+
+
+def load_provider_preset_definition(path: Path) -> ProviderPresetDefinition:
+    return parse_provider_preset_definition(load_connector_payload(path), source=str(path))
 
 
 def load_node_adapter_definition(path: Path) -> NodeAdapterDefinition:

--- a/backend/src/extensions/doctor.py
+++ b/backend/src/extensions/doctor.py
@@ -12,6 +12,7 @@ from src.extensions.capability_contributions import (
     parse_context_pack_definition,
     parse_messaging_connector_definition,
     parse_node_adapter_definition,
+    parse_provider_preset_definition,
     parse_speech_profile_definition,
     parse_toolset_preset_definition,
 )
@@ -53,6 +54,7 @@ _DEFINITION_PARSERS = {
     "browser_providers": ("invalid_browser_provider", "browser provider", parse_browser_provider_definition),
     "messaging_connectors": ("invalid_messaging_connector", "messaging connector", parse_messaging_connector_definition),
     "speech_profiles": ("invalid_speech_profile", "speech profile", parse_speech_profile_definition),
+    "provider_presets": ("invalid_provider_preset", "provider preset", parse_provider_preset_definition),
     "node_adapters": ("invalid_node_adapter", "node adapter", parse_node_adapter_definition),
 }
 
@@ -181,7 +183,11 @@ def _connector_implies_network(payload: Any) -> bool:
     )
 
 
-def doctor_extension(extension: ExtensionRecord) -> ExtensionDoctorResult:
+def doctor_extension(
+    extension: ExtensionRecord,
+    *,
+    available_mcp_server_names: set[str] | None = None,
+) -> ExtensionDoctorResult:
     issues: list[ExtensionDoctorIssue] = []
 
     if extension.source != "manifest" or extension.manifest is None:
@@ -425,6 +431,26 @@ def doctor_extension(extension: ExtensionRecord) -> ExtensionDoctorResult:
                             suggested_fix="set manifest.permissions.network to true for networked toolsets",
                         )
                     )
+                if definition.include_mcp_servers:
+                    missing_servers = sorted(
+                        server_name
+                        for server_name in definition.include_mcp_servers
+                        if server_name not in (available_mcp_server_names or set())
+                    )
+                    if missing_servers:
+                        issues.append(
+                            ExtensionDoctorIssue(
+                                code="missing_mcp_server_reference",
+                                severity="error",
+                                message=(
+                                    "Toolset preset references MCP servers that are not available in the current "
+                                    f"registry/runtime: {', '.join(missing_servers)}"
+                                ),
+                                contribution_type=contribution.contribution_type,
+                                reference=contribution.reference,
+                                suggested_fix="fix include_mcp_servers or install/configure the missing MCP server packages first",
+                            )
+                        )
                 continue
             permission_profile = evaluate_contribution_permissions(
                 extension,
@@ -570,7 +596,29 @@ def doctor_extension(extension: ExtensionRecord) -> ExtensionDoctorResult:
 
 
 def doctor_snapshot(snapshot: ExtensionRegistrySnapshot) -> ExtensionDoctorReport:
+    try:
+        from src.tools.mcp_manager import mcp_manager
+
+        runtime_mcp_servers = {
+            str(name).strip()
+            for name in getattr(mcp_manager, "_config", {}).keys()
+            if str(name).strip()
+        }
+    except Exception:
+        runtime_mcp_servers = set()
+    packaged_mcp_servers = {
+        str(contribution.metadata.get("name")).strip()
+        for contribution in snapshot.list_contributions("mcp_servers")
+        if isinstance(contribution.metadata.get("name"), str) and str(contribution.metadata.get("name")).strip()
+    }
+    available_mcp_server_names = packaged_mcp_servers | runtime_mcp_servers
     return ExtensionDoctorReport(
-        results=[doctor_extension(extension) for extension in snapshot.extensions],
+        results=[
+            doctor_extension(
+                extension,
+                available_mcp_server_names=available_mcp_server_names,
+            )
+            for extension in snapshot.extensions
+        ],
         load_errors=list(snapshot.load_errors),
     )

--- a/backend/src/extensions/lifecycle.py
+++ b/backend/src/extensions/lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import asdict
 import hashlib
 import os
@@ -76,17 +77,19 @@ _STUDIO_TYPE_ORDER = {
     "starter_packs": 4,
     "toolset_presets": 5,
     "context_packs": 6,
-    "speech_profiles": 7,
-    "mcp_servers": 8,
-    "managed_connectors": 9,
-    "automation_triggers": 10,
-    "browser_providers": 11,
-    "messaging_connectors": 12,
-    "observer_definitions": 13,
-    "observer_connectors": 14,
-    "channel_adapters": 15,
-    "node_adapters": 16,
-    "workspace_adapters": 17,
+    "prompt_packs": 7,
+    "speech_profiles": 8,
+    "provider_presets": 9,
+    "mcp_servers": 10,
+    "managed_connectors": 11,
+    "automation_triggers": 12,
+    "browser_providers": 13,
+    "messaging_connectors": 14,
+    "observer_definitions": 15,
+    "observer_connectors": 16,
+    "channel_adapters": 17,
+    "node_adapters": 18,
+    "workspace_adapters": 19,
 }
 _CONNECTOR_CONTRIBUTION_TYPES = {
     "mcp_servers",
@@ -100,6 +103,7 @@ _CONNECTOR_CONTRIBUTION_TYPES = {
     "node_adapters",
     "workspace_adapters",
 }
+_REDACTED_CONFIG_SENTINEL = "__SERAPH_STORED_SECRET__"
 _PLANNED_CONNECTOR_CONTRIBUTION_TYPES = {
     "automation_triggers",
     "browser_providers",
@@ -117,8 +121,10 @@ _PASSIVE_TYPED_CONTRIBUTION_FIELDS = {
         "execution_boundaries",
         "default_enabled",
     ),
+    "prompt_packs": ("name", "title", "description", "instructions"),
     "context_packs": ("name", "description", "instructions", "memory_tags", "profile_fields", "prompt_refs", "domains"),
     "speech_profiles": ("name", "description", "provider", "voice", "supports_tts", "supports_stt", "wake_word"),
+    "provider_presets": ("name", "label", "default_model", "notes"),
 }
 
 
@@ -333,6 +339,92 @@ def _contribution_config(
     if not isinstance(config_entry, dict):
         return {}
     return config_entry
+
+
+def _sensitive_config_field_keys(metadata: dict[str, Any]) -> set[str]:
+    config_fields = metadata.get("config_fields")
+    if not isinstance(config_fields, list):
+        return set()
+    keys: set[str] = set()
+    for field in config_fields:
+        if not isinstance(field, dict):
+            continue
+        if str(field.get("input") or "") != "password":
+            continue
+        key = field.get("key")
+        if isinstance(key, str) and key.strip():
+            keys.add(key)
+    return keys
+
+
+def _redact_config_entry(metadata: dict[str, Any], config_entry: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(config_entry, dict):
+        return {}
+    redacted = deepcopy(config_entry)
+    for key in _sensitive_config_field_keys(metadata):
+        value = redacted.get(key)
+        if value is None:
+            continue
+        if isinstance(value, str) and not value:
+            continue
+        redacted[key] = _REDACTED_CONFIG_SENTINEL
+    return redacted
+
+
+def _redact_extension_config(extension: ExtensionRecord, raw_config: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(raw_config, dict):
+        return {}
+    redacted = deepcopy(raw_config)
+    for contribution in extension.contributions:
+        contribution_type = contribution.contribution_type
+        contribution_name = _contribution_name(contribution)
+        if contribution_type not in _CONNECTOR_CONTRIBUTION_TYPES or not contribution_name:
+            continue
+        type_config = redacted.get(contribution_type)
+        if not isinstance(type_config, dict):
+            continue
+        config_entry = type_config.get(contribution_name)
+        if not isinstance(config_entry, dict):
+            continue
+        type_config[contribution_name] = _redact_config_entry(contribution.metadata, config_entry)
+    return redacted
+
+
+def _preserve_secret_placeholders(
+    extension: ExtensionRecord,
+    *,
+    incoming_config: dict[str, Any],
+    existing_config: dict[str, Any],
+) -> dict[str, Any]:
+    merged = deepcopy(incoming_config)
+    for contribution in extension.contributions:
+        contribution_type = contribution.contribution_type
+        contribution_name = _contribution_name(contribution)
+        if contribution_type not in _CONNECTOR_CONTRIBUTION_TYPES or not contribution_name:
+            continue
+        sensitive_keys = _sensitive_config_field_keys(contribution.metadata)
+        if not sensitive_keys:
+            continue
+        type_config = merged.get(contribution_type)
+        if not isinstance(type_config, dict):
+            continue
+        contribution_config = type_config.get(contribution_name)
+        if not isinstance(contribution_config, dict):
+            continue
+        existing_type_config = existing_config.get(contribution_type)
+        existing_entry = (
+            existing_type_config.get(contribution_name)
+            if isinstance(existing_type_config, dict)
+            else None
+        )
+        for key in sensitive_keys:
+            if contribution_config.get(key) != _REDACTED_CONFIG_SENTINEL:
+                continue
+            if isinstance(existing_entry, dict) and key in existing_entry:
+                contribution_config[key] = existing_entry[key]
+            else:
+                contribution_config.pop(key, None)
+    return merged
 
 
 def _contribution_config_errors(
@@ -1721,7 +1813,7 @@ def _extension_payload(
             )
         ),
         "enabled": enabled,
-        "config": state_entry.get("config", {}),
+        "config": _redact_extension_config(extension, state_entry.get("config", {})),
         "connector_summary": connector_summary,
         "contributions": contributions,
         "studio_files": _studio_files(extension, indexes=indexes),
@@ -2519,7 +2611,14 @@ def configure_extension(extension_id: str, config: dict[str, Any]) -> dict[str, 
     payload = _state_payload()
     extensions = payload.setdefault("extensions", {})
     entry = extensions.setdefault(extension_id, {})
-    entry["config"] = config
+    existing_config = entry.get("config")
+    if not isinstance(existing_config, dict):
+        existing_config = {}
+    entry["config"] = _preserve_secret_placeholders(
+        extension,
+        incoming_config=config,
+        existing_config=existing_config,
+    )
     _save_state(payload)
     return get_extension(extension_id)
 

--- a/backend/src/extensions/permissions.py
+++ b/backend/src/extensions/permissions.py
@@ -100,6 +100,18 @@ def _tools_accept_secret_refs(tool_names: list[str]) -> bool:
     return False
 
 
+def _password_config_fields_present(metadata: dict[str, Any]) -> bool:
+    config_fields = metadata.get("config_fields")
+    if not isinstance(config_fields, list):
+        return False
+    for field in config_fields:
+        if not isinstance(field, dict):
+            continue
+        if str(field.get("input") or "") == "password":
+            return True
+    return False
+
+
 def _runtime_approval_behavior(*, boundaries: list[str], risk_level: str) -> tuple[str, bool]:
     if "external_mcp" in boundaries:
         return "mcp_policy", True
@@ -122,9 +134,13 @@ def _merge_explicit_boundaries_into_profile(
         for boundary in required_boundaries
         if declared_boundaries and boundary not in declared_boundaries
     ]
-    requires_network = any(boundary in NETWORK_BOUNDARIES for boundary in required_boundaries)
+    requires_network = bool(profile.get("requires_network")) or any(
+        boundary in NETWORK_BOUNDARIES for boundary in required_boundaries
+    )
     network_declared = profile.get("network")
-    missing_network = bool(network_declared is False and requires_network)
+    missing_network = bool(profile.get("missing_network")) or bool(
+        network_declared is False and requires_network
+    )
     lifecycle_boundaries = [
         boundary
         for boundary in required_boundaries
@@ -254,9 +270,12 @@ def evaluate_contribution_permissions(
             extension,
             tool_names=_dedupe_strings(metadata.get("include_tools")),
         )
+        explicit_boundaries = _dedupe_strings(metadata.get("execution_boundaries"))
+        if _dedupe_strings(metadata.get("include_mcp_servers")) and "external_mcp" not in explicit_boundaries:
+            explicit_boundaries.append("external_mcp")
         return _merge_explicit_boundaries_into_profile(
             profile,
-            explicit_boundaries=_dedupe_strings(metadata.get("execution_boundaries")),
+            explicit_boundaries=explicit_boundaries,
         )
 
     if contribution_type == "mcp_servers":
@@ -292,6 +311,66 @@ def evaluate_contribution_permissions(
         tool_profile["ok"] = not tool_profile["missing_execution_boundaries"] and not tool_profile["missing_network"]
         tool_profile["status"] = "granted" if tool_profile["ok"] else "insufficient"
         return tool_profile
+
+    if contribution_type in {
+        "managed_connectors",
+        "automation_triggers",
+        "browser_providers",
+        "messaging_connectors",
+        "node_adapters",
+    }:
+        profile = {
+            "status": "granted",
+            "ok": True,
+            "declared_tools": (
+                _dedupe_strings(extension.manifest.permissions.tools)
+                if extension is not None and extension.manifest is not None
+                else []
+            ),
+            "required_tools": [],
+            "missing_tools": [],
+            "declared_execution_boundaries": (
+                _dedupe_strings(extension.manifest.permissions.execution_boundaries)
+                if extension is not None and extension.manifest is not None
+                else []
+            ),
+            "required_execution_boundaries": [],
+            "missing_execution_boundaries": [],
+            "network": (
+                bool(extension.manifest.permissions.network)
+                if extension is not None and extension.manifest is not None
+                else None
+            ),
+            "requires_network": bool(metadata.get("requires_network")),
+            "missing_network": bool(
+                extension is not None
+                and extension.manifest is not None
+                and metadata.get("requires_network")
+                and not extension.manifest.permissions.network
+            ),
+            "secrets": (
+                _dedupe_strings(extension.manifest.permissions.secrets)
+                if extension is not None and extension.manifest is not None
+                else []
+            ),
+            "env": (
+                _dedupe_strings(extension.manifest.permissions.env)
+                if extension is not None and extension.manifest is not None
+                else []
+            ),
+            "accepts_secret_refs": False,
+            "risk_level": "low",
+            "approval_behavior": "never",
+            "requires_approval": False,
+            "lifecycle_approval_boundaries": [],
+        }
+        explicit_boundaries: list[str] = []
+        if _password_config_fields_present(metadata):
+            explicit_boundaries.append("secret_management")
+        return _merge_explicit_boundaries_into_profile(
+            profile,
+            explicit_boundaries=explicit_boundaries,
+        )
 
     requires_network = bool(metadata.get("requires_network"))
     missing_network = bool(

--- a/backend/src/extensions/registry.py
+++ b/backend/src/extensions/registry.py
@@ -18,6 +18,8 @@ from src.extensions.capability_contributions import (
     load_context_pack_definition,
     load_messaging_connector_definition,
     load_node_adapter_definition,
+    load_prompt_pack_definition,
+    load_provider_preset_definition,
     load_speech_profile_definition,
     load_toolset_preset_definition,
 )
@@ -322,6 +324,11 @@ class ExtensionRegistry:
                         metadata.update(load_context_pack_definition(resolved_path).as_metadata())
                     except Exception:
                         pass
+                if contribution_type == "prompt_packs":
+                    try:
+                        metadata.update(load_prompt_pack_definition(resolved_path).as_metadata())
+                    except Exception:
+                        pass
                 if contribution_type == "automation_triggers":
                     try:
                         metadata.update(load_automation_trigger_definition(resolved_path).as_metadata())
@@ -350,6 +357,11 @@ class ExtensionRegistry:
                 if contribution_type == "speech_profiles":
                     try:
                         metadata.update(load_speech_profile_definition(resolved_path).as_metadata())
+                    except Exception:
+                        pass
+                if contribution_type == "provider_presets":
+                    try:
+                        metadata.update(load_provider_preset_definition(resolved_path).as_metadata())
                     except Exception:
                         pass
                 if contribution_type == "node_adapters":

--- a/backend/src/extensions/scaffold.py
+++ b/backend/src/extensions/scaffold.py
@@ -80,7 +80,7 @@ def _placeholder_skill(slug: str, display_name: str) -> str:
     return (
         "---\n"
         f"name: {slug}\n"
-        f"description: {display_name} skill\n"
+        f"description: {json.dumps(f'{display_name} skill')}\n"
         "requires:\n"
         "  tools: []\n"
         "user_invocable: true\n"
@@ -92,8 +92,8 @@ def _placeholder_skill(slug: str, display_name: str) -> str:
 def _placeholder_workflow(slug: str, display_name: str) -> str:
     return (
         "---\n"
-        f"name: {display_name}\n"
-        f"description: {display_name} workflow\n"
+        f"name: {slug}\n"
+        f"description: {json.dumps(f'{display_name} workflow')}\n"
         "requires:\n"
         "  tools: [read_file]\n"
         "inputs:\n"

--- a/backend/src/native_tools/registry.py
+++ b/backend/src/native_tools/registry.py
@@ -132,6 +132,11 @@ TOOL_METADATA: dict[str, dict] = {
         "policy_modes": ["safe", "balanced", "full"],
         "execution_boundaries": ["external_read"],
     },
+    "browser_session": {
+        "description": "Manage structured browser sessions, page refs, and snapshots for the current session",
+        "policy_modes": ["safe", "balanced", "full"],
+        "execution_boundaries": ["external_read"],
+    },
     # Vault tools
     "store_secret": {
         "description": "Store an encrypted secret in the vault",

--- a/backend/src/tools/browser_session_tool.py
+++ b/backend/src/tools/browser_session_tool.py
@@ -1,0 +1,188 @@
+"""Structured browser-session runtime tool."""
+
+from __future__ import annotations
+
+from smolagents import tool
+
+from config.settings import settings
+from src.approval.runtime import get_current_session_id
+from src.browser.sessions import browser_session_runtime
+from src.extensions.browser_providers import select_active_browser_provider
+from src.extensions.registry import ExtensionRegistry, default_manifest_roots_for_workspace
+from src.extensions.state import connector_enabled_overrides, load_extension_state_payload
+from src.tools.browser_tool import browse_webpage
+
+
+def _resolve_browser_provider(requested_name: str = "") -> tuple[dict[str, str], str | None]:
+    requested = requested_name.strip()
+    state_payload = load_extension_state_payload()
+    state_by_id = state_payload.get("extensions")
+    snapshot = ExtensionRegistry(
+        manifest_roots=default_manifest_roots_for_workspace(settings.workspace_dir),
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    ).snapshot()
+    provider = select_active_browser_provider(
+        snapshot.list_contributions("browser_providers"),
+        state_by_id=state_by_id if isinstance(state_by_id, dict) else None,
+        enabled_overrides=connector_enabled_overrides(state_by_id if isinstance(state_by_id, dict) else None),
+        requested_name=requested or None,
+    )
+    if provider is None:
+        if requested:
+            return {}, f"Error: Browser provider '{requested}' is not enabled and configured."
+        return {
+            "provider_name": "local-browser",
+            "provider_kind": "local",
+            "execution_mode": "local_runtime",
+        }, None
+    execution_mode = "remote_provider" if provider.provider_kind != "local" else "local_runtime"
+    if provider.provider_kind != "local":
+        execution_mode = "local_fallback"
+    return {
+        "provider_name": provider.name,
+        "provider_kind": provider.provider_kind,
+        "execution_mode": execution_mode,
+    }, None
+
+
+def _browser_capture_failed(content: str) -> bool:
+    return str(content or "").startswith("Error:")
+
+
+def _require_owner_session_id() -> str | None:
+    session_id = get_current_session_id()
+    if not session_id:
+        return None
+    return session_id
+
+
+def _render_session_list(owner_session_id: str) -> str:
+    sessions = browser_session_runtime.list_sessions(owner_session_id=owner_session_id)
+    if not sessions:
+        return "No browser sessions are open."
+    lines = []
+    for item in sessions:
+        lines.append(
+            f"- {item['session_id']} · {item['provider_name']} ({item['provider_kind']}) · "
+            f"{item['url']} · {item['snapshot_count']} snapshots · mode={item['execution_mode']}"
+        )
+    return "\n".join(lines)
+
+
+@tool
+def browser_session(
+    action: str = "list",
+    url: str = "",
+    session_id: str = "",
+    ref: str = "",
+    provider: str = "",
+    capture: str = "extract",
+) -> str:
+    """Manage structured browser sessions and page references.
+
+    Args:
+        action: One of open, list, read, snapshot, or close.
+        url: URL for open.
+        session_id: Session id for read, snapshot, or close.
+        ref: Snapshot reference for read.
+        provider: Optional browser provider name.
+        capture: extract, html, or screenshot.
+    """
+    normalized_action = action.strip().lower()
+    normalized_capture = capture.strip().lower()
+    if normalized_capture not in {"extract", "html", "screenshot"}:
+        return "Error: capture must be 'extract', 'html', or 'screenshot'."
+
+    owner_session_id = _require_owner_session_id()
+    if owner_session_id is None:
+        return "Error: browser_session requires an active session."
+
+    if normalized_action == "list":
+        return _render_session_list(owner_session_id)
+
+    provider_info, provider_error = _resolve_browser_provider(provider)
+    if provider_error:
+        return provider_error
+
+    if normalized_action == "open":
+        if not url.strip():
+            return "Error: browser_session open requires a URL."
+        content = browse_webpage(url.strip(), action=normalized_capture)
+        if _browser_capture_failed(content):
+            return content
+        payload = browser_session_runtime.open_session(
+            owner_session_id=owner_session_id,
+            url=url.strip(),
+            provider_name=provider_info["provider_name"],
+            provider_kind=provider_info["provider_kind"],
+            execution_mode=provider_info["execution_mode"],
+            capture=normalized_capture,
+            content=content,
+        )
+        fallback_note = (
+            f" Remote provider '{provider_info['provider_name']}' is staged; this session used the local browser runtime as the current execution mode."
+            if provider_info["execution_mode"] == "local_fallback"
+            else ""
+        )
+        return (
+            f"Opened browser session {payload['session_id']} using {provider_info['provider_name']} "
+            f"({provider_info['provider_kind']}). Latest ref: {payload['latest_ref']}.{fallback_note}\n\n"
+            f"{payload['content']}"
+        )
+
+    if normalized_action == "snapshot":
+        if not session_id.strip():
+            return "Error: browser_session snapshot requires a session_id."
+        session = browser_session_runtime.get_session(session_id.strip(), owner_session_id=owner_session_id)
+        if session is None:
+            return f"Error: Browser session '{session_id}' was not found."
+        content = browse_webpage(str(session["url"]), action=normalized_capture)
+        if _browser_capture_failed(content):
+            return content
+        payload = browser_session_runtime.snapshot_session(
+            owner_session_id=owner_session_id,
+            session_id=session_id.strip(),
+            capture=normalized_capture,
+            content=content,
+        )
+        assert payload is not None
+        return f"Captured snapshot {payload['latest_ref']} for session {session_id}.\n\n{payload['content']}"
+
+    if normalized_action == "read":
+        if ref.strip():
+            payload = browser_session_runtime.read_ref(ref.strip(), owner_session_id=owner_session_id)
+            if payload is None:
+                return f"Error: Browser ref '{ref}' was not found."
+            return (
+                f"{payload['ref']} · {payload['provider_name']} ({payload['provider_kind']}) · "
+                f"mode={payload['execution_mode']} · "
+                f"{payload['url']}\n\n{payload['content']}"
+            )
+        if session_id.strip():
+            payload = browser_session_runtime.get_session(session_id.strip(), owner_session_id=owner_session_id)
+            if payload is None:
+                return f"Error: Browser session '{session_id}' was not found."
+            snapshots = payload.get("snapshots") or []
+            latest_ref = snapshots[-1]["ref"] if snapshots else ""
+            if latest_ref:
+                ref_payload = browser_session_runtime.read_ref(str(latest_ref), owner_session_id=owner_session_id)
+                if ref_payload is not None:
+                    return (
+                        f"{ref_payload['ref']} · {ref_payload['provider_name']} ({ref_payload['provider_kind']}) · "
+                        f"mode={ref_payload['execution_mode']} · "
+                        f"{ref_payload['url']}\n\n{ref_payload['content']}"
+                    )
+            return f"Browser session '{session_id}' has no captured snapshots yet."
+        return "Error: browser_session read requires a session_id or ref."
+
+    if normalized_action == "close":
+        if not session_id.strip():
+            return "Error: browser_session close requires a session_id."
+        payload = browser_session_runtime.close_session(session_id.strip(), owner_session_id=owner_session_id)
+        if payload is None:
+            return f"Error: Browser session '{session_id}' was not found."
+        return f"Closed browser session {session_id}."
+
+    return "Error: Unsupported browser_session action. Use open, list, read, snapshot, or close."

--- a/backend/src/tools/browser_tool.py
+++ b/backend/src/tools/browser_tool.py
@@ -154,7 +154,7 @@ def browse_webpage(url: str, action: str = "extract") -> str:
             },
         )
         logger.exception("Browser automation timed out")
-        return f"Error browsing {url}: timed out after {settings.browser_timeout}s"
+        return f"Error: browsing {url} timed out after {settings.browser_timeout}s"
     except Exception as e:
         log_integration_event_sync(
             integration_type="browser",
@@ -166,4 +166,4 @@ def browse_webpage(url: str, action: str = "extract") -> str:
             },
         )
         logger.exception("Browser automation failed")
-        return f"Error browsing {url}: {e}"
+        return f"Error: browsing {url} failed: {e}"

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -28,3 +28,10 @@ async def test_runtime_status_exposes_release_and_model(client):
     assert payload["provider"] == "openrouter"
     assert payload["model"] == settings.default_model
     assert payload["model_label"] == settings.default_model.split("/")[-1]
+
+
+@pytest.mark.asyncio
+async def test_browser_session_api_is_not_publicly_exposed(client):
+    response = await client.get("/api/browser/sessions")
+
+    assert response.status_code == 404

--- a/backend/tests/test_browser_session_tool.py
+++ b/backend/tests/test_browser_session_tool.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from config.settings import settings
+from src.approval.runtime import reset_runtime_context, set_runtime_context
+from src.browser.sessions import browser_session_runtime
+from src.tools.browser_session_tool import browser_session
+
+
+@pytest.fixture(autouse=True)
+def reset_browser_sessions():
+    browser_session_runtime.reset_for_tests()
+    yield
+    browser_session_runtime.reset_for_tests()
+
+
+@pytest.fixture
+def browser_runtime_session():
+    tokens = set_runtime_context("session-1", "high_risk")
+    try:
+        yield "session-1"
+    finally:
+        reset_runtime_context(tokens)
+
+
+def test_browser_session_lists_empty_runtime(browser_runtime_session):
+    assert browser_session(action="list") == "No browser sessions are open."
+
+
+def test_browser_session_open_snapshot_read_and_close_round_trip(browser_runtime_session):
+    with patch("src.tools.browser_session_tool.browse_webpage", side_effect=["first capture", "second capture"]):
+        opened = browser_session(action="open", url="https://example.com/docs")
+        assert "Opened browser session" in opened
+        session_id = opened.split("session ")[1].split(" using")[0]
+        latest_ref = opened.split("Latest ref: ")[1].split(".")[0]
+
+        listed = browser_session(action="list")
+        assert session_id in listed
+
+        read_latest = browser_session(action="read", ref=latest_ref)
+        assert "first capture" in read_latest
+
+        snapshotted = browser_session(action="snapshot", session_id=session_id)
+        assert f"session {session_id}" in snapshotted
+        new_ref = snapshotted.split("snapshot ")[1].split(" for")[0]
+
+        read_new = browser_session(action="read", ref=new_ref)
+        assert "second capture" in read_new
+
+        closed = browser_session(action="close", session_id=session_id)
+        assert closed == f"Closed browser session {session_id}."
+
+
+def test_browser_session_uses_configured_browser_provider_with_local_fallback(tmp_path, browser_runtime_session):
+    workspace = tmp_path / "workspace"
+    extension_dir = workspace / "extensions" / "browserbase-pack"
+    (extension_dir / "connectors" / "browser").mkdir(parents=True)
+    (extension_dir / "manifest.yaml").write_text(
+        "id: seraph.browserbase-pack\n"
+        "version: 2026.3.23\n"
+        "display_name: Browserbase Pack\n"
+        "kind: connector-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  browser_providers:\n"
+        "    - connectors/browser/browserbase.yaml\n"
+        "permissions:\n"
+        "  network: true\n",
+        encoding="utf-8",
+    )
+    (extension_dir / "connectors" / "browser" / "browserbase.yaml").write_text(
+        "name: browserbase\n"
+        "description: Browserbase provider\n"
+        "provider_kind: browserbase\n"
+        "enabled: true\n"
+        "config_fields:\n"
+        "  - key: api_key\n"
+        "    label: Browserbase API Key\n"
+        "    input: password\n"
+        "    required: true\n",
+        encoding="utf-8",
+    )
+    (workspace / "extensions-state.json").write_text(
+        json.dumps(
+            {
+                "extensions": {
+                    "seraph.browserbase-pack": {
+                        "config": {
+                            "browser_providers": {
+                                "browserbase": {"api_key": "secret"},
+                            }
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with (
+        patch.object(settings, "workspace_dir", str(workspace)),
+        patch("src.tools.browser_session_tool.browse_webpage", return_value="provider capture"),
+    ):
+        opened = browser_session(action="open", url="https://example.com", provider="browserbase")
+
+    assert "browserbase (browserbase)" in opened
+    assert "local browser runtime" in opened
+    listed = browser_session(action="list")
+    assert "mode=local_fallback" in listed
+    latest_ref = opened.split("Latest ref: ")[1].split(".")[0]
+    read_latest = browser_session(action="read", ref=latest_ref)
+    assert "mode=local_fallback" in read_latest
+
+
+def test_browser_session_errors_for_missing_requested_provider(tmp_path, browser_runtime_session):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    with patch.object(settings, "workspace_dir", str(workspace)):
+        result = browser_session(action="open", url="https://example.com", provider="browserbase")
+
+    assert result == "Error: Browser provider 'browserbase' is not enabled and configured."
+
+
+def test_browser_session_rejects_open_failure_without_persisting_session(browser_runtime_session):
+    with patch("src.tools.browser_session_tool.browse_webpage", return_value="Error: Access to 'blocked.example' is blocked by site policy."):
+        result = browser_session(action="open", url="https://blocked.example")
+
+    assert result == "Error: Access to 'blocked.example' is blocked by site policy."
+    assert browser_session(action="list") == "No browser sessions are open."
+
+
+def test_browser_session_rejects_snapshot_failure_without_persisting_capture(browser_runtime_session):
+    timeout_error = f"Error: browsing https://example.com/docs timed out after {settings.browser_timeout}s"
+    with patch("src.tools.browser_session_tool.browse_webpage", side_effect=["first capture", timeout_error]):
+        opened = browser_session(action="open", url="https://example.com/docs")
+        session_id = opened.split("session ")[1].split(" using")[0]
+        latest_ref = opened.split("Latest ref: ")[1].split(".")[0]
+
+        failed = browser_session(action="snapshot", session_id=session_id)
+        assert failed == timeout_error
+
+        session_payload = browser_session_runtime.get_session(session_id, owner_session_id="session-1")
+        assert session_payload is not None
+        assert len(session_payload["snapshots"]) == 1
+        assert session_payload["snapshots"][0]["ref"] == latest_ref
+
+
+def test_browser_session_scopes_sessions_and_refs_to_current_session():
+    first_tokens = set_runtime_context("session-1", "high_risk")
+    try:
+        with patch("src.tools.browser_session_tool.browse_webpage", return_value="first capture"):
+            opened = browser_session(action="open", url="https://example.com/docs")
+    finally:
+        reset_runtime_context(first_tokens)
+
+    session_id = opened.split("session ")[1].split(" using")[0]
+    latest_ref = opened.split("Latest ref: ")[1].split(".")[0]
+
+    second_tokens = set_runtime_context("session-2", "high_risk")
+    try:
+        assert browser_session(action="list") == "No browser sessions are open."
+        assert browser_session(action="read", ref=latest_ref) == f"Error: Browser ref '{latest_ref}' was not found."
+        assert browser_session(action="close", session_id=session_id) == f"Error: Browser session '{session_id}' was not found."
+    finally:
+        reset_runtime_context(second_tokens)
+
+
+def test_browser_session_allows_captures_whose_text_starts_with_error_label(browser_runtime_session):
+    with patch("src.tools.browser_session_tool.browse_webpage", return_value="Error budgets are rising in Q2"):
+        opened = browser_session(action="open", url="https://example.com/report")
+
+    assert "Opened browser session" in opened
+    assert "Error budgets are rising in Q2" in opened

--- a/backend/tests/test_capabilities_api.py
+++ b/backend/tests/test_capabilities_api.py
@@ -222,6 +222,262 @@ def test_attach_workflow_actions_uses_extension_enable_for_packaged_disabled_wor
     ]
 
 
+def test_mcp_status_list_exposes_packaged_toolset_presets(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    package_dir = workspace_dir / "extensions" / "github-pack"
+    (package_dir / "presets" / "toolset").mkdir(parents=True)
+    (package_dir / "manifest.yaml").write_text(
+        "id: seraph.github-pack\n"
+        "version: 2026.3.23\n"
+        "display_name: GitHub Pack\n"
+        "kind: capability-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  toolset_presets:\n"
+        "    - presets/toolset/github-operator.yaml\n"
+        "permissions:\n"
+        "  network: true\n",
+        encoding="utf-8",
+    )
+    (package_dir / "presets" / "toolset" / "github-operator.yaml").write_text(
+        "name: github-operator\n"
+        "description: GitHub MCP operator preset\n"
+        "include_mcp_servers:\n"
+        "  - github\n"
+        "execution_boundaries:\n"
+        "  - external_mcp\n",
+        encoding="utf-8",
+    )
+
+    with (
+        patch("src.api.capabilities.settings.workspace_dir", str(workspace_dir)),
+        patch(
+            "src.api.capabilities.mcp_manager.get_config",
+            return_value=[
+                {
+                    "name": "github",
+                    "enabled": True,
+                    "status": "connected",
+                    "tool_count": 2,
+                    "description": "GitHub MCP",
+                }
+            ],
+        ),
+        patch(
+            "src.api.capabilities.mcp_manager.get_server_tools",
+            return_value=[
+                SimpleNamespace(name="github_list_issues"),
+                SimpleNamespace(name="github_get_pull_request"),
+            ],
+        ),
+    ):
+        from src.api.capabilities import _mcp_status_list
+
+        servers = _mcp_status_list("full")
+
+    assert servers[0]["tool_names"] == ["github_get_pull_request", "github_list_issues"]
+    assert servers[0]["toolset_presets"] == [
+        {
+            "name": "github-operator",
+            "description": "GitHub MCP operator preset",
+            "reference": "presets/toolset/github-operator.yaml",
+            "extension_id": "seraph.github-pack",
+            "extension_display_name": "GitHub Pack",
+        }
+    ]
+
+
+def test_doctor_reports_missing_mcp_server_reference_for_toolset_preset(tmp_path):
+    package_dir = tmp_path / "extensions" / "github-pack"
+    (package_dir / "presets" / "toolset").mkdir(parents=True)
+    (package_dir / "manifest.yaml").write_text(
+        "id: seraph.github-pack\n"
+        "version: 2026.3.23\n"
+        "display_name: GitHub Pack\n"
+        "kind: capability-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  toolset_presets:\n"
+        "    - presets/toolset/github-operator.yaml\n"
+        "permissions:\n"
+        "  network: true\n",
+        encoding="utf-8",
+    )
+    (package_dir / "presets" / "toolset" / "github-operator.yaml").write_text(
+        "name: github-operator\n"
+        "description: GitHub MCP operator preset\n"
+        "include_mcp_servers:\n"
+        "  - github-typo\n"
+        "execution_boundaries:\n"
+        "  - external_mcp\n",
+        encoding="utf-8",
+    )
+
+    from src.extensions.doctor import doctor_snapshot
+    from src.extensions.registry import ExtensionRegistry
+
+    snapshot = ExtensionRegistry(
+        manifest_roots=[str(tmp_path / "extensions")],
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    ).snapshot()
+    report = doctor_snapshot(snapshot)
+
+    result = next(item for item in report.results if item.extension_id == "seraph.github-pack")
+    assert any(issue.code == "missing_mcp_server_reference" for issue in result.issues)
+
+
+@pytest.mark.asyncio
+async def test_capabilities_overview_includes_catalog_extension_packs(client):
+    catalog_payload = {
+        "skills": [],
+        "mcp_servers": [],
+        "extension_packages": [
+            {
+                "name": "Hermes Session Memory",
+                "catalog_id": "seraph.hermes-session-memory",
+                "type": "extension_pack",
+                "description": "Optional Hermes-style session recall and checklist skills.",
+                "category": "capability-pack",
+                "installed": False,
+                "bundled": True,
+                "trust": "bundled",
+                "version": "2026.3.23",
+                "installed_version": None,
+                "update_available": False,
+                "contribution_types": ["context_packs", "skills"],
+            }
+        ],
+    }
+
+    with (
+        patch("src.api.capabilities.load_catalog_items", return_value=catalog_payload),
+        patch("src.api.capabilities.catalog_skill_by_name", return_value={}),
+        patch("src.api.capabilities._tool_status_list", return_value=[]),
+        patch("src.api.capabilities._skill_status_map", return_value=([], {})),
+        patch("src.api.capabilities._workflow_status_map", return_value=([], {})),
+        patch("src.api.capabilities._mcp_status_list", return_value=[]),
+        patch("src.api.capabilities._starter_pack_statuses", return_value=[]),
+        patch("src.api.capabilities._load_explicit_runbooks", return_value=[]),
+        patch("src.api.capabilities.get_base_tools_and_active_skills", return_value=([], [], "disabled")),
+    ):
+        response = await client.get("/api/capabilities/overview")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["catalog_items"] == [
+        {
+            "name": "Hermes Session Memory",
+            "catalog_id": "seraph.hermes-session-memory",
+            "type": "extension_pack",
+            "description": "Optional Hermes-style session recall and checklist skills.",
+            "category": "capability-pack",
+            "bundled": True,
+            "installed": False,
+            "update_available": False,
+            "version": "2026.3.23",
+            "installed_version": None,
+            "trust": "bundled",
+            "contribution_types": ["context_packs", "skills"],
+            "status": "ready",
+            "doctor_ok": True,
+            "issues": [],
+            "load_errors": [],
+            "recommended_actions": [
+                {
+                    "type": "install_catalog_item",
+                    "label": "Install pack",
+                    "name": "seraph.hermes-session-memory",
+                }
+            ],
+        }
+    ]
+    assert payload["recommendations"] == [
+        {
+            "id": "catalog-extension:seraph.hermes-session-memory",
+            "label": "Install pack Hermes Session Memory",
+            "description": "Optional Hermes-style session recall and checklist skills.",
+            "action": {
+                "type": "install_catalog_item",
+                "label": "Install pack",
+                "name": "seraph.hermes-session-memory",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_capabilities_overview_surfaces_extension_pack_update_by_catalog_id(client):
+    catalog_payload = {
+        "skills": [],
+        "mcp_servers": [],
+        "extension_packages": [
+            {
+                "name": "Hermes Session Memory",
+                "catalog_id": "seraph.hermes-session-memory",
+                "type": "extension_pack",
+                "description": "Optional Hermes-style session recall and checklist skills.",
+                "category": "capability-pack",
+                "installed": True,
+                "bundled": True,
+                "trust": "bundled",
+                "version": "2026.3.23",
+                "installed_version": "2026.3.19",
+                "update_available": True,
+                "contribution_types": ["context_packs", "skills"],
+                "status": "ready",
+                "doctor_ok": True,
+                "issues": [],
+                "load_errors": [],
+            }
+        ],
+    }
+
+    with (
+        patch("src.api.capabilities.load_catalog_items", return_value=catalog_payload),
+        patch("src.api.capabilities.catalog_skill_by_name", return_value={}),
+        patch("src.api.capabilities._tool_status_list", return_value=[]),
+        patch("src.api.capabilities._skill_status_map", return_value=([], {})),
+        patch("src.api.capabilities._workflow_status_map", return_value=([], {})),
+        patch("src.api.capabilities._mcp_status_list", return_value=[]),
+        patch("src.api.capabilities._starter_pack_statuses", return_value=[]),
+        patch("src.api.capabilities._load_explicit_runbooks", return_value=[]),
+        patch("src.api.capabilities.get_base_tools_and_active_skills", return_value=([], [], "disabled")),
+    ):
+        response = await client.get("/api/capabilities/overview")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["catalog_items"][0]["recommended_actions"] == [
+        {
+            "type": "install_catalog_item",
+            "label": "Update pack",
+            "name": "seraph.hermes-session-memory",
+        }
+    ]
+    assert payload["recommendations"] == [
+        {
+            "id": "catalog-extension:seraph.hermes-session-memory",
+            "label": "Update pack Hermes Session Memory",
+            "description": "Optional Hermes-style session recall and checklist skills.",
+            "action": {
+                "type": "install_catalog_item",
+                "label": "Update pack",
+                "name": "seraph.hermes-session-memory",
+            },
+        }
+    ]
+
+
 @pytest.mark.asyncio
 async def test_capabilities_overview_aggregates_blocked_states_and_starter_packs(client):
     ctx = CurrentContext(tool_policy_mode="balanced", mcp_policy_mode="approval", approval_mode="high_risk")

--- a/backend/tests/test_catalog_api.py
+++ b/backend/tests/test_catalog_api.py
@@ -199,6 +199,44 @@ def bundled_skills_dir(tmp_path):
 
 class TestCatalogAPI:
     @pytest.mark.asyncio
+    async def test_get_catalog_includes_extension_packages(self, client):
+        resp = await client.get("/api/catalog")
+
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        extension_ids = {
+            item["catalog_id"]
+            for item in items
+            if item["type"] == "extension_pack"
+        }
+        assert "seraph.hermes-session-memory" in extension_ids
+        session_memory = next(item for item in items if item.get("catalog_id") == "seraph.hermes-session-memory")
+        assert session_memory["name"] == "Hermes Session Memory"
+        assert session_memory["bundled"] is True
+        assert "skills" in session_memory["contribution_types"]
+        browserbase = next(item for item in items if item.get("catalog_id") == "seraph.hermes-browserbase")
+        assert browserbase["name"] == "Hermes Browserbase"
+        assert "browser_providers" in browserbase["contribution_types"]
+        browser_ops = next(item for item in items if item.get("catalog_id") == "seraph.hermes-browser-ops")
+        assert browser_ops["name"] == "Hermes Browser Ops"
+        assert "toolset_presets" in browser_ops["contribution_types"]
+        telegram = next(item for item in items if item.get("catalog_id") == "seraph.hermes-telegram-relay")
+        assert telegram["name"] == "Hermes Telegram Relay"
+        assert telegram["kind"] == "connector-pack"
+        assert "messaging_connectors" in telegram["contribution_types"]
+        discord = next(item for item in items if item.get("catalog_id") == "seraph.hermes-discord-relay")
+        assert discord["name"] == "Hermes Discord Relay"
+        slack = next(item for item in items if item.get("catalog_id") == "seraph.hermes-slack-relay")
+        assert slack["name"] == "Hermes Slack Relay"
+        speech = next(item for item in items if item.get("catalog_id") == "seraph.hermes-speech-ops")
+        assert speech["name"] == "Hermes Speech Ops"
+        assert "speech_profiles" in speech["contribution_types"]
+        multimodal = next(item for item in items if item.get("catalog_id") == "seraph.hermes-multimodal-review")
+        assert multimodal["name"] == "Hermes Multimodal Review"
+        assert "prompt_packs" in multimodal["contribution_types"]
+        assert "context_packs" in multimodal["contribution_types"]
+
+    @pytest.mark.asyncio
     async def test_get_catalog_returns_items(self, client, catalog_data, workspace_dir):
         with patch("src.api.catalog._load_catalog", return_value=catalog_data), \
              patch("src.api.catalog.settings") as mock_settings, \
@@ -399,6 +437,305 @@ class TestCatalogAPI:
         with patch("src.api.catalog._load_catalog", return_value=catalog_data):
             resp = await client.post("/api/catalog/install/nonexistent")
             assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_extension_pack_success(self, client, catalog_extension_runtime):
+        resp = await client.post("/api/catalog/install/Hermes Session Memory")
+
+        assert resp.status_code == 201
+        payload = resp.json()
+        assert payload["status"] == "installed"
+        assert payload["type"] == "extension_pack"
+        assert payload["extension_id"] == "seraph.hermes-session-memory"
+        assert Path(
+            catalog_extension_runtime,
+            "extensions",
+            "seraph-hermes-session-memory",
+            "manifest.yaml",
+        ).is_file()
+
+    @pytest.mark.asyncio
+    async def test_get_catalog_marks_invalid_extension_pack_as_degraded(self, client, tmp_path):
+        bad_root = tmp_path / "bad-catalog"
+        package_dir = bad_root / "broken-pack"
+        package_dir.mkdir(parents=True)
+        (package_dir / "manifest.yaml").write_text(
+            "id: seraph.broken-pack\n"
+            "version: 2026.3.23\n"
+            "display_name: Broken Pack\n"
+            "kind: capability-pack\n"
+            "compatibility:\n"
+            "  seraph: \">=2026.3.19\"\n"
+            "publisher:\n"
+            "  name: Seraph\n"
+            "trust: bundled\n"
+            "contributes:\n"
+            "  skills:\n"
+            "    - skills/missing.md\n",
+            encoding="utf-8",
+        )
+
+        with patch("src.api.catalog._CATALOG_EXTENSION_ROOT", str(bad_root)):
+            resp = await client.get("/api/catalog")
+
+        assert resp.status_code == 200
+        broken = next(item for item in resp.json()["items"] if item.get("catalog_id") == "seraph.broken-pack")
+        assert broken["status"] == "degraded"
+        assert broken["doctor_ok"] is False
+        assert broken["issues"]
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_extension_pack_updates_existing_workspace_install(self, client, catalog_extension_runtime):
+        first = await client.post("/api/catalog/install/seraph.hermes-session-memory")
+        assert first.status_code == 201
+
+        installed_manifest = Path(
+            catalog_extension_runtime,
+            "extensions",
+            "seraph-hermes-session-memory",
+            "manifest.yaml",
+        )
+        manifest_text = installed_manifest.read_text(encoding="utf-8").replace("version: 2026.3.23", "version: 2026.3.19")
+        installed_manifest.write_text(manifest_text, encoding="utf-8")
+
+        update = await client.post("/api/catalog/install/seraph.hermes-session-memory")
+
+        assert update.status_code == 201
+        payload = update.json()
+        assert payload["status"] == "updated"
+        assert payload["type"] == "extension_pack"
+        assert "version: 2026.3.23" in installed_manifest.read_text(encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_messaging_connector_pack_can_be_configured_and_enabled(self, client, catalog_extension_runtime):
+        install = await client.post("/api/catalog/install/seraph.hermes-telegram-relay")
+
+        assert install.status_code == 409
+        approval_detail = install.json()["detail"]
+        assert approval_detail["type"] == "approval_required"
+
+        approve = await client.post(f"/api/approvals/{approval_detail['approval_id']}/approve")
+        assert approve.status_code == 200
+
+        install = await client.post("/api/catalog/install/seraph.hermes-telegram-relay")
+        assert install.status_code == 201
+        payload = install.json()
+        assert payload["status"] == "installed"
+        assert payload["extension_id"] == "seraph.hermes-telegram-relay"
+
+        connectors = await client.get("/api/extensions/seraph.hermes-telegram-relay/connectors")
+        assert connectors.status_code == 200
+        connector = connectors.json()["connectors"][0]
+        assert connector["type"] == "messaging_connectors"
+        assert connector["status"] == "requires_config"
+
+        configure = await client.post(
+            "/api/extensions/seraph.hermes-telegram-relay/configure",
+            json={
+                "config": {
+                    "messaging_connectors": {
+                        "telegram": {
+                            "bot_token": "secret",
+                            "default_chat_id": "12345",
+                        }
+                    }
+                }
+            },
+        )
+        assert configure.status_code == 409
+        configure_approval_id = configure.json()["detail"]["approval_id"]
+        approve_configure = await client.post(f"/api/approvals/{configure_approval_id}/approve")
+        assert approve_configure.status_code == 200
+
+        configure = await client.post(
+            "/api/extensions/seraph.hermes-telegram-relay/configure",
+            json={
+                "config": {
+                    "messaging_connectors": {
+                        "telegram": {
+                            "bot_token": "secret",
+                            "default_chat_id": "12345",
+                        }
+                    }
+                }
+            },
+        )
+        assert configure.status_code == 200
+        configured_extension = configure.json()["extension"]
+        configured_connector_config = configured_extension["config"]["messaging_connectors"]["telegram"]
+        assert configured_connector_config["bot_token"] == "__SERAPH_STORED_SECRET__"
+        assert configured_connector_config["default_chat_id"] == "12345"
+
+        reconfigure = await client.post(
+            "/api/extensions/seraph.hermes-telegram-relay/configure",
+            json={"config": configured_extension["config"]},
+        )
+        assert reconfigure.status_code == 200
+
+        enable_connector = await client.post(
+            "/api/extensions/seraph.hermes-telegram-relay/connectors/enabled",
+            json={"reference": "connectors/messaging/telegram.yaml", "enabled": True},
+        )
+        assert enable_connector.status_code == 200
+        assert enable_connector.json()["connector"]["status"] == "planned"
+
+        enable_extension = await client.post("/api/extensions/seraph.hermes-telegram-relay/enable")
+        assert enable_extension.status_code == 200
+        extension_payload = enable_extension.json()["extension"]
+        messaging_connector = next(
+            contribution
+            for contribution in extension_payload["contributions"]
+            if contribution["type"] == "messaging_connectors"
+        )
+        assert messaging_connector["enabled"] is True
+        assert messaging_connector["status"] == "planned"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("catalog_id", "connector_name", "reference", "config"),
+        [
+            (
+                "seraph.hermes-discord-relay",
+                "discord",
+                "connectors/messaging/discord.yaml",
+                {"bot_token": "secret", "guild_id": "guild-1"},
+            ),
+            (
+                "seraph.hermes-slack-relay",
+                "slack",
+                "connectors/messaging/slack.yaml",
+                {"bot_token": "secret", "app_token": "app-secret"},
+            ),
+        ],
+    )
+    async def test_install_catalog_additional_messaging_connector_packs(
+        self,
+        client,
+        catalog_extension_runtime,
+        catalog_id,
+        connector_name,
+        reference,
+        config,
+    ):
+        install = await client.post(f"/api/catalog/install/{catalog_id}")
+
+        assert install.status_code == 409
+        approval_detail = install.json()["detail"]
+        assert approval_detail["type"] == "approval_required"
+
+        approve = await client.post(f"/api/approvals/{approval_detail['approval_id']}/approve")
+        assert approve.status_code == 200
+
+        install = await client.post(f"/api/catalog/install/{catalog_id}")
+        assert install.status_code == 201
+
+        configure = await client.post(
+            f"/api/extensions/{catalog_id}/configure",
+            json={"config": {"messaging_connectors": {connector_name: config}}},
+        )
+        assert configure.status_code == 409
+        configure_approval_id = configure.json()["detail"]["approval_id"]
+        approve_configure = await client.post(f"/api/approvals/{configure_approval_id}/approve")
+        assert approve_configure.status_code == 200
+
+        configure = await client.post(
+            f"/api/extensions/{catalog_id}/configure",
+            json={"config": {"messaging_connectors": {connector_name: config}}},
+        )
+        assert configure.status_code == 200
+
+        enable_connector = await client.post(
+            f"/api/extensions/{catalog_id}/connectors/enabled",
+            json={"reference": reference, "enabled": True},
+        )
+        assert enable_connector.status_code == 200
+        assert enable_connector.json()["connector"]["status"] == "planned"
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_browserbase_pack_surfaces_browser_provider_metadata(self, client, catalog_extension_runtime):
+        install = await client.post("/api/catalog/install/seraph.hermes-browserbase")
+
+        assert install.status_code == 409
+        approval_detail = install.json()["detail"]
+        assert approval_detail["type"] == "approval_required"
+
+        approve = await client.post(f"/api/approvals/{approval_detail['approval_id']}/approve")
+        assert approve.status_code == 200
+
+        install = await client.post("/api/catalog/install/seraph.hermes-browserbase")
+        assert install.status_code == 201
+        assert install.json()["extension_id"] == "seraph.hermes-browserbase"
+
+        extension = await client.get("/api/extensions/seraph.hermes-browserbase")
+        assert extension.status_code == 200
+        contributions = extension.json()["extension"]["contributions"]
+        provider = next(item for item in contributions if item["type"] == "browser_providers")
+        preset = next(item for item in contributions if item["type"] == "toolset_presets")
+        assert provider["name"] == "browserbase"
+        assert provider["provider_kind"] == "browserbase"
+        assert provider["status"] == "requires_config"
+        assert preset["name"] == "browserbase-ops"
+        assert "browser_session" in preset["include_tools"]
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_browser_ops_pack_surfaces_browser_skills_and_toolset(self, client, catalog_extension_runtime):
+        install = await client.post("/api/catalog/install/seraph.hermes-browser-ops")
+
+        assert install.status_code == 201
+        assert install.json()["extension_id"] == "seraph.hermes-browser-ops"
+
+        extension = await client.get("/api/extensions/seraph.hermes-browser-ops")
+        assert extension.status_code == 200
+        contributions = extension.json()["extension"]["contributions"]
+        skill_names = {
+            item["name"]
+            for item in contributions
+            if item["type"] == "skills"
+        }
+        preset = next(item for item in contributions if item["type"] == "toolset_presets")
+        assert skill_names == {"browser-session-review", "browser-snapshot"}
+        assert preset["name"] == "browser-session-ops"
+        assert "browser_session" in preset["include_tools"]
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_speech_pack_surfaces_speech_profile_metadata(self, client, catalog_extension_runtime):
+        install = await client.post("/api/catalog/install/seraph.hermes-speech-ops")
+
+        assert install.status_code == 201
+        payload = install.json()
+        assert payload["extension_id"] == "seraph.hermes-speech-ops"
+
+        extension = await client.get("/api/extensions/seraph.hermes-speech-ops")
+        assert extension.status_code == 200
+        contributions = extension.json()["extension"]["contributions"]
+        speech_profile = next(item for item in contributions if item["type"] == "speech_profiles")
+        prompt_pack = next(item for item in contributions if item["type"] == "prompt_packs")
+        assert speech_profile["name"] == "openai-realtime-voice"
+        assert speech_profile["supports_tts"] is True
+        assert speech_profile["supports_stt"] is True
+        assert prompt_pack["name"] == "voice-relay"
+        assert prompt_pack["title"] == "Voice Relay"
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_multimodal_pack_surfaces_provider_preset_metadata(self, client, catalog_extension_runtime):
+        install = await client.post("/api/catalog/install/seraph.hermes-multimodal-review")
+
+        assert install.status_code == 201
+        payload = install.json()
+        assert payload["extension_id"] == "seraph.hermes-multimodal-review"
+
+        extension = await client.get("/api/extensions/seraph.hermes-multimodal-review")
+        assert extension.status_code == 200
+        contributions = extension.json()["extension"]["contributions"]
+        context_pack = next(item for item in contributions if item["type"] == "context_packs")
+        prompt_pack = next(item for item in contributions if item["type"] == "prompt_packs")
+        provider_preset = next(item for item in contributions if item["type"] == "provider_presets")
+        assert context_pack["name"] == "multimodal-review"
+        assert "review" in context_pack["domains"]
+        assert prompt_pack["name"] == "vision-triage"
+        assert prompt_pack["title"] == "Vision Triage"
+        assert provider_preset["name"] == "multimodal-review"
+        assert provider_preset["default_model"] == "multimodal-primary"
 
     @pytest.mark.asyncio
     async def test_install_already_installed_skill(

--- a/backend/tests/test_extension_registry.py
+++ b/backend/tests/test_extension_registry.py
@@ -49,6 +49,7 @@ def test_registry_enriches_wave2_contribution_metadata(tmp_path: Path):
     pack_dir = tmp_path / "extensions" / "guardian-reach"
     (pack_dir / "presets" / "toolset").mkdir(parents=True)
     (pack_dir / "context").mkdir()
+    (pack_dir / "prompts").mkdir()
     (pack_dir / "automation").mkdir()
     (pack_dir / "connectors" / "browser").mkdir(parents=True)
     (pack_dir / "connectors" / "messaging").mkdir()
@@ -73,6 +74,8 @@ contributes:
     - presets/toolset/research.yaml
   context_packs:
     - context/research.yaml
+  prompt_packs:
+    - prompts/review.md
   automation_triggers:
     - automation/daily-brief.yaml
   browser_providers:
@@ -92,6 +95,10 @@ contributes:
     )
     (pack_dir / "context" / "research.yaml").write_text(
         "name: research\ninstructions: Keep context tight.\ndomains:\n  - research\n",
+        encoding="utf-8",
+    )
+    (pack_dir / "prompts" / "review.md").write_text(
+        "# Review Prompt\n\nUse this pack when reviewing artifacts.\n",
         encoding="utf-8",
     )
     (pack_dir / "automation" / "daily-brief.yaml").write_text(
@@ -127,6 +134,8 @@ contributes:
     contributions = {item.contribution_type: item.metadata for item in extension.contributions}
     assert contributions["toolset_presets"]["include_tools"] == ["read_file"]
     assert contributions["context_packs"]["domains"] == ["research"]
+    assert contributions["prompt_packs"]["name"] == "review-prompt"
+    assert contributions["prompt_packs"]["title"] == "Review Prompt"
     assert contributions["automation_triggers"]["requires_network"] is True
     assert contributions["browser_providers"]["provider_kind"] == "browserbase"
     assert contributions["messaging_connectors"]["platform"] == "telegram"

--- a/backend/tests/test_extension_scaffold.py
+++ b/backend/tests/test_extension_scaffold.py
@@ -17,6 +17,10 @@ def test_scaffold_capability_pack_creates_valid_manifest_and_files(tmp_path: Pat
     assert (package.package_root / "skills" / "research-pack.md").exists()
     assert (package.package_root / "workflows" / "research-pack.md").exists()
     assert (package.package_root / "runbooks" / "research-pack.yaml").exists()
+    workflow_contents = (package.package_root / "workflows" / "research-pack.md").read_text(encoding="utf-8")
+    runbook_contents = (package.package_root / "runbooks" / "research-pack.yaml").read_text(encoding="utf-8")
+    assert "name: research-pack" in workflow_contents
+    assert "workflow: research-pack" in runbook_contents
 
     report = validate_extension_package(package.package_root)
 

--- a/backend/tests/test_extensions_api.py
+++ b/backend/tests/test_extensions_api.py
@@ -649,6 +649,76 @@ async def test_validate_extension_package_path_returns_manifest_report(client, t
 
 
 @pytest.mark.asyncio
+async def test_scaffold_extension_package_creates_workspace_skill_pack(client, extension_runtime):
+    with patch("src.api.extensions.log_integration_event", AsyncMock()) as log_event:
+        response = await client.post(
+            "/api/extensions/scaffold",
+            json={
+                "package_name": "skill-lab",
+                "display_name": "Skill Lab",
+            },
+        )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["status"] == "scaffolded"
+    assert payload["path"].endswith("/extensions/skill-lab")
+    assert "manifest.yaml" in payload["created_files"]
+    assert "skills/skill-lab.md" in payload["created_files"]
+    assert payload["preview"]["extension_id"] == "seraph.skill-lab"
+    assert payload["preview"]["ok"] is True
+    assert Path(extension_runtime, "extensions", "skill-lab", "manifest.yaml").is_file()
+    assert log_event.await_count == 1
+    assert log_event.await_args.kwargs["outcome"] == "succeeded"
+    assert log_event.await_args.kwargs["details"]["status"] == "scaffold"
+
+
+@pytest.mark.asyncio
+async def test_scaffold_extension_package_rejects_existing_workspace_package(client, extension_runtime):
+    existing_root = Path(extension_runtime, "extensions", "skill-lab")
+    existing_root.mkdir(parents=True)
+    (existing_root / "manifest.yaml").write_text("id: seraph.existing\n", encoding="utf-8")
+
+    with patch("src.api.extensions.log_integration_event", AsyncMock()) as log_event:
+        response = await client.post(
+            "/api/extensions/scaffold",
+            json={
+                "package_name": "skill-lab",
+                "display_name": "Skill Lab",
+            },
+        )
+
+    assert response.status_code == 409
+    assert "manifest already exists" in response.json()["detail"]
+    assert log_event.await_count == 1
+    assert log_event.await_args.kwargs["outcome"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_scaffold_extension_package_quotes_display_name_for_frontmatter(client, extension_runtime):
+    with patch("src.api.extensions.log_integration_event", AsyncMock()):
+        response = await client.post(
+            "/api/extensions/scaffold",
+            json={
+                "package_name": "quoted-pack",
+                "display_name": "Quoted: Pack",
+                "contributions": ["skills", "workflows"],
+            },
+        )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["status"] == "scaffolded"
+    assert payload["preview"]["ok"] is True
+
+    skill_file = Path(extension_runtime, "extensions", "quoted-pack", "skills", "quoted-pack.md").read_text(encoding="utf-8")
+    workflow_file = Path(extension_runtime, "extensions", "quoted-pack", "workflows", "quoted-pack.md").read_text(encoding="utf-8")
+    assert 'description: "Quoted: Pack skill"' in skill_file
+    assert 'description: "Quoted: Pack workflow"' in workflow_file
+    assert "name: quoted-pack" in workflow_file
+
+
+@pytest.mark.asyncio
 async def test_validate_extension_reports_lifecycle_approval_for_boundary_only_toolset(client, tmp_path):
     package_dir = _write_toolset_boundary_extension(tmp_path, boundary="secret_read")
 
@@ -1321,6 +1391,14 @@ async def test_install_configure_and_toggle_wave2_contribution_surfaces(client, 
         AsyncMock(),
     ):
         install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 409
+        approval_detail = install_response.json()["detail"]
+        assert approval_detail["type"] == "approval_required"
+
+        approve_response = await client.post(f"/api/approvals/{approval_detail['approval_id']}/approve")
+        assert approve_response.status_code == 200
+
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
         assert install_response.status_code == 201
         installed = install_response.json()["extension"]
         assert installed["id"] == "seraph.wave2-pack"
@@ -1359,6 +1437,22 @@ async def test_install_configure_and_toggle_wave2_contribution_surfaces(client, 
         )
         assert enable_before_config.status_code == 422
         assert "requires valid configuration" in enable_before_config.json()["detail"]
+
+        configure_response = await client.post(
+            "/api/extensions/seraph.wave2-pack/configure",
+            json={
+                "config": {
+                    "browser_providers": {"browserbase": {"api_key": "secret"}},
+                    "messaging_connectors": {"telegram": {"bot_token": "secret"}},
+                    "automation_triggers": {"daily-brief": {"signing_secret": "secret"}},
+                    "node_adapters": {"companion": {"node_url": "https://nodes.example.test"}},
+                }
+            },
+        )
+        assert configure_response.status_code == 409
+        configure_approval_id = configure_response.json()["detail"]["approval_id"]
+        approve_response = await client.post(f"/api/approvals/{configure_approval_id}/approve")
+        assert approve_response.status_code == 200
 
         configure_response = await client.post(
             "/api/extensions/seraph.wave2-pack/configure",

--- a/backend/tests/test_extensions_api.py
+++ b/backend/tests/test_extensions_api.py
@@ -1431,6 +1431,29 @@ async def test_install_configure_and_toggle_wave2_contribution_surfaces(client, 
         assert connectors["messaging_connectors"]["status"] == "requires_config"
         assert connectors["node_adapters"]["status"] == "requires_config"
 
+        invalid_secret_config = {
+            "messaging_connectors": {"telegram": {"bot_token": None}}
+        }
+        invalid_secret_response = await client.post(
+            "/api/extensions/seraph.wave2-pack/configure",
+            json={"config": invalid_secret_config},
+        )
+        assert invalid_secret_response.status_code == 409
+        invalid_secret_detail = invalid_secret_response.json()["detail"]
+        assert invalid_secret_detail["type"] == "approval_required"
+
+        approve_invalid_secret = await client.post(
+            f"/api/approvals/{invalid_secret_detail['approval_id']}/approve"
+        )
+        assert approve_invalid_secret.status_code == 200
+
+        invalid_secret_retry = await client.post(
+            "/api/extensions/seraph.wave2-pack/configure",
+            json={"config": invalid_secret_config},
+        )
+        assert invalid_secret_retry.status_code == 422
+        assert "missing required config field 'bot_token'" in invalid_secret_retry.json()["detail"]
+
         enable_before_config = await client.post(
             "/api/extensions/seraph.wave2-pack/connectors/enabled",
             json={"reference": "connectors/browser/browserbase.yaml", "enabled": True},
@@ -1477,6 +1500,12 @@ async def test_install_configure_and_toggle_wave2_contribution_surfaces(client, 
         assert configured_connectors["messaging_connectors"]["config_keys"] == ["bot_token"]
         assert configured_connectors["automation_triggers"]["config_keys"] == ["signing_secret"]
         assert configured_connectors["node_adapters"]["config_keys"] == ["node_url"]
+
+        redacted_reconfigure = await client.post(
+            "/api/extensions/seraph.wave2-pack/configure",
+            json={"config": configured["config"]},
+        )
+        assert redacted_reconfigure.status_code == 200
 
         enable_browser = await client.post(
             "/api/extensions/seraph.wave2-pack/connectors/enabled",

--- a/backend/tests/test_specialists.py
+++ b/backend/tests/test_specialists.py
@@ -27,7 +27,7 @@ class TestToolDomainMapping:
             "view_soul", "update_soul",
             "store_secret", "get_secret", "get_secret_ref", "list_secrets", "delete_secret",
             "create_goal", "update_goal", "get_goals", "get_goal_progress",
-            "web_search", "browse_webpage",
+            "web_search", "browse_webpage", "browser_session",
             "read_file", "write_file", "fill_template", "execute_code",
         }
         assert set(TOOL_DOMAINS.keys()) == expected_tools
@@ -176,7 +176,7 @@ class TestNamedFactories:
         create_web_researcher(tools_by_name)
         agent_kwargs = mock_agent_cls.call_args[1]
         tool_names = {t.name for t in agent_kwargs["tools"]}
-        assert tool_names == {"web_search", "browse_webpage"}
+        assert tool_names == {"web_search", "browse_webpage", "browser_session"}
 
     @patch("src.agent.specialists.ToolCallingAgent")
     @patch("src.agent.specialists.LiteLLMModel")

--- a/backend/tests/test_tools_api.py
+++ b/backend/tests/test_tools_api.py
@@ -52,6 +52,16 @@ async def test_tools_api_safe_mode_keeps_session_search_available(client):
 
 
 @pytest.mark.asyncio
+async def test_tools_api_safe_mode_keeps_browser_session_available(client):
+    ctx = CurrentContext(tool_policy_mode="safe")
+    with patch("src.tools.policy.context_manager.get_context", return_value=ctx):
+        resp = await client.get("/api/tools")
+    assert resp.status_code == 200
+    names = {tool["name"] for tool in resp.json()}
+    assert "browser_session" in names
+
+
+@pytest.mark.asyncio
 async def test_tools_api_safe_mode_keeps_get_scheduled_jobs_available(client):
     ctx = CurrentContext(tool_policy_mode="safe")
     with patch("src.tools.policy.context_manager.get_context", return_value=ctx):

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -391,21 +391,21 @@ See [Capability Import Wave 2](./12-capability-import-wave-2.md) for the impleme
 
 ### Wave 3: Hermes Packaged Reach And Capability Parity
 
-17. [ ] `hermes-skill-registry-v1`:
+17. [x] `hermes-skill-registry-v1`:
     build the first real install, search, update, and trust-scanned registry loop for skill packs so Seraph’s extension ecosystem compounds more like Hermes
-18. [ ] `hermes-optional-skill-packs-v1`:
+18. [x] `hermes-optional-skill-packs-v1`:
     add optional installable skill packs instead of only bundled defaults so operators can grow capability breadth without repo edits
-19. [ ] `hermes-mcp-toolset-bridge-v1`:
+19. [x] `hermes-mcp-toolset-bridge-v1`:
     make MCP servers publish cleaner toolset and preset surfaces with stronger per-server filtering, visibility, and activation ergonomics
-20. [ ] `hermes-browserbase-connector-v1`:
+20. [x] `hermes-browserbase-connector-v1`:
     add a managed Browserbase-style browser provider package so Seraph gains a stronger isolated browser lane without overloading generic web tools
-21. [ ] `hermes-browser-session-ops-v1`:
+21. [x] `hermes-browser-session-ops-v1`:
     add stronger browser session primitives such as page refs, snapshots, and more structured browser actions so browsing can support real multi-step operator work
-22. [ ] `hermes-messaging-connectors-wave1-v1`:
+22. [x] `hermes-messaging-connectors-wave1-v1`:
     ship the first high-value messaging connectors such as Telegram, Discord, and Slack through the new messaging-connector contribution type
-23. [ ] `hermes-vision-image-speech-v1`:
-    import the most valuable Hermes multimodal surfaces, including vision, image generation, and TTS or STT paths where they fit Seraph’s operator product
-24. [ ] `hermes-skill-authoring-loop-v1`:
+23. [x] `hermes-vision-image-speech-v1`:
+    import the most valuable Hermes multimodal packaging surfaces as operator-ready speech and multimodal scaffolding, without overclaiming a full remote media runtime before those transports ship
+24. [x] `hermes-skill-authoring-loop-v1`:
     let Seraph create, patch, validate, and install skill packs more directly so the extension platform compounds through agent-assisted authoring
 
 ### Wave 4: Selective OpenClaw Imports

--- a/docs/implementation/13-capability-import-wave-3.md
+++ b/docs/implementation/13-capability-import-wave-3.md
@@ -1,0 +1,351 @@
+# Capability Import Wave 3
+
+## Scope
+
+Wave 3 covers the Hermes packaged reach and capability-parity slices from the
+capability import program:
+
+17. `hermes-skill-registry-v1`
+18. `hermes-optional-skill-packs-v1`
+19. `hermes-mcp-toolset-bridge-v1`
+20. `hermes-browserbase-connector-v1`
+21. `hermes-browser-session-ops-v1`
+22. `hermes-messaging-connectors-wave1-v1`
+23. `hermes-vision-image-speech-v1`
+24. `hermes-skill-authoring-loop-v1`
+
+This wave is where the extension platform starts compounding into packaged
+reach. It does not claim that every Hermes/OpenClaw surface is feature-complete
+or remotely hosted already; the goal is to make skill packs, connector packs,
+browser/provider inventory, and operator authoring feel like first-class
+runtime surfaces instead of roadmap placeholders.
+
+## Slice Log
+
+### 17. hermes-skill-registry-v1
+
+- status: complete
+- intent:
+  - turn the packaged catalog into the first real registry loop for optional
+    skill-focused extension packs
+  - surface install and update actions through the same operator and cockpit
+    paths as the rest of the capability system
+- implementation:
+  - catalog extension packages are now discovered from
+    `backend/src/defaults/catalog-extensions/` and surfaced alongside skill and
+    MCP catalog entries
+  - packaged extension entries now carry install/update metadata including
+    `catalog_id`, trust, installed version, and contribution types
+  - degraded catalog packages are now doctor-scanned before they are surfaced
+    as installable, so broken packaged entries stop at the catalog layer rather
+    than failing only at install time
+  - install/update actions now route by stable `catalog_id` instead of display
+    name for extension packs
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py tests/test_capabilities_api.py -q`
+  - `cd frontend && npm test -- src/components/cockpit/CockpitView.test.tsx`
+
+### 18. hermes-optional-skill-packs-v1
+
+- status: complete
+- intent:
+  - ship optional Hermes-style packaged skill bundles instead of only bundled
+    defaults
+  - prove that installable capability packs can bundle skills, context, and
+    operator presets cleanly
+- implementation:
+  - added optional catalog extension packs:
+    - `seraph.hermes-session-memory`
+    - `seraph.hermes-research-ops`
+  - these packs bundle real skills, context packs, and toolset presets so the
+    extension registry and catalog expose optional operator-ready capability
+    bundles instead of only base runtime content
+  - cockpit and settings install surfaces now distinguish installed packs from
+    updatable packs
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py tests/test_capabilities_api.py -q`
+  - `cd frontend && npm test -- src/components/cockpit/CockpitView.test.tsx`
+  - `cd frontend && npm run build`
+
+### 19. hermes-mcp-toolset-bridge-v1
+
+- status: complete
+- intent:
+  - let packaged toolset presets bind to MCP server inventory cleanly, so
+    operator-facing packs can advertise server-specific tool surfaces instead
+    of opaque connector names
+- implementation:
+  - `toolset_presets` now support `include_mcp_servers`
+  - MCP status payloads now surface server-linked toolset presets and concrete
+    tool names
+  - toolset permission evaluation now treats MCP-linked presets as
+    `external_mcp` boundary consumers
+  - doctor now reports broken MCP preset references when a preset targets
+    missing server names
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py tests/test_capabilities_api.py -q`
+
+### 20. hermes-browserbase-connector-v1
+
+- status: complete
+- intent:
+  - package a Browserbase-style managed browser provider so browser-oriented
+    packs feel first-class inside the extension platform
+  - make the current execution mode explicit instead of overclaiming remote
+    isolation before a real remote transport exists
+- implementation:
+  - added bundled connector pack `seraph.hermes-browserbase` with:
+    - browser provider contribution
+    - browser-oriented toolset preset
+  - provider selection now surfaces Browserbase-style packaged inventory through
+    the same connector registry as other extension-backed reach surfaces
+  - the packaged Browserbase copy now explicitly describes the current staged
+    local-fallback behavior instead of claiming live remote isolation
+  - the public browser-session REST surface was deferred; the runtime remains
+    tool-scoped until a later operator-surface wave adds a stronger ownership
+    model
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_browser_session_tool.py tests/test_tools_api.py tests/test_catalog_api.py tests/test_app.py -q`
+
+### 21. hermes-browser-session-ops-v1
+
+- status: complete
+- intent:
+  - make browser sessions usable for real multi-step operator work with stable
+    refs, snapshots, and provider-aware execution metadata
+  - keep session handles scoped to the active Seraph thread instead of a
+    process-global scratchpad
+- implementation:
+  - added bundled browser-session runtime primitives:
+    - in-memory session store
+    - `browser_session` native tool
+    - browser-session operator skill and toolset preset
+  - browser sessions are now scoped to the active runtime session, so one chat
+    cannot list, read, or close another chat's browser captures through the
+    tool path
+  - browser capture failures no longer persist as successful sessions or
+    snapshots; only successful `browse_webpage` results are stored
+  - browser reads and listings now surface `execution_mode`, making
+    `local_runtime` vs `local_fallback` visible in operator output
+  - browser transport failures are normalized back to the `Error:` contract so
+    capture validation is exact rather than brittle string-prefix guessing
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_browser_session_tool.py tests/test_tools_api.py tests/test_catalog_api.py tests/test_app.py -q`
+
+### 22. hermes-messaging-connectors-wave1-v1
+
+- status: complete
+- intent:
+  - ship the first Hermes-style messaging reach surfaces through typed connector
+    packages rather than special-case runtime code
+  - prove that messaging connectors install, configure, and enable through the
+    extension lifecycle
+- implementation:
+  - added bundled messaging connector packs:
+    - `seraph.hermes-telegram-relay`
+    - `seraph.hermes-discord-relay`
+    - `seraph.hermes-slack-relay`
+  - each pack contributes a typed `messaging_connectors` manifest with config
+    fields and delivery-mode metadata
+  - catalog install/configure/enable flows now cover messaging connector packs,
+    so the first channel wave uses the same extension lifecycle as the rest of
+    the platform
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py -q`
+
+### 23. hermes-vision-image-speech-v1
+
+- status: complete
+- intent:
+  - import the highest-value Hermes multimodal packaging surfaces without
+    pretending the full remote media runtime already exists
+  - add speech and multimodal review scaffolding as installable capability
+    packs
+- implementation:
+  - added bundled capability pack `seraph.hermes-speech-ops` with:
+    - `speech_profiles`
+    - a speech-oriented prompt pack
+  - added bundled capability pack `seraph.hermes-multimodal-review` with:
+    - `context_packs`
+    - `prompt_packs`
+    - `provider_presets`
+  - the pack copy explicitly frames these as operator-ready scaffolding for the
+    current runtime rather than claiming full voice or rich multimodal transport
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py tests/test_extensions_api.py tests/test_extension_scaffold.py -q`
+
+### 24. hermes-skill-authoring-loop-v1
+
+- status: complete
+- intent:
+  - let operators scaffold a skill-focused extension package directly from the
+    workspace instead of hand-authoring every manifest and file
+  - keep authoring constrained to safe workspace-local paths
+- implementation:
+  - added `POST /api/extensions/scaffold` for workspace-local extension package
+    scaffolding
+  - scaffold requests now:
+    - sanitize package names
+    - create under `WORKSPACE_DIR/extensions/`
+    - validate the new package immediately
+    - log extension lifecycle events for scaffold success and failure
+  - Extension Studio now exposes a `Scaffold skill pack` flow that creates a
+    packaged skill bundle, validates it, and opens it in the existing studio
+    path/install loop
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_extensions_api.py tests/test_extension_scaffold.py -q`
+  - `cd frontend && npm test -- src/components/cockpit/CockpitView.test.tsx`
+
+## Subagent Review
+
+### Review 1
+
+- reviewer: `Hooke`
+- scope:
+  - Wave 3 batch A (`17-19`): catalog-backed skill registry, optional packaged
+    skill packs, and MCP-linked toolset presets
+- findings:
+  - installed extension packs with `update_available=true` were effectively not
+    updatable from the main cockpit/settings surfaces because those views hid
+    installed catalog items entirely
+  - catalog extension packs were being surfaced directly from the registry
+    snapshot without doctor status, so degraded/broken packages could appear
+    installable and only fail later during install
+  - extension-pack install actions still routed through display names instead of
+    stable `catalog_id` values, which would collide if two packs shared a
+    display label
+  - `include_mcp_servers` had no validation, so a typo produced a dead preset
+    with no warning
+- resolution:
+  - cockpit and settings surfaces now keep extension packs visible when they are
+    updateable, and install/update actions are keyed by `catalog_id`
+  - catalog extension entries now carry doctor/load-error status and degraded
+    packs no longer receive install recommendations
+  - capability recommendations now emit extension-pack install/update actions
+    using `catalog_id`
+  - doctor now validates `include_mcp_servers` against packaged/runtime MCP
+    names and reports `missing_mcp_server_reference`
+
+### Review 2
+
+- reviewer: `Galileo`
+- scope:
+  - Wave 3 batch B (`20-21`): Browserbase-style packaged provider plus browser
+    session runtime/tooling
+- findings:
+  - browser sessions were stored in a process-global map with no thread
+    ownership, so one session could enumerate, read, or close another
+    session's captures through the runtime
+  - browser capture failures and site-policy blocks were being stored as
+    successful browser sessions or snapshots because `browser_session`
+    persisted raw `browse_webpage` error strings
+  - packaged Browserbase copy and browser-session guidance overclaimed isolated
+    remote behavior even though the shipped runtime still executes through
+    local fallback
+- resolution:
+  - browser sessions are now owned by the active runtime session, and the
+    browser-session tool scopes list/read/close/snapshot operations to that
+    owner session only
+  - browser capture failures now return immediately and no longer create or
+    append browser-session state
+  - Browserbase/browser-ops packaging now explicitly documents the current
+    local-fallback execution mode, and the public REST browser-session surface
+    was deferred until a later operator-surface wave can provide a stronger
+    ownership model
+
+### Review 3
+
+- reviewer: `Kierkegaard`
+- scope:
+  - Wave 3 branch after the browser/session, connector-redaction, provider
+    preset, and scaffold fixes landed
+- findings:
+  - no new correctness findings
+- note:
+  - `backend/src/api/browser.py` remains intentionally unmounted until a later
+    operator-surface wave introduces a stronger ownership model for any public
+    browser-session API
+
+### Review 4
+
+- reviewer: `Leibniz`
+- scope:
+  - Wave 3 docs and test consistency across the full branch
+- findings:
+  - Wave 3 roadmap items were still unchecked even though the branch had landed
+    slices `17-24`
+  - the Wave 3 implementation doc still described later slices as only
+    "implemented locally"
+  - a stale backend test still expected the old install-time approval behavior
+    for the synthetic Wave 2 capability pack
+  - shipped browser, messaging, and multimodal packs were not yet pinned by
+    end-to-end install-path tests, and `prompt_packs` were still effectively
+    unpinned runtime metadata
+- resolution:
+  - the capability-pack approval expectation now matches the current permission
+    model: secret-bearing capability packs require approval, while the no-secret
+    managed GitHub test pack installs directly
+  - the master roadmap now marks Wave 3 complete and aligns slice `23` with the
+    shipped multimodal scaffolding scope
+  - real bundled browserbase, browser-ops, Discord, Slack, speech, and
+    multimodal packs now have install-path coverage
+  - `prompt_packs` are now first-class runtime metadata surfaced by the
+    registry and extension payloads
+
+### Review 5
+
+- reviewer: `Hooke`
+- scope:
+  - final Wave 3 follow-up after the shipped-pack coverage pass
+- findings:
+  - secret-bearing packs were install-gated, but configure operations that
+    stored new secret values were still bypassing the lifecycle approval gate
+  - the roadmap still drifted from the branch state
+- resolution:
+  - configure operations now require lifecycle approval when the request
+    supplies new password-backed secret values, while redacted no-op
+    reconfigure passes keep working without repeated approval prompts
+  - the roadmap now mirrors the completed Wave 3 state directly
+
+### Review 6
+
+- reviewer: `Hooke`
+- scope:
+  - final re-review after the configure-approval and roadmap-sync fixes landed
+- findings:
+  - no new correctness findings
+
+## Final Validation
+
+- focused backend Wave 3 suite:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py tests/test_extensions_api.py tests/test_extension_scaffold.py tests/test_app.py tests/test_browser_session_tool.py tests/test_tools_api.py tests/test_extension_registry.py -q`
+  - result: `123 passed`
+- focused regressions:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_browserbase_pack_surfaces_browser_provider_metadata tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_browser_ops_pack_surfaces_browser_skills_and_toolset tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_additional_messaging_connector_packs tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_speech_pack_surfaces_speech_profile_metadata tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_multimodal_pack_surfaces_provider_preset_metadata tests/test_extension_registry.py -q`
+  - result: `25 passed`
+- secret-approval follow-up:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_messaging_connector_pack_can_be_configured_and_enabled tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_additional_messaging_connector_packs tests/test_extensions_api.py::test_install_configure_and_toggle_wave2_contribution_surfaces tests/test_extensions_api.py::test_install_and_configure_workspace_managed_connector_extension -q`
+  - result: `5 passed`
+- backend full suite:
+  - `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
+  - result: `1154 passed`, `4 warnings`
+- frontend full suite:
+  - `cd frontend && npm test`
+  - result: `156 passed`
+- frontend build:
+  - `cd frontend && npm run build`
+  - result: passed
+- docs build:
+  - `cd docs && npm run build`
+  - result: passed
+- diff hygiene:
+  - `git diff --check`
+  - result: clean
+
+## Current Validation State
+
+- Wave 3 is complete across slices `17-24`.
+- Batch A, Batch B, and Batch C are all landed on the branch and covered by
+  focused backend validation, full backend/frontend validation, and docs/build
+  checks.
+- The branch is ready for the Wave 3 PR.

--- a/examples/extensions/research-pack/skills/research-pack.md
+++ b/examples/extensions/research-pack/skills/research-pack.md
@@ -1,6 +1,6 @@
 ---
 name: research-pack
-description: Research Pack skill
+description: "Research Pack skill"
 requires:
   tools: []
 user_invocable: true

--- a/examples/extensions/research-pack/workflows/research-pack.md
+++ b/examples/extensions/research-pack/workflows/research-pack.md
@@ -1,6 +1,6 @@
 ---
-name: Research Pack
-description: Research Pack workflow
+name: research-pack
+description: "Research Pack workflow"
 requires:
   tools: [read_file]
 inputs:

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -56,12 +56,16 @@ function SkillRow({
 
 interface CatalogItem {
   name: string;
-  type: "skill" | "mcp_server";
+  catalog_id?: string;
+  type: "skill" | "mcp_server" | "extension_pack";
   description: string;
   category: string;
   requires_tools: string[];
   installed: boolean;
   bundled: boolean;
+  contribution_types?: string[];
+  update_available?: boolean;
+  status?: string;
 }
 
 function CatalogRow({
@@ -70,11 +74,14 @@ function CatalogRow({
   installing,
 }: {
   item: CatalogItem;
-  onInstall: (name: string) => void;
+  onInstall: (item: CatalogItem) => void;
   installing: string | null;
 }) {
   const statusColor = item.installed ? "bg-green-400" : "bg-retro-text/30";
-  const typeBadge = item.type === "skill" ? "skill" : "mcp";
+  const itemKey = item.catalog_id ?? item.name;
+  const typeBadge = item.type === "skill" ? "skill" : item.type === "mcp_server" ? "mcp" : "pack";
+  const actionable = item.type !== "extension_pack" || item.status === undefined || item.status === "ready";
+  const installLabel = item.installed && item.update_available ? "update" : "install";
 
   return (
     <div className="flex items-center gap-1 px-1 py-0.5 border-b border-retro-text/10 last:border-b-0">
@@ -89,17 +96,22 @@ function CatalogRow({
           {item.requires_tools.length > 0 && (
             <span> · needs: {item.requires_tools.join(", ")}</span>
           )}
+          {item.type === "extension_pack" && item.contribution_types?.length ? (
+            <span> · {item.contribution_types.join(", ")}</span>
+          ) : null}
         </div>
       </div>
-      {item.installed ? (
+      {item.installed && !item.update_available ? (
         <span className="text-[9px] text-green-400/60 px-0.5">installed</span>
+      ) : !actionable ? (
+        <span className="text-[9px] text-red-400/60 px-0.5">invalid</span>
       ) : (
         <button
-          onClick={() => onInstall(item.name)}
-          disabled={installing === item.name}
+          onClick={() => onInstall(item)}
+          disabled={installing === itemKey}
           className="text-[9px] text-retro-highlight hover:text-retro-text px-0.5 disabled:text-retro-text/20"
         >
-          {installing === item.name ? "..." : "install"}
+          {installing === itemKey ? "..." : installLabel}
         </button>
       )}
     </div>
@@ -479,10 +491,11 @@ export function SettingsPanel() {
     }
   };
 
-  const handleInstall = async (name: string) => {
-    setInstalling(name);
+  const handleInstall = async (item: CatalogItem) => {
+    const identifier = item.catalog_id ?? item.name;
+    setInstalling(identifier);
     try {
-      const res = await fetch(`${API_URL}/api/catalog/install/${name}`, { method: "POST" });
+      const res = await fetch(`${API_URL}/api/catalog/install/${encodeURIComponent(identifier)}`, { method: "POST" });
       if (res.ok) {
         fetchCatalog();
         fetchSkills();
@@ -643,7 +656,7 @@ export function SettingsPanel() {
               <div className="border border-retro-text/10 rounded mb-1">
                 {catalogItems.map((item) => (
                   <CatalogRow
-                    key={item.name}
+                    key={item.catalog_id ?? `${item.type}:${item.name}`}
                     item={item}
                     onInstall={handleInstall}
                     installing={installing}

--- a/frontend/src/components/cockpit/CockpitView.test.tsx
+++ b/frontend/src/components/cockpit/CockpitView.test.tsx
@@ -3844,6 +3844,200 @@ describe("CockpitView", () => {
     await waitFor(() => expect(within(studio).getAllByText("Test Installable").length).toBeGreaterThan(0));
   }, 15000);
 
+  it("scaffolds a new skill pack from extension studio", async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/sessions")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/goals/tree")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/goals/dashboard")) {
+        return Promise.resolve(mockResponse({ domains: {}, active_count: 0, completed_count: 0, total_count: 0 }));
+      }
+      if (url.includes("/api/observer/state")) return Promise.resolve(mockResponse({}));
+      if (url.includes("/api/audit/events")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/approvals/pending")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/operator/timeline")) return Promise.resolve(mockResponse({ items: [] }));
+      if (url.includes("/api/observer/continuity")) {
+        return Promise.resolve(mockResponse({
+          daemon: { connected: false, pending_notification_count: 0, capture_mode: "balanced" },
+          notifications: [],
+          queued_insights: [],
+          queued_insight_count: 0,
+          recent_interventions: [],
+        }));
+      }
+      if (url.includes("/api/capabilities/overview")) {
+        return Promise.resolve(mockResponse({
+          tool_policy_mode: "balanced",
+          mcp_policy_mode: "approval",
+          approval_mode: "high_risk",
+          summary: {
+            native_tools_ready: 0,
+            native_tools_total: 0,
+            skills_ready: 0,
+            skills_total: 0,
+            workflows_ready: 0,
+            workflows_total: 0,
+            starter_packs_ready: 0,
+            starter_packs_total: 0,
+            mcp_servers_ready: 0,
+            mcp_servers_total: 0,
+          },
+          native_tools: [],
+          skills: [],
+          workflows: [],
+          mcp_servers: [],
+          starter_packs: [],
+          catalog_items: [],
+          recommendations: [],
+          runbooks: [],
+        }));
+      }
+      if (url.includes("/api/workflows/runs")) return Promise.resolve(mockResponse({ runs: [] }));
+      if (url.includes("/api/settings/tool-policy-mode")) return Promise.resolve(mockResponse({ mode: "balanced" }));
+      if (url.includes("/api/settings/mcp-policy-mode")) return Promise.resolve(mockResponse({ mode: "approval" }));
+      if (url.includes("/api/settings/approval-mode")) return Promise.resolve(mockResponse({ mode: "high_risk" }));
+      if (url.includes("/api/extensions/scaffold") && init?.method === "POST") {
+        return Promise.resolve(mockResponse({
+          status: "scaffolded",
+          path: "/tmp/seraph-test/extensions/research-pack",
+          created_files: ["manifest.yaml", "skills/research-pack.md"],
+          preview: {
+            path: "/tmp/seraph-test/extensions/research-pack",
+            extension_id: "seraph.research-pack",
+            display_name: "Research Pack",
+            ok: true,
+            results: [],
+          },
+        }, true, 201));
+      }
+      if (url.includes("/api/extensions") && !url.includes("/source")) {
+        return Promise.resolve(mockResponse({ extensions: [] }));
+      }
+      return Promise.resolve(mockResponse({}));
+    });
+
+    render(<CockpitView onSend={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Extension studio" })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Extension studio" }));
+
+    const studio = await screen.findByLabelText("Extension studio");
+    fireEvent.change(within(studio).getByLabelText("New extension package name"), {
+      target: { value: "research-pack" },
+    });
+    fireEvent.change(within(studio).getByLabelText("New extension display name"), {
+      target: { value: "Research Pack" },
+    });
+    fireEvent.click(within(studio).getByRole("button", { name: "Scaffold skill pack" }));
+
+    await waitFor(() => {
+      const scaffoldCall = fetchMock.mock.calls.find(
+        ([input, callInit]) => String(input).includes("/api/extensions/scaffold") && (callInit as RequestInit | undefined)?.method === "POST",
+      );
+      expect(scaffoldCall).toBeDefined();
+      const body = JSON.parse(String((scaffoldCall?.[1] as RequestInit | undefined)?.body ?? "{}")) as { package_name?: string; display_name?: string; contributions?: string[] };
+      expect(body.package_name).toBe("research-pack");
+      expect(body.display_name).toBe("Research Pack");
+      expect(body.contributions).toEqual(["skills"]);
+    });
+
+    await waitFor(() => {
+      expect(within(studio).getByLabelText("Extension package path")).toHaveValue("/tmp/seraph-test/extensions/research-pack");
+      expect(within(studio).getByText("Research Pack scaffolded with 2 files")).toBeInTheDocument();
+    });
+  }, 15000);
+
+  it("surfaces scaffolded-invalid responses as warnings in extension studio", async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/sessions")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/goals/tree")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/goals/dashboard")) {
+        return Promise.resolve(mockResponse({ domains: {}, active_count: 0, completed_count: 0, total_count: 0 }));
+      }
+      if (url.includes("/api/observer/state")) return Promise.resolve(mockResponse({}));
+      if (url.includes("/api/audit/events")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/approvals/pending")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/operator/timeline")) return Promise.resolve(mockResponse({ items: [] }));
+      if (url.includes("/api/observer/continuity")) {
+        return Promise.resolve(mockResponse({
+          daemon: { connected: false, pending_notification_count: 0, capture_mode: "balanced" },
+          notifications: [],
+          queued_insights: [],
+          queued_insight_count: 0,
+          recent_interventions: [],
+        }));
+      }
+      if (url.includes("/api/capabilities/overview")) {
+        return Promise.resolve(mockResponse({
+          tool_policy_mode: "balanced",
+          mcp_policy_mode: "approval",
+          approval_mode: "high_risk",
+          summary: {
+            native_tools_ready: 0,
+            native_tools_total: 0,
+            skills_ready: 0,
+            skills_total: 0,
+            workflows_ready: 0,
+            workflows_total: 0,
+            starter_packs_ready: 0,
+            starter_packs_total: 0,
+            mcp_servers_ready: 0,
+            mcp_servers_total: 0,
+          },
+          native_tools: [],
+          skills: [],
+          workflows: [],
+          mcp_servers: [],
+          starter_packs: [],
+          catalog_items: [],
+          recommendations: [],
+          runbooks: [],
+        }));
+      }
+      if (url.includes("/api/workflows/runs")) return Promise.resolve(mockResponse({ runs: [] }));
+      if (url.includes("/api/settings/tool-policy-mode")) return Promise.resolve(mockResponse({ mode: "balanced" }));
+      if (url.includes("/api/settings/mcp-policy-mode")) return Promise.resolve(mockResponse({ mode: "approval" }));
+      if (url.includes("/api/settings/approval-mode")) return Promise.resolve(mockResponse({ mode: "high_risk" }));
+      if (url.includes("/api/extensions/scaffold") && init?.method === "POST") {
+        return Promise.resolve(mockResponse({
+          status: "scaffolded_invalid",
+          path: "/tmp/seraph-test/extensions/research-pack",
+          created_files: ["manifest.yaml", "skills/research-pack.md"],
+          preview: {
+            path: "/tmp/seraph-test/extensions/research-pack",
+            extension_id: "seraph.research-pack",
+            display_name: "Research Pack",
+            ok: false,
+            results: [{ issues: [{ code: "invalid_frontmatter" }] }],
+          },
+        }, true, 201));
+      }
+      if (url.includes("/api/extensions") && !url.includes("/source")) {
+        return Promise.resolve(mockResponse({ extensions: [] }));
+      }
+      return Promise.resolve(mockResponse({}));
+    });
+
+    render(<CockpitView onSend={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Extension studio" })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Extension studio" }));
+
+    const studio = await screen.findByLabelText("Extension studio");
+    fireEvent.change(within(studio).getByLabelText("New extension package name"), {
+      target: { value: "research-pack" },
+    });
+    fireEvent.change(within(studio).getByLabelText("New extension display name"), {
+      target: { value: "Research Pack" },
+    });
+    fireEvent.click(within(studio).getByRole("button", { name: "Scaffold skill pack" }));
+
+    await waitFor(() => {
+      expect(within(studio).getByText("Research Pack scaffolded but needs fixes (1 issue)")).toBeInTheDocument();
+    });
+  }, 15000);
+
   it("surfaces approval-required install responses in extension studio", async () => {
     let approvalQueued = false;
     fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {

--- a/frontend/src/components/cockpit/CockpitView.tsx
+++ b/frontend/src/components/cockpit/CockpitView.tsx
@@ -411,6 +411,13 @@ interface ExtensionPathPreview {
   lifecycle_plan?: ExtensionLifecyclePlan | null;
 }
 
+interface ExtensionScaffoldResponse {
+  status: string;
+  path: string;
+  created_files: string[];
+  preview: ExtensionPathPreview;
+}
+
 interface ExtensionLifecycleApprovalDetail {
   type: "approval_required";
   approval_id: string;
@@ -423,12 +430,22 @@ type LoggedOperatorError = Error & { operatorLogged?: boolean };
 
 interface CatalogItemInfo {
   name: string;
-  type: "skill" | "mcp_server";
+  catalog_id?: string;
+  type: "skill" | "mcp_server" | "extension_pack";
   description: string;
   category?: string;
   bundled?: boolean;
   installed: boolean;
   missing_tools?: string[];
+  contribution_types?: string[];
+  trust?: string;
+  version?: string | null;
+  installed_version?: string | null;
+  update_available?: boolean;
+  status?: string;
+  doctor_ok?: boolean;
+  issues?: unknown[];
+  load_errors?: unknown[];
   recommended_actions?: CapabilityAction[];
 }
 
@@ -1827,6 +1844,8 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
   const [studioMcpUrl, setStudioMcpUrl] = useState("");
   const [studioMcpDescription, setStudioMcpDescription] = useState("");
   const [studioExtensionPath, setStudioExtensionPath] = useState("");
+  const [studioScaffoldName, setStudioScaffoldName] = useState("");
+  const [studioScaffoldDisplayName, setStudioScaffoldDisplayName] = useState("");
   const [studioExtensionConfigDraft, setStudioExtensionConfigDraft] = useState("{}");
   const [studioExtensionConfigDirty, setStudioExtensionConfigDirty] = useState(false);
   const [pendingLifecycleApprovalId, setPendingLifecycleApprovalId] = useState<string | null>(null);
@@ -2807,13 +2826,22 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
       });
     });
     catalogItems.forEach((item) => {
-      if (item.installed) return;
+      if (item.installed && !item.update_available) return;
+      if (item.type === "extension_pack" && item.status && item.status !== "ready") return;
+      const itemKind = item.type === "extension_pack"
+        ? (item.installed && item.update_available ? "update pack" : "install pack")
+        : `install ${item.type}`;
+      const detailParts = [item.description];
+      if (item.missing_tools?.length) detailParts.push(`missing tools ${item.missing_tools.join(", ")}`);
+      if (item.type === "extension_pack" && item.contribution_types?.length) {
+        detailParts.push(item.contribution_types.join(", "));
+      }
       items.push({
         id: `catalog:${item.type}:${item.name}`,
-        kind: `install ${item.type}`,
+        kind: itemKind,
         label: item.name,
-        detail: `${item.description}${item.missing_tools?.length ? ` · missing tools ${item.missing_tools.join(", ")}` : ""}`,
-        action: item.recommended_actions?.[0] ?? { type: "install_catalog_item", label: "Install", name: item.name },
+        detail: detailParts.filter(Boolean).join(" · "),
+        action: item.recommended_actions?.[0] ?? { type: "install_catalog_item", label: item.installed && item.update_available ? "Update" : "Install", name: item.catalog_id ?? item.name },
       });
     });
 
@@ -3277,6 +3305,65 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
     } catch {
       setStudioPackagePreview(null);
       setStudioPackageStatus(`Failed to validate ${path}`);
+    } finally {
+      setStudioBusy(null);
+    }
+  }
+
+  async function scaffoldStudioSkillPack() {
+    const packageName = studioScaffoldName.trim();
+    const displayName = studioScaffoldDisplayName.trim() || packageName;
+    if (!packageName) {
+      setStudioPackageStatus("Enter a package slug before scaffolding");
+      return;
+    }
+    setStudioBusy("extension-scaffold");
+    setStudioPackagePreview(null);
+    setStudioPackageStatus(`Scaffolding ${displayName}...`);
+    try {
+      const response = await fetch(`${API_URL}/api/extensions/scaffold`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          package_name: packageName,
+          display_name: displayName,
+          kind: "capability-pack",
+          contributions: ["skills"],
+        }),
+      });
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        setStudioPackageStatus(
+          typeof payload?.detail === "string"
+            ? payload.detail
+            : `Failed to scaffold ${displayName}`,
+        );
+        return;
+      }
+      const scaffold = payload as ExtensionScaffoldResponse;
+      setStudioExtensionPath(scaffold.path);
+      setStudioPackagePreview(scaffold.preview);
+      const scaffoldLabel = scaffold.preview.display_name ?? displayName;
+      const invalidScaffold = scaffold.status !== "scaffolded" || scaffold.preview.ok === false;
+      if (invalidScaffold) {
+        const issueCount = Array.isArray(scaffold.preview.results)
+          ? scaffold.preview.results.reduce((count, result) => count + (Array.isArray(result.issues) ? result.issues.length : 0), 0)
+          : 0;
+        setStudioPackageStatus(
+          `${scaffoldLabel} scaffolded but needs fixes${issueCount > 0 ? ` (${issueCount} issue${issueCount === 1 ? "" : "s"})` : ""}`,
+        );
+        appendOperatorFeed(
+          `Scaffolded extension package needs fixes: ${scaffoldLabel}`,
+          "info",
+        );
+        return;
+      }
+      setStudioPackageStatus(
+        `${scaffoldLabel} scaffolded with ${scaffold.created_files.length} file${scaffold.created_files.length === 1 ? "" : "s"}`,
+      );
+      appendOperatorFeed(`Scaffolded extension package: ${scaffoldLabel}`, "success");
+    } catch {
+      setStudioPackageStatus(`Failed to scaffold ${displayName}`);
     } finally {
       setStudioBusy(null);
     }
@@ -3804,7 +3891,8 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
       executionBoundaries: [],
     });
     try {
-      const response = await fetch(`${API_URL}/api/catalog/install/${item.name}`, {
+      const identifier = item.catalog_id ?? item.name;
+      const response = await fetch(`${API_URL}/api/catalog/install/${encodeURIComponent(identifier)}`, {
         method: "POST",
       });
       const payload = await response.json().catch(() => null);
@@ -3919,7 +4007,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
         }
         return true;
       case "install_catalog_item": {
-        const item = catalogItems.find((entry) => entry.name === action.name);
+        const item = catalogItems.find((entry) => entry.name === action.name || entry.catalog_id === action.name);
         if (item) await installCatalogItem(item);
         return true;
       }
@@ -6121,11 +6209,19 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                     <div className="cockpit-operator-row">
                       <span className="cockpit-key">installable now</span>
                       <span className="cockpit-operator-link">
-                        {catalogItems.filter((item) => !item.installed).length} missing
+                        {
+                          catalogItems.filter((item) =>
+                            (!item.installed || item.update_available)
+                            && (item.type !== "extension_pack" || !item.status || item.status === "ready"),
+                          ).length
+                        } missing
                       </span>
                     </div>
-                    {catalogItems.filter((item) => !item.installed).map((item) => (
-                      <div key={`${item.type}:${item.name}`} className="cockpit-operator-row cockpit-operator-row--entry">
+                    {catalogItems.filter((item) =>
+                      (!item.installed || item.update_available)
+                      && (item.type !== "extension_pack" || !item.status || item.status === "ready"),
+                    ).map((item) => (
+                      <div key={item.catalog_id ?? `${item.type}:${item.name}`} className="cockpit-operator-row cockpit-operator-row--entry">
                         <button
                           type="button"
                           className="cockpit-operator-details cockpit-operator-details--button"
@@ -6133,14 +6229,29 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                             setSelectedInspector({
                               kind: "operator",
                               entity: {
-                                entityType: item.type === "skill" ? "skill" : "mcp",
+                                entityType:
+                                  item.type === "skill"
+                                    ? "skill"
+                                    : item.type === "mcp_server"
+                                      ? "mcp"
+                                      : "extension_manifest",
                                 name: item.name,
-                                meta: `install ${item.type.replace("_", " ")}`,
+                                meta: `${item.installed && item.update_available ? "update" : "install"} ${item.type.replace("_", " ")}`,
                                 summary: item.description,
                                 details: {
+                                  catalog_id: item.catalog_id ?? item.name,
                                   category: item.category ?? "",
                                   bundled: item.bundled ?? false,
                                   missing_tools: item.missing_tools ?? [],
+                                  contribution_types: item.contribution_types ?? [],
+                                  trust: item.trust ?? "",
+                                  version: item.version ?? "",
+                                  installed_version: item.installed_version ?? "",
+                                  update_available: item.update_available ?? false,
+                                  status: item.status ?? "ready",
+                                  doctor_ok: item.doctor_ok ?? true,
+                                  issues: item.issues ?? [],
+                                  load_errors: item.load_errors ?? [],
                                 },
                               },
                             })
@@ -6155,7 +6266,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                             className="cockpit-operator-button"
                             onClick={() => void installCatalogItem(item)}
                           >
-                            install
+                            {item.installed && item.update_available ? "update" : "install"}
                           </button>
                           {item.recommended_actions?.length ? (
                             <button
@@ -6496,6 +6607,41 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                 <div className="cockpit-operator-row">
                   <span className="cockpit-key">extensions</span>
                   <span className="cockpit-operator-link">{studioEntries.length} loaded</span>
+                </div>
+                <div className="cockpit-studio-sidebar-group">
+                  <div className="cockpit-operator-row">
+                    <span className="cockpit-key">new skill pack</span>
+                    <span className="cockpit-row-age">workspace scaffold</span>
+                  </div>
+                  <input
+                    className="cockpit-input"
+                    aria-label="New extension package name"
+                    value={studioScaffoldName}
+                    onChange={(event) => setStudioScaffoldName(event.target.value)}
+                    placeholder="research-pack"
+                  />
+                  <input
+                    className="cockpit-input"
+                    aria-label="New extension display name"
+                    value={studioScaffoldDisplayName}
+                    onChange={(event) => setStudioScaffoldDisplayName(event.target.value)}
+                    placeholder="Research Pack"
+                  />
+                  <div className="cockpit-feedback-row">
+                    <button
+                      className="cockpit-feedback-button"
+                      onClick={() => void scaffoldStudioSkillPack()}
+                      disabled={
+                        !studioScaffoldName.trim()
+                        || studioBusy === "extension-scaffold"
+                        || studioBusy === "extension-install"
+                        || studioBusy === "extension-validate"
+                        || studioBusy === "extension-update"
+                      }
+                    >
+                      Scaffold skill pack
+                    </button>
+                  </div>
                 </div>
                 <div className="cockpit-studio-sidebar-group">
                   <div className="cockpit-operator-row">


### PR DESCRIPTION
## Done on develop
- [x] Wave 1 Hermes runtime parity primitives are landed on `develop`
- [x] Wave 2 extension contribution types are landed on `develop`

## Working in this PR
- [x] add Wave 3 packaged reach imports: skill registry, optional skill packs, MCP toolset bridging, browser provider/session packs, messaging connectors, multimodal scaffolding, and the workspace scaffold flow
- [x] extend extension lifecycle, permissions, doctor, and cockpit/settings surfaces so the new packaged capability types behave like first-class runtime inventory
- [x] document Wave 3 completion, validation, and per-slice subagent reviews in the roadmap and Wave 3 implementation log

## Still to do after this PR
- [ ] Wave 4 selective OpenClaw imports
- [ ] Wave 5 operator-surface hardening, attribution, and cleanup

## Validation
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py tests/test_extensions_api.py tests/test_extension_scaffold.py tests/test_app.py tests/test_browser_session_tool.py tests/test_tools_api.py tests/test_extension_registry.py -q`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_browserbase_pack_surfaces_browser_provider_metadata tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_browser_ops_pack_surfaces_browser_skills_and_toolset tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_additional_messaging_connector_packs tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_speech_pack_surfaces_speech_profile_metadata tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_multimodal_pack_surfaces_provider_preset_metadata tests/test_extension_registry.py -q`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_messaging_connector_pack_can_be_configured_and_enabled tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_additional_messaging_connector_packs tests/test_extensions_api.py::test_install_configure_and_toggle_wave2_contribution_surfaces tests/test_extensions_api.py::test_install_and_configure_workspace_managed_connector_extension -q`
- `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
- `cd frontend && npm test`
- `cd frontend && npm run build`
- `cd docs && npm run build`
- `git diff --check`
