### PR TITLE
Complete capability import wave 4

### DIFF
--- a/backend/src/api/automation.py
+++ b/backend/src/api/automation.py
@@ -1,0 +1,127 @@
+"""Automation trigger inventory and webhook ingress."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Header, HTTPException, Request
+
+from config.settings import settings
+from src.audit.runtime import log_integration_event
+from src.extensions.automation import list_automation_trigger_inventory, select_automation_trigger
+from src.extensions.registry import ExtensionRegistry, default_manifest_roots_for_workspace
+from src.extensions.state import connector_enabled_overrides, load_extension_state_payload
+
+router = APIRouter()
+
+
+def _automation_snapshot() -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    state_payload = load_extension_state_payload()
+    state_by_id = state_payload.get("extensions")
+    snapshot = ExtensionRegistry(
+        manifest_roots=default_manifest_roots_for_workspace(settings.workspace_dir),
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    ).snapshot()
+    inventory = list_automation_trigger_inventory(
+        snapshot.list_contributions("automation_triggers"),
+        state_by_id=state_by_id if isinstance(state_by_id, dict) else None,
+        enabled_overrides=connector_enabled_overrides(state_by_id if isinstance(state_by_id, dict) else None),
+    )
+    return state_payload, [
+        {
+            "extension_id": item.extension_id,
+            "name": item.name,
+            "trigger_type": item.trigger_type,
+            "description": item.description,
+            "enabled": item.enabled,
+            "configured": item.configured,
+            "config_keys": list(item.config_keys),
+            "schedule": item.schedule,
+            "endpoint": item.endpoint,
+            "topic": item.topic,
+            "capabilities": list(item.capabilities),
+            "requires_network": item.requires_network,
+            "runtime_state": item.runtime_state,
+            "reference": item.reference,
+        }
+        for item in inventory
+    ]
+
+
+@router.get("/automation/triggers")
+async def list_automation_triggers():
+    _state_payload, inventory = _automation_snapshot()
+    return {"triggers": inventory}
+
+
+@router.post("/automation/webhooks/{trigger_name}")
+async def receive_automation_webhook(
+    trigger_name: str,
+    request: Request,
+    x_seraph_signature: str | None = Header(default=None),
+):
+    state_payload = load_extension_state_payload()
+    state_by_id = state_payload.get("extensions")
+    snapshot = ExtensionRegistry(
+        manifest_roots=default_manifest_roots_for_workspace(settings.workspace_dir),
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    ).snapshot()
+    trigger = select_automation_trigger(
+        snapshot.list_contributions("automation_triggers"),
+        trigger_name=trigger_name,
+        state_by_id=state_by_id if isinstance(state_by_id, dict) else None,
+        enabled_overrides=connector_enabled_overrides(state_by_id if isinstance(state_by_id, dict) else None),
+    )
+    if trigger is None or not trigger.enabled or not trigger.configured or trigger.trigger_type != "webhook":
+        raise HTTPException(status_code=404, detail=f"Webhook trigger '{trigger_name}' is not armed")
+
+    config_secret: str | None = None
+    if isinstance(state_by_id, dict):
+        extension_entry = state_by_id.get(trigger.extension_id)
+        if isinstance(extension_entry, dict):
+            config = extension_entry.get("config")
+            if isinstance(config, dict):
+                trigger_config = config.get("automation_triggers")
+                if isinstance(trigger_config, dict):
+                    named_config = trigger_config.get(trigger.name)
+                    if isinstance(named_config, dict):
+                        candidate_secret = named_config.get("signing_secret")
+                        if isinstance(candidate_secret, str) and candidate_secret.strip():
+                            config_secret = candidate_secret
+    if config_secret is not None and x_seraph_signature != config_secret:
+        raise HTTPException(status_code=403, detail="Webhook signature rejected")
+
+    try:
+        payload = await request.json()
+    except Exception:
+        payload = {"raw_body": (await request.body()).decode("utf-8", errors="replace")}
+
+    await log_integration_event(
+        integration_type="automation_trigger",
+        name=trigger.name,
+        outcome="accepted",
+        details={
+            "trigger_type": trigger.trigger_type,
+            "extension_id": trigger.extension_id,
+            "capabilities": list(trigger.capabilities),
+            "payload_keys": (
+                sorted(str(key) for key in payload.keys())
+                if isinstance(payload, dict)
+                else None
+            ),
+        },
+    )
+    return {
+        "status": "accepted",
+        "trigger": {
+            "name": trigger.name,
+            "trigger_type": trigger.trigger_type,
+            "extension_id": trigger.extension_id,
+            "runtime_state": trigger.runtime_state,
+        },
+        "payload": payload,
+    }

--- a/backend/src/api/browser.py
+++ b/backend/src/api/browser.py
@@ -1,30 +1,50 @@
-"""Structured browser session API."""
+"""Browser provider inventory API."""
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter
 
-from src.browser.sessions import browser_session_runtime
+from config.settings import settings
+from src.extensions.browser_providers import list_browser_provider_inventory
+from src.extensions.registry import ExtensionRegistry, default_manifest_roots_for_workspace
+from src.extensions.state import connector_enabled_overrides, load_extension_state_payload
 
 router = APIRouter()
 
 
-@router.get("/browser/sessions")
-async def list_browser_sessions(session_id: str = Query(...)):
-    return {"sessions": browser_session_runtime.list_sessions(owner_session_id=session_id)}
-
-
-@router.get("/browser/sessions/{browser_session_id}")
-async def get_browser_session(browser_session_id: str, session_id: str = Query(...)):
-    session = browser_session_runtime.get_session(browser_session_id, owner_session_id=session_id)
-    if session is None:
-        raise HTTPException(status_code=404, detail=f"Browser session '{browser_session_id}' not found")
-    return {"session": session}
-
-
-@router.delete("/browser/sessions/{browser_session_id}")
-async def close_browser_session(browser_session_id: str, session_id: str = Query(...)):
-    session = browser_session_runtime.close_session(browser_session_id, owner_session_id=session_id)
-    if session is None:
-        raise HTTPException(status_code=404, detail=f"Browser session '{browser_session_id}' not found")
-    return {"status": "closed", "session": session}
+@router.get("/browser/providers")
+async def list_browser_providers():
+    state_payload = load_extension_state_payload()
+    state_by_id = state_payload.get("extensions")
+    snapshot = ExtensionRegistry(
+        manifest_roots=default_manifest_roots_for_workspace(settings.workspace_dir),
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    ).snapshot()
+    inventory = list_browser_provider_inventory(
+        snapshot.list_contributions("browser_providers"),
+        state_by_id=state_by_id if isinstance(state_by_id, dict) else None,
+        enabled_overrides=connector_enabled_overrides(state_by_id if isinstance(state_by_id, dict) else None),
+    )
+    return {
+        "providers": [
+            {
+                "extension_id": item.extension_id,
+                "name": item.name,
+                "provider_kind": item.provider_kind,
+                "description": item.description,
+                "enabled": item.enabled,
+                "configured": item.configured,
+                "selected": item.selected,
+                "execution_mode": item.execution_mode,
+                "runtime_state": item.runtime_state,
+                "config_keys": list(item.config_keys),
+                "requires_network": item.requires_network,
+                "requires_daemon": item.requires_daemon,
+                "capabilities": list(item.capabilities),
+                "reference": item.reference,
+            }
+            for item in inventory
+        ]
+    }

--- a/backend/src/api/canvas.py
+++ b/backend/src/api/canvas.py
@@ -1,0 +1,38 @@
+"""Structured canvas output inventory for operator-visible result surfaces."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from config.settings import settings
+from src.extensions.canvas_outputs import list_canvas_output_inventory
+from src.extensions.registry import ExtensionRegistry, default_manifest_roots_for_workspace
+
+router = APIRouter()
+
+
+@router.get("/canvas/outputs")
+async def list_canvas_outputs():
+    snapshot = ExtensionRegistry(
+        manifest_roots=default_manifest_roots_for_workspace(settings.workspace_dir),
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    ).snapshot()
+    inventory = list_canvas_output_inventory(snapshot.list_contributions("canvas_outputs"))
+    return {
+        "outputs": [
+            {
+                "extension_id": item.extension_id,
+                "name": item.name,
+                "title": item.title,
+                "description": item.description,
+                "surface_kind": item.surface_kind,
+                "sections": list(item.sections),
+                "artifact_types": list(item.artifact_types),
+                "preferred_panel": item.preferred_panel,
+                "reference": item.reference,
+            }
+            for item in inventory
+        ]
+    }

--- a/backend/src/api/extensions.py
+++ b/backend/src/api/extensions.py
@@ -13,6 +13,12 @@ from smolagents import MCPClient
 from config.settings import settings
 from src.approval.repository import approval_repository, fingerprint_tool_call
 from src.audit.runtime import log_integration_event
+from src.extensions.channel_routing import (
+    SUPPORTED_CHANNEL_ROUTE_TRANSPORTS,
+    list_channel_route_bindings,
+    set_channel_route_binding,
+)
+from src.extensions.channels import select_active_channel_adapters
 from src.extensions.lifecycle import (
     configure_extension,
     disable_extension,
@@ -29,10 +35,31 @@ from src.extensions.lifecycle import (
     update_extension_path,
     validate_extension_path,
 )
+from src.extensions.registry import ExtensionRegistry, default_manifest_roots_for_workspace
 from src.extensions.scaffold import scaffold_extension_package
+from src.extensions.state import (
+    connector_enabled_overrides,
+    load_extension_state_payload,
+    save_extension_state_payload,
+)
 from src.tools.mcp_manager import mcp_manager
 
 router = APIRouter()
+
+_BUILTIN_CHANNEL_ADAPTERS = (
+    {
+        "extension_id": "seraph.builtin-channel-adapters",
+        "name": "websocket",
+        "transport": "websocket",
+        "reference": "builtin:websocket",
+    },
+    {
+        "extension_id": "seraph.builtin-channel-adapters",
+        "name": "native-notification",
+        "transport": "native_notification",
+        "reference": "builtin:native_notification",
+    },
+)
 _REDACTED_CONFIG_SENTINEL = "__SERAPH_STORED_SECRET__"
 
 
@@ -64,6 +91,59 @@ class ExtensionConnectorTestRequest(BaseModel):
 class ExtensionConnectorToggleRequest(BaseModel):
     reference: str
     enabled: bool
+
+
+class ChannelRoutingBindingUpdateRequest(BaseModel):
+    primary_transport: str
+    fallback_transport: str | None = None
+
+
+class ChannelRoutingUpdateRequest(BaseModel):
+    bindings: dict[str, ChannelRoutingBindingUpdateRequest] = Field(default_factory=dict)
+
+
+def _active_channel_adapter_payloads(state_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    state_by_id = state_payload.get("extensions")
+    snapshot = ExtensionRegistry(
+        manifest_roots=default_manifest_roots_for_workspace(settings.workspace_dir),
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    ).snapshot()
+    contributions = snapshot.list_contributions("channel_adapters")
+    adapters = select_active_channel_adapters(
+        contributions,
+        enabled_overrides=connector_enabled_overrides(state_by_id if isinstance(state_by_id, dict) else None),
+    )
+    payloads = [
+        {
+            "extension_id": item.extension_id,
+            "name": item.name,
+            "transport": item.transport,
+            "reference": item.reference,
+        }
+        for item in adapters
+    ]
+    active_transports = {
+        str(item.get("transport"))
+        for item in payloads
+        if isinstance(item.get("transport"), str) and str(item.get("transport")).strip()
+    }
+    for builtin in _BUILTIN_CHANNEL_ADAPTERS:
+        if builtin["transport"] in active_transports:
+            continue
+        payloads.append(dict(builtin))
+    return payloads
+
+
+def _channel_routing_response(state_payload: dict[str, Any]) -> dict[str, Any]:
+    adapters = _active_channel_adapter_payloads(state_payload)
+    return {
+        "bindings": [item.as_payload() for item in list_channel_route_bindings(state_payload)],
+        "supported_transports": list(SUPPORTED_CHANNEL_ROUTE_TRANSPORTS),
+        "active_transports": sorted({item["transport"] for item in adapters}),
+        "active_adapters": adapters,
+    }
 
 
 def _extension_issue_count(preview: dict[str, Any] | None) -> int:
@@ -429,6 +509,35 @@ async def scaffold_extension_package_in_workspace(req: ExtensionScaffoldRequest)
 @router.get("/extensions")
 async def list_extension_packages():
     return list_extensions()
+
+
+@router.get("/extensions/channel-routing")
+async def get_channel_routing():
+    state_payload = load_extension_state_payload()
+    return _channel_routing_response(state_payload)
+
+
+@router.put("/extensions/channel-routing")
+async def update_channel_routing(req: ChannelRoutingUpdateRequest):
+    state_payload = load_extension_state_payload()
+    try:
+        for route, binding in req.bindings.items():
+            set_channel_route_binding(
+                state_payload,
+                route=route,
+                primary_transport=binding.primary_transport,
+                fallback_transport=binding.fallback_transport,
+            )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    save_extension_state_payload(state_payload)
+    await log_integration_event(
+        integration_type="channel_routing",
+        name="observer_delivery",
+        outcome="updated",
+        details={"routes": sorted(req.bindings.keys())},
+    )
+    return _channel_routing_response(state_payload)
 
 
 @router.get("/extensions/{extension_id}")

--- a/backend/src/api/nodes.py
+++ b/backend/src/api/nodes.py
@@ -1,0 +1,48 @@
+"""Node and device adapter inventory API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from config.settings import settings
+from src.extensions.node_adapters import list_node_adapter_inventory
+from src.extensions.registry import ExtensionRegistry, default_manifest_roots_for_workspace
+from src.extensions.state import connector_enabled_overrides, load_extension_state_payload
+
+router = APIRouter()
+
+
+@router.get("/nodes/adapters")
+async def list_node_adapters():
+    state_payload = load_extension_state_payload()
+    state_by_id = state_payload.get("extensions")
+    snapshot = ExtensionRegistry(
+        manifest_roots=default_manifest_roots_for_workspace(settings.workspace_dir),
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    ).snapshot()
+    inventory = list_node_adapter_inventory(
+        snapshot.list_contributions("node_adapters"),
+        state_by_id=state_by_id if isinstance(state_by_id, dict) else None,
+        enabled_overrides=connector_enabled_overrides(state_by_id if isinstance(state_by_id, dict) else None),
+    )
+    return {
+        "adapters": [
+            {
+                "extension_id": item.extension_id,
+                "name": item.name,
+                "adapter_kind": item.adapter_kind,
+                "description": item.description,
+                "enabled": item.enabled,
+                "configured": item.configured,
+                "config_keys": list(item.config_keys),
+                "capabilities": list(item.capabilities),
+                "requires_network": item.requires_network,
+                "requires_daemon": item.requires_daemon,
+                "runtime_state": item.runtime_state,
+                "reference": item.reference,
+            }
+            for item in inventory
+        ]
+    }

--- a/backend/src/api/router.py
+++ b/backend/src/api/router.py
@@ -3,12 +3,16 @@ from fastapi import APIRouter
 from src.api.activity import router as activity_router
 from src.api.audit import router as audit_router
 from src.api.approvals import router as approvals_router
+from src.api.automation import router as automation_router
+from src.api.browser import router as browser_router
+from src.api.canvas import router as canvas_router
 from src.api.catalog import router as catalog_router
 from src.api.capabilities import router as capabilities_router
 from src.api.chat import router as chat_router
 from src.api.extensions import router as extensions_router
 from src.api.goals import router as goals_router
 from src.api.mcp import router as mcp_router
+from src.api.nodes import router as nodes_router
 from src.api.operator import router as operator_router
 from src.api.profile import router as profile_router
 from src.api.sessions import router as sessions_router
@@ -25,6 +29,9 @@ api_router = APIRouter()
 api_router.include_router(activity_router, prefix="/api", tags=["activity"])
 api_router.include_router(audit_router, prefix="/api", tags=["audit"])
 api_router.include_router(approvals_router, prefix="/api", tags=["approvals"])
+api_router.include_router(automation_router, prefix="/api", tags=["automation"])
+api_router.include_router(browser_router, prefix="/api", tags=["browser"])
+api_router.include_router(canvas_router, prefix="/api", tags=["canvas"])
 api_router.include_router(catalog_router, prefix="/api", tags=["catalog"])
 api_router.include_router(capabilities_router, prefix="/api", tags=["capabilities"])
 api_router.include_router(chat_router, prefix="/api", tags=["chat"])
@@ -34,6 +41,7 @@ api_router.include_router(goals_router, prefix="/api", tags=["goals"])
 api_router.include_router(profile_router, prefix="/api", tags=["profile"])
 api_router.include_router(tools_router, prefix="/api", tags=["tools"])
 api_router.include_router(mcp_router, prefix="/api", tags=["mcp"])
+api_router.include_router(nodes_router, prefix="/api", tags=["nodes"])
 api_router.include_router(operator_router, prefix="/api", tags=["operator"])
 api_router.include_router(skills_router, prefix="/api", tags=["skills"])
 api_router.include_router(workflows_router, prefix="/api", tags=["workflows"])

--- a/backend/src/api/workflows.py
+++ b/backend/src/api/workflows.py
@@ -21,7 +21,9 @@ from src.audit.repository import audit_repository
 from src.audit.runtime import log_integration_event
 from src.db.engine import get_session
 from src.db.models import AuditEvent
+from src.extensions.registry import ExtensionRegistry
 from src.extensions.registry import default_manifest_roots_for_workspace
+from src.extensions.workflow_runtimes import list_workflow_runtime_inventory
 from src.extensions.workspace_package import save_workspace_contribution
 from src.tools.policy import get_current_tool_policy_mode
 from src.workflows.loader import parse_workflow_content
@@ -78,6 +80,54 @@ def _ensure_workflow_manager_workspace_extensions_loaded() -> None:
         workflow_manager.init(workflows_dir, manifest_roots=manifest_roots)
 
 
+def _workflow_extension_snapshot():
+    return ExtensionRegistry(
+        manifest_roots=default_manifest_roots_for_workspace(settings.workspace_dir),
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    ).snapshot()
+
+
+def _workflow_surface_maps(snapshot) -> tuple[dict[str, str], dict[str, dict[str, Any]]]:
+    runtime_defaults_by_name: dict[str, str] = {}
+    canvas_metadata_by_name: dict[str, dict[str, Any]] = {}
+    for contribution in snapshot.list_contributions("workflow_runtimes"):
+        if isinstance(contribution.metadata.get("registry_conflict"), dict):
+            continue
+        name = contribution.metadata.get("name")
+        default_output_surface = contribution.metadata.get("default_output_surface")
+        if (
+            isinstance(name, str)
+            and name.strip()
+            and isinstance(default_output_surface, str)
+            and default_output_surface.strip()
+        ):
+            runtime_defaults_by_name[name.strip()] = default_output_surface.strip()
+    for contribution in snapshot.list_contributions("canvas_outputs"):
+        if isinstance(contribution.metadata.get("registry_conflict"), dict):
+            continue
+        name = contribution.metadata.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        raw_sections = contribution.metadata.get("sections")
+        raw_artifact_types = contribution.metadata.get("artifact_types")
+        canvas_metadata_by_name[name.strip()] = {
+            "title": str(contribution.metadata.get("title") or ""),
+            "sections": [
+                str(item).strip()
+                for item in raw_sections
+                if isinstance(item, str) and item.strip()
+            ] if isinstance(raw_sections, list) else [],
+            "artifact_types": [
+                str(item).strip()
+                for item in raw_artifact_types
+                if isinstance(item, str) and item.strip()
+            ] if isinstance(raw_artifact_types, list) else [],
+        }
+    return runtime_defaults_by_name, canvas_metadata_by_name
+
+
 def _validate_workflow_content(content: str, *, path: str = "<draft>") -> dict[str, Any]:
     errors: list[dict[str, str]] = []
     workflow = parse_workflow_content(content, path=path, errors=errors)
@@ -101,6 +151,37 @@ def _validate_workflow_content(content: str, *, path: str = "<draft>") -> dict[s
         skill_name for skill_name in workflow.requires_skills
         if skill_name not in set(active_skill_names)
     ]
+    snapshot = _workflow_extension_snapshot()
+    runtime_defaults_by_name, canvas_metadata_by_name = _workflow_surface_maps(snapshot)
+    available_runtime_profiles = {
+        str(item.metadata.get("name"))
+        for item in snapshot.list_contributions("workflow_runtimes")
+        if not isinstance(item.metadata.get("registry_conflict"), dict)
+        if isinstance(item.metadata.get("name"), str) and str(item.metadata.get("name")).strip()
+    }
+    available_output_surfaces = {
+        str(item.metadata.get("name"))
+        for item in snapshot.list_contributions("canvas_outputs")
+        if not isinstance(item.metadata.get("registry_conflict"), dict)
+        if isinstance(item.metadata.get("name"), str) and str(item.metadata.get("name")).strip()
+    }
+    missing_runtime_profiles = (
+        [workflow.runtime_profile]
+        if workflow.runtime_profile and workflow.runtime_profile not in available_runtime_profiles
+        else []
+    )
+    declared_output_surface = workflow.output_surface
+    effective_output_surface = workflow.output_surface or (
+        runtime_defaults_by_name.get(workflow.runtime_profile, "")
+        if workflow.runtime_profile
+        else ""
+    )
+    canvas_metadata = canvas_metadata_by_name.get(effective_output_surface, {})
+    missing_output_surfaces = (
+        [effective_output_surface]
+        if effective_output_surface and effective_output_surface not in available_output_surfaces
+        else []
+    )
     execution_boundaries = workflow_manager._infer_execution_boundaries(workflow)
     risk_level = workflow_manager._infer_risk_level(workflow)
     policy_modes = workflow_manager._infer_policy_modes(workflow)
@@ -118,6 +199,13 @@ def _validate_workflow_content(content: str, *, path: str = "<draft>") -> dict[s
             "inputs": workflow.inputs,
             "requires_tools": workflow.requires_tools,
             "requires_skills": workflow.requires_skills,
+            "runtime_profile": workflow.runtime_profile,
+            "output_surface": effective_output_surface,
+            "declared_output_surface": declared_output_surface,
+            "effective_output_surface": effective_output_surface,
+            "output_surface_title": str(canvas_metadata.get("title") or ""),
+            "output_surface_sections": list(canvas_metadata.get("sections") or []),
+            "output_surface_artifact_types": list(canvas_metadata.get("artifact_types") or []),
             "user_invocable": workflow.user_invocable,
             "enabled": workflow.enabled,
             "file_path": workflow.file_path,
@@ -127,9 +215,17 @@ def _validate_workflow_content(content: str, *, path: str = "<draft>") -> dict[s
             "risk_level": risk_level,
             "accepts_secret_refs": workflow_manager._accepts_secret_refs(workflow),
         },
-        "runtime_ready": not missing_tools and not missing_skills and workflow.enabled,
+        "runtime_ready": (
+            not missing_tools
+            and not missing_skills
+            and not missing_runtime_profiles
+            and not missing_output_surfaces
+            and workflow.enabled
+        ),
         "missing_tools": missing_tools,
         "missing_skills": missing_skills,
+        "missing_runtime_profiles": missing_runtime_profiles,
+        "missing_output_surfaces": missing_output_surfaces,
         "requires_approval": requires_approval,
     }
 
@@ -800,6 +896,21 @@ async def _list_workflow_runs(
                 value for value in details.get("continued_error_steps", [])
                 if isinstance(value, str)
             ] or run.get("continued_error_steps", []),
+            "runtime_profile": (
+                str(details.get("runtime_profile"))
+                if details.get("runtime_profile") is not None
+                else workflow_meta.get("runtime_profile", "")
+            ),
+            "output_surface": (
+                str(details.get("output_surface"))
+                if details.get("output_surface") is not None
+                else workflow_meta.get("output_surface", "")
+            ),
+            "canvas_output": (
+                details.get("canvas_output")
+                if isinstance(details.get("canvas_output"), dict)
+                else run.get("canvas_output")
+            ),
             "risk_level": workflow_meta.get("risk_level", "high"),
             "execution_boundaries": workflow_meta.get("execution_boundaries", ["unknown"]),
             "accepts_secret_refs": bool(workflow_meta.get("accepts_secret_refs", False)),
@@ -1075,6 +1186,28 @@ async def list_workflows():
 async def workflow_diagnostics():
     diagnostics = workflow_manager.get_diagnostics()
     return diagnostics
+
+
+@router.get("/workflows/runtimes")
+async def list_workflow_runtimes():
+    snapshot = _workflow_extension_snapshot()
+    inventory = list_workflow_runtime_inventory(snapshot.list_contributions("workflow_runtimes"))
+    return {
+        "runtimes": [
+            {
+                "extension_id": item.extension_id,
+                "name": item.name,
+                "engine_kind": item.engine_kind,
+                "description": item.description,
+                "delegation_mode": item.delegation_mode,
+                "checkpoint_policy": item.checkpoint_policy,
+                "structured_output": item.structured_output,
+                "default_output_surface": item.default_output_surface,
+                "reference": item.reference,
+            }
+            for item in inventory
+        ]
+    }
 
 
 @router.get("/workflows/{name}/source")

--- a/backend/src/defaults/catalog-extensions/openclaw-canvas-board/canvas/guardian-board.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-canvas-board/canvas/guardian-board.yaml
@@ -1,0 +1,13 @@
+name: guardian-board
+title: Guardian Board
+description: Multi-section operator board for workflow summaries, execution steps, and produced artifacts.
+surface_kind: board
+sections:
+  - Summary
+  - Steps
+  - Artifacts
+artifact_types:
+  - note
+  - report
+  - file
+preferred_panel: operations-inspector

--- a/backend/src/defaults/catalog-extensions/openclaw-canvas-board/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-canvas-board/manifest.yaml
@@ -1,0 +1,17 @@
+id: seraph.openclaw-canvas-board
+version: 2026.3.24
+display_name: OpenClaw Canvas Board
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Structured canvas-output surfaces for richer operator-visible workflow results.
+description: Packages board-style output definitions so workflows and later operator surfaces can present summaries, steps, and artifact lineages in a structured canvas form.
+permissions:
+  tools: []
+  network: false
+contributes:
+  canvas_outputs:
+    - canvas/guardian-board.yaml

--- a/backend/src/defaults/catalog-extensions/openclaw-companion-node/connectors/nodes/companion.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-companion-node/connectors/nodes/companion.yaml
@@ -1,0 +1,12 @@
+name: openclaw-companion
+description: Companion node adapter for staged desktop and phone bridge sessions.
+adapter_kind: companion
+enabled: true
+capabilities:
+  - notify
+  - sync
+config_fields:
+  - key: node_url
+    label: Node URL
+    input: url
+    required: true

--- a/backend/src/defaults/catalog-extensions/openclaw-companion-node/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-companion-node/manifest.yaml
@@ -1,0 +1,16 @@
+id: seraph.openclaw-companion-node
+version: 2026.3.24
+display_name: OpenClaw Companion Node
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Companion-node package for staged OpenClaw-style device reach.
+description: Packages a guarded companion node adapter so Seraph can stage device and desktop reach through typed node adapters.
+permissions:
+  network: true
+contributes:
+  node_adapters:
+    - connectors/nodes/companion.yaml

--- a/backend/src/defaults/catalog-extensions/openclaw-device-bridge/connectors/nodes/device.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-device-bridge/connectors/nodes/device.yaml
@@ -1,0 +1,12 @@
+name: openclaw-device
+description: Device adapter for staged hardware and companion-bridge reach.
+adapter_kind: device
+enabled: false
+capabilities:
+  - capture
+  - notify
+config_fields:
+  - key: node_url
+    label: Node URL
+    input: url
+    required: true

--- a/backend/src/defaults/catalog-extensions/openclaw-device-bridge/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-device-bridge/manifest.yaml
@@ -1,0 +1,16 @@
+id: seraph.openclaw-device-bridge
+version: 2026.3.24
+display_name: OpenClaw Device Bridge
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Device-bridge package for staged OpenClaw hardware reach.
+description: Packages a guarded device node adapter so Seraph can stage direct device reach through the extension platform.
+permissions:
+  network: true
+contributes:
+  node_adapters:
+    - connectors/nodes/device.yaml

--- a/backend/src/defaults/catalog-extensions/openclaw-extension-relay/connectors/browser/extension-relay.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-extension-relay/connectors/browser/extension-relay.yaml
@@ -1,0 +1,16 @@
+name: extension-relay
+description: Browser-extension relay provider for staged session capture through a paired browser surface.
+provider_kind: extension_relay
+enabled: false
+capabilities:
+  - browser_mode_matrix
+  - extension_relay
+config_fields:
+  - key: relay_token
+    label: Relay Token
+    input: password
+    required: true
+  - key: bridge_origin
+    label: Relay Origin
+    input: url
+    required: false

--- a/backend/src/defaults/catalog-extensions/openclaw-extension-relay/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-extension-relay/manifest.yaml
@@ -1,0 +1,22 @@
+id: seraph.openclaw-extension-relay
+version: 2026.3.24
+display_name: OpenClaw Extension Relay
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Browser-extension relay provider package with staged local-fallback execution until relay transport lands.
+contributes:
+  browser_providers:
+    - connectors/browser/extension-relay.yaml
+  toolset_presets:
+    - presets/toolset/extension-relay-ops.yaml
+permissions:
+  tools:
+    - browse_webpage
+    - browser_session
+  execution_boundaries:
+    - external_read
+  network: true

--- a/backend/src/defaults/catalog-extensions/openclaw-extension-relay/presets/toolset/extension-relay-ops.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-extension-relay/presets/toolset/extension-relay-ops.yaml
@@ -1,0 +1,11 @@
+name: extension-relay-ops
+description: Prefer the staged browser-extension relay lane when paired browser reach matters more than generic browsing.
+mode: balanced
+include_tools:
+  - browser_session
+  - browse_webpage
+capabilities:
+  - browser
+  - paired-browser
+execution_boundaries:
+  - external_read

--- a/backend/src/defaults/catalog-extensions/openclaw-poll-watch/automation/poll-watch.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-poll-watch/automation/poll-watch.yaml
@@ -1,0 +1,7 @@
+name: openclaw-poll-watch
+description: Staged polling trigger for recurring external checks.
+trigger_type: poll
+schedule: "*/15 * * * *"
+enabled: false
+capabilities:
+  - external_poll

--- a/backend/src/defaults/catalog-extensions/openclaw-poll-watch/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-poll-watch/manifest.yaml
@@ -1,0 +1,16 @@
+id: seraph.openclaw-poll-watch
+version: 2026.3.24
+display_name: OpenClaw Poll Watch
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Poll-trigger package for staged OpenClaw-style recurring fetch workflows.
+description: Packages poll-trigger metadata so Seraph can stage external watch loops through the extension platform before the full poll runtime lands.
+permissions:
+  network: true
+contributes:
+  automation_triggers:
+    - automation/poll-watch.yaml

--- a/backend/src/defaults/catalog-extensions/openclaw-pubsub-relay/automation/pubsub-relay.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-pubsub-relay/automation/pubsub-relay.yaml
@@ -1,0 +1,7 @@
+name: openclaw-pubsub
+description: Staged pubsub trigger for event-stream driven automation.
+trigger_type: pubsub
+topic: seraph.events.guardian
+enabled: false
+capabilities:
+  - pubsub_ingress

--- a/backend/src/defaults/catalog-extensions/openclaw-pubsub-relay/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-pubsub-relay/manifest.yaml
@@ -1,0 +1,16 @@
+id: seraph.openclaw-pubsub-relay
+version: 2026.3.24
+display_name: OpenClaw PubSub Relay
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: PubSub-trigger package for staged OpenClaw event-stream automations.
+description: Packages pubsub-trigger metadata so Seraph can stage topic-driven external automation without adopting a raw OpenClaw plugin transport.
+permissions:
+  network: true
+contributes:
+  automation_triggers:
+    - automation/pubsub-relay.yaml

--- a/backend/src/defaults/catalog-extensions/openclaw-remote-cdp/connectors/browser/remote-cdp.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-remote-cdp/connectors/browser/remote-cdp.yaml
@@ -1,0 +1,12 @@
+name: remote-cdp
+description: Remote Chrome DevTools Protocol provider for staged OpenClaw-style browser sessions.
+provider_kind: remote_cdp
+enabled: false
+capabilities:
+  - browser_mode_matrix
+  - remote_cdp
+config_fields:
+  - key: ws_endpoint
+    label: CDP WebSocket Endpoint
+    input: url
+    required: true

--- a/backend/src/defaults/catalog-extensions/openclaw-remote-cdp/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-remote-cdp/manifest.yaml
@@ -1,0 +1,22 @@
+id: seraph.openclaw-remote-cdp
+version: 2026.3.24
+display_name: OpenClaw Remote CDP
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Remote CDP browser provider package with explicit local-fallback execution until remote session transport ships.
+contributes:
+  browser_providers:
+    - connectors/browser/remote-cdp.yaml
+  toolset_presets:
+    - presets/toolset/remote-cdp-ops.yaml
+permissions:
+  tools:
+    - browse_webpage
+    - browser_session
+  execution_boundaries:
+    - external_read
+  network: true

--- a/backend/src/defaults/catalog-extensions/openclaw-remote-cdp/presets/toolset/remote-cdp-ops.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-remote-cdp/presets/toolset/remote-cdp-ops.yaml
@@ -1,0 +1,11 @@
+name: remote-cdp-ops
+description: Use staged remote CDP browser sessions for cross-site inspection and replay-friendly captures.
+mode: balanced
+include_tools:
+  - browser_session
+  - browse_webpage
+capabilities:
+  - browser
+  - remote-debugging
+execution_boundaries:
+  - external_read

--- a/backend/src/defaults/catalog-extensions/openclaw-webhook-gateway/automation/webhook-ingress.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-webhook-gateway/automation/webhook-ingress.yaml
@@ -1,0 +1,12 @@
+name: openclaw-webhook
+description: Signed webhook ingress trigger for guarded external automations.
+trigger_type: webhook
+endpoint: /api/automation/webhooks/openclaw-webhook
+enabled: true
+capabilities:
+  - webhook_ingress
+config_fields:
+  - key: signing_secret
+    label: Signing Secret
+    input: password
+    required: true

--- a/backend/src/defaults/catalog-extensions/openclaw-webhook-gateway/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-webhook-gateway/manifest.yaml
@@ -1,0 +1,16 @@
+id: seraph.openclaw-webhook-gateway
+version: 2026.3.24
+display_name: OpenClaw Webhook Gateway
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Webhook-trigger package for OpenClaw-style inbound automation.
+description: Packages a guarded webhook automation trigger so Seraph can accept signed external trigger calls through the extension platform.
+permissions:
+  network: true
+contributes:
+  automation_triggers:
+    - automation/webhook-ingress.yaml

--- a/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/manifest.yaml
@@ -1,0 +1,25 @@
+id: seraph.openclaw-workflow-runtimes
+version: 2026.3.24
+display_name: OpenClaw Workflow Runtimes
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: bundled
+summary: Typed workflow-runtime profiles inspired by OpenClaw runtime families.
+description: Packages OpenProse, Lobster, and LLM Task style workflow-runtime profiles plus example workflows that reinterpret those ideas inside Seraph's workflow engine.
+permissions:
+  tools:
+    - session_search
+    - delegate_task
+  network: false
+contributes:
+  workflow_runtimes:
+    - runtimes/openprose.yaml
+    - runtimes/lobster.yaml
+    - runtimes/llm-task.yaml
+  workflows:
+    - workflows/openprose-brief.md
+    - workflows/lobster-review.md
+    - workflows/llm-task-triage.md

--- a/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/runtimes/llm-task.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/runtimes/llm-task.yaml
@@ -1,0 +1,7 @@
+name: llm-task
+engine_kind: llm_task
+description: Lightweight task runtime for triage and structured follow-up preparation.
+delegation_mode: inline
+checkpoint_policy: manual
+structured_output: true
+default_output_surface: guardian-board

--- a/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/runtimes/lobster.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/runtimes/lobster.yaml
@@ -1,0 +1,7 @@
+name: lobster
+engine_kind: lobster
+description: Delegation-first review loop for bounded specialist execution.
+delegation_mode: delegate
+checkpoint_policy: approval
+structured_output: true
+default_output_surface: guardian-board

--- a/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/runtimes/openprose.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/runtimes/openprose.yaml
@@ -1,0 +1,7 @@
+name: openprose
+engine_kind: openprose
+description: Narrative composition flow for drafting a structured brief from recalled context.
+delegation_mode: inline
+checkpoint_policy: step
+structured_output: true
+default_output_surface: guardian-board

--- a/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/workflows/llm-task-triage.md
+++ b/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/workflows/llm-task-triage.md
@@ -1,0 +1,20 @@
+---
+name: llm-task-triage
+description: Gather prior context for a bounded task using the LLM Task runtime profile.
+runtime_profile: llm-task
+requires:
+  tools: [session_search]
+inputs:
+  task:
+    type: string
+    description: Task prompt to recall context for.
+steps:
+  - id: context
+    tool: session_search
+    arguments:
+      query: "{{ task }}"
+      limit: 2
+result: LLM task triage prepared for {{ task }}.
+---
+
+LLM Task-style triage workflow.

--- a/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/workflows/lobster-review.md
+++ b/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/workflows/lobster-review.md
@@ -1,0 +1,20 @@
+---
+name: lobster-review
+description: Delegate a bounded review pass using the Lobster runtime profile.
+runtime_profile: lobster
+requires:
+  tools: [delegate_task]
+inputs:
+  task:
+    type: string
+    description: Review task to delegate.
+steps:
+  - id: delegate
+    tool: delegate_task
+    arguments:
+      task: "{{ task }}"
+      specialist: workflow
+result: Lobster review delegation launched for {{ task }}.
+---
+
+Lobster-style delegated review workflow.

--- a/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/workflows/openprose-brief.md
+++ b/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/workflows/openprose-brief.md
@@ -1,0 +1,20 @@
+---
+name: openprose-brief
+description: Reconstruct a brief from prior session context using the OpenProse runtime profile.
+runtime_profile: openprose
+requires:
+  tools: [session_search]
+inputs:
+  topic:
+    type: string
+    description: Topic or thread to recall.
+steps:
+  - id: recall
+    tool: session_search
+    arguments:
+      query: "{{ topic }}"
+      limit: 3
+result: OpenProse brief scaffold prepared for {{ topic }}.
+---
+
+OpenProse-style briefing workflow.

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -3533,7 +3533,11 @@ async def _eval_observer_delivery_transport_audit() -> dict[str, Any]:
     failed_ctx = _make_context(user_state="available", interruption_mode="balanced", attention_budget_remaining=3)
     mock_context_manager = MagicMock()
     mock_context_manager.get_context.side_effect = [delivered_ctx, failed_ctx]
+    mock_context_manager.is_daemon_connected.return_value = False
     mock_context_manager.decrement_attention_budget = MagicMock()
+    # Keep the transport audit deterministic: websocket failures should stay
+    # failed here rather than rerouting through the native-notification lane.
+    mock_context_manager.is_daemon_connected.return_value = False
     mock_ws_manager = MagicMock()
     mock_ws_manager.broadcast = AsyncMock(
         side_effect=[

--- a/backend/src/extensions/automation.py
+++ b/backend/src/extensions/automation.py
@@ -1,0 +1,135 @@
+"""Automation-trigger inventory for extension-backed trigger surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.extensions.registry import ExtensionContributionRecord
+
+
+@dataclass(frozen=True)
+class AutomationTriggerInventoryEntry:
+    extension_id: str
+    name: str
+    trigger_type: str
+    description: str
+    enabled: bool
+    configured: bool
+    config_keys: tuple[str, ...]
+    schedule: str
+    endpoint: str
+    topic: str
+    capabilities: tuple[str, ...]
+    requires_network: bool
+    runtime_state: str
+    reference: str
+
+
+def _required_config_missing(config_fields: list[dict[str, Any]], config_entry: dict[str, Any]) -> bool:
+    for field in config_fields:
+        if not isinstance(field, dict):
+            continue
+        key = field.get("key")
+        if not isinstance(key, str) or not key:
+            continue
+        if not bool(field.get("required", False)):
+            continue
+        value = config_entry.get(key)
+        if value is None:
+            return True
+        if isinstance(value, str) and not value.strip():
+            return True
+    return False
+
+
+def list_automation_trigger_inventory(
+    contributions: list["ExtensionContributionRecord"],
+    *,
+    state_by_id: dict[str, Any] | None = None,
+    enabled_overrides: dict[tuple[str, str], bool] | None = None,
+) -> list[AutomationTriggerInventoryEntry]:
+    inventory: list[AutomationTriggerInventoryEntry] = []
+    for contribution in contributions:
+        if contribution.contribution_type != "automation_triggers":
+            continue
+        if isinstance(contribution.metadata.get("registry_conflict"), dict):
+            continue
+        name = contribution.metadata.get("name")
+        trigger_type = contribution.metadata.get("trigger_type")
+        if not isinstance(name, str) or not name:
+            continue
+        if not isinstance(trigger_type, str) or not trigger_type:
+            continue
+        default_enabled = bool(contribution.metadata.get("default_enabled", False))
+        enabled = (
+            enabled_overrides.get((contribution.extension_id, contribution.reference), default_enabled)
+            if enabled_overrides
+            else default_enabled
+        )
+        state_entry = state_by_id.get(contribution.extension_id, {}) if isinstance(state_by_id, dict) else {}
+        config_entry: dict[str, Any] = {}
+        if isinstance(state_entry, dict):
+            raw_config = state_entry.get("config")
+            if isinstance(raw_config, dict):
+                trigger_bucket = raw_config.get("automation_triggers")
+                if isinstance(trigger_bucket, dict):
+                    candidate_entry = trigger_bucket.get(name)
+                    if isinstance(candidate_entry, dict):
+                        config_entry = candidate_entry
+        config_fields = contribution.metadata.get("config_fields")
+        config_field_list = config_fields if isinstance(config_fields, list) else []
+        configured = not _required_config_missing(config_field_list, config_entry)
+        if not enabled:
+            runtime_state = "disabled"
+        elif not configured:
+            runtime_state = "requires_config"
+        elif trigger_type == "webhook":
+            runtime_state = "armed_webhook"
+        else:
+            runtime_state = "staged_runtime"
+        inventory.append(
+            AutomationTriggerInventoryEntry(
+                extension_id=contribution.extension_id,
+                name=name,
+                trigger_type=trigger_type,
+                description=str(contribution.metadata.get("description") or ""),
+                enabled=enabled,
+                configured=configured,
+                config_keys=tuple(sorted(config_entry.keys())),
+                schedule=str(contribution.metadata.get("schedule") or ""),
+                endpoint=str(contribution.metadata.get("endpoint") or ""),
+                topic=str(contribution.metadata.get("topic") or ""),
+                capabilities=tuple(
+                    item
+                    for item in contribution.metadata.get("capabilities", [])
+                    if isinstance(item, str) and item.strip()
+                ) if isinstance(contribution.metadata.get("capabilities"), list) else (),
+                requires_network=bool(contribution.metadata.get("requires_network", trigger_type != "cron")),
+                runtime_state=runtime_state,
+                reference=contribution.reference,
+            )
+        )
+    return sorted(
+        inventory,
+        key=lambda item: (item.extension_id, item.trigger_type, item.name),
+    )
+
+
+def select_automation_trigger(
+    contributions: list["ExtensionContributionRecord"],
+    *,
+    trigger_name: str,
+    state_by_id: dict[str, Any] | None = None,
+    enabled_overrides: dict[tuple[str, str], bool] | None = None,
+) -> AutomationTriggerInventoryEntry | None:
+    normalized = trigger_name.strip().casefold()
+    for item in list_automation_trigger_inventory(
+        contributions,
+        state_by_id=state_by_id,
+        enabled_overrides=enabled_overrides,
+    ):
+        if item.name.casefold() == normalized:
+            return item
+    return None

--- a/backend/src/extensions/browser_providers.py
+++ b/backend/src/extensions/browser_providers.py
@@ -1,4 +1,4 @@
-"""Active browser-provider selection for packaged browser reach."""
+"""Active browser-provider selection and inventory for packaged browser reach."""
 
 from __future__ import annotations
 
@@ -34,6 +34,48 @@ class ActiveBrowserProvider:
     capabilities: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class BrowserProviderInventoryEntry:
+    extension_id: str
+    name: str
+    provider_kind: str
+    description: str
+    default_enabled: bool
+    enabled: bool
+    reference: str
+    resolved_path: str | None
+    manifest_root_index: int
+    configured: bool
+    config_keys: tuple[str, ...]
+    requires_network: bool
+    requires_daemon: bool
+    capabilities: tuple[str, ...]
+    execution_mode: str
+    runtime_state: str
+    selected: bool
+
+
+_LOCAL_PROVIDER_ENTRY = BrowserProviderInventoryEntry(
+    extension_id="seraph.runtime-browser",
+    name="local-browser",
+    provider_kind="local",
+    description="Built-in local browser runtime available without packaged remote transport.",
+    default_enabled=True,
+    enabled=True,
+    reference="runtime/local-browser",
+    resolved_path=None,
+    manifest_root_index=999999,
+    configured=True,
+    config_keys=(),
+    requires_network=False,
+    requires_daemon=False,
+    capabilities=("extract", "html", "screenshot"),
+    execution_mode="local_runtime",
+    runtime_state="ready",
+    selected=False,
+)
+
+
 def _required_config_missing(config_fields: list[dict[str, Any]], config_entry: dict[str, Any]) -> bool:
     for field in config_fields:
         if not isinstance(field, dict):
@@ -51,73 +93,162 @@ def _required_config_missing(config_fields: list[dict[str, Any]], config_entry: 
     return False
 
 
-def select_active_browser_provider(
+def _provider_inventory_entry(
+    contribution: "ExtensionContributionRecord",
+    *,
+    state_by_id: dict[str, Any] | None = None,
+    enabled_overrides: dict[tuple[str, str], bool] | None = None,
+    selected_name: str | None = None,
+) -> BrowserProviderInventoryEntry | None:
+    name = contribution.metadata.get("name")
+    provider_kind = contribution.metadata.get("provider_kind")
+    if not isinstance(name, str) or not name:
+        return None
+    if not isinstance(provider_kind, str) or not provider_kind:
+        return None
+
+    default_enabled = bool(contribution.metadata.get("default_enabled", True))
+    enabled = (
+        enabled_overrides.get((contribution.extension_id, contribution.reference), default_enabled)
+        if enabled_overrides
+        else default_enabled
+    )
+
+    state_entry = state_by_id.get(contribution.extension_id, {}) if isinstance(state_by_id, dict) else {}
+    config_entry: dict[str, Any] = {}
+    if isinstance(state_entry, dict):
+        raw_config = state_entry.get("config")
+        if isinstance(raw_config, dict):
+            provider_bucket = raw_config.get("browser_providers")
+            if isinstance(provider_bucket, dict):
+                candidate_entry = provider_bucket.get(name)
+                if isinstance(candidate_entry, dict):
+                    config_entry = candidate_entry
+
+    config_fields = contribution.metadata.get("config_fields")
+    config_field_list = config_fields if isinstance(config_fields, list) else []
+    configured = not _required_config_missing(config_field_list, config_entry)
+    execution_mode = "local_runtime" if provider_kind == "local" else "local_fallback"
+    if not enabled:
+        runtime_state = "disabled"
+    elif not configured:
+        runtime_state = "requires_config"
+    elif provider_kind == "local":
+        runtime_state = "ready"
+    else:
+        runtime_state = "staged_local_fallback"
+
+    return BrowserProviderInventoryEntry(
+        extension_id=contribution.extension_id,
+        name=name,
+        provider_kind=provider_kind,
+        description=str(contribution.metadata.get("description") or ""),
+        default_enabled=default_enabled,
+        enabled=enabled,
+        reference=contribution.reference,
+        resolved_path=(
+            str(contribution.metadata.get("resolved_path"))
+            if isinstance(contribution.metadata.get("resolved_path"), str)
+            else None
+        ),
+        manifest_root_index=int(contribution.metadata.get("manifest_root_index", 999999)),
+        configured=configured,
+        config_keys=tuple(sorted(config_entry.keys())),
+        requires_network=bool(contribution.metadata.get("requires_network", provider_kind != "local")),
+        requires_daemon=bool(contribution.metadata.get("requires_daemon", provider_kind == "extension_relay")),
+        capabilities=tuple(
+            item
+            for item in contribution.metadata.get("capabilities", [])
+            if isinstance(item, str) and item.strip()
+        ) if isinstance(contribution.metadata.get("capabilities"), list) else (),
+        execution_mode=execution_mode,
+        runtime_state=runtime_state,
+        selected=selected_name == name,
+    )
+
+
+def list_browser_provider_inventory(
     contributions: list["ExtensionContributionRecord"],
     *,
     state_by_id: dict[str, Any] | None = None,
     enabled_overrides: dict[tuple[str, str], bool] | None = None,
-    requested_name: str | None = None,
-) -> ActiveBrowserProvider | None:
-    selected: ActiveBrowserProvider | None = None
-    requested = requested_name.strip().casefold() if isinstance(requested_name, str) and requested_name.strip() else None
-
+) -> list[BrowserProviderInventoryEntry]:
+    inventory: list[BrowserProviderInventoryEntry] = [_LOCAL_PROVIDER_ENTRY]
     for contribution in contributions:
         if contribution.contribution_type != "browser_providers":
             continue
-        name = contribution.metadata.get("name")
-        provider_kind = contribution.metadata.get("provider_kind")
-        if not isinstance(name, str) or not name:
+        if isinstance(contribution.metadata.get("registry_conflict"), dict):
             continue
-        if not isinstance(provider_kind, str) or not provider_kind:
-            continue
-        if requested is not None and name.casefold() != requested:
-            continue
-
-        default_enabled = bool(contribution.metadata.get("default_enabled", True))
-        enabled = enabled_overrides.get((contribution.extension_id, contribution.reference), default_enabled) if enabled_overrides else default_enabled
-        if not enabled:
-            continue
-
-        state_entry = state_by_id.get(contribution.extension_id, {}) if isinstance(state_by_id, dict) else {}
-        config_entry = {}
-        if isinstance(state_entry, dict):
-            raw_config = state_entry.get("config")
-            if isinstance(raw_config, dict):
-                provider_bucket = raw_config.get("browser_providers")
-                if isinstance(provider_bucket, dict):
-                    candidate_entry = provider_bucket.get(name)
-                    if isinstance(candidate_entry, dict):
-                        config_entry = candidate_entry
-
-        config_fields = contribution.metadata.get("config_fields")
-        config_field_list = config_fields if isinstance(config_fields, list) else []
-        configured = not _required_config_missing(config_field_list, config_entry)
-
-        candidate = ActiveBrowserProvider(
-            extension_id=contribution.extension_id,
-            name=name,
-            provider_kind=provider_kind,
-            description=str(contribution.metadata.get("description") or ""),
-            default_enabled=default_enabled,
-            reference=contribution.reference,
-            resolved_path=(
-                str(contribution.metadata.get("resolved_path"))
-                if isinstance(contribution.metadata.get("resolved_path"), str)
-                else None
-            ),
-            manifest_root_index=int(contribution.metadata.get("manifest_root_index", 999999)),
-            configured=configured,
-            config_keys=tuple(sorted(config_entry.keys())),
-            requires_network=bool(contribution.metadata.get("requires_network", provider_kind != "local")),
-            requires_daemon=bool(contribution.metadata.get("requires_daemon", provider_kind == "extension_relay")),
-            capabilities=tuple(
-                item
-                for item in contribution.metadata.get("capabilities", [])
-                if isinstance(item, str) and item.strip()
-            ) if isinstance(contribution.metadata.get("capabilities"), list) else (),
+        entry = _provider_inventory_entry(
+            contribution,
+            state_by_id=state_by_id,
+            enabled_overrides=enabled_overrides,
+            selected_name=None,
         )
-        if not candidate.configured:
+        if entry is not None:
+            inventory.append(entry)
+    inventory.sort(
+        key=lambda item: (
+            item.manifest_root_index,
+            _PROVIDER_KIND_ORDER.get(item.provider_kind, 999),
+            item.extension_id,
+            item.name,
+        )
+    )
+    selected = _select_active_provider_from_inventory(inventory)
+    selected_name = selected.name if selected is not None else None
+    display_inventory = [
+        BrowserProviderInventoryEntry(
+            **{
+                **item.__dict__,
+                "selected": (
+                    item.name == selected_name
+                    if selected_name is not None
+                    else item.name == _LOCAL_PROVIDER_ENTRY.name
+                ),
+            }
+        )
+        for item in inventory
+    ]
+    return sorted(
+        display_inventory,
+        key=lambda item: (
+            0 if item.name == _LOCAL_PROVIDER_ENTRY.name else 1,
+            item.manifest_root_index,
+            _PROVIDER_KIND_ORDER.get(item.provider_kind, 999),
+            item.extension_id,
+            item.name,
+        ),
+    )
+
+
+def _select_active_provider_from_inventory(
+    inventory: list[BrowserProviderInventoryEntry],
+    *,
+    requested_name: str | None = None,
+) -> ActiveBrowserProvider | None:
+    requested = requested_name.strip().casefold() if isinstance(requested_name, str) and requested_name.strip() else None
+    selected: ActiveBrowserProvider | None = None
+    for item in inventory:
+        if requested is not None and item.name.casefold() != requested:
             continue
+        if not item.enabled or not item.configured:
+            continue
+        candidate = ActiveBrowserProvider(
+            extension_id=item.extension_id,
+            name=item.name,
+            provider_kind=item.provider_kind,
+            description=item.description,
+            default_enabled=item.default_enabled,
+            reference=item.reference,
+            resolved_path=item.resolved_path,
+            manifest_root_index=item.manifest_root_index,
+            configured=item.configured,
+            config_keys=item.config_keys,
+            requires_network=item.requires_network,
+            requires_daemon=item.requires_daemon,
+            capabilities=item.capabilities,
+        )
         if selected is None:
             selected = candidate
             continue
@@ -135,5 +266,19 @@ def select_active_browser_provider(
         )
         if candidate_priority < selected_priority:
             selected = candidate
-
     return selected
+
+
+def select_active_browser_provider(
+    contributions: list["ExtensionContributionRecord"],
+    *,
+    state_by_id: dict[str, Any] | None = None,
+    enabled_overrides: dict[tuple[str, str], bool] | None = None,
+    requested_name: str | None = None,
+) -> ActiveBrowserProvider | None:
+    inventory = list_browser_provider_inventory(
+        contributions,
+        state_by_id=state_by_id,
+        enabled_overrides=enabled_overrides,
+    )
+    return _select_active_provider_from_inventory(inventory, requested_name=requested_name)

--- a/backend/src/extensions/canvas_outputs.py
+++ b/backend/src/extensions/canvas_outputs.py
@@ -1,0 +1,59 @@
+"""Inventory helpers for extension-backed structured canvas outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.extensions.registry import ExtensionContributionRecord
+
+
+@dataclass(frozen=True)
+class CanvasOutputInventoryEntry:
+    extension_id: str
+    name: str
+    title: str
+    description: str
+    surface_kind: str
+    sections: tuple[str, ...]
+    artifact_types: tuple[str, ...]
+    preferred_panel: str
+    reference: str
+
+
+def list_canvas_output_inventory(
+    contributions: list["ExtensionContributionRecord"],
+) -> list[CanvasOutputInventoryEntry]:
+    inventory: list[CanvasOutputInventoryEntry] = []
+    for contribution in contributions:
+        if contribution.contribution_type != "canvas_outputs":
+            continue
+        if isinstance(contribution.metadata.get("registry_conflict"), dict):
+            continue
+        name = contribution.metadata.get("name")
+        title = contribution.metadata.get("title")
+        if not isinstance(name, str) or not name:
+            continue
+        if not isinstance(title, str) or not title:
+            continue
+        sections = contribution.metadata.get("sections")
+        artifact_types = contribution.metadata.get("artifact_types")
+        inventory.append(
+            CanvasOutputInventoryEntry(
+                extension_id=contribution.extension_id,
+                name=name,
+                title=title,
+                description=str(contribution.metadata.get("description") or ""),
+                surface_kind=str(contribution.metadata.get("surface_kind") or "board"),
+                sections=tuple(
+                    item for item in sections if isinstance(item, str) and item.strip()
+                ) if isinstance(sections, list) else (),
+                artifact_types=tuple(
+                    item for item in artifact_types if isinstance(item, str) and item.strip()
+                ) if isinstance(artifact_types, list) else (),
+                preferred_panel=str(contribution.metadata.get("preferred_panel") or ""),
+                reference=contribution.reference,
+            )
+        )
+    return sorted(inventory, key=lambda item: (item.extension_id, item.surface_kind, item.name))

--- a/backend/src/extensions/capability_contributions.py
+++ b/backend/src/extensions/capability_contributions.py
@@ -95,6 +95,26 @@ def _parse_config_fields(payload: Any, *, source: str, field_name: str = "config
     return tuple(fields)
 
 
+def _ensure_config_field(
+    fields: tuple[ContributionConfigField, ...],
+    *,
+    key: str,
+    label: str,
+    input_kind: str,
+    required: bool = True,
+) -> tuple[ContributionConfigField, ...]:
+    if any(field.key == key for field in fields):
+        return fields
+    return fields + (
+        ContributionConfigField(
+            key=key,
+            label=label,
+            required=required,
+            input=input_kind,
+        ),
+    )
+
+
 @dataclass(frozen=True)
 class ToolsetPresetDefinition:
     name: str
@@ -272,6 +292,50 @@ class ProviderPresetDefinition:
 
 
 @dataclass(frozen=True)
+class CanvasOutputDefinition:
+    name: str
+    title: str
+    description: str = ""
+    surface_kind: str = "board"
+    sections: tuple[str, ...] = ()
+    artifact_types: tuple[str, ...] = ()
+    preferred_panel: str = ""
+
+    def as_metadata(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "title": self.title,
+            "description": self.description,
+            "surface_kind": self.surface_kind,
+            "sections": list(self.sections),
+            "artifact_types": list(self.artifact_types),
+            "preferred_panel": self.preferred_panel,
+        }
+
+
+@dataclass(frozen=True)
+class WorkflowRuntimeDefinition:
+    name: str
+    engine_kind: str
+    description: str = ""
+    delegation_mode: str = ""
+    checkpoint_policy: str = ""
+    structured_output: bool = False
+    default_output_surface: str = ""
+
+    def as_metadata(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "engine_kind": self.engine_kind,
+            "description": self.description,
+            "delegation_mode": self.delegation_mode,
+            "checkpoint_policy": self.checkpoint_policy,
+            "structured_output": self.structured_output,
+            "default_output_surface": self.default_output_surface,
+        }
+
+
+@dataclass(frozen=True)
 class NodeAdapterDefinition:
     name: str
     adapter_kind: str
@@ -432,17 +496,35 @@ def parse_automation_trigger_definition(payload: Any, *, source: str) -> Automat
     for field_name, value in {"schedule": raw_schedule, "endpoint": raw_endpoint, "topic": raw_topic}.items():
         if value is not None and not isinstance(value, str):
             raise ConnectorDefinitionError(f"{source}: automation {field_name} must be a string")
+    normalized_endpoint = raw_endpoint.strip() if isinstance(raw_endpoint, str) else ""
+    if trigger_type == "webhook":
+        canonical_endpoint = f"/api/automation/webhooks/{name}"
+        if normalized_endpoint and normalized_endpoint != canonical_endpoint:
+            raise ConnectorDefinitionError(
+                f"{source}: webhook endpoint must be '{canonical_endpoint}'"
+            )
+        normalized_endpoint = canonical_endpoint
+    else:
+        normalized_endpoint = ""
     requires_network = _parse_optional_bool(payload.get("requires_network"), source=source, field_name="requires_network")
+    config_fields = _parse_config_fields(payload.get("config_fields"), source=source)
+    if trigger_type == "webhook":
+        config_fields = _ensure_config_field(
+            config_fields,
+            key="signing_secret",
+            label="Signing Secret",
+            input_kind="password",
+        )
     return AutomationTriggerDefinition(
         name=name,
         trigger_type=trigger_type,
         description=description,
         enabled=False if raw_enabled is None else raw_enabled,
         schedule=raw_schedule.strip() if isinstance(raw_schedule, str) else "",
-        endpoint=raw_endpoint.strip() if isinstance(raw_endpoint, str) else "",
+        endpoint=normalized_endpoint,
         topic=raw_topic.strip() if isinstance(raw_topic, str) else "",
         capabilities=_parse_string_list(payload.get("capabilities"), source=source, field_name="capabilities"),
-        config_fields=_parse_config_fields(payload.get("config_fields"), source=source),
+        config_fields=config_fields,
         requires_network=(trigger_type in {"webhook", "poll", "pubsub"}) if requires_network is None else requires_network,
     )
 
@@ -558,6 +640,83 @@ def parse_provider_preset_definition(payload: Any, *, source: str) -> ProviderPr
     )
 
 
+def parse_canvas_output_definition(payload: Any, *, source: str) -> CanvasOutputDefinition:
+    name, description = _parse_named_object(payload, source=source, noun="canvas output")
+    if not isinstance(payload, dict):
+        raise ConnectorDefinitionError(f"{source}: canvas output definition must be an object")
+    raw_title = payload.get("title")
+    if not isinstance(raw_title, str) or not raw_title.strip():
+        raise ConnectorDefinitionError(f"{source}: canvas output must include a non-empty title")
+    raw_surface_kind = payload.get("surface_kind")
+    if raw_surface_kind is not None and not isinstance(raw_surface_kind, str):
+        raise ConnectorDefinitionError(f"{source}: canvas output surface_kind must be a string")
+    surface_kind = raw_surface_kind.strip() if isinstance(raw_surface_kind, str) and raw_surface_kind.strip() else "board"
+    if surface_kind not in {"board", "report", "checklist", "gallery"}:
+        raise ConnectorDefinitionError(f"{source}: canvas output surface_kind '{surface_kind}' is not supported")
+    raw_preferred_panel = payload.get("preferred_panel")
+    if raw_preferred_panel is not None and not isinstance(raw_preferred_panel, str):
+        raise ConnectorDefinitionError(f"{source}: canvas output preferred_panel must be a string")
+    sections = _parse_string_list(payload.get("sections"), source=source, field_name="sections")
+    artifact_types = _parse_string_list(payload.get("artifact_types"), source=source, field_name="artifact_types")
+    if not any((description, sections, artifact_types)):
+        raise ConnectorDefinitionError(
+            f"{source}: canvas output must declare description, sections, or artifact_types"
+        )
+    return CanvasOutputDefinition(
+        name=name,
+        title=raw_title.strip(),
+        description=description,
+        surface_kind=surface_kind,
+        sections=sections,
+        artifact_types=artifact_types,
+        preferred_panel=raw_preferred_panel.strip() if isinstance(raw_preferred_panel, str) else "",
+    )
+
+
+def parse_workflow_runtime_definition(payload: Any, *, source: str) -> WorkflowRuntimeDefinition:
+    name, description = _parse_named_object(payload, source=source, noun="workflow runtime")
+    if not isinstance(payload, dict):
+        raise ConnectorDefinitionError(f"{source}: workflow runtime definition must be an object")
+    raw_engine_kind = payload.get("engine_kind")
+    if not isinstance(raw_engine_kind, str) or not raw_engine_kind.strip():
+        raise ConnectorDefinitionError(f"{source}: workflow runtime must include a non-empty engine_kind")
+    engine_kind = raw_engine_kind.strip()
+    if engine_kind not in {"openprose", "lobster", "llm_task"}:
+        raise ConnectorDefinitionError(f"{source}: workflow runtime engine_kind '{engine_kind}' is not supported")
+    raw_delegation_mode = payload.get("delegation_mode")
+    raw_checkpoint_policy = payload.get("checkpoint_policy")
+    raw_default_output_surface = payload.get("default_output_surface")
+    for field_name, value in {
+        "delegation_mode": raw_delegation_mode,
+        "checkpoint_policy": raw_checkpoint_policy,
+        "default_output_surface": raw_default_output_surface,
+    }.items():
+        if value is not None and not isinstance(value, str):
+            raise ConnectorDefinitionError(f"{source}: workflow runtime {field_name} must be a string")
+    delegation_mode = raw_delegation_mode.strip() if isinstance(raw_delegation_mode, str) else ""
+    if delegation_mode and delegation_mode not in {"inline", "delegate", "multi_agent"}:
+        raise ConnectorDefinitionError(
+            f"{source}: workflow runtime delegation_mode '{delegation_mode}' is not supported"
+        )
+    checkpoint_policy = raw_checkpoint_policy.strip() if isinstance(raw_checkpoint_policy, str) else ""
+    if checkpoint_policy and checkpoint_policy not in {"manual", "step", "approval"}:
+        raise ConnectorDefinitionError(
+            f"{source}: workflow runtime checkpoint_policy '{checkpoint_policy}' is not supported"
+        )
+    raw_structured_output = payload.get("structured_output")
+    if raw_structured_output is not None and not isinstance(raw_structured_output, bool):
+        raise ConnectorDefinitionError(f"{source}: workflow runtime structured_output must be a boolean")
+    return WorkflowRuntimeDefinition(
+        name=name,
+        engine_kind=engine_kind,
+        description=description,
+        delegation_mode=delegation_mode,
+        checkpoint_policy=checkpoint_policy,
+        structured_output=bool(raw_structured_output),
+        default_output_surface=raw_default_output_surface.strip() if isinstance(raw_default_output_surface, str) else "",
+    )
+
+
 def parse_node_adapter_definition(payload: Any, *, source: str) -> NodeAdapterDefinition:
     name, description = _parse_named_object(payload, source=source, noun="node adapter")
     if not isinstance(payload, dict):
@@ -580,7 +739,7 @@ def parse_node_adapter_definition(payload: Any, *, source: str) -> NodeAdapterDe
         enabled=False if raw_enabled is None else raw_enabled,
         capabilities=_parse_string_list(payload.get("capabilities"), source=source, field_name="capabilities"),
         config_fields=_parse_config_fields(payload.get("config_fields"), source=source),
-        requires_network=False if requires_network is None else requires_network,
+        requires_network=(adapter_kind != "canvas") if requires_network is None else requires_network,
         requires_daemon=(adapter_kind != "canvas") if requires_daemon is None else requires_daemon,
     )
 
@@ -615,6 +774,14 @@ def load_speech_profile_definition(path: Path) -> SpeechProfileDefinition:
 
 def load_provider_preset_definition(path: Path) -> ProviderPresetDefinition:
     return parse_provider_preset_definition(load_connector_payload(path), source=str(path))
+
+
+def load_canvas_output_definition(path: Path) -> CanvasOutputDefinition:
+    return parse_canvas_output_definition(load_connector_payload(path), source=str(path))
+
+
+def load_workflow_runtime_definition(path: Path) -> WorkflowRuntimeDefinition:
+    return parse_workflow_runtime_definition(load_connector_payload(path), source=str(path))
 
 
 def load_node_adapter_definition(path: Path) -> NodeAdapterDefinition:

--- a/backend/src/extensions/channel_routing.py
+++ b/backend/src/extensions/channel_routing.py
@@ -1,0 +1,173 @@
+"""Channel routing bindings for proactive delivery surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+SUPPORTED_CHANNEL_ROUTE_TRANSPORTS = ("websocket", "native_notification")
+
+
+@dataclass(frozen=True)
+class ChannelRouteSpec:
+    route: str
+    label: str
+    default_primary_transport: str
+    default_fallback_transport: str | None
+    description: str
+
+
+@dataclass(frozen=True)
+class ChannelRouteBinding:
+    route: str
+    label: str
+    primary_transport: str
+    fallback_transport: str | None
+    description: str
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "route": self.route,
+            "label": self.label,
+            "primary_transport": self.primary_transport,
+            "fallback_transport": self.fallback_transport,
+            "description": self.description,
+        }
+
+
+_CHANNEL_ROUTE_SPECS = (
+    ChannelRouteSpec(
+        route="live_delivery",
+        label="Live delivery",
+        default_primary_transport="websocket",
+        default_fallback_transport="native_notification",
+        description="Immediate advisory delivery while the workspace is live.",
+    ),
+    ChannelRouteSpec(
+        route="alert_delivery",
+        label="Alert delivery",
+        default_primary_transport="native_notification",
+        default_fallback_transport="websocket",
+        description="Urgent alerts that should break through with the strongest surface first.",
+    ),
+    ChannelRouteSpec(
+        route="scheduled_delivery",
+        label="Scheduled delivery",
+        default_primary_transport="native_notification",
+        default_fallback_transport="websocket",
+        description="Scheduled proactive updates and reminders.",
+    ),
+    ChannelRouteSpec(
+        route="bundle_delivery",
+        label="Bundle delivery",
+        default_primary_transport="websocket",
+        default_fallback_transport="native_notification",
+        description="Queued bundle delivery when blocked work becomes visible again.",
+    ),
+)
+
+_CHANNEL_ROUTE_SPECS_BY_NAME = {item.route: item for item in _CHANNEL_ROUTE_SPECS}
+
+
+def channel_route_specs() -> tuple[ChannelRouteSpec, ...]:
+    return _CHANNEL_ROUTE_SPECS
+
+
+def _route_bindings_bucket(payload: dict[str, Any], *, create: bool = False) -> dict[str, Any]:
+    channel_routing = payload.get("channel_routing")
+    if not isinstance(channel_routing, dict):
+        if not create:
+            return {}
+        channel_routing = {}
+        payload["channel_routing"] = channel_routing
+    bindings = channel_routing.get("bindings")
+    if not isinstance(bindings, dict):
+        if not create:
+            return {}
+        bindings = {}
+        channel_routing["bindings"] = bindings
+    return bindings
+
+
+def list_channel_route_bindings(payload: dict[str, Any] | None) -> list[ChannelRouteBinding]:
+    payload = payload if isinstance(payload, dict) else {}
+    bindings = _route_bindings_bucket(payload, create=False)
+    resolved: list[ChannelRouteBinding] = []
+    for spec in _CHANNEL_ROUTE_SPECS:
+        raw_entry = bindings.get(spec.route)
+        primary_transport = spec.default_primary_transport
+        fallback_transport = spec.default_fallback_transport
+        if isinstance(raw_entry, dict):
+            raw_primary = raw_entry.get("primary_transport")
+            raw_fallback = raw_entry.get("fallback_transport")
+            if isinstance(raw_primary, str) and raw_primary in SUPPORTED_CHANNEL_ROUTE_TRANSPORTS:
+                primary_transport = raw_primary
+            if raw_fallback is None:
+                fallback_transport = None
+            elif isinstance(raw_fallback, str) and raw_fallback in SUPPORTED_CHANNEL_ROUTE_TRANSPORTS:
+                fallback_transport = raw_fallback
+        if fallback_transport == primary_transport:
+            fallback_transport = None
+        resolved.append(
+            ChannelRouteBinding(
+                route=spec.route,
+                label=spec.label,
+                primary_transport=primary_transport,
+                fallback_transport=fallback_transport,
+                description=spec.description,
+            )
+        )
+    return resolved
+
+
+def get_channel_route_binding(
+    payload: dict[str, Any] | None,
+    route: str,
+) -> ChannelRouteBinding:
+    bindings = list_channel_route_bindings(payload)
+    for item in bindings:
+        if item.route == route:
+            return item
+    raise KeyError(route)
+
+
+def set_channel_route_binding(
+    payload: dict[str, Any],
+    *,
+    route: str,
+    primary_transport: str,
+    fallback_transport: str | None,
+) -> None:
+    if route not in _CHANNEL_ROUTE_SPECS_BY_NAME:
+        raise ValueError(f"Unknown channel route '{route}'.")
+    if primary_transport not in SUPPORTED_CHANNEL_ROUTE_TRANSPORTS:
+        raise ValueError(f"Unsupported channel route transport '{primary_transport}'.")
+    if fallback_transport is not None and fallback_transport not in SUPPORTED_CHANNEL_ROUTE_TRANSPORTS:
+        raise ValueError(f"Unsupported channel route fallback transport '{fallback_transport}'.")
+    bindings = _route_bindings_bucket(payload, create=True)
+    bindings[route] = {
+        "primary_transport": primary_transport,
+        "fallback_transport": (
+            None if fallback_transport is None or fallback_transport == primary_transport else fallback_transport
+        ),
+    }
+
+
+def ordered_route_transports(
+    payload: dict[str, Any] | None,
+    *,
+    route: str,
+    active_transports: set[str],
+) -> tuple[ChannelRouteBinding, list[str]]:
+    binding = get_channel_route_binding(payload, route)
+    ordered: list[str] = []
+    if binding.primary_transport in active_transports:
+        ordered.append(binding.primary_transport)
+    if (
+        binding.fallback_transport is not None
+        and binding.fallback_transport in active_transports
+        and binding.fallback_transport not in ordered
+    ):
+        ordered.append(binding.fallback_transport)
+    return binding, ordered

--- a/backend/src/extensions/doctor.py
+++ b/backend/src/extensions/doctor.py
@@ -9,12 +9,14 @@ from typing import Any
 from src.extensions.capability_contributions import (
     parse_automation_trigger_definition,
     parse_browser_provider_definition,
+    parse_canvas_output_definition,
     parse_context_pack_definition,
     parse_messaging_connector_definition,
     parse_node_adapter_definition,
     parse_provider_preset_definition,
     parse_speech_profile_definition,
     parse_toolset_preset_definition,
+    parse_workflow_runtime_definition,
 )
 from src.extensions.connectors import (
     ConnectorDefinitionError,
@@ -53,6 +55,8 @@ _DEFINITION_PARSERS = {
     "automation_triggers": ("invalid_automation_trigger", "automation trigger", parse_automation_trigger_definition),
     "browser_providers": ("invalid_browser_provider", "browser provider", parse_browser_provider_definition),
     "messaging_connectors": ("invalid_messaging_connector", "messaging connector", parse_messaging_connector_definition),
+    "canvas_outputs": ("invalid_canvas_output", "canvas output", parse_canvas_output_definition),
+    "workflow_runtimes": ("invalid_workflow_runtime", "workflow runtime", parse_workflow_runtime_definition),
     "speech_profiles": ("invalid_speech_profile", "speech profile", parse_speech_profile_definition),
     "provider_presets": ("invalid_provider_preset", "provider preset", parse_provider_preset_definition),
     "node_adapters": ("invalid_node_adapter", "node adapter", parse_node_adapter_definition),

--- a/backend/src/extensions/layout.py
+++ b/backend/src/extensions/layout.py
@@ -24,6 +24,8 @@ CONTRIBUTION_LAYOUTS: dict[str, tuple[str, ...]] = {
     "observer_definitions": ("observers/definitions/",),
     "observer_connectors": ("observers/connectors/",),
     "channel_adapters": ("channels/",),
+    "canvas_outputs": ("canvas/",),
+    "workflow_runtimes": ("runtimes/",),
     "speech_profiles": ("speech/",),
     "node_adapters": ("connectors/nodes/",),
     "workspace_adapters": ("workspace/",),

--- a/backend/src/extensions/lifecycle.py
+++ b/backend/src/extensions/lifecycle.py
@@ -88,8 +88,10 @@ _STUDIO_TYPE_ORDER = {
     "observer_definitions": 15,
     "observer_connectors": 16,
     "channel_adapters": 17,
-    "node_adapters": 18,
-    "workspace_adapters": 19,
+    "canvas_outputs": 18,
+    "workflow_runtimes": 19,
+    "node_adapters": 20,
+    "workspace_adapters": 21,
 }
 _CONNECTOR_CONTRIBUTION_TYPES = {
     "mcp_servers",
@@ -125,6 +127,23 @@ _PASSIVE_TYPED_CONTRIBUTION_FIELDS = {
     "context_packs": ("name", "description", "instructions", "memory_tags", "profile_fields", "prompt_refs", "domains"),
     "speech_profiles": ("name", "description", "provider", "voice", "supports_tts", "supports_stt", "wake_word"),
     "provider_presets": ("name", "label", "default_model", "notes"),
+    "canvas_outputs": ("name", "title", "description", "surface_kind", "sections", "artifact_types", "preferred_panel"),
+    "workflow_runtimes": (
+        "name",
+        "engine_kind",
+        "description",
+        "delegation_mode",
+        "checkpoint_policy",
+        "structured_output",
+        "default_output_surface",
+    ),
+}
+
+_PLANNED_CONNECTOR_REQUIRED_FIELDS = {
+    "automation_triggers": ("name", "trigger_type"),
+    "browser_providers": ("name", "provider_kind"),
+    "messaging_connectors": ("name", "platform"),
+    "node_adapters": ("name", "adapter_kind"),
 }
 
 
@@ -1226,6 +1245,26 @@ def _contribution_indexes(
     }
 
 
+def _planned_connector_definition_errors(contribution: ExtensionContributionRecord) -> list[str]:
+    errors: list[str] = []
+    required_fields = _PLANNED_CONNECTOR_REQUIRED_FIELDS.get(contribution.contribution_type, ())
+    for field_name in required_fields:
+        value = contribution.metadata.get(field_name)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(
+                f"{contribution.contribution_type.removesuffix('s').replace('_', ' ')} definition is invalid and cannot load"
+            )
+            break
+    conflict = contribution.metadata.get("registry_conflict")
+    if isinstance(conflict, dict):
+        name = str(conflict.get("name") or contribution.metadata.get("name") or contribution.reference)
+        winner = str(conflict.get("winner_display_name") or conflict.get("winner_extension_id") or "another extension")
+        errors.append(
+            f"{contribution.contribution_type.removesuffix('s').replace('_', ' ')} '{name}' conflicts with {winner}"
+        )
+    return errors
+
+
 def _contribution_payload(
     extension: ExtensionRecord,
     contribution: ExtensionContributionRecord,
@@ -1363,22 +1402,40 @@ def _contribution_payload(
         contribution_name = _contribution_name(contribution)
         config_entry = _contribution_config(state_entry, contribution.contribution_type, contribution_name)
         config_errors = _contribution_config_errors(contribution.metadata, config_entry) if config_entry else []
+        definition_errors = _planned_connector_definition_errors(contribution)
         requires_config = bool(contribution.metadata.get("config_fields"))
         configured = bool(config_entry) if requires_config else True
         if config_entry:
             payload["config_keys"] = sorted(config_entry.keys())
         if config_errors:
             payload["config_errors"] = config_errors
-        health = planned_configurable_connector_health(
-            "Runtime support for this connector surface lands in the later capability-reach waves.",
-            enabled=enabled,
-            configured=configured,
-            config_errors=config_errors,
-            supports_test=False,
-        )
-        payload["configured"] = configured and not config_errors
-        payload["health"] = health.as_payload()
-        payload["status"] = str(payload["health"].get("state") or "planned")
+        if definition_errors:
+            payload["configured"] = False
+            payload["health"] = ConnectorHealthSnapshot(
+                state="invalid",
+                summary=definition_errors[0],
+                ready=False,
+                enabled=enabled,
+                configured=False,
+                connected=False,
+                error="; ".join(definition_errors),
+                supports_test=False,
+                supports_configure=True,
+                supports_enable=True,
+                supports_disable=True,
+            ).as_payload()
+            payload["status"] = "invalid"
+        else:
+            health = planned_configurable_connector_health(
+                "Runtime support for this connector surface lands in the later capability-reach waves.",
+                enabled=enabled,
+                configured=configured,
+                config_errors=config_errors,
+                supports_test=False,
+            )
+            payload["configured"] = configured and not config_errors
+            payload["health"] = health.as_payload()
+            payload["status"] = str(payload["health"].get("state") or "planned")
         return payload
     if contribution.contribution_type == "observer_definitions":
         active_definition = (
@@ -1570,7 +1627,23 @@ def _contribution_payload(
             if field_name in item:
                 payload[field_name] = item[field_name]
     if contribution.contribution_type in {"skills", "workflows"}:
-        for field_name in ("name", "description", "requires_tools", "requires_skills", "step_tools", "tool_name", "user_invocable", "default_enabled"):
+        for field_name in (
+            "name",
+            "description",
+            "requires_tools",
+            "requires_skills",
+            "step_tools",
+            "tool_name",
+            "runtime_profile",
+            "output_surface",
+            "declared_output_surface",
+            "effective_output_surface",
+            "output_surface_title",
+            "output_surface_sections",
+            "output_surface_artifact_types",
+            "user_invocable",
+            "default_enabled",
+        ):
             field_value = contribution.metadata.get(field_name)
             if field_value not in (None, "", [], {}):
                 payload.setdefault(field_name, field_value)
@@ -1952,6 +2025,9 @@ def _set_planned_connector_enabled(
         raise ValueError(
             f"connector '{contribution.reference}' in extension '{extension.id}' is not a valid {changed_type} definition"
         )
+    definition_errors = _planned_connector_definition_errors(contribution)
+    if definition_errors:
+        raise ValueError(definition_errors[0])
     state_payload = _state_payload()
     state_by_id = state_payload.get("extensions")
     state_entry = (

--- a/backend/src/extensions/manifest.py
+++ b/backend/src/extensions/manifest.py
@@ -31,6 +31,8 @@ _CONTRIBUTION_FIELDS = (
     "observer_definitions",
     "observer_connectors",
     "channel_adapters",
+    "canvas_outputs",
+    "workflow_runtimes",
     "speech_profiles",
     "node_adapters",
     "workspace_adapters",
@@ -173,6 +175,8 @@ class ExtensionContributionPaths(BaseModel):
     observer_definitions: list[str] = Field(default_factory=list)
     observer_connectors: list[str] = Field(default_factory=list)
     channel_adapters: list[str] = Field(default_factory=list)
+    canvas_outputs: list[str] = Field(default_factory=list)
+    workflow_runtimes: list[str] = Field(default_factory=list)
     speech_profiles: list[str] = Field(default_factory=list)
     node_adapters: list[str] = Field(default_factory=list)
     workspace_adapters: list[str] = Field(default_factory=list)

--- a/backend/src/extensions/node_adapters.py
+++ b/backend/src/extensions/node_adapters.py
@@ -1,0 +1,108 @@
+"""Node-adapter inventory for staged device and companion reach."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.extensions.registry import ExtensionContributionRecord
+
+
+@dataclass(frozen=True)
+class NodeAdapterInventoryEntry:
+    extension_id: str
+    name: str
+    adapter_kind: str
+    description: str
+    enabled: bool
+    configured: bool
+    config_keys: tuple[str, ...]
+    capabilities: tuple[str, ...]
+    requires_network: bool
+    requires_daemon: bool
+    runtime_state: str
+    reference: str
+
+
+def _required_config_missing(config_fields: list[dict[str, Any]], config_entry: dict[str, Any]) -> bool:
+    for field in config_fields:
+        if not isinstance(field, dict):
+            continue
+        key = field.get("key")
+        if not isinstance(key, str) or not key:
+            continue
+        if not bool(field.get("required", False)):
+            continue
+        value = config_entry.get(key)
+        if value is None:
+            return True
+        if isinstance(value, str) and not value.strip():
+            return True
+    return False
+
+
+def list_node_adapter_inventory(
+    contributions: list["ExtensionContributionRecord"],
+    *,
+    state_by_id: dict[str, Any] | None = None,
+    enabled_overrides: dict[tuple[str, str], bool] | None = None,
+) -> list[NodeAdapterInventoryEntry]:
+    inventory: list[NodeAdapterInventoryEntry] = []
+    for contribution in contributions:
+        if contribution.contribution_type != "node_adapters":
+            continue
+        name = contribution.metadata.get("name")
+        adapter_kind = contribution.metadata.get("adapter_kind")
+        if not isinstance(name, str) or not name:
+            continue
+        if not isinstance(adapter_kind, str) or not adapter_kind:
+            continue
+        default_enabled = bool(contribution.metadata.get("default_enabled", False))
+        enabled = (
+            enabled_overrides.get((contribution.extension_id, contribution.reference), default_enabled)
+            if enabled_overrides
+            else default_enabled
+        )
+        state_entry = state_by_id.get(contribution.extension_id, {}) if isinstance(state_by_id, dict) else {}
+        config_entry: dict[str, Any] = {}
+        if isinstance(state_entry, dict):
+            raw_config = state_entry.get("config")
+            if isinstance(raw_config, dict):
+                adapter_bucket = raw_config.get("node_adapters")
+                if isinstance(adapter_bucket, dict):
+                    candidate_entry = adapter_bucket.get(name)
+                    if isinstance(candidate_entry, dict):
+                        config_entry = candidate_entry
+        config_fields = contribution.metadata.get("config_fields")
+        config_field_list = config_fields if isinstance(config_fields, list) else []
+        configured = not _required_config_missing(config_field_list, config_entry)
+        if not enabled:
+            runtime_state = "disabled"
+        elif not configured:
+            runtime_state = "requires_config"
+        elif adapter_kind == "canvas":
+            runtime_state = "staged_canvas"
+        else:
+            runtime_state = "staged_link"
+        inventory.append(
+            NodeAdapterInventoryEntry(
+                extension_id=contribution.extension_id,
+                name=name,
+                adapter_kind=adapter_kind,
+                description=str(contribution.metadata.get("description") or ""),
+                enabled=enabled,
+                configured=configured,
+                config_keys=tuple(sorted(config_entry.keys())),
+                capabilities=tuple(
+                    item
+                    for item in contribution.metadata.get("capabilities", [])
+                    if isinstance(item, str) and item.strip()
+                ) if isinstance(contribution.metadata.get("capabilities"), list) else (),
+                requires_network=bool(contribution.metadata.get("requires_network", False)),
+                requires_daemon=bool(contribution.metadata.get("requires_daemon", adapter_kind != "canvas")),
+                runtime_state=runtime_state,
+                reference=contribution.reference,
+            )
+        )
+    return sorted(inventory, key=lambda item: (item.extension_id, item.adapter_kind, item.name))

--- a/backend/src/extensions/registry.py
+++ b/backend/src/extensions/registry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import hashlib
 from importlib.metadata import PackageNotFoundError, version as package_version
 import os
@@ -15,6 +15,7 @@ from config.settings import settings
 from src.extensions.capability_contributions import (
     load_automation_trigger_definition,
     load_browser_provider_definition,
+    load_canvas_output_definition,
     load_context_pack_definition,
     load_messaging_connector_definition,
     load_node_adapter_definition,
@@ -22,6 +23,7 @@ from src.extensions.capability_contributions import (
     load_provider_preset_definition,
     load_speech_profile_definition,
     load_toolset_preset_definition,
+    load_workflow_runtime_definition,
 )
 from src.extensions.channels import load_channel_adapter_definition
 from src.extensions.connectors import load_managed_connector_definition, load_mcp_server_definition
@@ -162,8 +164,11 @@ class ExtensionRegistry:
         load_errors: list[ExtensionLoadErrorRecord] = []
 
         manifest_extensions, manifest_errors = self._scan_manifest_extensions()
+        manifest_extensions = self._enrich_workflow_contribution_metadata(manifest_extensions)
+        manifest_extensions, manifest_conflict_errors = self._annotate_named_contribution_conflicts(manifest_extensions)
         extensions.extend(manifest_extensions)
         load_errors.extend(manifest_errors)
+        load_errors.extend(manifest_conflict_errors)
 
         manifest_claims = self._manifest_claims(manifest_extensions)
 
@@ -295,18 +300,20 @@ class ExtensionRegistry:
                             errors=[],
                         )
                         if workflow is not None:
-                            metadata.update(
-                                {
-                                    "name": workflow.name,
-                                    "description": workflow.description,
-                                    "requires_tools": list(workflow.requires_tools),
-                                    "requires_skills": list(workflow.requires_skills),
-                                    "step_tools": list(workflow.step_tools),
-                                    "user_invocable": workflow.user_invocable,
-                                    "default_enabled": workflow.enabled,
-                                    "tool_name": workflow.tool_name,
-                                }
-                            )
+                                metadata.update(
+                                    {
+                                        "name": workflow.name,
+                                        "description": workflow.description,
+                                        "requires_tools": list(workflow.requires_tools),
+                                        "requires_skills": list(workflow.requires_skills),
+                                        "step_tools": list(workflow.step_tools),
+                                        "runtime_profile": workflow.runtime_profile,
+                                        "output_surface": workflow.output_surface,
+                                        "user_invocable": workflow.user_invocable,
+                                        "default_enabled": workflow.enabled,
+                                        "tool_name": workflow.tool_name,
+                                    }
+                                )
                     except Exception:
                         pass
                 if contribution_type == "managed_connectors":
@@ -352,6 +359,16 @@ class ExtensionRegistry:
                 if contribution_type == "channel_adapters":
                     try:
                         metadata.update(load_channel_adapter_definition(resolved_path).as_metadata())
+                    except Exception:
+                        pass
+                if contribution_type == "canvas_outputs":
+                    try:
+                        metadata.update(load_canvas_output_definition(resolved_path).as_metadata())
+                    except Exception:
+                        pass
+                if contribution_type == "workflow_runtimes":
+                    try:
+                        metadata.update(load_workflow_runtime_definition(resolved_path).as_metadata())
                     except Exception:
                         pass
                 if contribution_type == "speech_profiles":
@@ -409,6 +426,178 @@ class ExtensionRegistry:
                     if isinstance(connector_name, str) and connector_name:
                         claims.setdefault("mcp_server_names", set()).add(connector_name)
         return claims
+
+    def _enrich_workflow_contribution_metadata(
+        self,
+        extensions: list[ExtensionRecord],
+    ) -> list[ExtensionRecord]:
+        runtime_defaults_by_name: dict[str, str] = {}
+        canvas_metadata_by_name: dict[str, dict[str, Any]] = {}
+        for extension in extensions:
+            for contribution in extension.contributions:
+                if contribution.contribution_type == "workflow_runtimes":
+                    name = contribution.metadata.get("name")
+                    default_output_surface = contribution.metadata.get("default_output_surface")
+                    if (
+                        isinstance(name, str)
+                        and name.strip()
+                        and isinstance(default_output_surface, str)
+                        and default_output_surface.strip()
+                    ):
+                        runtime_defaults_by_name[name.strip()] = default_output_surface.strip()
+                elif contribution.contribution_type == "canvas_outputs":
+                    name = contribution.metadata.get("name")
+                    if not isinstance(name, str) or not name.strip():
+                        continue
+                    raw_sections = contribution.metadata.get("sections")
+                    raw_artifact_types = contribution.metadata.get("artifact_types")
+                    canvas_metadata_by_name[name.strip()] = {
+                        "title": str(contribution.metadata.get("title") or ""),
+                        "sections": [
+                            str(item).strip()
+                            for item in raw_sections
+                            if isinstance(item, str) and item.strip()
+                        ] if isinstance(raw_sections, list) else [],
+                        "artifact_types": [
+                            str(item).strip()
+                            for item in raw_artifact_types
+                            if isinstance(item, str) and item.strip()
+                        ] if isinstance(raw_artifact_types, list) else [],
+                    }
+
+        updated_extensions: list[ExtensionRecord] = []
+        for extension in extensions:
+            updated_contributions: list[ExtensionContributionRecord] = []
+            for contribution in extension.contributions:
+                if contribution.contribution_type != "workflows":
+                    updated_contributions.append(contribution)
+                    continue
+                metadata = dict(contribution.metadata)
+                runtime_profile = metadata.get("runtime_profile")
+                declared_output_surface = (
+                    str(metadata.get("output_surface") or "").strip()
+                    if metadata.get("output_surface") is not None
+                    else ""
+                )
+                effective_output_surface = declared_output_surface
+                if (
+                    not effective_output_surface
+                    and isinstance(runtime_profile, str)
+                    and runtime_profile.strip()
+                ):
+                    effective_output_surface = runtime_defaults_by_name.get(runtime_profile.strip(), "")
+                if effective_output_surface:
+                    metadata["output_surface"] = effective_output_surface
+                    metadata["effective_output_surface"] = effective_output_surface
+                    if declared_output_surface:
+                        metadata["declared_output_surface"] = declared_output_surface
+                    canvas_metadata = canvas_metadata_by_name.get(effective_output_surface, {})
+                    if canvas_metadata:
+                        metadata["output_surface_title"] = str(canvas_metadata.get("title") or "")
+                        metadata["output_surface_sections"] = list(canvas_metadata.get("sections") or [])
+                        metadata["output_surface_artifact_types"] = list(canvas_metadata.get("artifact_types") or [])
+                updated_contributions.append(replace(contribution, metadata=metadata))
+            updated_extensions.append(replace(extension, contributions=updated_contributions))
+        return updated_extensions
+
+    def _annotate_named_contribution_conflicts(
+        self,
+        extensions: list[ExtensionRecord],
+    ) -> tuple[list[ExtensionRecord], list[ExtensionLoadErrorRecord]]:
+        unique_name_types = {
+            "automation_triggers": {"label": "automation trigger", "conflict_mode": "all"},
+            "browser_providers": {"label": "browser provider", "conflict_mode": "winner"},
+            "workflow_runtimes": {"label": "workflow runtime", "conflict_mode": "winner"},
+            "canvas_outputs": {"label": "canvas output", "conflict_mode": "winner"},
+        }
+        grouped: dict[tuple[str, str], list[tuple[ExtensionRecord, ExtensionContributionRecord]]] = {}
+        prioritized_extensions = sorted(extensions, key=_extension_priority)
+        for extension in prioritized_extensions:
+            for contribution in extension.contributions:
+                policy = unique_name_types.get(contribution.contribution_type)
+                if policy is None:
+                    continue
+                name = contribution.metadata.get("name")
+                if not isinstance(name, str) or not name.strip():
+                    continue
+                key = (contribution.contribution_type, name.strip().casefold())
+                grouped.setdefault(key, []).append((extension, contribution))
+
+        updated_extensions: list[ExtensionRecord] = []
+        load_errors: list[ExtensionLoadErrorRecord] = []
+        for extension in extensions:
+            updated_contributions: list[ExtensionContributionRecord] = []
+            for contribution in extension.contributions:
+                policy = unique_name_types.get(contribution.contribution_type)
+                if policy is None:
+                    updated_contributions.append(contribution)
+                    continue
+                name = contribution.metadata.get("name")
+                if not isinstance(name, str) or not name.strip():
+                    updated_contributions.append(contribution)
+                    continue
+                duplicates = grouped.get((contribution.contribution_type, name.strip().casefold()), [])
+                if len(duplicates) <= 1:
+                    updated_contributions.append(contribution)
+                    continue
+                label = str(policy["label"])
+                conflict_mode = str(policy["conflict_mode"])
+                winner_extension, winner_contribution = duplicates[0]
+                if (
+                    conflict_mode == "winner"
+                    and (winner_extension.id, winner_contribution.reference)
+                    == (extension.id, contribution.reference)
+                ):
+                    updated_contributions.append(contribution)
+                    continue
+                conflicting_peers = [
+                    {
+                        "extension_id": peer_extension.id,
+                        "reference": peer_contribution.reference,
+                        "display_name": peer_extension.display_name,
+                    }
+                    for peer_extension, peer_contribution in duplicates
+                    if (peer_extension.id, peer_contribution.reference)
+                    != (extension.id, contribution.reference)
+                ]
+                metadata = dict(contribution.metadata)
+                metadata["registry_conflict"] = {
+                    "kind": "duplicate_name",
+                    "name": name.strip(),
+                    "winner_extension_id": winner_extension.id,
+                    "winner_reference": winner_contribution.reference,
+                    "winner_display_name": winner_extension.display_name,
+                    "conflict_mode": conflict_mode,
+                    "conflicting_peers": conflicting_peers,
+                }
+                updated_contributions.append(replace(contribution, metadata=metadata))
+                if conflict_mode == "all":
+                    message = (
+                        f"Duplicate {label} name '{name.strip()}' in {contribution.reference}; "
+                        "all matching definitions are disabled until the collision is removed"
+                    )
+                else:
+                    message = (
+                        f"Duplicate {label} name '{name.strip()}' in {contribution.reference}; "
+                        f"keeping {winner_extension.display_name} ({winner_contribution.reference})"
+                    )
+                load_errors.append(
+                    ExtensionLoadErrorRecord(
+                        source=str(extension.manifest_path or metadata.get("resolved_path") or contribution.reference),
+                        message=message,
+                        phase=f"duplicate-{contribution.contribution_type.removesuffix('s')}-name",
+                        details=[
+                            {
+                                "name": name.strip(),
+                                "winner_extension_id": winner_extension.id,
+                                "winner_reference": winner_contribution.reference,
+                                "conflict_mode": conflict_mode,
+                            }
+                        ],
+                    )
+                )
+            updated_extensions.append(replace(extension, contributions=updated_contributions))
+        return updated_extensions, load_errors
 
     def _scan_legacy_skill_extensions(
         self,

--- a/backend/src/extensions/registry.py
+++ b/backend/src/extensions/registry.py
@@ -164,8 +164,10 @@ class ExtensionRegistry:
         load_errors: list[ExtensionLoadErrorRecord] = []
 
         manifest_extensions, manifest_errors = self._scan_manifest_extensions()
+        manifest_extensions, manifest_conflict_errors = self._annotate_named_contribution_conflicts(
+            manifest_extensions
+        )
         manifest_extensions = self._enrich_workflow_contribution_metadata(manifest_extensions)
-        manifest_extensions, manifest_conflict_errors = self._annotate_named_contribution_conflicts(manifest_extensions)
         extensions.extend(manifest_extensions)
         load_errors.extend(manifest_errors)
         load_errors.extend(manifest_conflict_errors)
@@ -435,6 +437,8 @@ class ExtensionRegistry:
         canvas_metadata_by_name: dict[str, dict[str, Any]] = {}
         for extension in extensions:
             for contribution in extension.contributions:
+                if isinstance(contribution.metadata.get("registry_conflict"), dict):
+                    continue
                 if contribution.contribution_type == "workflow_runtimes":
                     name = contribution.metadata.get("name")
                     default_output_surface = contribution.metadata.get("default_output_surface")

--- a/backend/src/extensions/workflow_runtimes.py
+++ b/backend/src/extensions/workflow_runtimes.py
@@ -1,0 +1,53 @@
+"""Inventory helpers for typed workflow runtime profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.extensions.registry import ExtensionContributionRecord
+
+
+@dataclass(frozen=True)
+class WorkflowRuntimeInventoryEntry:
+    extension_id: str
+    name: str
+    engine_kind: str
+    description: str
+    delegation_mode: str
+    checkpoint_policy: str
+    structured_output: bool
+    default_output_surface: str
+    reference: str
+
+
+def list_workflow_runtime_inventory(
+    contributions: list["ExtensionContributionRecord"],
+) -> list[WorkflowRuntimeInventoryEntry]:
+    inventory: list[WorkflowRuntimeInventoryEntry] = []
+    for contribution in contributions:
+        if contribution.contribution_type != "workflow_runtimes":
+            continue
+        if isinstance(contribution.metadata.get("registry_conflict"), dict):
+            continue
+        name = contribution.metadata.get("name")
+        engine_kind = contribution.metadata.get("engine_kind")
+        if not isinstance(name, str) or not name:
+            continue
+        if not isinstance(engine_kind, str) or not engine_kind:
+            continue
+        inventory.append(
+            WorkflowRuntimeInventoryEntry(
+                extension_id=contribution.extension_id,
+                name=name,
+                engine_kind=engine_kind,
+                description=str(contribution.metadata.get("description") or ""),
+                delegation_mode=str(contribution.metadata.get("delegation_mode") or ""),
+                checkpoint_policy=str(contribution.metadata.get("checkpoint_policy") or ""),
+                structured_output=bool(contribution.metadata.get("structured_output", False)),
+                default_output_surface=str(contribution.metadata.get("default_output_surface") or ""),
+                reference=contribution.reference,
+            )
+        )
+    return sorted(inventory, key=lambda item: (item.extension_id, item.engine_kind, item.name))

--- a/backend/src/observer/delivery.py
+++ b/backend/src/observer/delivery.py
@@ -9,6 +9,8 @@ from src.observer.native_notification_queue import native_notification_queue
 
 logger = logging.getLogger(__name__)
 
+_BUILTIN_CHANNEL_TRANSPORTS = {"websocket", "native_notification"}
+
 
 def _transport_failure_reason(
     *,
@@ -23,6 +25,20 @@ def _transport_failure_reason(
     if failed_connections >= attempted_connections:
         return "all_connections_failed"
     return "unknown_transport_failure"
+
+
+def _prefer_delivery_error(current_error: str | None, next_error: str) -> str:
+    if not current_error or current_error in {"no_active_route_transport", "unknown_transport_failure"}:
+        return next_error
+    if next_error in {"daemon_unavailable", "no_active_route_transport"}:
+        return current_error
+    return next_error
+
+
+def _route_disabled_error(*, primary_transport: str | None) -> str:
+    if primary_transport == "websocket":
+        return "websocket_adapter_disabled"
+    return "no_active_route_transport"
 
 
 def _active_channel_adapters() -> set[str]:
@@ -44,11 +60,33 @@ def _active_channel_adapters() -> set[str]:
         contributions,
         enabled_overrides=connector_enabled_overrides(state_by_id),
     )
-    if active_adapters:
-        return {item.transport for item in active_adapters}
-    if contributions:
-        return set()
-    return {"websocket", "native_notification"}
+    active_transports = {item.transport for item in active_adapters}
+    return active_transports | (_BUILTIN_CHANNEL_TRANSPORTS - active_transports)
+
+
+def _delivery_route_name(*, message: WSResponse, is_scheduled: bool) -> str:
+    if is_scheduled:
+        return "scheduled_delivery"
+    if message.intervention_type == "alert":
+        return "alert_delivery"
+    return "live_delivery"
+
+
+def _route_transport_order(route_name: str, *, active_channel_adapters: set[str]) -> tuple[dict[str, str | None], list[str]]:
+    from src.extensions.channel_routing import ordered_route_transports
+    from src.extensions.state import load_extension_state_payload
+
+    state_payload = load_extension_state_payload()
+    binding, ordered = ordered_route_transports(
+        state_payload,
+        route=route_name,
+        active_transports=active_channel_adapters,
+    )
+    return {
+        "route": binding.route,
+        "primary_transport": binding.primary_transport,
+        "fallback_transport": binding.fallback_transport,
+    }, ordered
 
 
 def _should_offer_native_notification(
@@ -245,36 +283,74 @@ async def deliver_or_queue(
             event_details["intervention_id"] = intervention_id
 
         if policy_decision.action.value == "act":
-            websocket_enabled = "websocket" in active_channel_adapters
-            if websocket_enabled:
-                broadcast_result = await ws_manager.broadcast(message)
-            else:
-                from src.scheduler.connection_manager import BroadcastResult
-
-                broadcast_result = BroadcastResult(
-                    attempted_connections=0,
-                    delivered_connections=0,
-                    failed_connections=0,
-                )
+            route_name = _delivery_route_name(message=message, is_scheduled=is_scheduled)
+            route_binding, transport_order = _route_transport_order(
+                route_name,
+                active_channel_adapters=active_channel_adapters,
+            )
             event_details.update(
                 {
-                    "attempted_connections": broadcast_result.attempted_connections,
-                    "delivered_connections": broadcast_result.delivered_connections,
-                    "failed_connections": broadcast_result.failed_connections,
                     "active_channel_adapters": sorted(active_channel_adapters),
+                    "channel_route": route_binding["route"],
+                    "primary_transport": route_binding["primary_transport"],
+                    "fallback_transport": route_binding["fallback_transport"],
+                    "transport_order": transport_order,
                 }
             )
-            if broadcast_result.delivered_connections <= 0:
-                if (
-                    "native_notification" in active_channel_adapters
-                    and
-                    context_manager.is_daemon_connected()
-                    and _should_offer_native_notification(
-                        message,
-                        is_scheduled=is_scheduled,
-                        channel_bias=learning_signal.channel_bias,
+
+            last_error = _route_disabled_error(primary_transport=route_binding["primary_transport"])
+            for transport in transport_order:
+                if transport == "websocket":
+                    websocket_enabled = "websocket" in active_channel_adapters
+                    if websocket_enabled:
+                        broadcast_result = await ws_manager.broadcast(message)
+                    else:
+                        from src.scheduler.connection_manager import BroadcastResult
+
+                        broadcast_result = BroadcastResult(
+                            attempted_connections=0,
+                            delivered_connections=0,
+                            failed_connections=0,
+                        )
+                    event_details.update(
+                        {
+                            "attempted_connections": broadcast_result.attempted_connections,
+                            "delivered_connections": broadcast_result.delivered_connections,
+                            "failed_connections": broadcast_result.failed_connections,
+                        }
                     )
-                ):
+                    if broadcast_result.delivered_connections > 0:
+                        if policy_decision.should_cost_budget:
+                            context_manager.decrement_attention_budget()
+                        logger.info("Delivered proactive message (type=%s)", message.type)
+                        await _update_intervention_outcome(
+                            intervention_id,
+                            latest_outcome="delivered",
+                            transport="websocket",
+                        )
+                        await log_observer_delivery_event(
+                            decision="delivered",
+                            message_type=message.type,
+                            intervention_type=intervention_type,
+                            urgency=urgency,
+                            is_scheduled=is_scheduled,
+                            details={**event_details, "transport": "websocket"},
+                        )
+                        return policy_decision
+                    last_error = _prefer_delivery_error(
+                        last_error,
+                        _transport_failure_reason(
+                        attempted_connections=broadcast_result.attempted_connections,
+                        failed_connections=broadcast_result.failed_connections,
+                        websocket_enabled=websocket_enabled,
+                        ),
+                    )
+                    continue
+
+                if transport == "native_notification":
+                    if not context_manager.is_daemon_connected():
+                        last_error = _prefer_delivery_error(last_error, "daemon_unavailable")
+                        continue
                     notification = await native_notification_queue.enqueue(
                         intervention_id=intervention_id,
                         title=_native_notification_title(message, is_scheduled=is_scheduled),
@@ -301,7 +377,7 @@ async def deliver_or_queue(
                         notification_id=notification.id,
                     )
                     logger.info(
-                        "Rerouted proactive message to native notification (type=%s, notification_id=%s)",
+                        "Delivered proactive message over native notification (type=%s, notification_id=%s)",
                         message.type,
                         notification.id,
                     )
@@ -322,53 +398,33 @@ async def deliver_or_queue(
                     )
                     return policy_decision
 
-                logger.warning(
-                    "Failed to deliver proactive message over WebSocket transport (attempted=%d failed=%d)",
-                    broadcast_result.attempted_connections,
-                    broadcast_result.failed_connections,
-                )
-                await _update_intervention_outcome(
-                    intervention_id,
-                    latest_outcome="failed",
-                    transport="websocket",
-                )
-                await log_observer_delivery_event(
-                    decision="failed",
-                    message_type=message.type,
-                    intervention_type=intervention_type,
-                    urgency=urgency,
-                    is_scheduled=is_scheduled,
-                    details={
-                        **event_details,
-                        "transport": "websocket",
-                        "delivery_decision": policy_decision.delivery_decision.value
-                        if policy_decision.delivery_decision is not None
-                        else None,
-                        "error": _transport_failure_reason(
-                            attempted_connections=broadcast_result.attempted_connections,
-                            failed_connections=broadcast_result.failed_connections,
-                            websocket_enabled=websocket_enabled,
-                        ),
-                    },
-                )
-                return policy_decision
-            # Decrement budget if this delivery costs budget
-            if policy_decision.should_cost_budget:
-                context_manager.decrement_attention_budget()
-            logger.info("Delivered proactive message (type=%s)", message.type)
+            logger.warning(
+                "Failed to deliver proactive message (type=%s, route=%s, error=%s)",
+                message.type,
+                route_name,
+                last_error,
+            )
             await _update_intervention_outcome(
                 intervention_id,
-                latest_outcome="delivered",
-                transport="websocket",
+                latest_outcome="failed",
+                transport=transport_order[0] if transport_order else None,
             )
             await log_observer_delivery_event(
-                decision="delivered",
+                decision="failed",
                 message_type=message.type,
                 intervention_type=intervention_type,
                 urgency=urgency,
                 is_scheduled=is_scheduled,
-                details={**event_details, "transport": "websocket"},
+                details={
+                    **event_details,
+                    "transport": transport_order[0] if transport_order else None,
+                    "delivery_decision": policy_decision.delivery_decision.value
+                    if policy_decision.delivery_decision is not None
+                    else None,
+                    "error": last_error,
+                },
             )
+            return policy_decision
 
         elif policy_decision.action.value == "bundle":
             await insight_queue.enqueue(
@@ -450,18 +506,40 @@ async def deliver_queued_bundle() -> int:
     if not items:
         return 0
     active_channel_adapters = _active_channel_adapters()
-    if "websocket" not in active_channel_adapters:
-        if (
-            "native_notification" in active_channel_adapters
-            and context_manager.is_daemon_connected()
-        ):
+    route_binding, transport_order = _route_transport_order(
+        "bundle_delivery",
+        active_channel_adapters=active_channel_adapters,
+    )
+    details = {
+        "bundle_item_count": len(items),
+        "intervention_ids": [item.intervention_id for item in items if item.intervention_id],
+        "delivery_decision": "deliver",
+        "active_channel_adapters": sorted(active_channel_adapters),
+        "channel_route": route_binding["route"],
+        "primary_transport": route_binding["primary_transport"],
+        "fallback_transport": route_binding["fallback_transport"],
+        "transport_order": transport_order,
+    }
+    parts = [f"- {item.content}" for item in items]
+    bundle_content = f"While you were away ({len(items)} update{'s' if len(items) != 1 else ''}):\n" + "\n".join(parts)
+    message = WSResponse(
+        type="proactive",
+        content=bundle_content,
+        intervention_type="proactive_bundle",
+        urgency=3,
+        reasoning=f"Bundle of {len(items)} queued insight(s) delivered on state transition",
+    )
+
+    last_error = _route_disabled_error(primary_transport=route_binding["primary_transport"])
+    for transport in transport_order:
+        if transport == "native_notification":
+            if not context_manager.is_daemon_connected():
+                last_error = _prefer_delivery_error(last_error, "daemon_unavailable")
+                continue
             notification = await native_notification_queue.enqueue(
                 intervention_id=None,
                 title="Seraph update",
-                body=(
-                    f"While you were away ({len(items)} update{'s' if len(items) != 1 else ''}):\n"
-                    + "\n".join(f"- {item.content}" for item in items)
-                ),
+                body=bundle_content,
                 intervention_type="proactive_bundle",
                 urgency=3,
                 surface="action_card",
@@ -488,98 +566,62 @@ async def deliver_queued_bundle() -> int:
                 urgency=3,
                 is_scheduled=False,
                 details={
-                    "bundle_item_count": len(items),
-                    "intervention_ids": [item.intervention_id for item in items if item.intervention_id],
-                    "delivery_decision": "deliver",
-                    "active_channel_adapters": sorted(active_channel_adapters),
+                    **details,
                     "transport": "native_notification",
                     "notification_id": notification.id,
                 },
             )
             return len(items)
-        await log_observer_delivery_event(
-            decision="failed",
-            message_type="proactive",
-            intervention_type="proactive_bundle",
-            urgency=3,
-            is_scheduled=False,
-            details={
-                "bundle_item_count": len(items),
-                "queue_retained": True,
-                "delivery_decision": "deliver",
-                "active_channel_adapters": sorted(active_channel_adapters),
-                "error": _transport_failure_reason(
-                    attempted_connections=0,
-                    failed_connections=0,
-                    websocket_enabled=False,
+
+        if transport == "websocket":
+            broadcast_result = await ws_manager.broadcast(message)
+            details.update(
+                {
+                    "attempted_connections": broadcast_result.attempted_connections,
+                    "delivered_connections": broadcast_result.delivered_connections,
+                    "failed_connections": broadcast_result.failed_connections,
+                }
+            )
+            if broadcast_result.delivered_connections > 0:
+                await insight_queue.delete_many(
+                    [item.id for item in items if getattr(item, "id", None)]
+                )
+                for item in items:
+                    await _update_intervention_outcome(
+                        item.intervention_id,
+                        latest_outcome="bundle_delivered",
+                        transport="websocket_bundle",
+                    )
+                logger.info("Delivered bundle of %d queued insight(s)", len(items))
+                await log_observer_delivery_event(
+                    decision="delivered",
+                    message_type=message.type,
+                    intervention_type=message.intervention_type,
+                    urgency=message.urgency,
+                    is_scheduled=False,
+                    details={**details, "transport": "websocket"},
+                )
+                return len(items)
+            last_error = _prefer_delivery_error(
+                last_error,
+                _transport_failure_reason(
+                attempted_connections=broadcast_result.attempted_connections,
+                failed_connections=broadcast_result.failed_connections,
+                websocket_enabled=True,
                 ),
-            },
-        )
-        return 0
+            )
 
-    # Format as a single bundle message
-    parts = []
-    for item in items:
-        parts.append(f"- {item.content}")
-    bundle_content = f"While you were away ({len(items)} update{'s' if len(items) != 1 else ''}):\n" + "\n".join(parts)
-
-    message = WSResponse(
-        type="proactive",
-        content=bundle_content,
-        intervention_type="proactive_bundle",
-        urgency=3,
-        reasoning=f"Bundle of {len(items)} queued insight(s) delivered on state transition",
-    )
-    broadcast_result = await ws_manager.broadcast(message)
-    details = {
-        "bundle_item_count": len(items),
-        "intervention_ids": [item.intervention_id for item in items if item.intervention_id],
-        "attempted_connections": broadcast_result.attempted_connections,
-        "delivered_connections": broadcast_result.delivered_connections,
-        "failed_connections": broadcast_result.failed_connections,
-        "delivery_decision": "deliver",
-        "active_channel_adapters": sorted(active_channel_adapters),
-    }
-    if broadcast_result.delivered_connections <= 0:
-        logger.warning(
-            "Failed to deliver queued bundle over WebSocket transport (attempted=%d failed=%d)",
-            broadcast_result.attempted_connections,
-            broadcast_result.failed_connections,
-        )
-        await log_observer_delivery_event(
-            decision="failed",
-            message_type=message.type,
-            intervention_type=message.intervention_type,
-            urgency=message.urgency,
-            is_scheduled=False,
-            details={
-                **details,
-                "queue_retained": True,
-                "error": _transport_failure_reason(
-                    attempted_connections=broadcast_result.attempted_connections,
-                    failed_connections=broadcast_result.failed_connections,
-                    websocket_enabled=True,
-                ),
-            },
-        )
-        return 0
-
-    await insight_queue.delete_many(
-        [item.id for item in items if getattr(item, "id", None)]
-    )
-    for item in items:
-        await _update_intervention_outcome(
-            item.intervention_id,
-            latest_outcome="bundle_delivered",
-            transport="websocket_bundle",
-        )
-    logger.info("Delivered bundle of %d queued insight(s)", len(items))
     await log_observer_delivery_event(
-        decision="delivered",
+        decision="failed",
         message_type=message.type,
         intervention_type=message.intervention_type,
         urgency=message.urgency,
         is_scheduled=False,
-        details=details,
+        details={
+            **details,
+            "queue_retained": True,
+            "transport": transport_order[0] if transport_order else None,
+            "error": last_error,
+        },
     )
-    return len(items)
+    return 0

--- a/backend/src/tools/browser_session_tool.py
+++ b/backend/src/tools/browser_session_tool.py
@@ -7,7 +7,7 @@ from smolagents import tool
 from config.settings import settings
 from src.approval.runtime import get_current_session_id
 from src.browser.sessions import browser_session_runtime
-from src.extensions.browser_providers import select_active_browser_provider
+from src.extensions.browser_providers import list_browser_provider_inventory, select_active_browser_provider
 from src.extensions.registry import ExtensionRegistry, default_manifest_roots_for_workspace
 from src.extensions.state import connector_enabled_overrides, load_extension_state_payload
 from src.tools.browser_tool import browse_webpage
@@ -58,6 +58,67 @@ def _require_owner_session_id() -> str | None:
     return session_id
 
 
+def _browser_provider_inventory() -> list[dict[str, object]]:
+    state_payload = load_extension_state_payload()
+    state_by_id = state_payload.get("extensions")
+    snapshot = ExtensionRegistry(
+        manifest_roots=default_manifest_roots_for_workspace(settings.workspace_dir),
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    ).snapshot()
+    inventory = list_browser_provider_inventory(
+        snapshot.list_contributions("browser_providers"),
+        state_by_id=state_by_id if isinstance(state_by_id, dict) else None,
+        enabled_overrides=connector_enabled_overrides(state_by_id if isinstance(state_by_id, dict) else None),
+    )
+    return [
+        {
+            "name": item.name,
+            "provider_kind": item.provider_kind,
+            "enabled": item.enabled,
+            "configured": item.configured,
+            "selected": item.selected,
+            "execution_mode": item.execution_mode,
+            "runtime_state": item.runtime_state,
+            "config_keys": list(item.config_keys),
+            "requires_network": item.requires_network,
+            "requires_daemon": item.requires_daemon,
+            "capabilities": list(item.capabilities),
+            "description": item.description,
+        }
+        for item in inventory
+    ]
+
+
+def _render_provider_inventory() -> str:
+    inventory = _browser_provider_inventory()
+    if not inventory:
+        return (
+            "- local-browser · local · ready · local_runtime · selected\n"
+            "  Built-in local browser runtime. Remote providers are not configured."
+        )
+    lines: list[str] = []
+    for item in inventory:
+        state_bits = [
+            item["runtime_state"],
+            str(item["execution_mode"]),
+        ]
+        if item["selected"]:
+            state_bits.append("selected")
+        elif item["enabled"]:
+            state_bits.append("enabled")
+        else:
+            state_bits.append("disabled")
+        lines.append(
+            f"- {item['name']} · {item['provider_kind']} · {' · '.join(state_bits)}"
+        )
+        description = str(item.get("description") or "").strip()
+        if description:
+            lines.append(f"  {description}")
+    return "\n".join(lines)
+
+
 def _render_session_list(owner_session_id: str) -> str:
     sessions = browser_session_runtime.list_sessions(owner_session_id=owner_session_id)
     if not sessions:
@@ -83,7 +144,7 @@ def browser_session(
     """Manage structured browser sessions and page references.
 
     Args:
-        action: One of open, list, read, snapshot, or close.
+        action: One of providers, open, list, read, snapshot, or close.
         url: URL for open.
         session_id: Session id for read, snapshot, or close.
         ref: Snapshot reference for read.
@@ -98,6 +159,9 @@ def browser_session(
     owner_session_id = _require_owner_session_id()
     if owner_session_id is None:
         return "Error: browser_session requires an active session."
+
+    if normalized_action == "providers":
+        return _render_provider_inventory()
 
     if normalized_action == "list":
         return _render_session_list(owner_session_id)
@@ -185,4 +249,4 @@ def browser_session(
             return f"Error: Browser session '{session_id}' was not found."
         return f"Closed browser session {session_id}."
 
-    return "Error: Unsupported browser_session action. Use open, list, read, snapshot, or close."
+    return "Error: Unsupported browser_session action. Use providers, open, list, read, snapshot, or close."

--- a/backend/src/workflows/loader.py
+++ b/backend/src/workflows/loader.py
@@ -59,6 +59,11 @@ class Workflow:
     result_template: str = ""
     source: str = "legacy"
     extension_id: str | None = None
+    runtime_profile: str = ""
+    output_surface: str = ""
+    output_surface_title: str = ""
+    output_surface_sections: list[str] = field(default_factory=list)
+    output_surface_artifact_types: list[str] = field(default_factory=list)
 
     @property
     def tool_name(self) -> str:
@@ -114,6 +119,8 @@ def parse_workflow_content(
     requires = frontmatter.get("requires", {})
     inputs = frontmatter.get("inputs", {})
     result_template = frontmatter.get("result", "")
+    runtime_profile = frontmatter.get("runtime_profile", "")
+    output_surface = frontmatter.get("output_surface", "")
     if not isinstance(requires, dict):
         requires = {}
     if not isinstance(inputs, dict):
@@ -121,6 +128,12 @@ def parse_workflow_content(
         return None
     if result_template and not isinstance(result_template, str):
         _record_workflow_error(errors, path=path, message=f"Workflow file {path} has invalid 'result' field")
+        return None
+    if runtime_profile and not isinstance(runtime_profile, str):
+        _record_workflow_error(errors, path=path, message=f"Workflow file {path} has invalid 'runtime_profile' field")
+        return None
+    if output_surface and not isinstance(output_surface, str):
+        _record_workflow_error(errors, path=path, message=f"Workflow file {path} has invalid 'output_surface' field")
         return None
 
     parsed_steps: list[WorkflowStep] = []
@@ -203,6 +216,8 @@ def parse_workflow_content(
         file_path=path,
         body=body,
         result_template=result_template if isinstance(result_template, str) else "",
+        runtime_profile=runtime_profile.strip() if isinstance(runtime_profile, str) else "",
+        output_surface=output_surface.strip() if isinstance(output_surface, str) else "",
     )
 
 

--- a/backend/src/workflows/manager.py
+++ b/backend/src/workflows/manager.py
@@ -814,9 +814,12 @@ class WorkflowManager:
         skill_set = set(active_skill_names)
         runtime_profiles = available_runtime_profiles or set()
         output_surfaces = available_output_surfaces or set()
+        required_runtime_tools = _canonicalize_tool_names(
+            list(workflow.requires_tools) + list(workflow.step_tools)
+        )
         missing_tools = [
-            canonical_tool_name(tool_name) for tool_name in workflow.requires_tools
-            if canonical_tool_name(tool_name) not in tool_set
+            tool_name for tool_name in required_runtime_tools
+            if tool_name not in tool_set
         ]
         missing_skills = [
             skill_name for skill_name in workflow.requires_skills

--- a/backend/src/workflows/manager.py
+++ b/backend/src/workflows/manager.py
@@ -73,6 +73,71 @@ def _summarize_workflow_result(workflow: Workflow, step_results: dict[str, dict[
     return "\n".join(lines)
 
 
+def _build_canvas_output(
+    workflow: Workflow,
+    *,
+    result_text: str,
+    step_records: list[dict[str, Any]],
+    artifact_paths: list[str],
+) -> dict[str, Any] | None:
+    if not workflow.output_surface:
+        return None
+    step_items = [
+        f"{step['id']} · {step['tool']} · {step['status']}"
+        + (f" · {step['result_summary']}" if step.get("result_summary") else "")
+        for step in step_records
+    ]
+    configured_sections = workflow.output_surface_sections or ["Summary", "Steps"]
+    sections: list[dict[str, Any]] = []
+    for label in configured_sections:
+        normalized = label.strip().casefold()
+        if normalized == "summary":
+            items = [result_text]
+        elif normalized == "steps":
+            items = step_items
+        elif normalized == "artifacts":
+            items = list(artifact_paths)
+        else:
+            items = [result_text]
+        if items:
+            sections.append({"label": label, "items": items})
+    if artifact_paths and not any(section["label"].strip().casefold() == "artifacts" for section in sections):
+        sections.append({"label": "Artifacts", "items": list(artifact_paths)})
+    return {
+        "surface": workflow.output_surface,
+        "title": workflow.output_surface_title or workflow.name,
+        "summary": result_text,
+        "section_count": len(sections),
+        "sections": sections,
+    }
+
+
+def _redact_canvas_output(canvas_output: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(canvas_output, dict):
+        return None
+    redacted_sections: list[dict[str, Any]] = []
+    raw_sections = canvas_output.get("sections")
+    if isinstance(raw_sections, list):
+        for section in raw_sections:
+            if not isinstance(section, dict):
+                continue
+            items = section.get("items")
+            item_count = len(items) if isinstance(items, list) else 0
+            redacted_sections.append(
+                {
+                    "label": str(section.get("label") or ""),
+                    "item_count": item_count,
+                }
+            )
+    return {
+        "surface": str(canvas_output.get("surface") or ""),
+        "title": str(canvas_output.get("title") or ""),
+        "summary": "workflow content redacted",
+        "section_count": int(canvas_output.get("section_count") or len(redacted_sections)),
+        "sections": redacted_sections,
+    }
+
+
 def _collect_artifact_paths(value: Any) -> list[str]:
     paths: list[str] = []
 
@@ -226,6 +291,12 @@ class WorkflowTool(Tool):
             result_text = str(rendered)
         else:
             result_text = _summarize_workflow_result(self.workflow, context["steps"])
+        canvas_output = _build_canvas_output(
+            self.workflow,
+            result_text=result_text,
+            step_records=step_records,
+            artifact_paths=artifact_paths,
+        )
 
         status = "degraded" if continued_error_steps else "succeeded"
         summary = f"{self.name} {status} ({len(self.workflow.steps)} steps)"
@@ -255,6 +326,9 @@ class WorkflowTool(Tool):
                 "artifact_paths": artifact_paths,
                 "continued_error_steps": continued_error_steps,
                 "failed_step_ids": continued_error_steps,
+                "runtime_profile": self.workflow.runtime_profile,
+                "output_surface": self.workflow.output_surface,
+                "canvas_output": _redact_canvas_output(canvas_output),
                 "content_redacted": True,
             },
         )
@@ -329,6 +403,38 @@ class WorkflowManager:
 
     def _reload_from_registry(self) -> None:
         snapshot = self._snapshot()
+        runtime_defaults_by_name: dict[str, str] = {}
+        canvas_metadata_by_name: dict[str, dict[str, Any]] = {}
+        for contribution in snapshot.list_contributions("workflow_runtimes"):
+            if isinstance(contribution.metadata.get("registry_conflict"), dict):
+                continue
+            name = contribution.metadata.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            default_output_surface = contribution.metadata.get("default_output_surface")
+            if isinstance(default_output_surface, str) and default_output_surface.strip():
+                runtime_defaults_by_name[name.strip()] = default_output_surface.strip()
+        for contribution in snapshot.list_contributions("canvas_outputs"):
+            if isinstance(contribution.metadata.get("registry_conflict"), dict):
+                continue
+            name = contribution.metadata.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            raw_sections = contribution.metadata.get("sections")
+            raw_artifact_types = contribution.metadata.get("artifact_types")
+            canvas_metadata_by_name[name.strip()] = {
+                "title": str(contribution.metadata.get("title") or ""),
+                "sections": [
+                    str(item).strip()
+                    for item in raw_sections
+                    if isinstance(item, str) and item.strip()
+                ] if isinstance(raw_sections, list) else [],
+                "artifact_types": [
+                    str(item).strip()
+                    for item in raw_artifact_types
+                    if isinstance(item, str) and item.strip()
+                ] if isinstance(raw_artifact_types, list) else [],
+            }
         contribution_paths: list[str] = []
         contribution_index: dict[str, tuple[str, str | None, int]] = {}
         for contribution in snapshot.list_contributions("workflows"):
@@ -351,6 +457,13 @@ class WorkflowManager:
             )
             workflow.source = source
             workflow.extension_id = extension_id
+            if not workflow.output_surface and workflow.runtime_profile:
+                workflow.output_surface = runtime_defaults_by_name.get(workflow.runtime_profile, "")
+            if workflow.output_surface:
+                canvas_metadata = canvas_metadata_by_name.get(workflow.output_surface, {})
+                workflow.output_surface_title = str(canvas_metadata.get("title") or "")
+                workflow.output_surface_sections = list(canvas_metadata.get("sections") or [])
+                workflow.output_surface_artifact_types = list(canvas_metadata.get("artifact_types") or [])
             manifest_priority_by_path[os.path.abspath(workflow.file_path)] = manifest_root_index
 
         load_errors: list[dict[str, str]] = []
@@ -500,6 +613,18 @@ class WorkflowManager:
     ) -> list[dict[str, Any]]:
         snapshot = self._snapshot()
         extensions_by_id = {extension.id: extension for extension in snapshot.extensions}
+        available_runtime_profiles = {
+            str(item.metadata.get("name"))
+            for item in snapshot.list_contributions("workflow_runtimes")
+            if not isinstance(item.metadata.get("registry_conflict"), dict)
+            if isinstance(item.metadata.get("name"), str) and str(item.metadata.get("name")).strip()
+        }
+        available_output_surfaces = {
+            str(item.metadata.get("name"))
+            for item in snapshot.list_contributions("canvas_outputs")
+            if not isinstance(item.metadata.get("registry_conflict"), dict)
+            if isinstance(item.metadata.get("name"), str) and str(item.metadata.get("name")).strip()
+        }
         workflows: list[dict[str, Any]] = []
         for workflow in self._workflows:
             permission_profile = evaluate_tool_permissions(
@@ -519,6 +644,11 @@ class WorkflowManager:
                 "file_path": workflow.file_path,
                 "source": workflow.source,
                 "extension_id": workflow.extension_id,
+                "runtime_profile": workflow.runtime_profile,
+                "output_surface": workflow.output_surface,
+                "output_surface_title": workflow.output_surface_title,
+                "output_surface_sections": list(workflow.output_surface_sections),
+                "output_surface_artifact_types": list(workflow.output_surface_artifact_types),
                 "policy_modes": self._infer_policy_modes(workflow),
                 "execution_boundaries": self._infer_execution_boundaries(workflow),
                 "risk_level": self._infer_risk_level(workflow),
@@ -537,6 +667,8 @@ class WorkflowManager:
                         workflow,
                         available_tool_names,
                         active_skill_names,
+                        available_runtime_profiles=available_runtime_profiles,
+                        available_output_surfaces=available_output_surfaces,
                         permission_profile=permission_profile,
                     )
                 )
@@ -598,6 +730,18 @@ class WorkflowManager:
         skill_set = set(active_skill_names)
         snapshot = self._snapshot()
         extensions_by_id = {extension.id: extension for extension in snapshot.extensions}
+        available_runtime_profiles = {
+            str(item.metadata.get("name"))
+            for item in snapshot.list_contributions("workflow_runtimes")
+            if not isinstance(item.metadata.get("registry_conflict"), dict)
+            if isinstance(item.metadata.get("name"), str) and str(item.metadata.get("name")).strip()
+        }
+        available_output_surfaces = {
+            str(item.metadata.get("name"))
+            for item in snapshot.list_contributions("canvas_outputs")
+            if not isinstance(item.metadata.get("registry_conflict"), dict)
+            if isinstance(item.metadata.get("name"), str) and str(item.metadata.get("name")).strip()
+        }
         result: list[Workflow] = []
         for workflow in self._workflows:
             if not workflow.enabled:
@@ -606,15 +750,15 @@ class WorkflowManager:
                 extensions_by_id.get(workflow.extension_id) if workflow.extension_id else None,
                 tool_names=workflow.step_tools,
             )
-            if not permission_profile["ok"]:
-                continue
-            if workflow.step_tools and not all(
-                canonical_tool_name(tool_name) in tool_set for tool_name in workflow.step_tools
-            ):
-                continue
-            if workflow.requires_skills and not all(
-                skill_name in skill_set for skill_name in workflow.requires_skills
-            ):
+            availability = self._get_runtime_availability(
+                workflow,
+                list(tool_set),
+                list(skill_set),
+                available_runtime_profiles=available_runtime_profiles,
+                available_output_surfaces=available_output_surfaces,
+                permission_profile=permission_profile,
+            )
+            if not permission_profile["ok"] or not availability["is_available"]:
                 continue
             result.append(workflow)
         return result
@@ -642,6 +786,11 @@ class WorkflowManager:
         return {
             "description": workflow.description,
             "inputs": workflow.inputs,
+            "runtime_profile": workflow.runtime_profile,
+            "output_surface": workflow.output_surface,
+            "output_surface_title": workflow.output_surface_title,
+            "output_surface_sections": list(workflow.output_surface_sections),
+            "output_surface_artifact_types": list(workflow.output_surface_artifact_types),
             "policy_modes": policy_modes,
             "requires_tools": _canonicalize_tool_names(workflow.requires_tools),
             "requires_skills": workflow.requires_skills,
@@ -657,10 +806,14 @@ class WorkflowManager:
         available_tool_names: list[str],
         active_skill_names: list[str],
         *,
+        available_runtime_profiles: set[str] | None = None,
+        available_output_surfaces: set[str] | None = None,
         permission_profile: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         tool_set = {canonical_tool_name(name) for name in available_tool_names}
         skill_set = set(active_skill_names)
+        runtime_profiles = available_runtime_profiles or set()
+        output_surfaces = available_output_surfaces or set()
         missing_tools = [
             canonical_tool_name(tool_name) for tool_name in workflow.requires_tools
             if canonical_tool_name(tool_name) not in tool_set
@@ -669,6 +822,16 @@ class WorkflowManager:
             skill_name for skill_name in workflow.requires_skills
             if skill_name not in skill_set
         ]
+        missing_runtime_profiles = (
+            [workflow.runtime_profile]
+            if workflow.runtime_profile and workflow.runtime_profile not in runtime_profiles
+            else []
+        )
+        missing_output_surfaces = (
+            [workflow.output_surface]
+            if workflow.output_surface and workflow.output_surface not in output_surfaces
+            else []
+        )
         missing_manifest_tools = list((permission_profile or {}).get("missing_tools", []))
         missing_manifest_execution_boundaries = list(
             (permission_profile or {}).get("missing_execution_boundaries", [])
@@ -678,12 +841,16 @@ class WorkflowManager:
             "is_available": (
                 not missing_tools
                 and not missing_skills
+                and not missing_runtime_profiles
+                and not missing_output_surfaces
                 and not missing_manifest_tools
                 and not missing_manifest_execution_boundaries
                 and not missing_manifest_network
             ),
             "missing_tools": missing_tools,
             "missing_skills": missing_skills,
+            "missing_runtime_profiles": missing_runtime_profiles,
+            "missing_output_surfaces": missing_output_surfaces,
             "missing_manifest_tools": missing_manifest_tools,
             "missing_manifest_execution_boundaries": missing_manifest_execution_boundaries,
             "missing_manifest_network": missing_manifest_network,

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -31,7 +31,7 @@ async def test_runtime_status_exposes_release_and_model(client):
 
 
 @pytest.mark.asyncio
-async def test_browser_session_api_is_not_publicly_exposed(client):
-    response = await client.get("/api/browser/sessions")
+async def test_browser_provider_api_is_publicly_exposed(client):
+    response = await client.get("/api/browser/providers")
 
-    assert response.status_code == 404
+    assert response.status_code == 200

--- a/backend/tests/test_automation_api.py
+++ b/backend/tests/test_automation_api.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from config.settings import settings
+
+
+def _write_automation_pack(workspace):
+    package_dir = workspace / "extensions" / "openclaw-automation"
+    (package_dir / "automation").mkdir(parents=True)
+    package_dir.joinpath("manifest.yaml").write_text(
+        "id: seraph.openclaw-automation\n"
+        "version: 2026.3.24\n"
+        "display_name: OpenClaw Automation\n"
+        "kind: connector-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  automation_triggers:\n"
+        "    - automation/webhook.yaml\n"
+        "    - automation/poll.yaml\n"
+        "    - automation/pubsub.yaml\n",
+        encoding="utf-8",
+    )
+    package_dir.joinpath("automation", "webhook.yaml").write_text(
+        "name: inbound-webhook\n"
+        "description: Signed inbound webhook.\n"
+        "trigger_type: webhook\n"
+        "endpoint: /api/automation/webhooks/inbound-webhook\n"
+        "enabled: true\n"
+        "config_fields:\n"
+        "  - key: signing_secret\n"
+        "    label: Signing Secret\n"
+        "    input: password\n"
+        "    required: true\n",
+        encoding="utf-8",
+    )
+    package_dir.joinpath("automation", "poll.yaml").write_text(
+        "name: remote-poll\n"
+        "description: Remote poll watcher.\n"
+        "trigger_type: poll\n"
+        "schedule: \"*/5 * * * *\"\n"
+        "enabled: true\n",
+        encoding="utf-8",
+    )
+    package_dir.joinpath("automation", "pubsub.yaml").write_text(
+        "name: guardian-topic\n"
+        "description: Guarded pubsub topic.\n"
+        "trigger_type: pubsub\n"
+        "topic: seraph.guardian\n"
+        "enabled: false\n",
+        encoding="utf-8",
+    )
+    return package_dir
+
+
+def _write_duplicate_webhook_pack(workspace, *, package_name: str, extension_id: str):
+    package_dir = workspace / "extensions" / package_name
+    (package_dir / "automation").mkdir(parents=True)
+    package_dir.joinpath("manifest.yaml").write_text(
+        f"id: {extension_id}\n"
+        "version: 2026.3.24\n"
+        "display_name: Duplicate Webhook\n"
+        "kind: connector-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  automation_triggers:\n"
+        "    - automation/shared.yaml\n",
+        encoding="utf-8",
+    )
+    package_dir.joinpath("automation", "shared.yaml").write_text(
+        "name: shared-hook\n"
+        "description: Shared webhook.\n"
+        "trigger_type: webhook\n"
+        "endpoint: /api/automation/webhooks/shared-hook\n"
+        "enabled: true\n",
+        encoding="utf-8",
+    )
+    return package_dir
+
+
+@pytest.mark.asyncio
+async def test_automation_trigger_inventory_lists_runtime_states(client, tmp_path):
+    workspace = tmp_path / "workspace"
+    package_dir = _write_automation_pack(workspace)
+    (workspace / "extensions-state.json").write_text(
+        json.dumps(
+            {
+                "extensions": {
+                    "seraph.openclaw-automation": {
+                        "config": {
+                            "automation_triggers": {
+                                "inbound-webhook": {"signing_secret": "top-secret"},
+                            }
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with patch.object(settings, "workspace_dir", str(workspace)):
+        response = await client.get("/api/automation/triggers")
+
+    assert response.status_code == 200
+    triggers = {item["name"]: item for item in response.json()["triggers"]}
+    assert triggers["inbound-webhook"]["runtime_state"] == "armed_webhook"
+    assert triggers["inbound-webhook"]["endpoint"] == "/api/automation/webhooks/inbound-webhook"
+    assert triggers["remote-poll"]["runtime_state"] == "staged_runtime"
+    assert triggers["remote-poll"]["endpoint"] == ""
+    assert triggers["guardian-topic"]["runtime_state"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_webhook_trigger_accepts_signed_payload(client, tmp_path):
+    workspace = tmp_path / "workspace"
+    _write_automation_pack(workspace)
+    (workspace / "extensions-state.json").write_text(
+        json.dumps(
+            {
+                "extensions": {
+                    "seraph.openclaw-automation": {
+                        "config": {
+                            "automation_triggers": {
+                                "inbound-webhook": {"signing_secret": "top-secret"},
+                            }
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with (
+        patch.object(settings, "workspace_dir", str(workspace)),
+        patch("src.api.automation.log_integration_event", AsyncMock()),
+    ):
+        rejected = await client.post(
+            "/api/automation/webhooks/inbound-webhook",
+            headers={"X-Seraph-Signature": "wrong"},
+            json={"kind": "sync"},
+        )
+        accepted = await client.post(
+            "/api/automation/webhooks/inbound-webhook",
+            headers={"X-Seraph-Signature": "top-secret"},
+            json={"kind": "sync"},
+        )
+
+    assert rejected.status_code == 403
+    assert accepted.status_code == 200
+    payload = accepted.json()
+    assert payload["status"] == "accepted"
+    assert payload["trigger"]["name"] == "inbound-webhook"
+    assert payload["payload"] == {"kind": "sync"}
+
+
+@pytest.mark.asyncio
+async def test_webhook_trigger_requires_signing_secret_even_when_pack_omits_config_fields(client, tmp_path):
+    workspace = tmp_path / "workspace"
+    package_dir = workspace / "extensions" / "unsigned-webhook"
+    (package_dir / "automation").mkdir(parents=True)
+    package_dir.joinpath("manifest.yaml").write_text(
+        "id: seraph.unsigned-webhook\n"
+        "version: 2026.3.24\n"
+        "display_name: Unsigned Webhook\n"
+        "kind: connector-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  automation_triggers:\n"
+        "    - automation/webhook.yaml\n",
+        encoding="utf-8",
+    )
+    package_dir.joinpath("automation", "webhook.yaml").write_text(
+        "name: unsigned-hook\n"
+        "description: Missing explicit config fields.\n"
+        "trigger_type: webhook\n"
+        "endpoint: /api/automation/webhooks/unsigned-hook\n"
+        "enabled: true\n",
+        encoding="utf-8",
+    )
+
+    with patch.object(settings, "workspace_dir", str(workspace)):
+        inventory_response = await client.get("/api/automation/triggers")
+        webhook_response = await client.post("/api/automation/webhooks/unsigned-hook", json={"kind": "sync"})
+
+    assert inventory_response.status_code == 200
+    triggers = {item["name"]: item for item in inventory_response.json()["triggers"]}
+    assert triggers["unsigned-hook"]["configured"] is False
+    assert triggers["unsigned-hook"]["runtime_state"] == "requires_config"
+    assert "signing_secret" not in triggers["unsigned-hook"]["config_keys"]
+    assert webhook_response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_duplicate_webhook_trigger_names_do_not_arm_inventory_or_route(client, tmp_path):
+    workspace = tmp_path / "workspace"
+    _write_duplicate_webhook_pack(workspace, package_name="dup-a", extension_id="seraph.dup-a")
+    _write_duplicate_webhook_pack(workspace, package_name="dup-b", extension_id="seraph.dup-b")
+
+    with patch.object(settings, "workspace_dir", str(workspace)):
+        response = await client.get("/api/automation/triggers")
+        webhook_response = await client.post("/api/automation/webhooks/shared-hook", json={"kind": "sync"})
+
+    assert response.status_code == 200
+    trigger_names = [item["name"] for item in response.json()["triggers"]]
+    assert trigger_names == []
+    assert webhook_response.status_code == 404

--- a/backend/tests/test_browser_api.py
+++ b/backend/tests/test_browser_api.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from config.settings import settings
+
+
+@pytest.mark.asyncio
+async def test_browser_provider_inventory_endpoint_lists_staged_remote_modes(client, tmp_path):
+    workspace = tmp_path / "workspace"
+    remote_pack = workspace / "extensions" / "openclaw-remote-cdp"
+    relay_pack = workspace / "extensions" / "openclaw-extension-relay"
+    (remote_pack / "connectors" / "browser").mkdir(parents=True)
+    (relay_pack / "connectors" / "browser").mkdir(parents=True)
+    remote_pack.joinpath("manifest.yaml").write_text(
+        "id: seraph.openclaw-remote-cdp\n"
+        "version: 2026.3.24\n"
+        "display_name: OpenClaw Remote CDP\n"
+        "kind: connector-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  browser_providers:\n"
+        "    - connectors/browser/remote-cdp.yaml\n",
+        encoding="utf-8",
+    )
+    remote_pack.joinpath("connectors", "browser", "remote-cdp.yaml").write_text(
+        "name: remote-cdp\n"
+        "description: Remote CDP provider.\n"
+        "provider_kind: remote_cdp\n"
+        "enabled: false\n"
+        "config_fields:\n"
+        "  - key: ws_endpoint\n"
+        "    label: CDP WebSocket Endpoint\n"
+        "    input: url\n"
+        "    required: true\n",
+        encoding="utf-8",
+    )
+    relay_pack.joinpath("manifest.yaml").write_text(
+        "id: seraph.openclaw-extension-relay\n"
+        "version: 2026.3.24\n"
+        "display_name: OpenClaw Extension Relay\n"
+        "kind: connector-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  browser_providers:\n"
+        "    - connectors/browser/extension-relay.yaml\n",
+        encoding="utf-8",
+    )
+    relay_pack.joinpath("connectors", "browser", "extension-relay.yaml").write_text(
+        "name: extension-relay\n"
+        "description: Extension relay provider.\n"
+        "provider_kind: extension_relay\n"
+        "enabled: false\n"
+        "config_fields:\n"
+        "  - key: relay_token\n"
+        "    label: Relay Token\n"
+        "    input: password\n"
+        "    required: true\n",
+        encoding="utf-8",
+    )
+    (workspace / "extensions-state.json").write_text(
+        json.dumps(
+            {
+                "extensions": {
+                    "seraph.openclaw-remote-cdp": {
+                        "config": {
+                            "browser_providers": {
+                                "remote-cdp": {"ws_endpoint": "wss://browser.example.test/devtools"},
+                            }
+                        },
+                        "connector_state": {
+                            "connectors/browser/remote-cdp.yaml": {"enabled": True},
+                        },
+                    },
+                    "seraph.openclaw-extension-relay": {
+                        "config": {
+                            "browser_providers": {
+                                "extension-relay": {"relay_token": "secret"},
+                            }
+                        },
+                        "connector_state": {
+                            "connectors/browser/extension-relay.yaml": {"enabled": True},
+                        },
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with patch.object(settings, "workspace_dir", str(workspace)):
+        response = await client.get("/api/browser/providers")
+
+    assert response.status_code == 200
+    providers = response.json()["providers"]
+    names = {item["name"] for item in providers}
+    assert {"local-browser", "remote-cdp", "extension-relay"}.issubset(names)
+    local_runtime = next(item for item in providers if item["name"] == "local-browser")
+    assert local_runtime["provider_kind"] == "local"
+    assert local_runtime["runtime_state"] == "ready"
+    assert local_runtime["execution_mode"] == "local_runtime"
+    remote_cdp = next(item for item in providers if item["name"] == "remote-cdp")
+    assert remote_cdp["provider_kind"] == "remote_cdp"
+    assert remote_cdp["runtime_state"] == "staged_local_fallback"
+    assert remote_cdp["execution_mode"] == "local_fallback"
+
+
+@pytest.mark.asyncio
+async def test_browser_session_rest_surface_remains_unmounted(client):
+    list_response = await client.get("/api/browser/sessions")
+    assert list_response.status_code == 404
+
+    get_response = await client.get("/api/browser/sessions/bs-123")
+    assert get_response.status_code == 404
+
+    delete_response = await client.delete("/api/browser/sessions/bs-123")
+    assert delete_response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_duplicate_browser_provider_names_keep_only_priority_winner_visible(client, tmp_path):
+    workspace = tmp_path / "workspace"
+    first_pack = workspace / "extensions" / "browser-a"
+    second_pack = workspace / "extensions" / "browser-z"
+    for package_dir, extension_id, display_name, description in (
+        (first_pack, "seraph.browser-a", "A Browser Winner", "Priority winner."),
+        (second_pack, "seraph.browser-z", "Z Browser Loser", "Lower priority loser."),
+    ):
+        (package_dir / "connectors" / "browser").mkdir(parents=True)
+        package_dir.joinpath("manifest.yaml").write_text(
+            f"id: {extension_id}\n"
+            "version: 2026.3.24\n"
+            f"display_name: {display_name}\n"
+            "kind: connector-pack\n"
+            "compatibility:\n"
+            "  seraph: \">=2026.3.19\"\n"
+            "publisher:\n"
+            "  name: Seraph\n"
+            "trust: local\n"
+            "contributes:\n"
+            "  browser_providers:\n"
+            "    - connectors/browser/shared.yaml\n",
+            encoding="utf-8",
+        )
+        package_dir.joinpath("connectors", "browser", "shared.yaml").write_text(
+            "name: shared-provider\n"
+            f"description: {description}\n"
+            "provider_kind: remote_cdp\n"
+            "enabled: true\n"
+            "config_fields:\n"
+            "  - key: ws_endpoint\n"
+            "    label: CDP WebSocket Endpoint\n"
+            "    input: url\n"
+            "    required: true\n",
+            encoding="utf-8",
+        )
+
+    with patch.object(settings, "workspace_dir", str(workspace)):
+        response = await client.get("/api/browser/providers")
+
+    assert response.status_code == 200
+    shared = [item for item in response.json()["providers"] if item["name"] == "shared-provider"]
+    assert len(shared) == 1
+    assert shared[0]["extension_id"] == "seraph.browser-a"
+    assert shared[0]["description"] == "Priority winner."

--- a/backend/tests/test_browser_session_tool.py
+++ b/backend/tests/test_browser_session_tool.py
@@ -32,6 +32,12 @@ def test_browser_session_lists_empty_runtime(browser_runtime_session):
     assert browser_session(action="list") == "No browser sessions are open."
 
 
+def test_browser_session_lists_provider_inventory_when_no_packaged_providers_are_configured(browser_runtime_session):
+    providers = browser_session(action="providers")
+
+    assert "local-browser · local · ready · local_runtime · selected" in providers
+
+
 def test_browser_session_open_snapshot_read_and_close_round_trip(browser_runtime_session):
     with patch("src.tools.browser_session_tool.browse_webpage", side_effect=["first capture", "second capture"]):
         opened = browser_session(action="open", url="https://example.com/docs")
@@ -119,6 +125,67 @@ def test_browser_session_uses_configured_browser_provider_with_local_fallback(tm
     latest_ref = opened.split("Latest ref: ")[1].split(".")[0]
     read_latest = browser_session(action="read", ref=latest_ref)
     assert "mode=local_fallback" in read_latest
+
+
+def test_browser_session_lists_staged_provider_inventory(tmp_path, browser_runtime_session):
+    workspace = tmp_path / "workspace"
+    extension_dir = workspace / "extensions" / "browserbase-pack"
+    state_path = workspace / "extensions-state.json"
+    (extension_dir / "connectors" / "browser").mkdir(parents=True)
+    workspace.mkdir(exist_ok=True)
+    (extension_dir / "manifest.yaml").write_text(
+        "id: seraph.hermes-browserbase\n"
+        "version: 2026.3.24\n"
+        "display_name: Hermes Browserbase\n"
+        "kind: connector-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  browser_providers:\n"
+        "    - connectors/browser/browserbase.yaml\n",
+        encoding="utf-8",
+    )
+    (extension_dir / "connectors" / "browser" / "browserbase.yaml").write_text(
+        "name: browserbase\n"
+        "description: Managed Browserbase-style browser provider.\n"
+        "provider_kind: browserbase\n"
+        "enabled: true\n"
+        "config_fields:\n"
+        "  - key: api_key\n"
+        "    label: Browserbase API Key\n"
+        "    input: password\n"
+        "    required: true\n",
+        encoding="utf-8",
+    )
+    state_path.write_text(
+        json.dumps(
+            {
+                "extensions": {
+                    "seraph.hermes-browserbase": {
+                        "config": {
+                            "browser_providers": {
+                                "browserbase": {"api_key": "secret"},
+                            }
+                        },
+                        "connector_state": {
+                            "connectors/browser/browserbase.yaml": {"enabled": True},
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with patch.object(settings, "workspace_dir", str(workspace)):
+        providers = browser_session(action="providers")
+
+    assert "local-browser · local · ready · local_runtime · enabled" in providers
+    assert "browserbase · browserbase · staged_local_fallback · local_fallback · selected" in providers
+    assert "Managed Browserbase-style browser provider" in providers
 
 
 def test_browser_session_errors_for_missing_requested_provider(tmp_path, browser_runtime_session):

--- a/backend/tests/test_canvas_api.py
+++ b/backend/tests/test_canvas_api.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from config.settings import settings
+
+
+def _write_canvas_pack(workspace):
+    package_dir = workspace / "extensions" / "openclaw-canvas"
+    (package_dir / "canvas").mkdir(parents=True)
+    package_dir.joinpath("manifest.yaml").write_text(
+        "id: seraph.openclaw-canvas\n"
+        "version: 2026.3.24\n"
+        "display_name: OpenClaw Canvas\n"
+        "kind: capability-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  canvas_outputs:\n"
+        "    - canvas/guardian-board.yaml\n",
+        encoding="utf-8",
+    )
+    package_dir.joinpath("canvas", "guardian-board.yaml").write_text(
+        "name: guardian-board\n"
+        "title: Guardian Board\n"
+        "description: Structured board for workflow runs.\n"
+        "surface_kind: board\n"
+        "sections:\n"
+        "  - Summary\n"
+        "  - Steps\n"
+        "artifact_types:\n"
+        "  - note\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_canvas_output_inventory_lists_structured_surfaces(client, tmp_path):
+    workspace = tmp_path / "workspace"
+    _write_canvas_pack(workspace)
+
+    with patch.object(settings, "workspace_dir", str(workspace)):
+        response = await client.get("/api/canvas/outputs")
+
+    assert response.status_code == 200
+    outputs = {item["name"]: item for item in response.json()["outputs"]}
+    assert outputs["guardian-board"]["title"] == "Guardian Board"
+    assert outputs["guardian-board"]["surface_kind"] == "board"
+    assert outputs["guardian-board"]["sections"] == ["Summary", "Steps"]

--- a/backend/tests/test_catalog_api.py
+++ b/backend/tests/test_catalog_api.py
@@ -678,6 +678,50 @@ class TestCatalogAPI:
         assert "browser_session" in preset["include_tools"]
 
     @pytest.mark.asyncio
+    async def test_install_catalog_remote_cdp_pack_surfaces_staged_browser_provider_metadata(self, client, catalog_extension_runtime):
+        install = await client.post("/api/catalog/install/seraph.openclaw-remote-cdp")
+
+        assert install.status_code == 201
+        assert install.json()["extension_id"] == "seraph.openclaw-remote-cdp"
+
+        extension = await client.get("/api/extensions/seraph.openclaw-remote-cdp")
+        assert extension.status_code == 200
+        contributions = extension.json()["extension"]["contributions"]
+        provider = next(item for item in contributions if item["type"] == "browser_providers")
+        preset = next(item for item in contributions if item["type"] == "toolset_presets")
+        assert provider["name"] == "remote-cdp"
+        assert provider["provider_kind"] == "remote_cdp"
+        assert provider["status"] == "requires_config"
+        assert preset["name"] == "remote-cdp-ops"
+        assert "browser_session" in preset["include_tools"]
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_extension_relay_pack_surfaces_staged_browser_provider_metadata(self, client, catalog_extension_runtime):
+        install = await client.post("/api/catalog/install/seraph.openclaw-extension-relay")
+
+        assert install.status_code == 409
+        approval_detail = install.json()["detail"]
+        assert approval_detail["type"] == "approval_required"
+
+        approve = await client.post(f"/api/approvals/{approval_detail['approval_id']}/approve")
+        assert approve.status_code == 200
+
+        install = await client.post("/api/catalog/install/seraph.openclaw-extension-relay")
+        assert install.status_code == 201
+        assert install.json()["extension_id"] == "seraph.openclaw-extension-relay"
+
+        extension = await client.get("/api/extensions/seraph.openclaw-extension-relay")
+        assert extension.status_code == 200
+        contributions = extension.json()["extension"]["contributions"]
+        provider = next(item for item in contributions if item["type"] == "browser_providers")
+        preset = next(item for item in contributions if item["type"] == "toolset_presets")
+        assert provider["name"] == "extension-relay"
+        assert provider["provider_kind"] == "extension_relay"
+        assert provider["status"] == "requires_config"
+        assert preset["name"] == "extension-relay-ops"
+        assert "browser_session" in preset["include_tools"]
+
+    @pytest.mark.asyncio
     async def test_install_catalog_browser_ops_pack_surfaces_browser_skills_and_toolset(self, client, catalog_extension_runtime):
         install = await client.post("/api/catalog/install/seraph.hermes-browser-ops")
 
@@ -696,6 +740,111 @@ class TestCatalogAPI:
         assert skill_names == {"browser-session-review", "browser-snapshot"}
         assert preset["name"] == "browser-session-ops"
         assert "browser_session" in preset["include_tools"]
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_webhook_gateway_pack_surfaces_automation_trigger_metadata(self, client, catalog_extension_runtime):
+        install = await client.post("/api/catalog/install/seraph.openclaw-webhook-gateway")
+
+        assert install.status_code == 409
+        approval_detail = install.json()["detail"]
+        assert approval_detail["type"] == "approval_required"
+
+        approve = await client.post(f"/api/approvals/{approval_detail['approval_id']}/approve")
+        assert approve.status_code == 200
+
+        install = await client.post("/api/catalog/install/seraph.openclaw-webhook-gateway")
+        assert install.status_code == 201
+        assert install.json()["extension_id"] == "seraph.openclaw-webhook-gateway"
+
+        extension = await client.get("/api/extensions/seraph.openclaw-webhook-gateway")
+        assert extension.status_code == 200
+        contributions = extension.json()["extension"]["contributions"]
+        trigger = next(item for item in contributions if item["type"] == "automation_triggers")
+        assert trigger["name"] == "openclaw-webhook"
+        assert trigger["trigger_type"] == "webhook"
+        assert trigger["status"] == "requires_config"
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_poll_and_pubsub_packs_surface_staged_trigger_metadata(self, client, catalog_extension_runtime):
+        poll_install = await client.post("/api/catalog/install/seraph.openclaw-poll-watch")
+        pubsub_install = await client.post("/api/catalog/install/seraph.openclaw-pubsub-relay")
+
+        assert poll_install.status_code == 201
+        assert pubsub_install.status_code == 201
+
+        poll_extension = await client.get("/api/extensions/seraph.openclaw-poll-watch")
+        pubsub_extension = await client.get("/api/extensions/seraph.openclaw-pubsub-relay")
+        assert poll_extension.status_code == 200
+        assert pubsub_extension.status_code == 200
+
+        poll_trigger = next(
+            item for item in poll_extension.json()["extension"]["contributions"] if item["type"] == "automation_triggers"
+        )
+        pubsub_trigger = next(
+            item for item in pubsub_extension.json()["extension"]["contributions"] if item["type"] == "automation_triggers"
+        )
+        assert poll_trigger["trigger_type"] == "poll"
+        assert poll_trigger["status"] == "disabled"
+        assert pubsub_trigger["trigger_type"] == "pubsub"
+        assert pubsub_trigger["status"] == "disabled"
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_node_packs_surface_node_adapter_metadata(self, client, catalog_extension_runtime):
+        companion_install = await client.post("/api/catalog/install/seraph.openclaw-companion-node")
+        device_install = await client.post("/api/catalog/install/seraph.openclaw-device-bridge")
+
+        assert companion_install.status_code == 201
+        assert device_install.status_code == 201
+
+        companion_extension = await client.get("/api/extensions/seraph.openclaw-companion-node")
+        device_extension = await client.get("/api/extensions/seraph.openclaw-device-bridge")
+        assert companion_extension.status_code == 200
+        assert device_extension.status_code == 200
+
+        companion_adapter = next(
+            item for item in companion_extension.json()["extension"]["contributions"] if item["type"] == "node_adapters"
+        )
+        device_adapter = next(
+            item for item in device_extension.json()["extension"]["contributions"] if item["type"] == "node_adapters"
+        )
+        assert companion_adapter["name"] == "openclaw-companion"
+        assert companion_adapter["adapter_kind"] == "companion"
+        assert companion_adapter["status"] == "requires_config"
+        assert device_adapter["name"] == "openclaw-device"
+        assert device_adapter["adapter_kind"] == "device"
+        assert device_adapter["status"] == "requires_config"
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_canvas_pack_surfaces_canvas_output_metadata(self, client, catalog_extension_runtime):
+        install = await client.post("/api/catalog/install/seraph.openclaw-canvas-board")
+
+        assert install.status_code == 201
+        assert install.json()["extension_id"] == "seraph.openclaw-canvas-board"
+
+        extension = await client.get("/api/extensions/seraph.openclaw-canvas-board")
+        assert extension.status_code == 200
+        contributions = extension.json()["extension"]["contributions"]
+        canvas_output = next(item for item in contributions if item["type"] == "canvas_outputs")
+        assert canvas_output["name"] == "guardian-board"
+        assert canvas_output["surface_kind"] == "board"
+        assert canvas_output["sections"] == ["Summary", "Steps", "Artifacts"]
+
+    @pytest.mark.asyncio
+    async def test_install_catalog_workflow_runtimes_pack_surfaces_runtime_and_workflow_metadata(self, client, catalog_extension_runtime):
+        install = await client.post("/api/catalog/install/seraph.openclaw-workflow-runtimes")
+
+        assert install.status_code == 201
+        assert install.json()["extension_id"] == "seraph.openclaw-workflow-runtimes"
+
+        extension = await client.get("/api/extensions/seraph.openclaw-workflow-runtimes")
+        assert extension.status_code == 200
+        contributions = extension.json()["extension"]["contributions"]
+        runtime_profile = next(item for item in contributions if item["type"] == "workflow_runtimes" and item["name"] == "openprose")
+        workflow = next(item for item in contributions if item["type"] == "workflows" and item["name"] == "openprose-brief")
+        assert runtime_profile["engine_kind"] == "openprose"
+        assert runtime_profile["structured_output"] is True
+        assert workflow["runtime_profile"] == "openprose"
+        assert workflow["output_surface"] == "guardian-board"
 
     @pytest.mark.asyncio
     async def test_install_catalog_speech_pack_surfaces_speech_profile_metadata(self, client, catalog_extension_runtime):

--- a/backend/tests/test_delivery.py
+++ b/backend/tests/test_delivery.py
@@ -7,7 +7,7 @@ import pytest
 from config.settings import settings
 from src.extensions.state import save_extension_state_payload
 from src.audit.repository import audit_repository
-from src.guardian.feedback import guardian_feedback_repository
+from src.guardian.feedback import GuardianLearningSignal, guardian_feedback_repository
 from src.models.schemas import WSResponse
 from src.observer.context import CurrentContext
 from src.observer.delivery import _active_channel_adapters, deliver_or_queue, deliver_queued_bundle
@@ -26,7 +26,7 @@ def _make_context(**overrides) -> CurrentContext:
     return CurrentContext(**defaults)
 
 
-def _patch_deps(ctx):
+def _patch_deps(ctx, *, use_actual_learning_signal: bool = False):
     """Patch the lazy-imported singletons at their source modules."""
     mock_cm = MagicMock()
     mock_cm.get_context.return_value = ctx
@@ -48,6 +48,13 @@ def _patch_deps(ctx):
         patch("src.scheduler.connection_manager.ws_manager", mock_ws),
         patch("src.observer.insight_queue.insight_queue", mock_iq),
     ]
+    if not use_actual_learning_signal:
+        patches.append(
+            patch(
+                "src.guardian.feedback.guardian_feedback_repository.get_learning_signal",
+                AsyncMock(side_effect=lambda intervention_type, limit=12: GuardianLearningSignal.neutral(intervention_type)),
+            )
+        )
     return patches, mock_cm, mock_ws, mock_iq
 
 
@@ -96,6 +103,48 @@ async def test_native_channel_adapter_can_deliver_without_websocket():
 
 
 @pytest.mark.asyncio
+async def test_channel_routing_can_prefer_native_notification_for_live_delivery(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    original_workspace_dir = settings.workspace_dir
+    settings.workspace_dir = str(workspace_dir)
+    save_extension_state_payload(
+        {
+            "extensions": {},
+            "channel_routing": {
+                "bindings": {
+                    "live_delivery": {
+                        "primary_transport": "native_notification",
+                        "fallback_transport": "websocket",
+                    }
+                }
+            },
+        }
+    )
+    ctx = _make_context()
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    mock_cm.is_daemon_connected.return_value = True
+    for p in patches:
+        p.start()
+    try:
+        await native_notification_queue.clear()
+        msg = WSResponse(type="proactive", content="Route to native", intervention_type="advisory", urgency=2)
+        with patch("src.observer.delivery._active_channel_adapters", return_value={"websocket", "native_notification"}):
+            decision = await deliver_or_queue(msg)
+
+        assert decision.action == InterventionAction.act
+        mock_ws.broadcast.assert_not_called()
+        notification = await native_notification_queue.peek()
+        assert notification is not None
+        assert notification.body == "Route to native"
+    finally:
+        await native_notification_queue.clear()
+        settings.workspace_dir = original_workspace_dir
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
 async def test_native_channel_adapter_can_deliver_queued_bundle_without_websocket():
     ctx = _make_context()
     patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
@@ -124,7 +173,135 @@ async def test_native_channel_adapter_can_deliver_queued_bundle_without_websocke
             p.stop()
 
 
-def test_active_channel_adapters_can_disable_all_packaged_transports(tmp_path):
+@pytest.mark.asyncio
+async def test_channel_routing_can_prefer_native_notification_for_bundle_delivery(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    original_workspace_dir = settings.workspace_dir
+    settings.workspace_dir = str(workspace_dir)
+    save_extension_state_payload(
+        {
+            "extensions": {},
+            "channel_routing": {
+                "bindings": {
+                    "bundle_delivery": {
+                        "primary_transport": "native_notification",
+                        "fallback_transport": "websocket",
+                    }
+                }
+            },
+        }
+    )
+    ctx = _make_context()
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    mock_cm.is_daemon_connected.return_value = True
+    mock_iq.peek_all = AsyncMock(
+        return_value=[
+            MagicMock(id="queued-1", content="Queued update", intervention_id="intervention-1"),
+        ]
+    )
+    for p in patches:
+        p.start()
+    try:
+        await native_notification_queue.clear()
+        with patch("src.observer.delivery._active_channel_adapters", return_value={"websocket", "native_notification"}):
+            delivered = await deliver_queued_bundle()
+
+        assert delivered == 1
+        mock_ws.broadcast.assert_not_called()
+        notification = await native_notification_queue.peek()
+        assert notification is not None
+        assert "Queued update" in notification.body
+    finally:
+        await native_notification_queue.clear()
+        settings.workspace_dir = original_workspace_dir
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_channel_routing_can_prefer_websocket_for_scheduled_delivery(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    original_workspace_dir = settings.workspace_dir
+    settings.workspace_dir = str(workspace_dir)
+    save_extension_state_payload(
+        {
+            "extensions": {},
+            "channel_routing": {
+                "bindings": {
+                    "scheduled_delivery": {
+                        "primary_transport": "websocket",
+                        "fallback_transport": "native_notification",
+                    }
+                }
+            },
+        }
+    )
+    ctx = _make_context()
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    mock_cm.is_daemon_connected.return_value = True
+    for p in patches:
+        p.start()
+    try:
+        await native_notification_queue.clear()
+        msg = WSResponse(type="proactive", content="Scheduled route", intervention_type="advisory", urgency=2)
+        with patch("src.observer.delivery._active_channel_adapters", return_value={"websocket", "native_notification"}):
+            decision = await deliver_or_queue(msg, is_scheduled=True)
+
+        assert decision.action == InterventionAction.act
+        mock_ws.broadcast.assert_called_once_with(msg)
+        assert await native_notification_queue.count() == 0
+    finally:
+        await native_notification_queue.clear()
+        settings.workspace_dir = original_workspace_dir
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_channel_routing_can_prefer_native_notification_for_alert_delivery(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    original_workspace_dir = settings.workspace_dir
+    settings.workspace_dir = str(workspace_dir)
+    save_extension_state_payload(
+        {
+            "extensions": {},
+            "channel_routing": {
+                "bindings": {
+                    "alert_delivery": {
+                        "primary_transport": "native_notification",
+                        "fallback_transport": "websocket",
+                    }
+                }
+            },
+        }
+    )
+    ctx = _make_context()
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    mock_cm.is_daemon_connected.return_value = True
+    for p in patches:
+        p.start()
+    try:
+        await native_notification_queue.clear()
+        msg = WSResponse(type="proactive", content="Alert route", intervention_type="alert", urgency=5)
+        with patch("src.observer.delivery._active_channel_adapters", return_value={"websocket", "native_notification"}):
+            decision = await deliver_or_queue(msg)
+
+        assert decision.action == InterventionAction.act
+        mock_ws.broadcast.assert_not_called()
+        notification = await native_notification_queue.peek()
+        assert notification is not None
+        assert notification.body == "Alert route"
+    finally:
+        await native_notification_queue.clear()
+        settings.workspace_dir = original_workspace_dir
+        for p in patches:
+            p.stop()
+
+
+def test_active_channel_adapters_fall_back_to_builtin_transports_when_none_are_active(tmp_path):
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
     original_workspace_dir = settings.workspace_dir
@@ -142,7 +319,41 @@ def test_active_channel_adapters_can_disable_all_packaged_transports(tmp_path):
                 }
             }
         )
-        assert _active_channel_adapters() == set()
+        assert _active_channel_adapters() == {"websocket", "native_notification"}
+    finally:
+        settings.workspace_dir = original_workspace_dir
+
+
+def test_active_channel_adapters_keep_builtin_transport_for_unclaimed_route(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    original_workspace_dir = settings.workspace_dir
+    settings.workspace_dir = str(workspace_dir)
+    try:
+        save_extension_state_payload({"extensions": {}})
+        with (
+            patch(
+                "src.extensions.channels.select_active_channel_adapters",
+                return_value=[
+                    type("Adapter", (), {"transport": "native_notification"})(),
+                ],
+            ),
+            patch(
+                "src.extensions.registry.ExtensionRegistry",
+                return_value=type(
+                    "Registry",
+                    (),
+                    {
+                        "snapshot": lambda self: type(
+                            "Snapshot",
+                            (),
+                            {"list_contributions": lambda _self, _kind: [object()]},
+                        )()
+                    },
+                )(),
+            ),
+        ):
+            assert _active_channel_adapters() == {"websocket", "native_notification"}
     finally:
         settings.workspace_dir = original_workspace_dir
 
@@ -325,7 +536,7 @@ async def test_queue_when_recent_negative_feedback(async_db):
     await guardian_feedback_repository.record_feedback(second.id, feedback_type="not_helpful")
 
     ctx = _make_context()
-    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx, use_actual_learning_signal=True)
     for p in patches:
         p.start()
     try:
@@ -378,7 +589,7 @@ async def test_learned_direct_delivery_overrides_high_interrupt_bundle(async_db)
         salience_reason="aligned_work_activity",
         interruption_cost="high",
     )
-    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx, use_actual_learning_signal=True)
     for p in patches:
         p.start()
     try:
@@ -425,7 +636,7 @@ async def test_acknowledged_native_feedback_can_lower_notification_threshold(asy
         await guardian_feedback_repository.record_feedback(intervention.id, feedback_type="acknowledged")
 
     ctx = _make_context()
-    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx)
+    patches, mock_cm, mock_ws, mock_iq = _patch_deps(ctx, use_actual_learning_signal=True)
     mock_cm.is_daemon_connected.return_value = True
     mock_ws.broadcast = AsyncMock(return_value=BroadcastResult(0, 0, 0))
     for p in patches:

--- a/backend/tests/test_extension_registry.py
+++ b/backend/tests/test_extension_registry.py
@@ -102,7 +102,7 @@ contributes:
         encoding="utf-8",
     )
     (pack_dir / "automation" / "daily-brief.yaml").write_text(
-        "name: daily-brief\ntrigger_type: webhook\nendpoint: https://example.test/hook\n",
+        "name: daily-brief\ntrigger_type: webhook\nendpoint: /api/automation/webhooks/daily-brief\n",
         encoding="utf-8",
     )
     (pack_dir / "connectors" / "browser" / "browserbase.yaml").write_text(
@@ -137,6 +137,8 @@ contributes:
     assert contributions["prompt_packs"]["name"] == "review-prompt"
     assert contributions["prompt_packs"]["title"] == "Review Prompt"
     assert contributions["automation_triggers"]["requires_network"] is True
+    assert contributions["automation_triggers"]["endpoint"] == "/api/automation/webhooks/daily-brief"
+    assert contributions["automation_triggers"]["config_fields"][0]["key"] == "signing_secret"
     assert contributions["browser_providers"]["provider_kind"] == "browserbase"
     assert contributions["messaging_connectors"]["platform"] == "telegram"
     assert contributions["speech_profiles"]["supports_tts"] is True

--- a/backend/tests/test_extension_registry.py
+++ b/backend/tests/test_extension_registry.py
@@ -563,6 +563,191 @@ contributes:
     assert extension.metadata["manifest_root_index"] == 0
 
 
+def test_registry_enriches_workflow_metadata_after_conflict_resolution(tmp_path: Path):
+    extensions_root = tmp_path / "extensions"
+
+    winner_canvas_dir = extensions_root / "canvas-a"
+    (winner_canvas_dir / "canvas").mkdir(parents=True)
+    (winner_canvas_dir / "manifest.yaml").write_text(
+        """
+id: seraph.canvas-a
+version: 2026.3.24
+display_name: A Canvas Winner
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: local
+contributes:
+  canvas_outputs:
+    - canvas/guardian-board.yaml
+""".strip(),
+        encoding="utf-8",
+    )
+    (winner_canvas_dir / "canvas" / "guardian-board.yaml").write_text(
+        """
+name: guardian-board
+title: Winner Board
+description: Preferred board.
+surface_kind: board
+sections:
+  - Summary
+  - Steps
+""".strip(),
+        encoding="utf-8",
+    )
+
+    loser_canvas_dir = extensions_root / "canvas-z"
+    (loser_canvas_dir / "canvas").mkdir(parents=True)
+    (loser_canvas_dir / "manifest.yaml").write_text(
+        """
+id: seraph.canvas-z
+version: 2026.3.24
+display_name: Z Canvas Loser
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: local
+contributes:
+  canvas_outputs:
+    - canvas/guardian-board.yaml
+""".strip(),
+        encoding="utf-8",
+    )
+    (loser_canvas_dir / "canvas" / "guardian-board.yaml").write_text(
+        """
+name: guardian-board
+title: Loser Board
+description: Losing board.
+surface_kind: board
+sections:
+  - Wrong
+""".strip(),
+        encoding="utf-8",
+    )
+
+    winner_runtime_dir = extensions_root / "runtime-a"
+    (winner_runtime_dir / "runtimes").mkdir(parents=True)
+    (winner_runtime_dir / "manifest.yaml").write_text(
+        """
+id: seraph.runtime-a
+version: 2026.3.24
+display_name: A Runtime Winner
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: local
+contributes:
+  workflow_runtimes:
+    - runtimes/openprose.yaml
+""".strip(),
+        encoding="utf-8",
+    )
+    (winner_runtime_dir / "runtimes" / "openprose.yaml").write_text(
+        """
+name: openprose
+engine_kind: openprose
+description: Preferred runtime.
+delegation_mode: inline
+checkpoint_policy: step
+structured_output: true
+default_output_surface: guardian-board
+""".strip(),
+        encoding="utf-8",
+    )
+
+    loser_runtime_dir = extensions_root / "runtime-z"
+    (loser_runtime_dir / "runtimes").mkdir(parents=True)
+    (loser_runtime_dir / "manifest.yaml").write_text(
+        """
+id: seraph.runtime-z
+version: 2026.3.24
+display_name: Z Runtime Loser
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: local
+contributes:
+  workflow_runtimes:
+    - runtimes/openprose.yaml
+""".strip(),
+        encoding="utf-8",
+    )
+    (loser_runtime_dir / "runtimes" / "openprose.yaml").write_text(
+        """
+name: openprose
+engine_kind: openprose
+description: Losing runtime.
+delegation_mode: inline
+checkpoint_policy: step
+structured_output: true
+default_output_surface: wrong-board
+""".strip(),
+        encoding="utf-8",
+    )
+
+    workflow_dir = extensions_root / "workflow-pack"
+    (workflow_dir / "workflows").mkdir(parents=True)
+    (workflow_dir / "manifest.yaml").write_text(
+        """
+id: seraph.workflow-pack
+version: 2026.3.24
+display_name: Workflow Pack
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.3.19"
+publisher:
+  name: Seraph
+trust: local
+contributes:
+  workflows:
+    - workflows/runtime-aware.md
+permissions:
+  tools: [web_search]
+""".strip(),
+        encoding="utf-8",
+    )
+    (workflow_dir / "workflows" / "runtime-aware.md").write_text(
+        "---\n"
+        "name: runtime-aware\n"
+        "description: Runtime-aware workflow\n"
+        "runtime_profile: openprose\n"
+        "requires:\n"
+        "  tools: [web_search]\n"
+        "steps:\n"
+        "  - id: search\n"
+        "    tool: web_search\n"
+        "    arguments: {}\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    snapshot = ExtensionRegistry(
+        manifest_roots=[str(extensions_root)],
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    ).snapshot()
+
+    extension = snapshot.get_extension("seraph.workflow-pack")
+    assert extension is not None
+    workflow_contribution = next(
+        contribution
+        for contribution in extension.contributions
+        if contribution.contribution_type == "workflows"
+    )
+    assert workflow_contribution.metadata["effective_output_surface"] == "guardian-board"
+    assert workflow_contribution.metadata["output_surface_title"] == "Winner Board"
+    assert workflow_contribution.metadata["output_surface_sections"] == ["Summary", "Steps"]
+
+
 def test_registry_enriches_manifest_backed_managed_connector_metadata(tmp_path: Path):
     pack_dir = tmp_path / "extensions" / "managed-connector-pack"
     connector_dir = pack_dir / "connectors" / "managed"

--- a/backend/tests/test_extensions_api.py
+++ b/backend/tests/test_extensions_api.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -362,7 +362,7 @@ def _write_wave2_extension(root: Path) -> Path:
         encoding="utf-8",
     )
     (package_dir / "automation" / "daily-brief.yaml").write_text(
-        "name: daily-brief\ntrigger_type: webhook\nendpoint: https://example.test/hooks/daily\nconfig_fields:\n  - key: signing_secret\n    label: Signing Secret\n    input: password\n",
+        "name: daily-brief\ntrigger_type: webhook\nendpoint: /api/automation/webhooks/daily-brief\nconfig_fields:\n  - key: signing_secret\n    label: Signing Secret\n    input: password\n",
         encoding="utf-8",
     )
     (package_dir / "connectors" / "browser" / "browserbase.yaml").write_text(
@@ -486,6 +486,69 @@ def _write_invalid_channel_adapter_extension(root: Path) -> Path:
     (package_dir / "channels" / "native.yaml").write_text(
         "name: invalid-native\n"
         "description: Missing transport\n"
+        "enabled: true\n",
+        encoding="utf-8",
+    )
+    return package_dir
+
+
+def _write_invalid_planned_connector_extension(root: Path) -> Path:
+    package_dir = root / "invalid-planned-pack"
+    (package_dir / "automation").mkdir(parents=True)
+    (package_dir / "connectors" / "nodes").mkdir(parents=True)
+    (package_dir / "manifest.yaml").write_text(
+        "id: seraph.invalid-planned\n"
+        "version: 2026.3.24\n"
+        "display_name: Invalid Planned Connectors\n"
+        "kind: connector-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  automation_triggers:\n"
+        "    - automation/trigger.yaml\n"
+        "  node_adapters:\n"
+        "    - connectors/nodes/adapter.yaml\n",
+        encoding="utf-8",
+    )
+    (package_dir / "automation" / "trigger.yaml").write_text(
+        "name: broken-trigger\n"
+        "description: Missing trigger type.\n",
+        encoding="utf-8",
+    )
+    (package_dir / "connectors" / "nodes" / "adapter.yaml").write_text(
+        "name: broken-node\n"
+        "description: Missing adapter kind.\n",
+        encoding="utf-8",
+    )
+    return package_dir
+
+
+def _write_duplicate_automation_extension(root: Path, *, package_name: str, extension_id: str) -> Path:
+    package_dir = root / package_name
+    (package_dir / "automation").mkdir(parents=True)
+    (package_dir / "manifest.yaml").write_text(
+        f"id: {extension_id}\n"
+        "version: 2026.3.24\n"
+        "display_name: Duplicate Automation\n"
+        "kind: connector-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  automation_triggers:\n"
+        "    - automation/shared.yaml\n",
+        encoding="utf-8",
+    )
+    (package_dir / "automation" / "shared.yaml").write_text(
+        "name: shared-hook\n"
+        "description: Duplicate shared webhook.\n"
+        "trigger_type: webhook\n"
+        "endpoint: /api/automation/webhooks/shared-hook\n"
         "enabled: true\n",
         encoding="utf-8",
     )
@@ -2197,6 +2260,181 @@ async def test_invalid_channel_adapter_surfaces_invalid_status_in_extension_payl
     assert adapter["loaded"] is False
     assert adapter["status"] == "invalid"
     assert invalid_extension["doctor_ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_invalid_planned_connectors_surface_invalid_status_in_extension_payload(client, extension_runtime):
+    _write_invalid_planned_connector_extension(extension_runtime / "extensions")
+
+    response = await client.get("/api/extensions")
+
+    assert response.status_code == 200
+    extensions = {item["id"]: item for item in response.json()["extensions"]}
+    invalid_extension = extensions["seraph.invalid-planned"]
+    connectors = {item["type"]: item for item in invalid_extension["contributions"]}
+
+    assert connectors["automation_triggers"]["status"] == "invalid"
+    assert connectors["automation_triggers"]["health"]["state"] == "invalid"
+    assert connectors["node_adapters"]["status"] == "invalid"
+    assert connectors["node_adapters"]["health"]["state"] == "invalid"
+    assert invalid_extension["doctor_ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_duplicate_automation_trigger_name_invalidates_all_colliding_definitions(client, extension_runtime):
+    _write_duplicate_automation_extension(
+        extension_runtime / "extensions",
+        package_name="dup-automation-a",
+        extension_id="seraph.dup-automation-a",
+    )
+    _write_duplicate_automation_extension(
+        extension_runtime / "extensions",
+        package_name="dup-automation-b",
+        extension_id="seraph.dup-automation-b",
+    )
+
+    responses = [
+        await client.get("/api/extensions/seraph.dup-automation-a"),
+        await client.get("/api/extensions/seraph.dup-automation-b"),
+    ]
+
+    for response in responses:
+        assert response.status_code == 200
+        extension = response.json()["extension"]
+        trigger = next(item for item in extension["contributions"] if item["type"] == "automation_triggers")
+        assert trigger["status"] == "invalid"
+        assert trigger["health"]["state"] == "invalid"
+        assert "conflicts with" in trigger["health"]["summary"]
+        assert any(error["phase"] == "duplicate-automation_trigger-name" for error in extension["load_errors"])
+
+
+@pytest.mark.asyncio
+async def test_channel_routing_defaults_surface_active_adapters(client, extension_runtime):
+    response = await client.get("/api/extensions/channel-routing")
+
+    assert response.status_code == 200
+    payload = response.json()
+    bindings = {item["route"]: item for item in payload["bindings"]}
+
+    assert payload["supported_transports"] == ["websocket", "native_notification"]
+    assert payload["active_transports"] == ["native_notification", "websocket"]
+    assert {item["transport"] for item in payload["active_adapters"]} == {
+        "websocket",
+        "native_notification",
+    }
+    assert bindings["live_delivery"]["primary_transport"] == "websocket"
+    assert bindings["live_delivery"]["fallback_transport"] == "native_notification"
+    assert bindings["alert_delivery"]["primary_transport"] == "native_notification"
+
+
+@pytest.mark.asyncio
+async def test_channel_routing_defaults_to_builtin_transports_when_no_channel_adapters_are_active(client, extension_runtime):
+    snapshot = MagicMock()
+    snapshot.list_contributions.return_value = [MagicMock()]
+    registry_instance = MagicMock()
+    registry_instance.snapshot.return_value = snapshot
+
+    with (
+        patch("src.api.extensions.ExtensionRegistry", return_value=registry_instance),
+        patch("src.api.extensions.select_active_channel_adapters", return_value=[]),
+    ):
+        response = await client.get("/api/extensions/channel-routing")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["active_transports"] == ["native_notification", "websocket"]
+    assert {item["transport"] for item in payload["active_adapters"]} == {
+        "websocket",
+        "native_notification",
+    }
+
+
+@pytest.mark.asyncio
+async def test_channel_routing_keeps_builtin_transport_for_unclaimed_route(client, extension_runtime):
+    snapshot = MagicMock()
+    snapshot.list_contributions.return_value = [MagicMock()]
+    registry_instance = MagicMock()
+    registry_instance.snapshot.return_value = snapshot
+
+    with (
+        patch("src.api.extensions.ExtensionRegistry", return_value=registry_instance),
+        patch(
+            "src.api.extensions.select_active_channel_adapters",
+            return_value=[
+                type(
+                    "Adapter",
+                    (),
+                    {
+                        "extension_id": "seraph.custom-native",
+                        "name": "custom-native",
+                        "transport": "native_notification",
+                        "reference": "channels/native.yaml",
+                    },
+                )()
+            ],
+        ),
+    ):
+        response = await client.get("/api/extensions/channel-routing")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["active_transports"] == ["native_notification", "websocket"]
+    assert {item["transport"] for item in payload["active_adapters"]} == {
+        "websocket",
+        "native_notification",
+    }
+    websocket_adapter = next(item for item in payload["active_adapters"] if item["transport"] == "websocket")
+    assert websocket_adapter["extension_id"] == "seraph.builtin-channel-adapters"
+
+
+@pytest.mark.asyncio
+async def test_channel_routing_update_persists_custom_bindings(client, extension_runtime):
+    with patch("src.api.extensions.log_integration_event", AsyncMock()):
+        update_response = await client.put(
+            "/api/extensions/channel-routing",
+            json={
+                "bindings": {
+                    "live_delivery": {
+                        "primary_transport": "native_notification",
+                        "fallback_transport": "websocket",
+                    },
+                    "bundle_delivery": {
+                        "primary_transport": "native_notification",
+                    },
+                }
+            },
+        )
+
+    assert update_response.status_code == 200
+    updated = {item["route"]: item for item in update_response.json()["bindings"]}
+    assert updated["live_delivery"]["primary_transport"] == "native_notification"
+    assert updated["live_delivery"]["fallback_transport"] == "websocket"
+    assert updated["bundle_delivery"]["primary_transport"] == "native_notification"
+    assert updated["bundle_delivery"]["fallback_transport"] is None
+
+    reread_response = await client.get("/api/extensions/channel-routing")
+    assert reread_response.status_code == 200
+    reread = {item["route"]: item for item in reread_response.json()["bindings"]}
+    assert reread["live_delivery"]["primary_transport"] == "native_notification"
+    assert reread["bundle_delivery"]["primary_transport"] == "native_notification"
+
+
+@pytest.mark.asyncio
+async def test_channel_routing_update_rejects_unknown_routes_and_transports(client, extension_runtime):
+    with patch("src.api.extensions.log_integration_event", AsyncMock()):
+        invalid_route = await client.put(
+            "/api/extensions/channel-routing",
+            json={"bindings": {"unknown_route": {"primary_transport": "websocket"}}},
+        )
+        invalid_transport = await client.put(
+            "/api/extensions/channel-routing",
+            json={"bindings": {"live_delivery": {"primary_transport": "email"}}},
+        )
+
+    assert invalid_route.status_code == 422
+    assert "Unknown channel route" in invalid_route.json()["detail"]
+    assert invalid_transport.status_code == 422
+    assert "Unsupported channel route transport" in invalid_transport.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_nodes_api.py
+++ b/backend/tests/test_nodes_api.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from config.settings import settings
+
+
+def _write_node_pack(workspace):
+    package_dir = workspace / "extensions" / "openclaw-node"
+    (package_dir / "connectors" / "nodes").mkdir(parents=True)
+    package_dir.joinpath("manifest.yaml").write_text(
+        "id: seraph.openclaw-node\n"
+        "version: 2026.3.24\n"
+        "display_name: OpenClaw Node\n"
+        "kind: connector-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  node_adapters:\n"
+        "    - connectors/nodes/companion.yaml\n"
+        "    - connectors/nodes/canvas.yaml\n",
+        encoding="utf-8",
+    )
+    package_dir.joinpath("connectors", "nodes", "companion.yaml").write_text(
+        "name: companion-node\n"
+        "description: Companion node link.\n"
+        "adapter_kind: companion\n"
+        "enabled: true\n"
+        "config_fields:\n"
+        "  - key: node_url\n"
+        "    label: Node URL\n"
+        "    input: url\n"
+        "    required: true\n",
+        encoding="utf-8",
+    )
+    package_dir.joinpath("connectors", "nodes", "canvas.yaml").write_text(
+        "name: canvas-node\n"
+        "description: Canvas adapter.\n"
+        "adapter_kind: canvas\n"
+        "enabled: true\n",
+        encoding="utf-8",
+    )
+    return package_dir
+
+
+@pytest.mark.asyncio
+async def test_node_adapter_inventory_lists_staged_and_canvas_states(client, tmp_path):
+    workspace = tmp_path / "workspace"
+    _write_node_pack(workspace)
+    (workspace / "extensions-state.json").write_text(
+        json.dumps(
+            {
+                "extensions": {
+                    "seraph.openclaw-node": {
+                        "config": {
+                            "node_adapters": {
+                                "companion-node": {"node_url": "https://nodes.example.test"},
+                            }
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with patch.object(settings, "workspace_dir", str(workspace)):
+        response = await client.get("/api/nodes/adapters")
+
+    assert response.status_code == 200
+    adapters = {item["name"]: item for item in response.json()["adapters"]}
+    assert adapters["companion-node"]["runtime_state"] == "staged_link"
+    assert adapters["companion-node"]["configured"] is True
+    assert adapters["companion-node"]["requires_network"] is True
+    assert adapters["canvas-node"]["runtime_state"] == "staged_canvas"
+    assert adapters["canvas-node"]["requires_network"] is False

--- a/backend/tests/test_workflow_runtimes_api.py
+++ b/backend/tests/test_workflow_runtimes_api.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from config.settings import settings
+
+
+def _write_workflow_runtime_pack(workspace):
+    package_dir = workspace / "extensions" / "openclaw-runtimes"
+    (package_dir / "runtimes").mkdir(parents=True)
+    package_dir.joinpath("manifest.yaml").write_text(
+        "id: seraph.openclaw-runtimes\n"
+        "version: 2026.3.24\n"
+        "display_name: OpenClaw Runtimes\n"
+        "kind: capability-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  workflow_runtimes:\n"
+        "    - runtimes/openprose.yaml\n",
+        encoding="utf-8",
+    )
+    package_dir.joinpath("runtimes", "openprose.yaml").write_text(
+        "name: openprose\n"
+        "engine_kind: openprose\n"
+        "description: Narrative drafting runtime.\n"
+        "delegation_mode: inline\n"
+        "checkpoint_policy: step\n"
+        "structured_output: true\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_runtimes_inventory_lists_profiles(client, tmp_path):
+    workspace = tmp_path / "workspace"
+    _write_workflow_runtime_pack(workspace)
+
+    with patch.object(settings, "workspace_dir", str(workspace)):
+        response = await client.get("/api/workflows/runtimes")
+
+    assert response.status_code == 200
+    runtimes = {item["name"]: item for item in response.json()["runtimes"]}
+    assert runtimes["openprose"]["engine_kind"] == "openprose"
+    assert runtimes["openprose"]["structured_output"] is True

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -328,6 +328,25 @@ class TestWorkflowManager:
             "goal-snapshot-to-file",
         }
 
+    def test_active_workflow_gating_uses_step_tools_even_without_requires_tools(self, workflows_dir):
+        mgr = WorkflowManager()
+        mgr.init(workflows_dir)
+        workflow = mgr.get_workflow("web-brief-to-file")
+        assert workflow is not None
+        workflow.requires_tools = []
+
+        listed = next(
+            workflow
+            for workflow in mgr.list_workflows(
+                available_tool_names=["web_search"],
+                active_skill_names=[],
+            )
+            if workflow["name"] == "web-brief-to-file"
+        )
+        assert listed["is_available"] is False
+        assert listed["missing_tools"] == ["write_file"]
+        assert mgr.get_active_workflows(["web_search"], []) == []
+
     def test_enable_disable_persists(self, workflows_dir):
         mgr = WorkflowManager()
         mgr.init(workflows_dir)

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -11,7 +11,7 @@ import pytest
 
 from src.extensions.registry import default_manifest_roots_for_workspace
 from src.workflows.loader import Workflow, WorkflowStep, _parse_workflow_file, load_workflows
-from src.workflows.manager import WorkflowManager, WorkflowTool
+from src.workflows.manager import WorkflowManager, WorkflowTool, workflow_manager
 from src.approval.exceptions import ApprovalRequired
 from src.approval.runtime import reset_runtime_context, set_runtime_context
 from src.agent.factory import get_tools
@@ -85,6 +85,82 @@ def _write_manifest_workflow_package(
     workflows_path = package_dir / "workflows"
     workflows_path.mkdir(exist_ok=True)
     (workflows_path / workflow_file_name).write_text(workflow_content, encoding="utf-8")
+    return package_dir
+
+
+def _write_manifest_canvas_package(
+    root,
+    *,
+    package_name: str = "canvas-pack",
+    extension_id: str = "seraph.canvas-pack",
+    display_name: str = "Canvas Pack",
+    title: str = "Guardian Board",
+):
+    package_dir = root / "extensions" / package_name
+    (package_dir / "canvas").mkdir(parents=True, exist_ok=True)
+    (package_dir / "manifest.yaml").write_text(
+        "id: " + extension_id + "\n"
+        "version: 2026.3.24\n"
+        f"display_name: {display_name}\n"
+        "kind: capability-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  canvas_outputs:\n"
+        "    - canvas/guardian-board.yaml\n",
+        encoding="utf-8",
+    )
+    (package_dir / "canvas" / "guardian-board.yaml").write_text(
+        "name: guardian-board\n"
+        f"title: {title}\n"
+        "description: Structured workflow board.\n"
+        "surface_kind: board\n"
+        "sections:\n"
+        "  - Summary\n"
+        "  - Steps\n",
+        encoding="utf-8",
+    )
+    return package_dir
+
+
+def _write_manifest_workflow_runtime_package(
+    root,
+    *,
+    package_name: str = "runtime-pack",
+    extension_id: str = "seraph.runtime-pack",
+    display_name: str = "Runtime Pack",
+    default_output_surface: str = "guardian-board",
+):
+    package_dir = root / "extensions" / package_name
+    (package_dir / "runtimes").mkdir(parents=True, exist_ok=True)
+    (package_dir / "manifest.yaml").write_text(
+        "id: " + extension_id + "\n"
+        "version: 2026.3.24\n"
+        f"display_name: {display_name}\n"
+        "kind: capability-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  workflow_runtimes:\n"
+        "    - runtimes/openprose.yaml\n",
+        encoding="utf-8",
+    )
+    (package_dir / "runtimes" / "openprose.yaml").write_text(
+        "name: openprose\n"
+        "engine_kind: openprose\n"
+        "description: Narrative drafting runtime.\n"
+        "delegation_mode: inline\n"
+        "checkpoint_policy: step\n"
+        "structured_output: true\n"
+        f"default_output_surface: {default_output_surface}\n",
+        encoding="utf-8",
+    )
     return package_dir
 
 
@@ -206,6 +282,31 @@ class TestWorkflowLoader:
         assert workflow is not None
         assert workflow.step_tools == ["web_search", "write_file"]
 
+    def test_parse_workflow_tracks_runtime_profile_and_output_surface(self, tmp_path):
+        workflow_path = tmp_path / "runtime-aware.md"
+        workflow_path.write_text(
+            "---\n"
+            "name: runtime-aware\n"
+            "description: Runtime-aware workflow\n"
+            "runtime_profile: openprose\n"
+            "output_surface: guardian-board\n"
+            "requires:\n"
+            "  tools: [web_search]\n"
+            "steps:\n"
+            "  - id: search\n"
+            "    tool: web_search\n"
+            "    arguments: {}\n"
+            "---\n\n"
+            "Runtime-aware workflow.\n",
+            encoding="utf-8",
+        )
+
+        workflow = _parse_workflow_file(str(workflow_path))
+
+        assert workflow is not None
+        assert workflow.runtime_profile == "openprose"
+        assert workflow.output_surface == "guardian-board"
+
 
 class TestWorkflowManager:
     def test_active_workflow_gating_uses_tools_and_skills(self, workflows_dir):
@@ -238,11 +339,136 @@ class TestWorkflowManager:
             data = json.load(f)
         assert data["disabled"] == ["web-brief-to-file"]
 
-        mgr2 = WorkflowManager()
-        mgr2.init(workflows_dir)
-        assert mgr2.get_workflow("web-brief-to-file").enabled is False
-        assert mgr2.enable("web-brief-to-file") is True
-        assert mgr2.get_workflow("web-brief-to-file").enabled is True
+    def test_runtime_availability_tracks_runtime_profiles_and_output_surfaces(self, tmp_path):
+        workflows_dir = tmp_path / "workflows"
+        workflows_dir.mkdir()
+        (workflows_dir / "runtime-aware.md").write_text(
+            "---\n"
+            "name: runtime-aware\n"
+            "description: Runtime-aware workflow\n"
+            "runtime_profile: openprose\n"
+            "output_surface: guardian-board\n"
+            "requires:\n"
+            "  tools: [web_search]\n"
+            "steps:\n"
+            "  - id: search\n"
+            "    tool: web_search\n"
+            "    arguments: {}\n"
+            "---\n\n"
+            "Runtime-aware workflow.\n",
+            encoding="utf-8",
+        )
+        _write_manifest_canvas_package(tmp_path)
+        manifest_roots = default_manifest_roots_for_workspace(str(tmp_path))
+
+        mgr = WorkflowManager()
+        mgr.init(str(workflows_dir), manifest_roots=manifest_roots)
+
+        without_runtime = next(
+            item
+            for item in mgr.list_workflows(available_tool_names=["web_search"], active_skill_names=[])
+            if item["name"] == "runtime-aware"
+        )
+        assert without_runtime["is_available"] is False
+        assert without_runtime["missing_runtime_profiles"] == ["openprose"]
+        assert without_runtime["missing_output_surfaces"] == []
+
+        _write_manifest_workflow_runtime_package(tmp_path)
+        mgr.init(str(workflows_dir), manifest_roots=manifest_roots)
+        with_runtime = next(
+            item
+            for item in mgr.list_workflows(available_tool_names=["web_search"], active_skill_names=[])
+            if item["name"] == "runtime-aware"
+        )
+        assert with_runtime["is_available"] is True
+        assert with_runtime["runtime_profile"] == "openprose"
+        assert with_runtime["output_surface"] == "guardian-board"
+        assert with_runtime["missing_runtime_profiles"] == []
+        assert with_runtime["missing_output_surfaces"] == []
+
+    def test_runtime_profile_defaults_output_surface_and_gates_active_workflows(self, tmp_path):
+        workflows_dir = tmp_path / "workflows"
+        workflows_dir.mkdir()
+        (workflows_dir / "runtime-default.md").write_text(
+            "---\n"
+            "name: runtime-default\n"
+            "description: Runtime-default workflow\n"
+            "runtime_profile: openprose\n"
+            "requires:\n"
+            "  tools: [web_search]\n"
+            "steps:\n"
+            "  - id: search\n"
+            "    tool: web_search\n"
+            "    arguments: {}\n"
+            "---\n\n"
+            "Runtime-default workflow.\n",
+            encoding="utf-8",
+        )
+        manifest_roots = default_manifest_roots_for_workspace(str(tmp_path))
+
+        mgr = WorkflowManager()
+        mgr.init(str(workflows_dir), manifest_roots=manifest_roots)
+        assert mgr.get_active_workflows(["web_search"], []) == []
+
+        _write_manifest_workflow_runtime_package(tmp_path)
+        _write_manifest_canvas_package(tmp_path)
+        mgr.init(str(workflows_dir), manifest_roots=manifest_roots)
+
+        workflow_item = next(
+            item
+            for item in mgr.list_workflows(available_tool_names=["web_search"], active_skill_names=[])
+            if item["name"] == "runtime-default"
+        )
+        assert workflow_item["is_available"] is True
+        assert workflow_item["output_surface"] == "guardian-board"
+        active_workflows = mgr.get_active_workflows(["web_search"], [])
+        assert [item.name for item in active_workflows if item.name == "runtime-default"] == ["runtime-default"]
+
+        workflow_tool = next(
+            tool
+            for tool in mgr.build_workflow_tools(
+                [DummyTool("web_search", lambda: "runtime result")],
+                [],
+            )
+            if tool.name == "workflow_runtime_default"
+        )
+        result = workflow_tool()
+        audit_payload = workflow_tool.get_audit_result_payload({}, result)
+        assert audit_payload is not None
+        _summary, details = audit_payload
+        canvas_output = details["canvas_output"]
+        assert canvas_output["surface"] == "guardian-board"
+        assert canvas_output["title"] == "Guardian Board"
+        assert [section["label"] for section in canvas_output["sections"]] == ["Summary", "Steps"]
+        assert canvas_output["summary"] == "workflow content redacted"
+        assert canvas_output["sections"][0]["item_count"] == 1
+
+    def test_workflow_tool_audit_payload_includes_canvas_output(self):
+        workflow = Workflow(
+            name="runtime-aware",
+            description="Runtime-aware workflow",
+            inputs={"query": {"type": "string", "required": True}},
+            steps=[WorkflowStep(tool="web_search", arguments={"query": "{{ query }}"}, id="search")],
+            requires_tools=["web_search"],
+            result_template="Done for {{ query }}.",
+            output_surface="guardian-board",
+        )
+        workflow_tool = WorkflowTool(
+            workflow,
+            tools_by_name={"web_search": DummyTool("web_search", lambda query: f"result for {query}")},
+        )
+
+        result = workflow_tool(query="seraph")
+        audit_payload = workflow_tool.get_audit_result_payload({"query": "seraph"}, result)
+
+        assert audit_payload is not None
+        _summary, details = audit_payload
+        canvas_output = details["canvas_output"]
+        assert canvas_output["surface"] == "guardian-board"
+        assert canvas_output["title"] == "runtime-aware"
+        assert canvas_output["section_count"] == 2
+        assert canvas_output["summary"] == "workflow content redacted"
+        assert all("items" not in section for section in canvas_output["sections"])
 
     def test_workflow_tool_resolves_legacy_shell_execute_alias(self):
         workflow = Workflow(
@@ -1612,6 +1838,134 @@ class TestWorkflowApi:
         assert payload["file_path"].endswith(
             "extensions/workspace-capabilities/workflows/retryable-save.md"
         )
+
+    @pytest.mark.asyncio
+    async def test_validate_workflow_draft_applies_runtime_default_output_surface(self, client, tmp_path):
+        workspace = tmp_path / "workspace"
+        (workspace / "extensions").mkdir(parents=True)
+        _write_manifest_canvas_package(workspace)
+        _write_manifest_workflow_runtime_package(workspace)
+        content = (
+            "---\n"
+            "name: Runtime Default\n"
+            "description: Use runtime default output surface.\n"
+            "runtime_profile: openprose\n"
+            "requires:\n"
+            "  tools: [web_search]\n"
+            "steps:\n"
+            "  - id: search\n"
+            "    tool: web_search\n"
+            "    arguments: {}\n"
+            "---\n"
+        )
+        with (
+            patch("src.api.workflows.settings.workspace_dir", str(workspace)),
+            patch(
+                "src.api.workflows.get_base_tools_and_active_skills",
+                return_value=([SimpleNamespace(name="web_search")], [], "disabled"),
+            ),
+        ):
+            resp = await client.post("/api/workflows/validate", json={"content": content})
+
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["workflow"]["runtime_profile"] == "openprose"
+        assert payload["workflow"]["output_surface"] == "guardian-board"
+        assert payload["workflow"]["output_surface_title"] == "Guardian Board"
+        assert payload["workflow"]["declared_output_surface"] == ""
+        assert payload["missing_output_surfaces"] == []
+
+    @pytest.mark.asyncio
+    async def test_workflow_source_surfaces_runtime_default_output_surface(self, client, tmp_path):
+        workflows_dir = tmp_path / "workflows"
+        workflows_dir.mkdir()
+        _write_manifest_canvas_package(tmp_path)
+        _write_manifest_workflow_runtime_package(tmp_path)
+        content = (
+            "---\n"
+            "name: runtime-source\n"
+            "description: Use runtime default output surface.\n"
+            "runtime_profile: openprose\n"
+            "requires:\n"
+            "  tools: [web_search]\n"
+            "steps:\n"
+            "  - id: search\n"
+            "    tool: web_search\n"
+            "    arguments: {}\n"
+            "---\n"
+        )
+        workflow_path = workflows_dir / "runtime-source.md"
+        workflow_path.write_text(content, encoding="utf-8")
+        with (
+            patch("src.api.workflows.settings.workspace_dir", str(tmp_path)),
+            patch(
+                "src.api.workflows.get_base_tools_and_active_skills",
+                return_value=([SimpleNamespace(name="web_search")], [], "disabled"),
+            ),
+        ):
+            workflow_manager.init(str(workflows_dir), manifest_roots=default_manifest_roots_for_workspace(str(tmp_path)))
+            resp = await client.get("/api/workflows/runtime-source/source")
+
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["workflow"]["runtime_profile"] == "openprose"
+        assert payload["workflow"]["output_surface"] == "guardian-board"
+        assert payload["workflow"]["output_surface_title"] == "Guardian Board"
+
+    @pytest.mark.asyncio
+    async def test_runtime_default_and_canvas_metadata_ignore_lower_priority_duplicate_names(self, client, tmp_path):
+        workflows_dir = tmp_path / "workflows"
+        workflows_dir.mkdir()
+        _write_manifest_canvas_package(
+            tmp_path,
+            package_name="canvas-a",
+            extension_id="seraph.canvas-a",
+            display_name="A Canvas Winner",
+            title="Winner Board",
+        )
+        _write_manifest_canvas_package(
+            tmp_path,
+            package_name="canvas-z",
+            extension_id="seraph.canvas-z",
+            display_name="Z Canvas Loser",
+            title="Loser Board",
+        )
+        _write_manifest_workflow_runtime_package(
+            tmp_path,
+            package_name="runtime-a",
+            extension_id="seraph.runtime-a",
+            display_name="A Runtime Winner",
+            default_output_surface="guardian-board",
+        )
+        _write_manifest_workflow_runtime_package(
+            tmp_path,
+            package_name="runtime-z",
+            extension_id="seraph.runtime-z",
+            display_name="Z Runtime Loser",
+            default_output_surface="loser-board",
+        )
+        content = (
+            "---\n"
+            "name: duplicate-runtime-surface\n"
+            "description: Use runtime default output surface.\n"
+            "runtime_profile: openprose\n"
+            "requires:\n"
+            "  tools: [web_search]\n"
+            "steps:\n"
+            "  - id: search\n"
+            "    tool: web_search\n"
+            "    arguments: {}\n"
+            "---\n"
+        )
+        workflow_path = workflows_dir / "duplicate-runtime-surface.md"
+        workflow_path.write_text(content, encoding="utf-8")
+
+        with patch("src.api.workflows.settings.workspace_dir", str(tmp_path)):
+            workflow_manager.init(str(workflows_dir), manifest_roots=default_manifest_roots_for_workspace(str(tmp_path)))
+            workflow = workflow_manager.get_workflow("duplicate-runtime-surface")
+            assert workflow is not None
+            assert workflow.output_surface == "guardian-board"
+            assert workflow.output_surface_title == "Winner Board"
 
 
 class TestWorkflowSurfaces:

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -410,17 +410,17 @@ See [Capability Import Wave 2](./12-capability-import-wave-2.md) for the impleme
 
 ### Wave 4: Selective OpenClaw Imports
 
-25. [ ] `openclaw-browser-mode-matrix-v1`:
+25. [x] `openclaw-browser-mode-matrix-v1`:
     add the browser mode matrix of managed browser, browser-extension relay, and remote CDP so Seraph can choose the right browser surface per task and trust boundary
-26. [ ] `openclaw-channel-routing-bindings-v1`:
+26. [x] `openclaw-channel-routing-bindings-v1`:
     add per-channel routing, bindings, and delivery rules so multi-channel reach behaves predictably instead of as independent connector silos
-27. [ ] `openclaw-webhook-poll-pubsub-v1`:
+27. [x] `openclaw-webhook-poll-pubsub-v1`:
     import higher-value automation breadth through typed trigger surfaces instead of one-off cron-only automation
-28. [ ] `openclaw-node-device-adapters-v1`:
+28. [x] `openclaw-node-device-adapters-v1`:
     add device and node companion surfaces through adapters so Seraph can reach phones, desktops, or later embodied surfaces without adopting OpenClaw’s raw plugin model
-29. [ ] `openclaw-canvas-output-v1`:
+29. [x] `openclaw-canvas-output-v1`:
     add richer structured output or canvas surfaces for operator-visible results, generated UIs, and tool-produced artifacts where text-only panes are too limiting
-30. [ ] `openclaw-workflow-engine-imports-v1`:
+30. [x] `openclaw-workflow-engine-imports-v1`:
     selectively reinterpret OpenClaw runtime ideas such as OpenProse, Lobster, or LLM-task style typed runtimes into Seraph’s workflow and execution architecture
 
 ### Wave 5: Operator Surface, Proof, And Hardening

--- a/docs/implementation/14-capability-import-wave-4.md
+++ b/docs/implementation/14-capability-import-wave-4.md
@@ -355,6 +355,17 @@ ideas through Seraph's extension platform and guardian trust boundaries.
 - resolution:
   - no additional changes were required before final validation
 
+### Review 12
+
+- reviewer: Darwin
+- scope:
+  - PR `#226` follow-up fixes for workflow step-tool gating and registry
+    conflict-order metadata enrichment
+- findings:
+  - none
+- resolution:
+  - no additional changes were required after the follow-up patch
+
 ## Wave Validation
 
 - focused Wave 4 follow-up suite:
@@ -363,6 +374,12 @@ ideas through Seraph's extension platform and guardian trust boundaries.
 - targeted Wave 4 backend matrix:
   - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_browser_session_tool.py tests/test_browser_api.py tests/test_extensions_api.py tests/test_delivery.py tests/test_automation_api.py tests/test_nodes_api.py tests/test_canvas_api.py tests/test_workflow_runtimes_api.py tests/test_workflows.py tests/test_catalog_api.py tests/test_app.py -q`
   - result: `187 passed`
+- PR review follow-up slice:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_workflows.py tests/test_extension_registry.py -q`
+  - result: `71 passed`
+- PR review follow-up matrix:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_extensions_api.py tests/test_workflow_runtimes_api.py tests/test_workflows.py tests/test_extension_registry.py -q`
+  - result: `125 passed`
 - backend full suite:
   - `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
   - result: `1192 passed, 4 warnings`

--- a/docs/implementation/14-capability-import-wave-4.md
+++ b/docs/implementation/14-capability-import-wave-4.md
@@ -1,0 +1,389 @@
+# Capability Import Wave 4
+
+## Scope
+
+Wave 4 covers the selective OpenClaw import slices from the capability import
+program:
+
+25. `openclaw-browser-mode-matrix-v1`
+26. `openclaw-channel-routing-bindings-v1`
+27. `openclaw-webhook-poll-pubsub-v1`
+28. `openclaw-node-device-adapters-v1`
+29. `openclaw-canvas-output-v1`
+30. `openclaw-workflow-engine-imports-v1`
+
+This wave does not copy OpenClaw's raw plugin runtime. The goal is to import
+the most valuable browser, routing, automation, adapter, and structured-output
+ideas through Seraph's extension platform and guardian trust boundaries.
+
+## Slice Log
+
+### 25. openclaw-browser-mode-matrix-v1
+
+- status: complete
+- intent:
+  - add an operator-visible browser mode matrix for local runtime, Browserbase,
+    remote CDP, and browser-extension relay surfaces
+  - make packaged browser-provider inventory visible through honest staged
+    metadata instead of overclaiming remote execution before those transports
+    land fully
+- implementation:
+  - mounted a public browser provider-inventory endpoint under
+    `/api/browser/providers`
+  - extended browser-provider selection and inventory reporting so packaged
+    Browserbase, remote CDP, and extension-relay contributions surface through
+    the same runtime path as local providers
+  - added `browser_session(action="providers")` output for operator-side mode
+    inspection
+  - kept browser-session list/read/close management on the tool/runtime path;
+    the public REST session-management surface remains deferred until a later
+    wave can attach a stronger ownership model
+  - added bundled catalog packs for:
+    - `seraph.openclaw-remote-cdp`
+    - `seraph.openclaw-extension-relay`
+  - provider inventory now always includes the built-in `local-browser` lane so
+    the matrix shows the real fallback/runtime path even when staged remote
+    providers are installed
+  - packaged provider copy explicitly describes staged `local_fallback`
+    behavior until the remote transports are implemented end to end
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_browser_session_tool.py tests/test_browser_api.py tests/test_app.py -q`
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_remote_cdp_pack_surfaces_staged_browser_provider_metadata tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_extension_relay_pack_surfaces_staged_browser_provider_metadata -q`
+
+### 26. openclaw-channel-routing-bindings-v1
+
+- status: complete
+- intent:
+  - replace hardcoded websocket-first proactive delivery with explicit,
+    inspectable delivery bindings
+  - let operators route live, alert, scheduled, and queued-bundle delivery
+    across the active websocket and native-notification channel adapters
+- implementation:
+  - added persisted channel-routing bindings in extension runtime state with
+    four explicit delivery classes:
+    - `live_delivery`
+    - `alert_delivery`
+    - `scheduled_delivery`
+    - `bundle_delivery`
+  - added `/api/extensions/channel-routing` get/update endpoints so bindings
+    are operator-visible and configurable without hand-editing state files
+  - proactive delivery and queued-bundle delivery now obey those bindings
+    instead of hardcoded websocket-first heuristics
+  - routing responses include the current active channel adapters and active
+    transports so the configured bindings are visible against live runtime
+    availability
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_extensions_api.py -k "channel_routing or channel_adapter" -q`
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_delivery.py -k "channel_routing or native_channel_adapter" -q`
+
+### 27. openclaw-webhook-poll-pubsub-v1
+
+- status: complete
+- intent:
+  - import OpenClaw-style automation breadth without adding a second ad hoc
+    scheduler/runtime model outside the extension platform
+  - make webhook, poll, and pubsub triggers visible through an honest staged
+    runtime inventory instead of pretending they already execute end to end
+- implementation:
+  - added `automation_triggers` as a typed connector contribution and exposed
+    inventory at `/api/automation/triggers`
+  - mounted signed webhook ingress at
+    `/api/automation/webhooks/{trigger_name}` and normalized webhook trigger
+    metadata so `endpoint` always reflects that real mounted path
+  - runtime inventory now distinguishes:
+    - `disabled`
+    - `requires_config`
+    - `armed_webhook`
+    - `staged_runtime`
+  - packaged the first OpenClaw-style trigger packs:
+    - `seraph.openclaw-webhook-gateway`
+    - `seraph.openclaw-poll-watch`
+    - `seraph.openclaw-pubsub-relay`
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_automation_api.py -q`
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py -k "webhook_gateway or poll_and_pubsub" -q`
+
+### 28. openclaw-node-device-adapters-v1
+
+- status: complete
+- intent:
+  - import OpenClaw’s node/device reach ideas through typed staged adapters
+    instead of raw in-process plugins
+  - surface honest readiness states for companion/device/canvas lanes without
+    claiming a live runtime that does not exist yet
+- implementation:
+  - added `node_adapters` as a typed connector contribution and exposed
+    inventory at `/api/nodes/adapters`
+  - adapter inventory now distinguishes:
+    - `disabled`
+    - `requires_config`
+    - `staged_link`
+    - `staged_canvas`
+  - default `requires_network` now follows adapter kind so non-canvas adapters
+    do not silently present as offline-safe unless a package explicitly opts
+    out
+  - packaged the first OpenClaw-style node/device packs:
+    - `seraph.openclaw-companion-node`
+    - `seraph.openclaw-device-bridge`
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_nodes_api.py -q`
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py -k "node_packs" -q`
+
+### 29. openclaw-canvas-output-v1
+
+- status: complete
+- intent:
+  - add richer structured output surfaces so workflows can publish operator
+    results into typed boards instead of only returning plain text
+  - keep those surfaces extension-backed and inspectable rather than hardcoded
+- implementation:
+  - added `canvas_outputs` as a passive typed contribution and exposed
+    inventory at `/api/canvas/outputs`
+  - bundled `seraph.openclaw-canvas-board`, which ships the
+    `guardian-board` surface definition
+  - workflow audit payloads now emit structured `canvas_output` data when a
+    workflow resolves an output surface
+  - the emitted sections now follow the registered canvas definition instead of
+    hardcoded section labels
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_canvas_api.py -q`
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py -k "canvas_pack" -q`
+
+### 30. openclaw-workflow-engine-imports-v1
+
+- status: complete
+- intent:
+  - selectively reinterpret OpenClaw runtime ideas such as OpenProse, Lobster,
+    and LLM-task into Seraph’s workflow architecture instead of importing a
+    second workflow engine wholesale
+  - make runtime-profile requirements real execution constraints, not cosmetic
+    metadata
+- implementation:
+  - added `workflow_runtimes` as a passive typed contribution and exposed
+    inventory at `/api/workflows/runtimes`
+  - workflows can now declare `runtime_profile` and optionally inherit their
+    default `output_surface` from the selected runtime profile
+  - workflow availability, active-workflow selection, and workflow-tool
+    building now all respect missing runtime profiles and missing output
+    surfaces
+  - bundled `seraph.openclaw-workflow-runtimes`, which ships:
+    - runtime profiles: `openprose`, `lobster`, `llm-task`
+    - example workflows for each runtime family
+- validation:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_workflow_runtimes_api.py tests/test_workflows.py -q`
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_catalog_api.py -k "workflow_runtimes_pack" -q`
+
+## Subagent Review
+
+### Review 1
+
+- reviewer: `Hooke`
+- scope:
+  - Wave 4 slice `25` browser-mode inventory, API mounting, and packaged remote
+    browser-provider metadata
+- findings:
+  - the first pass exposed list/get/close browser-session REST endpoints that
+    trusted a caller-supplied `session_id`, which was weaker than the existing
+    tool/runtime ownership model
+  - the provider matrix hid the built-in local runtime once packaged providers
+    existed, which made the browser-mode view misleading in the exact staged
+    cases it was supposed to clarify
+  - the Wave 4 docs and roadmap were not yet synced to the shipped slice state
+- resolution:
+  - the public browser API now exposes provider inventory only; session
+    management remains tool-scoped until a later operator-surface wave adds a
+    stronger ownership model
+  - provider inventory now always includes `local-browser`, and the tool/API
+    tests pin that visible fallback lane alongside staged remote providers
+  - the Wave 4 implementation doc and roadmap are updated inline as slices land
+
+### Review 2
+
+- reviewer: `Hooke`
+- scope:
+  - Wave 4 batch A (`25-26`): browser mode inventory plus explicit channel
+    routing and delivery bindings
+- findings:
+  - the channel-routing API and delivery runtime disagreed on the
+    no-channel-adapter-contributions case: the operator surface reported no
+    active transports while delivery still fell back to built-in websocket and
+    native-notification lanes
+  - the scheduled delivery lane was not pinned by any explicit routing test,
+    which made slice `26` broader in docs than in tests
+- resolution:
+  - `/api/extensions/channel-routing` now mirrors the delivery runtime fallback
+    and surfaces built-in websocket/native transports when no channel-adapter
+    contributions are present
+  - the delivery tests now include an explicit `scheduled_delivery` routing
+    case, not just `live_delivery` and `bundle_delivery`
+
+### Review 3
+
+- reviewer: `Galileo`
+- scope:
+  - Wave 4 batch B (`27-28`): automation triggers and node/device adapters
+- findings:
+  - webhook `endpoint` metadata was being surfaced as if it were a free-form
+    routing contract, even though the only mounted ingress path is
+    `/api/automation/webhooks/{trigger_name}`
+  - node adapters defaulted `requires_network` to `false`, which made URL-based
+    adapters look offline-safe unless a pack author opted in explicitly
+  - the `canvas_ready` node-adapter runtime state overclaimed a live runtime for
+    an inventory-only slice
+- resolution:
+  - webhook trigger definitions now validate/canonicalize their endpoint to the
+    mounted ingress path
+  - node adapters now default `requires_network` by adapter kind, and the API
+    tests pin the companion/canvas distinction
+  - canvas adapters now surface `staged_canvas` instead of `canvas_ready`
+
+### Review 4
+
+- reviewer: `Leibniz`
+- scope:
+  - Wave 4 batch C (`29-30`): canvas outputs and workflow runtimes
+- findings:
+  - runtime profile / output-surface availability was only reflected in
+    `list_workflows()` and did not actually gate `get_active_workflows()` or
+    `build_workflow_tools()`
+  - `default_output_surface` on workflow runtimes was dead metadata and was not
+    applied anywhere in execution or availability
+  - workflow canvas output payloads ignored the registered canvas surface
+    metadata and hardcoded their own sections
+  - the Wave 4 docs still stopped at slices `25-26`
+- resolution:
+  - active-workflow selection and workflow-tool building now both respect
+    runtime-profile and output-surface availability
+  - runtime profiles can now default an output surface into workflows when the
+    workflow itself does not set one
+  - canvas output payloads now derive their title/sections from the registered
+    canvas definition
+  - this document now records all six Wave 4 slices and the batch-level review
+    trail
+
+### Review 5
+
+- reviewer: `Hooke`
+- scope:
+  - Wave 4 batch A re-review after the channel-routing fallback and scheduled
+    delivery fixes
+- findings:
+  - no findings
+- resolution:
+  - none required
+
+### Review 6
+
+- reviewer: `Galileo`
+- scope:
+  - Wave 4 batch B re-review after endpoint canonicalization and node-adapter
+    readiness fixes
+- findings:
+  - no findings
+- resolution:
+  - none required
+
+### Review 7
+
+- reviewer: `Galileo`
+- scope:
+  - Wave 4 automation webhook ingress after the branch-wide follow-up pass
+- findings:
+  - webhook triggers without an explicit `signing_secret` config field still
+    surfaced as `armed_webhook`, which left `/api/automation/webhooks/{name}`
+    unsigned whenever a pack author omitted the field
+- resolution:
+  - webhook trigger definitions now inject a required `signing_secret`
+    password field even when a pack omits it, so unsigned webhook packs stay in
+    `requires_config` and the ingress route never exposes a public unsigned
+    POST lane
+
+### Review 8
+
+- reviewer: `Zeno`
+- scope:
+  - Wave 4 automation duplicate-name handling after the initial registry
+    conflict pass
+- findings:
+  - duplicate webhook trigger names still resolved to a live winner in runtime
+    selection, so a public webhook path could execute even while the duplicate
+    was flagged as invalid in `/api/extensions`
+- resolution:
+  - automation-trigger duplicates now use an all-definitions conflict mode, so
+    every colliding webhook contribution becomes invalid and the runtime
+    inventory and ingress route both refuse the duplicated name
+
+### Review 9
+
+- reviewer: `Leibniz`
+- scope:
+  - Wave 4 duplicate-name handling and channel-routing regression coverage
+- findings:
+  - duplicate-name handling was still inconsistent across browser providers,
+    workflow runtimes, and canvas outputs even though those surfaces are all
+    consumed by `name`
+  - `alert_delivery` still lacked an explicit routing regression despite being
+    a first-class channel lane
+- resolution:
+  - registry conflict handling now covers browser providers, workflow runtimes,
+    and canvas outputs, and the runtime/API inventories skip conflicted loser
+    entries
+  - delivery tests now pin the `alert_delivery` routing path explicitly
+
+### Review 10
+
+- reviewer: `Epicurus`
+- scope:
+  - Wave 4 workflow runtime and canvas metadata after the duplicate-name
+    hardening pass
+- findings:
+  - runtime and canvas metadata could still drift by snapshot display ordering
+    instead of extension priority because the name-keyed maps were not yet
+    skipping conflicted duplicate contributions everywhere
+- resolution:
+  - workflow runtime and canvas map building now skip registry-conflicted
+    contributions in both the workflow manager and the draft-validation API,
+    and regressions pin the higher-priority winner behavior
+
+### Review 11
+
+- reviewer: Schrodinger
+- scope:
+  - full Wave 4 diff after the webhook, duplicate-name, and alert-routing fixes
+- findings:
+  - none
+- resolution:
+  - no additional changes were required before final validation
+
+## Wave Validation
+
+- focused Wave 4 follow-up suite:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest --no-cov tests/test_automation_api.py tests/test_extensions_api.py tests/test_browser_api.py tests/test_delivery.py tests/test_workflows.py tests/test_workflow_runtimes_api.py tests/test_canvas_api.py -q`
+  - result: `146 passed`
+- targeted Wave 4 backend matrix:
+  - `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_browser_session_tool.py tests/test_browser_api.py tests/test_extensions_api.py tests/test_delivery.py tests/test_automation_api.py tests/test_nodes_api.py tests/test_canvas_api.py tests/test_workflow_runtimes_api.py tests/test_workflows.py tests/test_catalog_api.py tests/test_app.py -q`
+  - result: `187 passed`
+- backend full suite:
+  - `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
+  - result: `1192 passed, 4 warnings`
+- frontend full suite:
+  - `cd frontend && npm test`
+  - result: `156 passed`
+- frontend build:
+  - `cd frontend && npm run build`
+  - result: passed
+- docs build:
+  - `cd docs && npm run build`
+  - result: passed
+- diff hygiene:
+  - `git diff --check`
+  - result: passed
+
+## Current Validation State
+
+- Wave 4 is complete across slices `25-30`.
+- The late automation and duplicate-name findings are fixed and pinned by
+  focused backend regressions.
+- Final validation passed, including the full backend suite and final
+  subagent re-review.
+- Wave 4 is ready to publish as a single PR.


### PR DESCRIPTION
## Done on develop
- [x] Waves 1-3 of the capability import program are already landed on `develop`, including the runtime-parity and extension-platform foundation that this wave builds on.

## Working in this PR
- [x] add the Wave 4 selective OpenClaw import surfaces for browser modes, channel routing, automation triggers, node adapters, canvas outputs, and workflow runtimes
- [x] ship bundled catalog extension packs plus backend APIs for the new Wave 4 contribution types and surfaces
- [x] harden duplicate-name handling, webhook signing-secret requirements, builtin channel fallbacks, and canvas audit redaction around the new reach surfaces
- [x] record per-slice subagent review findings and final validation in the Wave 4 implementation docs

## Still to do after this PR
- [ ] execute Wave 5 for operator-surface integration, proof/evals expansion, and final hardening/cleanup

## Validation
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest --no-cov tests/test_automation_api.py tests/test_extensions_api.py tests/test_browser_api.py tests/test_delivery.py tests/test_workflows.py tests/test_workflow_runtimes_api.py tests/test_canvas_api.py -q`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_browser_session_tool.py tests/test_browser_api.py tests/test_extensions_api.py tests/test_delivery.py tests/test_automation_api.py tests/test_nodes_api.py tests/test_canvas_api.py tests/test_workflow_runtimes_api.py tests/test_workflows.py tests/test_catalog_api.py tests/test_app.py -q`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_extension_doctor.py tests/test_extension_registry.py tests/test_extension_manifest.py tests/test_extension_scaffold.py tests/test_extensions_api.py -q`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_delivery.py tests/test_eval_harness.py -q`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_e2e_conversation.py tests/test_embedder.py -q`
- `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
- `cd frontend && npm test`
- `cd frontend && npm run build`
- `cd docs && npm run build`
- `git diff --check`
