### PR TITLE
Add light theme and clarify onboarding scope

### DIFF
--- a/backend/src/agent/onboarding.py
+++ b/backend/src/agent/onboarding.py
@@ -35,6 +35,9 @@ You are a guardian system building enough context to work well.
 ## How to behave:
 
 - Be genuinely curious, not robotic
+- If you describe your capabilities or tools, explicitly say this onboarding mode is temporarily limited to identity,
+  guardian-record, and priority-building tasks. Do NOT imply these are Seraph's only capabilities or that the full
+  workspace lacks the broader tool, workflow, connector, or operator surfaces.
 - After each meaningful answer, use the `update_soul` tool to save what you learn
 - When they share priorities or concrete outcomes, use `create_goal` to add them to the goal hierarchy
 - If needed, explain plainly that Seraph tracks priorities as structured goals so they can be reviewed, decomposed, and followed through
@@ -42,7 +45,7 @@ You are a guardian system building enough context to work well.
 - At the end, summarize what you've learned and make the operating posture clear
 - Sign off with something like: "I have enough context to begin. I'll keep watch, think ahead, and stay ready."
 
-## Tools available:
+## Tools available in this onboarding mode:
 - `update_soul(section, content)` — Save identity, values, and priorities to the guardian record
 - `create_goal(title, level, domain, description)` — Add goals to the goal hierarchy
 - `view_soul()` — Check what you've saved in the guardian record so far

--- a/backend/src/api/ws.py
+++ b/backend/src/api/ws.py
@@ -102,6 +102,7 @@ async def websocket_chat(websocket: WebSocket):
                         "Seraph online. Before I begin acting on your behalf, I need a clearer read on who you are, "
                         "what matters most, and how you want this workspace to operate. "
                         "I'll ask a few short onboarding questions to establish that baseline. "
+                        "During onboarding I'm using a limited setup focused on your guardian record and priorities. "
                         "If you want the full workspace immediately, just say the word and I'll skip ahead."
                     ),
                     intervention_type="advisory",

--- a/backend/tests/test_tool_audit.py
+++ b/backend/tests/test_tool_audit.py
@@ -182,6 +182,13 @@ def test_onboarding_agent_uses_audited_tools():
         assert isinstance(agent.tools[tool_name], AuditedTool)
 
 
+def test_onboarding_agent_instructions_clarify_tool_scope():
+    agent = create_onboarding_agent()
+
+    assert "Do NOT imply these are Seraph's only capabilities" in agent.instructions
+    assert "Tools available in this onboarding mode" in agent.instructions
+
+
 @patch("src.agent.onboarding.LiteLLMModel")
 def test_onboarding_agent_uses_local_profile_runtime_path(mock_model_cls):
     mock_model_cls.return_value = object()

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -84,6 +84,7 @@ class TestWebSocket:
                 welcome = json.loads(ws.receive_text())
                 assert welcome["type"] == "proactive"
                 assert "Seraph online" in welcome["content"]
+                assert "limited setup" in welcome["content"].lower()
                 ws.send_text(json.dumps({"type": "ping"}))
                 resp = json.loads(ws.receive_text())
                 assert resp["type"] == "pong"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,43 @@
+import { useEffect } from "react";
 import { QuestPanel } from "./components/quest/QuestPanel";
 import { SettingsPanel } from "./components/SettingsPanel";
 import { useWebSocket } from "./hooks/useWebSocket";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { CockpitView } from "./components/cockpit/CockpitView";
+import { applyThemePreference } from "./lib/theme";
+import { useChatStore } from "./stores/chatStore";
 
 export default function App() {
   const { sendMessage, skipOnboarding } = useWebSocket();
+  const themePreference = useChatStore((s) => s.themePreference);
   useKeyboardShortcuts();
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const root = document.documentElement;
+    const media = typeof window !== "undefined" && typeof window.matchMedia === "function"
+      ? window.matchMedia("(prefers-color-scheme: light)")
+      : null;
+
+    const applyTheme = () => {
+      applyThemePreference(themePreference, root);
+    };
+
+    applyTheme();
+
+    if (themePreference !== "system" || !media) {
+      return () => {};
+    }
+
+    const handleChange = () => applyTheme();
+    if (typeof media.addEventListener === "function") {
+      media.addEventListener("change", handleChange);
+      return () => media.removeEventListener("change", handleChange);
+    }
+    media.addListener(handleChange);
+    return () => media.removeListener(handleChange);
+  }, [themePreference]);
 
   return (
     <>

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -407,6 +407,8 @@ export function SettingsPanel() {
   const setSettingsPanelOpen = useChatStore((s) => s.setSettingsPanelOpen);
   const cockpitHintsEnabled = useChatStore((s) => s.cockpitHintsEnabled);
   const setCockpitHintsEnabled = useChatStore((s) => s.setCockpitHintsEnabled);
+  const themePreference = useChatStore((s) => s.themePreference);
+  const setThemePreference = useChatStore((s) => s.setThemePreference);
   const onboardingCompleted = useChatStore((s) => s.onboardingCompleted);
   const restartOnboarding = useChatStore((s) => s.restartOnboarding);
   const loadSessions = useChatStore((s) => s.loadSessions);
@@ -590,6 +592,28 @@ export function SettingsPanel() {
                 Restart intro
               </button>
             )}
+            <div className="cockpit-settings-inline-row">
+              <div className="cockpit-settings-copy">
+                <div className="cockpit-settings-label">Theme</div>
+                <div className="cockpit-settings-note">
+                  Choose the guardian surface for this workspace, or follow the system appearance.
+                </div>
+              </div>
+              <div className="cockpit-settings-choice-group" role="group" aria-label="Theme preference">
+                {(["system", "dark", "light"] as const).map((option) => (
+                  <button
+                    key={option}
+                    type="button"
+                    className={`cockpit-settings-choice ${themePreference === option ? "is-active" : ""}`}
+                    onClick={() => setThemePreference(option)}
+                    aria-pressed={themePreference === option}
+                  >
+                    {option}
+                  </button>
+                ))}
+              </div>
+            </div>
+
             <div className="cockpit-settings-inline-row">
               <div className="cockpit-settings-copy">
                 <div className="cockpit-settings-label">Workspace hints</div>

--- a/frontend/src/components/cockpit/CockpitOverlays.test.tsx
+++ b/frontend/src/components/cockpit/CockpitOverlays.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SettingsPanel } from "../SettingsPanel";
@@ -27,6 +27,7 @@ describe("cockpit overlays", () => {
     useChatStore.setState({
       settingsPanelOpen: false,
       questPanelOpen: false,
+      themePreference: "system",
       onboardingCompleted: true,
       sessions: [],
       sessionId: null,
@@ -64,10 +65,33 @@ describe("cockpit overlays", () => {
     expect(await screen.findByText("Settings")).toBeInTheDocument();
     expect(container.querySelector(".cockpit-modal-card")).not.toBeNull();
     expect(container.querySelector(".rpg-frame")).toBeNull();
+    expect(screen.getByRole("group", { name: "Theme preference" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "light" })).toBeInTheDocument();
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalled();
     });
+  });
+
+  it("updates the theme preference from settings", async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/skills")) return Promise.resolve(mockResponse({ skills: [] }));
+      if (url.includes("/api/mcp/servers")) return Promise.resolve(mockResponse({ servers: [] }));
+      if (url.includes("/api/catalog")) return Promise.resolve(mockResponse({ items: [] }));
+      if (url.includes("/api/settings/")) return Promise.resolve(mockResponse({ mode: "balanced" }));
+      if (url.includes("/api/audit/log")) return Promise.resolve(mockResponse({ entries: [] }));
+      if (url.includes("/api/workflows")) return Promise.resolve(mockResponse({ workflows: [] }));
+      return Promise.resolve(mockResponse({}));
+    });
+
+    useChatStore.setState({ settingsPanelOpen: true, themePreference: "system" });
+    render(<SettingsPanel />);
+
+    const lightButton = await screen.findByRole("button", { name: "light" });
+    fireEvent.click(lightButton);
+
+    expect(useChatStore.getState().themePreference).toBe("light");
   });
 
   it("renders priorities and priority editor in cockpit modals", async () => {

--- a/frontend/src/components/cockpit/CockpitView.tsx
+++ b/frontend/src/components/cockpit/CockpitView.tsx
@@ -2127,7 +2127,7 @@ function CockpitWorkspaceWindow({
   minWidth?: number;
   minHeight?: number;
   onClose?: () => void;
-  children: ReactNode;
+  children: ReactNode | ((state: { isFront: boolean }) => ReactNode);
 }) {
   const resolvedMinWidth = PANEL_MIN_SIZES[panelId]?.width ?? minWidth ?? 240;
   const resolvedMinHeight = PANEL_MIN_SIZES[panelId]?.height ?? minHeight ?? 160;
@@ -2168,7 +2168,9 @@ function CockpitWorkspaceWindow({
         </div>
       </div>
       {showHint && hint ? <div className="cockpit-window-hint">{hint}</div> : null}
-      <div className="cockpit-window-body">{children}</div>
+      <div className="cockpit-window-body">
+        {typeof children === "function" ? children({ isFront }) : children}
+      </div>
     </section>
   );
 }
@@ -6035,7 +6037,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                 minHeight={256}
                 onClose={() => closeWindowPane("presence_pane")}
               >
-                <SeraphPresencePane snapshot={seraphPresenceSnapshot} />
+                {({ isFront }) => <SeraphPresencePane snapshot={seraphPresenceSnapshot} isSelected={isFront} />}
               </CockpitWorkspaceWindow>
             )}
 

--- a/frontend/src/components/cockpit/Seraph.tsx
+++ b/frontend/src/components/cockpit/Seraph.tsx
@@ -15,6 +15,8 @@ interface SeraphProps {
   detail?: string;
   telemetry?: SeraphTelemetryEntry[];
   statusLabel?: string;
+  dividerColor?: string;
+  edgeColor?: string;
 }
 
 const Seraph: React.FC<SeraphProps> = ({
@@ -22,6 +24,8 @@ const Seraph: React.FC<SeraphProps> = ({
   detail,
   telemetry,
   statusLabel,
+  dividerColor,
+  edgeColor,
 }) => {
   const [frame, setFrame] = useState(0);
 
@@ -231,15 +235,22 @@ const Seraph: React.FC<SeraphProps> = ({
 
   return (
     <div
-      className="seraph-surface relative flex h-full w-full min-h-0 flex-col overflow-hidden"
+      className="relative flex h-full w-full min-h-0 flex-col overflow-hidden bg-[#05090d] text-[#dbefff]"
       style={{
         boxShadow: `inset 0 1px 0 rgba(255,255,255,0.02), 0 0 24px ${glow}`,
       }}
     >
-      <div className="seraph-stage scanline relative flex min-h-0 flex-1 items-center justify-center overflow-hidden px-3 pb-3 pt-3">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 z-20"
+        style={{
+          boxShadow: `inset 1px 0 0 ${edgeColor ?? "rgba(141,226,255,0.12)"}, inset -1px 0 0 ${edgeColor ?? "rgba(141,226,255,0.12)"}, inset 0 -1px 0 ${edgeColor ?? "rgba(141,226,255,0.12)"}`,
+        }}
+      />
+      <div className="scanline relative flex min-h-0 flex-1 items-center justify-center overflow-hidden px-3 pb-3 pt-3">
         <div className="absolute inset-0 opacity-30 pointer-events-none" style={{
           backgroundImage:
-            'linear-gradient(var(--seraph-grid-line) 1px, transparent 1px), linear-gradient(90deg, var(--seraph-grid-line) 1px, transparent 1px)',
+            'linear-gradient(rgba(141,226,255,0.018) 1px, transparent 1px), linear-gradient(90deg, rgba(141,226,255,0.018) 1px, transparent 1px)',
           backgroundSize: '28px 28px',
         }} />
         <div
@@ -263,7 +274,10 @@ const Seraph: React.FC<SeraphProps> = ({
         </div>
       </div>
 
-      <div className="seraph-footer px-4 py-2.5 backdrop-blur-xl">
+      <div
+        className="border-t bg-[linear-gradient(180deg,rgba(7,19,29,0.9),rgba(6,16,25,0.97))] px-4 py-2.5 backdrop-blur-xl"
+        style={{ borderColor: dividerColor ?? 'rgba(141,226,255,0.12)' }}
+      >
         <div className="flex flex-wrap items-center justify-between gap-x-5 gap-y-2">
           <div className="min-w-0 flex-1">
             <div className={`text-[18px] font-bold uppercase tracking-[-0.04em] glow-text ${colorMap[state]}`}>
@@ -275,21 +289,21 @@ const Seraph: React.FC<SeraphProps> = ({
                   key={i}
                   className="h-1 w-3 rounded-full transition-all duration-300"
                   style={{
-                    background: i < (frame % 10) ? barColor : 'var(--seraph-empty-bar)',
+                    background: i < (frame % 10) ? barColor : 'rgba(255,255,255,0.05)',
                     boxShadow: i < (frame % 10) ? `0 0 8px ${barColor}` : 'none',
                   }}
                 />
               ))}
             </div>
-            <div className="seraph-detail mt-1.5 max-w-[420px] text-[10px] leading-5">{displayDetail}</div>
+            <div className="mt-1.5 max-w-[420px] text-[10px] leading-5 text-[#7a98ad]">{displayDetail}</div>
           </div>
 
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
             {displayTelemetry.map((entry) => (
-              <div key={entry.label} className="seraph-telemetry min-w-[88px] border-l pl-3">
-                <div className="seraph-telemetry-label text-[8px] uppercase tracking-[0.22em]">{entry.label}</div>
-                <div className="seraph-telemetry-value mt-0.5 text-[13px] font-bold tracking-[-0.03em]">{entry.value}</div>
-                <div className="seraph-telemetry-hint text-[8px] uppercase tracking-[0.1em]">{entry.hint ?? 'live'}</div>
+              <div key={entry.label} className="min-w-[88px] border-l border-[#1f4358] pl-3">
+                <div className="text-[8px] uppercase tracking-[0.22em] text-[#55758a]">{entry.label}</div>
+                <div className="mt-0.5 text-[13px] font-bold tracking-[-0.03em] text-[#e3f4ff]">{entry.value}</div>
+                <div className="text-[8px] uppercase tracking-[0.1em] text-[#6d8ba0]">{entry.hint ?? 'live'}</div>
               </div>
             ))}
           </div>

--- a/frontend/src/components/cockpit/Seraph.tsx
+++ b/frontend/src/components/cockpit/Seraph.tsx
@@ -231,15 +231,15 @@ const Seraph: React.FC<SeraphProps> = ({
 
   return (
     <div
-      className="relative flex h-full w-full min-h-0 flex-col overflow-hidden bg-[#05090d] text-[#dbefff]"
+      className="seraph-surface relative flex h-full w-full min-h-0 flex-col overflow-hidden"
       style={{
         boxShadow: `inset 0 1px 0 rgba(255,255,255,0.02), 0 0 24px ${glow}`,
       }}
     >
-      <div className="scanline relative flex min-h-0 flex-1 items-center justify-center overflow-hidden px-3 pb-3 pt-3">
+      <div className="seraph-stage scanline relative flex min-h-0 flex-1 items-center justify-center overflow-hidden px-3 pb-3 pt-3">
         <div className="absolute inset-0 opacity-30 pointer-events-none" style={{
           backgroundImage:
-            'linear-gradient(rgba(141,226,255,0.018) 1px, transparent 1px), linear-gradient(90deg, rgba(141,226,255,0.018) 1px, transparent 1px)',
+            'linear-gradient(var(--seraph-grid-line) 1px, transparent 1px), linear-gradient(90deg, var(--seraph-grid-line) 1px, transparent 1px)',
           backgroundSize: '28px 28px',
         }} />
         <div
@@ -263,7 +263,7 @@ const Seraph: React.FC<SeraphProps> = ({
         </div>
       </div>
 
-      <div className="border-t border-[#173547] bg-[linear-gradient(180deg,rgba(7,19,29,0.9),rgba(6,16,25,0.97))] px-4 py-2.5 backdrop-blur-xl">
+      <div className="seraph-footer px-4 py-2.5 backdrop-blur-xl">
         <div className="flex flex-wrap items-center justify-between gap-x-5 gap-y-2">
           <div className="min-w-0 flex-1">
             <div className={`text-[18px] font-bold uppercase tracking-[-0.04em] glow-text ${colorMap[state]}`}>
@@ -275,21 +275,21 @@ const Seraph: React.FC<SeraphProps> = ({
                   key={i}
                   className="h-1 w-3 rounded-full transition-all duration-300"
                   style={{
-                    background: i < (frame % 10) ? barColor : 'rgba(255,255,255,0.05)',
+                    background: i < (frame % 10) ? barColor : 'var(--seraph-empty-bar)',
                     boxShadow: i < (frame % 10) ? `0 0 8px ${barColor}` : 'none',
                   }}
                 />
               ))}
             </div>
-            <div className="mt-1.5 max-w-[420px] text-[10px] leading-5 text-[#7a98ad]">{displayDetail}</div>
+            <div className="seraph-detail mt-1.5 max-w-[420px] text-[10px] leading-5">{displayDetail}</div>
           </div>
 
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
             {displayTelemetry.map((entry) => (
-              <div key={entry.label} className="min-w-[88px] border-l border-[#1f4358] pl-3">
-                <div className="text-[8px] uppercase tracking-[0.22em] text-[#55758a]">{entry.label}</div>
-                <div className="mt-0.5 text-[13px] font-bold tracking-[-0.03em] text-[#e3f4ff]">{entry.value}</div>
-                <div className="text-[8px] uppercase tracking-[0.1em] text-[#6d8ba0]">{entry.hint ?? 'live'}</div>
+              <div key={entry.label} className="seraph-telemetry min-w-[88px] border-l pl-3">
+                <div className="seraph-telemetry-label text-[8px] uppercase tracking-[0.22em]">{entry.label}</div>
+                <div className="seraph-telemetry-value mt-0.5 text-[13px] font-bold tracking-[-0.03em]">{entry.value}</div>
+                <div className="seraph-telemetry-hint text-[8px] uppercase tracking-[0.1em]">{entry.hint ?? 'live'}</div>
               </div>
             ))}
           </div>

--- a/frontend/src/components/cockpit/SeraphPresencePane.tsx
+++ b/frontend/src/components/cockpit/SeraphPresencePane.tsx
@@ -9,6 +9,7 @@ import {
 
 interface SeraphPresencePaneProps {
   snapshot: SeraphPresenceSnapshot;
+  isSelected?: boolean;
 }
 
 function toSeraphState(state: SeraphPresenceState): SeraphState {
@@ -39,7 +40,7 @@ function queueLabel(snapshot: SeraphPresenceSnapshot): string {
   return total > 0 ? total.toString().padStart(2, "0") : "CLEAR";
 }
 
-export function SeraphPresencePane({ snapshot }: SeraphPresencePaneProps) {
+export function SeraphPresencePane({ snapshot, isSelected = false }: SeraphPresencePaneProps) {
   const descriptor = useMemo(() => deriveSeraphPresenceState(snapshot), [snapshot]);
   const telemetry = useMemo<SeraphTelemetryEntry[]>(
     () => [
@@ -69,6 +70,8 @@ export function SeraphPresencePane({ snapshot }: SeraphPresencePaneProps) {
         detail={descriptor.detail}
         telemetry={telemetry}
         statusLabel={descriptor.label.toUpperCase()}
+        dividerColor={isSelected ? "rgba(141,226,255,0.2)" : "rgba(141,226,255,0.12)"}
+        edgeColor={isSelected ? "rgba(141,226,255,0.2)" : "rgba(141,226,255,0.12)"}
       />
     </section>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -126,6 +126,40 @@ body {
   opacity: 0.3;
 }
 
+.seraph-surface {
+  background: var(--seraph-shell-bg);
+  color: var(--seraph-shell-text);
+}
+
+.seraph-stage {
+  background: var(--seraph-stage-bg);
+}
+
+.seraph-footer {
+  border-top: 1px solid var(--seraph-footer-border);
+  background: var(--seraph-footer-bg);
+}
+
+.seraph-detail {
+  color: var(--seraph-detail-text);
+}
+
+.seraph-telemetry {
+  border-color: var(--seraph-telemetry-border);
+}
+
+.seraph-telemetry-label {
+  color: var(--seraph-telemetry-label);
+}
+
+.seraph-telemetry-value {
+  color: var(--seraph-telemetry-value);
+}
+
+.seraph-telemetry-hint {
+  color: var(--seraph-telemetry-hint);
+}
+
 /* ── Cockpit Surface ─────────────────────────────────── */
 .cockpit-shell,
 .cockpit-shell * {
@@ -186,8 +220,10 @@ body {
   --cockpit-hint-chip-text: rgba(180, 208, 227, 0.72);
   --cockpit-pill-bg: linear-gradient(180deg, rgba(8, 22, 33, 0.96), rgba(9, 23, 36, 0.9));
   --cockpit-pill-success-bg: linear-gradient(180deg, rgba(8, 24, 27, 0.98), rgba(8, 24, 27, 0.92));
+  --cockpit-pill-text: #8fa8bc;
   --cockpit-action-bg: rgba(8, 22, 33, 0.86);
   --cockpit-action-active-bg: linear-gradient(180deg, rgba(35, 74, 104, 0.92), rgba(18, 46, 69, 0.9));
+  --cockpit-action-ghost-text: #8fa8bc;
   --cockpit-workspace-bg:
     linear-gradient(180deg, rgba(5, 14, 22, 0.56), rgba(5, 14, 22, 0)),
     repeating-linear-gradient(
@@ -266,6 +302,28 @@ body {
   --cockpit-settings-toggle-bg: rgba(8, 22, 33, 0.82);
   --cockpit-session-helper-bg: rgba(10, 25, 38, 0.36);
   --cockpit-input-bg: rgba(10, 23, 35, 0.9);
+  --cockpit-soft-button-bg: rgba(10, 26, 40, 0.34);
+  --cockpit-soft-button-hover-bg: rgba(16, 44, 67, 0.56);
+  --cockpit-soft-button-text: #d7e7f5;
+  --cockpit-soft-button-muted: #8fa8bc;
+  --cockpit-ledger-toolbar-bg: rgba(10, 25, 38, 0.28);
+  --cockpit-ledger-badge-bg: rgba(8, 20, 31, 0.52);
+  --cockpit-chip-bg: rgba(10, 23, 35, 0.72);
+  --cockpit-chip-text: #8fa8bc;
+  --cockpit-composer-bg: linear-gradient(180deg, rgba(7, 16, 25, 0), rgba(7, 16, 25, 0.92) 22%, rgba(7, 16, 25, 1) 100%);
+  --cockpit-send-text: #041119;
+  --seraph-shell-bg: linear-gradient(180deg, rgba(5, 9, 13, 0.98), rgba(5, 9, 13, 0.995));
+  --seraph-shell-text: #dbefff;
+  --seraph-stage-bg: #05090d;
+  --seraph-grid-line: rgba(141, 226, 255, 0.018);
+  --seraph-footer-bg: linear-gradient(180deg, rgba(7, 19, 29, 0.9), rgba(6, 16, 25, 0.97));
+  --seraph-footer-border: #173547;
+  --seraph-detail-text: #7a98ad;
+  --seraph-telemetry-border: #1f4358;
+  --seraph-telemetry-label: #55758a;
+  --seraph-telemetry-value: #e3f4ff;
+  --seraph-telemetry-hint: #6d8ba0;
+  --seraph-empty-bar: rgba(255, 255, 255, 0.05);
   --cockpit-tone-bg: rgba(7, 20, 31, 0.74);
   --cockpit-tone-border-soft: rgba(141, 226, 255, 0.12);
   --cockpit-tone-border: rgba(141, 226, 255, 0.18);
@@ -342,8 +400,10 @@ body {
   --cockpit-hint-chip-text: rgba(93, 118, 136, 0.9);
   --cockpit-pill-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.97), rgba(241, 247, 251, 0.92));
   --cockpit-pill-success-bg: linear-gradient(180deg, rgba(231, 250, 245, 0.98), rgba(223, 245, 237, 0.94));
+  --cockpit-pill-text: #476274;
   --cockpit-action-bg: rgba(250, 252, 254, 0.9);
   --cockpit-action-active-bg: linear-gradient(180deg, rgba(205, 231, 244, 0.98), rgba(187, 222, 239, 0.94));
+  --cockpit-action-ghost-text: #476274;
   --cockpit-workspace-bg:
     linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(255, 255, 255, 0)),
     repeating-linear-gradient(
@@ -422,6 +482,28 @@ body {
   --cockpit-settings-toggle-bg: rgba(248, 251, 253, 0.94);
   --cockpit-session-helper-bg: rgba(240, 246, 249, 0.82);
   --cockpit-input-bg: rgba(232, 239, 244, 0.94);
+  --cockpit-soft-button-bg: rgba(219, 231, 239, 0.96);
+  --cockpit-soft-button-hover-bg: rgba(197, 221, 235, 0.98);
+  --cockpit-soft-button-text: #173245;
+  --cockpit-soft-button-muted: #4a6476;
+  --cockpit-ledger-toolbar-bg: rgba(229, 238, 244, 0.96);
+  --cockpit-ledger-badge-bg: rgba(205, 218, 228, 0.96);
+  --cockpit-chip-bg: rgba(219, 231, 239, 0.96);
+  --cockpit-chip-text: #476274;
+  --cockpit-composer-bg: linear-gradient(180deg, rgba(244, 248, 251, 0), rgba(233, 240, 245, 0.94) 22%, rgba(227, 236, 243, 1) 100%);
+  --cockpit-send-text: #f8fcff;
+  --seraph-shell-bg: linear-gradient(180deg, rgba(248, 251, 253, 0.98), rgba(241, 246, 250, 0.99));
+  --seraph-shell-text: #173245;
+  --seraph-stage-bg: #0a1016;
+  --seraph-grid-line: rgba(131, 162, 181, 0.08);
+  --seraph-footer-bg: linear-gradient(180deg, rgba(243, 248, 251, 0.98), rgba(233, 240, 245, 0.96));
+  --seraph-footer-border: rgba(41, 96, 126, 0.18);
+  --seraph-detail-text: #5b7486;
+  --seraph-telemetry-border: rgba(41, 96, 126, 0.22);
+  --seraph-telemetry-label: #5f7788;
+  --seraph-telemetry-value: #173245;
+  --seraph-telemetry-hint: #6e8698;
+  --seraph-empty-bar: rgba(93, 118, 136, 0.16);
   --cockpit-tone-bg: rgba(234, 241, 246, 0.92);
   --cockpit-tone-border-soft: rgba(31, 116, 162, 0.12);
   --cockpit-tone-border: rgba(31, 116, 162, 0.18);
@@ -574,7 +656,7 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.12em;
   background: var(--cockpit-pill-bg);
-  color: var(--cockpit-muted);
+  color: var(--cockpit-pill-text);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
@@ -613,7 +695,7 @@ body {
 
 .cockpit-action--ghost {
   border-color: var(--cockpit-border);
-  color: var(--cockpit-muted);
+  color: var(--cockpit-action-ghost-text);
 }
 
 .cockpit-action--ghost:hover {
@@ -1648,7 +1730,7 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  background: rgba(10, 26, 40, 0.34);
+  background: var(--cockpit-soft-button-bg);
   color: var(--cockpit-text);
   cursor: pointer;
   font: inherit;
@@ -1658,7 +1740,7 @@ body {
 .cockpit-session:hover,
 .cockpit-session.active {
   border-color: var(--cockpit-state-selected-border);
-  background: rgba(16, 44, 67, 0.56);
+  background: var(--cockpit-soft-button-hover-bg);
 }
 
 .cockpit-session-title {
@@ -1681,7 +1763,7 @@ body {
 .cockpit-row-age,
 .cockpit-row-meta,
 .cockpit-feedback-status {
-  color: var(--cockpit-muted);
+  color: var(--cockpit-soft-button-muted);
   font-size: 10px;
 }
 
@@ -1793,8 +1875,8 @@ body {
   border: 1px solid rgba(141, 226, 255, 0.08);
   border-radius: 0;
   padding: 7px 8px;
-  background: rgba(10, 26, 40, 0.34);
-  color: var(--cockpit-text);
+  background: var(--cockpit-soft-button-bg);
+  color: var(--cockpit-soft-button-text);
   font: inherit;
   text-align: left;
   cursor: pointer;
@@ -1806,7 +1888,7 @@ body {
   gap: 8px;
   padding: 8px var(--cockpit-pane-gutter) 4px;
   border-bottom: 1px solid rgba(141, 226, 255, 0.08);
-  background: rgba(10, 25, 38, 0.28);
+  background: var(--cockpit-ledger-toolbar-bg);
 }
 
 .cockpit-ledger-summary,
@@ -1827,13 +1909,13 @@ body {
 }
 
 .cockpit-ledger-badge {
-  color: var(--cockpit-muted);
-  background: rgba(8, 20, 31, 0.52);
+  color: var(--cockpit-soft-button-muted);
+  background: var(--cockpit-ledger-badge-bg);
 }
 
 .cockpit-ledger-filter {
-  background: rgba(10, 26, 40, 0.34);
-  color: var(--cockpit-text);
+  background: var(--cockpit-soft-button-bg);
+  color: var(--cockpit-soft-button-text);
   cursor: pointer;
   font: inherit;
 }
@@ -1841,7 +1923,7 @@ body {
 .cockpit-ledger-filter:hover,
 .cockpit-ledger-filter.active {
   border-color: var(--cockpit-state-selected-border);
-  background: rgba(16, 44, 67, 0.56);
+  background: var(--cockpit-soft-button-hover-bg);
 }
 
 .cockpit-ledger-group {
@@ -1895,7 +1977,7 @@ body {
   border: 1px solid rgba(141, 226, 255, 0.06);
   border-radius: 0;
   padding: 5px 8px;
-  background: rgba(7, 19, 30, 0.4);
+  background: var(--cockpit-soft-button-bg);
   color: var(--cockpit-text);
   font: inherit;
   text-align: left;
@@ -1904,7 +1986,7 @@ body {
 
 .cockpit-ledger-child:hover {
   border-color: rgba(141, 226, 255, 0.16);
-  background: rgba(12, 28, 41, 0.48);
+  background: var(--cockpit-soft-button-hover-bg);
 }
 
 .cockpit-ledger-child--static {
@@ -1947,7 +2029,7 @@ body {
 .cockpit-sublist-button:hover,
 .cockpit-sublist-button.active {
   border-color: var(--cockpit-state-selected-border);
-  background: rgba(16, 44, 67, 0.56);
+  background: var(--cockpit-soft-button-hover-bg);
 }
 
 .cockpit-state-grid {
@@ -2434,8 +2516,8 @@ body {
 .cockpit-operator-link {
   border: 1px solid rgba(141, 226, 255, 0.14);
   border-radius: 0;
-  background: rgba(8, 22, 33, 0.78);
-  color: var(--cockpit-muted);
+  background: var(--cockpit-soft-button-bg);
+  color: var(--cockpit-soft-button-muted);
   padding: 5px 8px;
   font: inherit;
   font-size: 10px;
@@ -2525,8 +2607,8 @@ body {
   font-size: 10px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--cockpit-muted);
-  background: rgba(10, 23, 35, 0.72);
+  color: var(--cockpit-chip-text);
+  background: var(--cockpit-chip-bg);
 }
 
 .cockpit-inspector-value {
@@ -2541,7 +2623,7 @@ body {
 
 .cockpit-composer {
   padding: 0 20px calc(20px + env(safe-area-inset-bottom, 0px));
-  background: linear-gradient(180deg, rgba(7, 16, 25, 0), rgba(7, 16, 25, 0.92) 22%, rgba(7, 16, 25, 1) 100%);
+  background: var(--cockpit-composer-bg);
 }
 
 .cockpit-composer-meta {
@@ -2595,7 +2677,7 @@ body {
   border-radius: 0;
   padding: 0 20px;
   background: linear-gradient(135deg, var(--cockpit-accent), var(--cockpit-accent-strong));
-  color: #041119;
+  color: var(--cockpit-send-text);
   font: inherit;
   font-size: 12px;
   font-weight: 700;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -255,10 +255,27 @@ body {
   --cockpit-modal-card-bg:
     linear-gradient(180deg, rgba(7, 21, 32, 0.98), rgba(8, 22, 34, 0.96)),
     radial-gradient(circle at top right, rgba(141, 226, 255, 0.1), transparent 44%);
+  --cockpit-overlay-backdrop-bg:
+    linear-gradient(180deg, rgba(3, 9, 15, 0.72), rgba(2, 8, 15, 0.82)),
+    radial-gradient(circle at top, rgba(141, 226, 255, 0.08), transparent 34%);
+  --cockpit-palette-bg:
+    linear-gradient(180deg, rgba(7, 20, 31, 0.98), rgba(9, 24, 37, 0.97)),
+    radial-gradient(circle at top right, rgba(141, 226, 255, 0.08), transparent 42%);
   --cockpit-modal-close-bg: rgba(11, 27, 40, 0.78);
   --cockpit-settings-inline-bg: rgba(9, 24, 36, 0.44);
   --cockpit-settings-toggle-bg: rgba(8, 22, 33, 0.82);
   --cockpit-session-helper-bg: rgba(10, 25, 38, 0.36);
+  --cockpit-input-bg: rgba(10, 23, 35, 0.9);
+  --cockpit-tone-bg: rgba(7, 20, 31, 0.74);
+  --cockpit-tone-border-soft: rgba(141, 226, 255, 0.12);
+  --cockpit-tone-border: rgba(141, 226, 255, 0.18);
+  --cockpit-tone-border-strong: rgba(141, 226, 255, 0.28);
+  --cockpit-tone-muted-20: rgba(126, 154, 176, 0.46);
+  --cockpit-tone-muted-30: rgba(126, 154, 176, 0.58);
+  --cockpit-tone-muted-40: rgba(126, 154, 176, 0.72);
+  --cockpit-tone-muted-60: rgba(152, 180, 201, 0.84);
+  --cockpit-tone-shadow-inset: rgba(7, 16, 25, 0.92);
+  --cockpit-tone-shadow-outline: rgba(141, 226, 255, 0.1);
   font-family: "IBM Plex Mono", "Iosevka", "SFMono-Regular", Menlo, Consolas, monospace;
   display: flex;
   flex-direction: column;
@@ -394,10 +411,27 @@ body {
   --cockpit-modal-card-bg:
     linear-gradient(180deg, rgba(252, 254, 255, 0.99), rgba(244, 248, 251, 0.97)),
     radial-gradient(circle at top right, rgba(30, 127, 174, 0.08), transparent 44%);
+  --cockpit-overlay-backdrop-bg:
+    linear-gradient(180deg, rgba(224, 233, 240, 0.7), rgba(216, 227, 235, 0.8)),
+    radial-gradient(circle at top, rgba(30, 127, 174, 0.08), transparent 34%);
+  --cockpit-palette-bg:
+    linear-gradient(180deg, rgba(248, 251, 253, 0.99), rgba(240, 246, 250, 0.97)),
+    radial-gradient(circle at top right, rgba(30, 127, 174, 0.08), transparent 42%);
   --cockpit-modal-close-bg: rgba(248, 251, 253, 0.96);
   --cockpit-settings-inline-bg: rgba(243, 248, 251, 0.82);
   --cockpit-settings-toggle-bg: rgba(248, 251, 253, 0.94);
   --cockpit-session-helper-bg: rgba(240, 246, 249, 0.82);
+  --cockpit-input-bg: rgba(232, 239, 244, 0.94);
+  --cockpit-tone-bg: rgba(234, 241, 246, 0.92);
+  --cockpit-tone-border-soft: rgba(31, 116, 162, 0.12);
+  --cockpit-tone-border: rgba(31, 116, 162, 0.18);
+  --cockpit-tone-border-strong: rgba(31, 116, 162, 0.28);
+  --cockpit-tone-muted-20: rgba(93, 118, 136, 0.62);
+  --cockpit-tone-muted-30: rgba(93, 118, 136, 0.74);
+  --cockpit-tone-muted-40: rgba(93, 118, 136, 0.82);
+  --cockpit-tone-muted-60: rgba(74, 98, 116, 0.9);
+  --cockpit-tone-shadow-inset: rgba(255, 255, 255, 0.92);
+  --cockpit-tone-shadow-outline: rgba(31, 116, 162, 0.08);
 }
 
 .cockpit-shell::before {
@@ -1109,9 +1143,7 @@ body {
   align-items: flex-start;
   justify-content: center;
   padding: 96px 24px 24px;
-  background:
-    linear-gradient(180deg, rgba(3, 9, 15, 0.72), rgba(2, 8, 15, 0.82)),
-    radial-gradient(circle at top, rgba(141, 226, 255, 0.08), transparent 34%);
+  background: var(--cockpit-overlay-backdrop-bg);
   backdrop-filter: blur(10px);
 }
 
@@ -1123,9 +1155,7 @@ body {
   border: 1px solid var(--cockpit-border-strong);
   border-radius: 0;
   overflow: hidden;
-  background:
-    linear-gradient(180deg, rgba(7, 20, 31, 0.98), rgba(9, 24, 37, 0.97)),
-    radial-gradient(circle at top right, rgba(141, 226, 255, 0.08), transparent 42%);
+  background: var(--cockpit-palette-bg);
   box-shadow:
     0 22px 64px rgba(0, 0, 0, 0.42),
     inset 0 1px 0 rgba(255, 255, 255, 0.03);
@@ -1437,37 +1467,37 @@ body {
 }
 
 .cockpit-tone-scope [class*="text-retro-text/20"] {
-  color: rgba(126, 154, 176, 0.46);
+  color: var(--cockpit-tone-muted-20);
 }
 
 .cockpit-tone-scope [class*="text-retro-text/30"] {
-  color: rgba(126, 154, 176, 0.58);
+  color: var(--cockpit-tone-muted-30);
 }
 
 .cockpit-tone-scope [class*="text-retro-text/40"] {
-  color: rgba(126, 154, 176, 0.72);
+  color: var(--cockpit-tone-muted-40);
 }
 
 .cockpit-tone-scope [class*="text-retro-text/50"],
 .cockpit-tone-scope [class*="text-retro-text/60"] {
-  color: rgba(152, 180, 201, 0.84);
+  color: var(--cockpit-tone-muted-60);
 }
 
 .cockpit-tone-scope [class*="border-retro-text/10"] {
-  border-color: rgba(141, 226, 255, 0.12);
+  border-color: var(--cockpit-tone-border-soft);
 }
 
 .cockpit-tone-scope [class*="border-retro-text/20"],
 .cockpit-tone-scope [class*="border-retro-border/20"] {
-  border-color: rgba(141, 226, 255, 0.18);
+  border-color: var(--cockpit-tone-border);
 }
 
 .cockpit-tone-scope [class*="border-retro-text/40"] {
-  border-color: rgba(141, 226, 255, 0.28);
+  border-color: var(--cockpit-tone-border-strong);
 }
 
 .cockpit-tone-scope [class*="bg-retro-bg"] {
-  background: rgba(7, 20, 31, 0.74);
+  background: var(--cockpit-tone-bg);
 }
 
 .cockpit-tone-scope [class~="rounded"],
@@ -1480,23 +1510,23 @@ body {
 }
 
 .cockpit-tone-scope .pixel-border-thin {
-  border-color: rgba(141, 226, 255, 0.18);
+  border-color: var(--cockpit-tone-border);
   box-shadow:
-    inset 0 0 0 1px rgba(7, 16, 25, 0.92),
-    0 0 0 1px rgba(141, 226, 255, 0.1);
+    inset 0 0 0 1px var(--cockpit-tone-shadow-inset),
+    0 0 0 1px var(--cockpit-tone-shadow-outline);
 }
 
 .cockpit-tone-scope input,
 .cockpit-tone-scope select,
 .cockpit-tone-scope textarea {
   color: var(--cockpit-text);
-  background-color: rgba(7, 20, 31, 0.74);
+  background-color: var(--cockpit-tone-bg);
   border-radius: 0;
 }
 
 .cockpit-tone-scope input::placeholder,
 .cockpit-tone-scope textarea::placeholder {
-  color: rgba(126, 154, 176, 0.56);
+  color: var(--cockpit-tone-muted-30);
 }
 
 .cockpit-tone-scope button {
@@ -2539,7 +2569,7 @@ body {
   min-width: 0;
   border: 1px solid rgba(141, 226, 255, 0.14);
   border-radius: 0;
-  background: rgba(10, 23, 35, 0.9);
+  background: var(--cockpit-input-bg);
   color: var(--cockpit-text);
   padding: 14px 16px;
   font: inherit;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -127,6 +127,8 @@ body {
 }
 
 .seraph-surface {
+  --app-glass-bg: var(--seraph-core-bg);
+  --app-glass-border: rgba(255, 255, 255, 0.04);
   background: var(--seraph-shell-bg);
   color: var(--seraph-shell-text);
 }
@@ -324,6 +326,8 @@ body {
   --seraph-telemetry-value: #e3f4ff;
   --seraph-telemetry-hint: #6d8ba0;
   --seraph-empty-bar: rgba(255, 255, 255, 0.05);
+  --seraph-core-bg: rgba(14, 20, 28, 0.88);
+  --seraph-core-inner-ring: rgba(255, 255, 255, 0.05);
   --cockpit-tone-bg: rgba(7, 20, 31, 0.74);
   --cockpit-tone-border-soft: rgba(141, 226, 255, 0.12);
   --cockpit-tone-border: rgba(141, 226, 255, 0.18);
@@ -492,18 +496,20 @@ body {
   --cockpit-chip-text: #476274;
   --cockpit-composer-bg: linear-gradient(180deg, rgba(244, 248, 251, 0), rgba(233, 240, 245, 0.94) 22%, rgba(227, 236, 243, 1) 100%);
   --cockpit-send-text: #f8fcff;
-  --seraph-shell-bg: linear-gradient(180deg, rgba(248, 251, 253, 0.98), rgba(241, 246, 250, 0.99));
-  --seraph-shell-text: #173245;
-  --seraph-stage-bg: #0a1016;
-  --seraph-grid-line: rgba(131, 162, 181, 0.08);
-  --seraph-footer-bg: linear-gradient(180deg, rgba(243, 248, 251, 0.98), rgba(233, 240, 245, 0.96));
-  --seraph-footer-border: rgba(41, 96, 126, 0.18);
-  --seraph-detail-text: #5b7486;
-  --seraph-telemetry-border: rgba(41, 96, 126, 0.22);
-  --seraph-telemetry-label: #5f7788;
-  --seraph-telemetry-value: #173245;
-  --seraph-telemetry-hint: #6e8698;
-  --seraph-empty-bar: rgba(93, 118, 136, 0.16);
+  --seraph-shell-bg: linear-gradient(180deg, rgba(5, 9, 13, 0.98), rgba(5, 9, 13, 0.995));
+  --seraph-shell-text: #dbefff;
+  --seraph-stage-bg: #05090d;
+  --seraph-grid-line: rgba(141, 226, 255, 0.018);
+  --seraph-footer-bg: linear-gradient(180deg, rgba(7, 19, 29, 0.9), rgba(6, 16, 25, 0.97));
+  --seraph-footer-border: #173547;
+  --seraph-detail-text: #7a98ad;
+  --seraph-telemetry-border: #1f4358;
+  --seraph-telemetry-label: #55758a;
+  --seraph-telemetry-value: #e3f4ff;
+  --seraph-telemetry-hint: #6d8ba0;
+  --seraph-empty-bar: rgba(255, 255, 255, 0.05);
+  --seraph-core-bg: rgba(14, 20, 28, 0.88);
+  --seraph-core-inner-ring: rgba(255, 255, 255, 0.05);
   --cockpit-tone-bg: rgba(234, 241, 246, 0.92);
   --cockpit-tone-border-soft: rgba(31, 116, 162, 0.12);
   --cockpit-tone-border: rgba(31, 116, 162, 0.18);
@@ -1855,6 +1861,7 @@ body {
 .cockpit-message-body {
   font-size: 12px;
   line-height: 1.6;
+  color: var(--cockpit-text);
 }
 
 .cockpit-response-body {
@@ -2355,20 +2362,19 @@ body {
 
 .cockpit-row,
 .cockpit-message {
-  border: 1px solid rgba(141, 226, 255, 0.08);
+  border: 1px solid var(--cockpit-border);
   border-radius: 0;
   padding: 8px;
-  background: rgba(10, 26, 40, 0.34);
+  background: var(--cockpit-soft-button-bg);
+  color: var(--cockpit-text);
 }
 
 .cockpit-message--pending,
 .cockpit-pending-response {
-  border: 1px solid rgba(141, 226, 255, 0.18);
+  border: 1px solid var(--cockpit-state-selected-border);
   border-radius: 0;
   padding: 8px;
-  background:
-    linear-gradient(180deg, rgba(13, 33, 52, 0.52), rgba(13, 33, 52, 0.38)),
-    radial-gradient(circle at top right, rgba(141, 226, 255, 0.12), transparent 48%);
+  background: var(--cockpit-panel-response-bg);
 }
 
 .cockpit-pending-copy {
@@ -2424,10 +2430,10 @@ body {
 }
 
 .cockpit-feedback-button {
-  border: 1px solid rgba(141, 226, 255, 0.14);
+  border: 1px solid var(--cockpit-border);
   border-radius: 0;
-  background: rgba(8, 22, 33, 0.78);
-  color: var(--cockpit-text);
+  background: var(--cockpit-soft-button-bg);
+  color: var(--cockpit-soft-button-text);
   padding: 6px 8px;
   font: inherit;
   font-size: 10px;
@@ -2438,7 +2444,8 @@ body {
 
 .cockpit-feedback-button:hover {
   border-color: var(--cockpit-state-selected-border);
-  background: var(--cockpit-state-selected-fill);
+  background: var(--cockpit-soft-button-hover-bg);
+  color: var(--cockpit-text);
 }
 
 .cockpit-operator-section {
@@ -2479,11 +2486,11 @@ body {
 }
 
 .cockpit-operator-details--button {
-  border: 1px solid rgba(141, 226, 255, 0.08);
+  border: 1px solid var(--cockpit-border);
   border-radius: 0;
   padding: 8px 10px;
-  background: rgba(10, 27, 41, 0.42);
-  color: inherit;
+  background: var(--cockpit-soft-button-bg);
+  color: var(--cockpit-text);
   font: inherit;
   text-align: left;
   cursor: pointer;
@@ -2491,7 +2498,7 @@ body {
 
 .cockpit-operator-details--button:hover {
   border-color: var(--cockpit-state-selected-border);
-  background: rgba(17, 47, 72, 0.62);
+  background: var(--cockpit-soft-button-hover-bg);
 }
 
 .cockpit-operator-note {
@@ -2582,16 +2589,16 @@ body {
   grid-template-columns: 120px minmax(0, 1fr);
   gap: 10px;
   padding: 10px 12px;
-  border: 1px solid rgba(141, 226, 255, 0.08);
+  border: 1px solid var(--cockpit-border);
   border-radius: 0;
-  background: rgba(13, 33, 52, 0.3);
+  background: var(--cockpit-soft-button-bg);
 }
 
 .cockpit-inspector-detail {
-  border: 1px solid rgba(141, 226, 255, 0.08);
+  border: 1px solid var(--cockpit-border);
   border-radius: 0;
   padding: 10px 12px;
-  background: rgba(13, 33, 52, 0.38);
+  background: var(--cockpit-soft-button-bg);
 }
 
 .cockpit-chip-row {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --app-bg: #0a0a1a;
+  --app-text: #e0e0e0;
+  --app-glass-bg: rgba(255, 255, 255, 0.03);
+  --app-glass-border: rgba(255, 255, 255, 0.1);
+  color-scheme: dark;
+}
+
+:root[data-theme="light"] {
+  --app-bg: #e8f0f4;
+  --app-text: #1a3140;
+  --app-glass-bg: rgba(255, 255, 255, 0.72);
+  --app-glass-border: rgba(37, 92, 122, 0.14);
+  color-scheme: light;
+}
+
 /* ── Base ──────────────────────────────────────────────── */
 * {
   image-rendering: pixelated;
@@ -14,12 +30,12 @@ body,
   margin: 0;
   padding: 0;
   overflow: hidden;
-  background: #0a0a1a;
+  background: var(--app-bg);
 }
 
 body {
   font-family: "Press Start 2P", monospace;
-  color: #e0e0e0;
+  color: var(--app-text);
   font-size: 11px;
   line-height: 1.6;
 }
@@ -29,9 +45,9 @@ body {
 }
 
 .glass-panel {
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--app-glass-bg);
   backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--app-glass-border);
 }
 
 @keyframes float {
@@ -116,7 +132,8 @@ body {
   image-rendering: auto;
 }
 
-.cockpit-shell {
+.cockpit-shell,
+.cockpit-modal-shell {
   --cockpit-bg: #071019;
   --cockpit-panel: rgba(9, 25, 39, 0.92);
   --cockpit-panel-soft: rgba(13, 33, 52, 0.82);
@@ -138,26 +155,8 @@ body {
   --cockpit-state-danger-border: rgba(255, 125, 121, 0.42);
   --cockpit-state-danger-fill: rgba(255, 125, 121, 0.08);
   --cockpit-pane-gutter: 12px;
-  font-family: "IBM Plex Mono", "Iosevka", "SFMono-Regular", Menlo, Consolas, monospace;
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  isolation: isolate;
-  min-height: 100vh;
-  min-height: 100dvh;
-  height: 100vh;
-  height: 100dvh;
-  color: var(--cockpit-text);
-  background: linear-gradient(180deg, #05101a 0%, #07131d 42%, #091722 100%);
-}
-
-.cockpit-shell::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  background:
+  --cockpit-shell-bg: linear-gradient(180deg, #05101a 0%, #07131d 42%, #091722 100%);
+  --cockpit-shell-overlay:
     linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 24%),
     repeating-linear-gradient(
       0deg,
@@ -173,6 +172,241 @@ body {
       transparent 1px,
       transparent 28px
     );
+  --cockpit-topbar-bg:
+    linear-gradient(180deg, rgba(7, 18, 27, 0.98), rgba(7, 18, 27, 0.94)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(141, 226, 255, 0.026) 0,
+      rgba(141, 226, 255, 0.026) 1px,
+      transparent 1px,
+      transparent 14px
+    );
+  --cockpit-hint-strip-bg: linear-gradient(180deg, rgba(7, 17, 26, 0.96), rgba(7, 17, 26, 0.84));
+  --cockpit-hint-chip-bg: rgba(10, 23, 35, 0.72);
+  --cockpit-hint-chip-text: rgba(180, 208, 227, 0.72);
+  --cockpit-pill-bg: linear-gradient(180deg, rgba(8, 22, 33, 0.96), rgba(9, 23, 36, 0.9));
+  --cockpit-pill-success-bg: linear-gradient(180deg, rgba(8, 24, 27, 0.98), rgba(8, 24, 27, 0.92));
+  --cockpit-action-bg: rgba(8, 22, 33, 0.86);
+  --cockpit-action-active-bg: linear-gradient(180deg, rgba(35, 74, 104, 0.92), rgba(18, 46, 69, 0.9));
+  --cockpit-workspace-bg:
+    linear-gradient(180deg, rgba(5, 14, 22, 0.56), rgba(5, 14, 22, 0)),
+    repeating-linear-gradient(
+      0deg,
+      rgba(141, 226, 255, 0.018) 0,
+      rgba(141, 226, 255, 0.018) 1px,
+      transparent 1px,
+      transparent 24px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(141, 226, 255, 0.014) 0,
+      rgba(141, 226, 255, 0.014) 1px,
+      transparent 1px,
+      transparent 24px
+    );
+  --cockpit-menu-bg: rgba(6, 16, 25, 0.98);
+  --cockpit-menu-toolbar-bg: rgba(10, 24, 36, 0.92);
+  --cockpit-menu-header-bg: rgba(10, 24, 36, 0.96);
+  --cockpit-menu-button-bg: rgba(8, 21, 32, 0.9);
+  --cockpit-menu-button-hover-bg: rgba(15, 39, 58, 0.9);
+  --cockpit-menu-scroll-track: linear-gradient(180deg, rgba(6, 18, 28, 0.98), rgba(9, 23, 35, 0.98));
+  --cockpit-menu-scroll-thumb: linear-gradient(180deg, rgba(130, 209, 247, 0.92), rgba(89, 171, 215, 0.9));
+  --cockpit-menu-scroll-thumb-hover: linear-gradient(180deg, rgba(164, 229, 255, 0.98), rgba(110, 244, 195, 0.9));
+  --cockpit-menu-scroll-thumb-border: rgba(8, 22, 34, 0.94);
+  --cockpit-window-bg: linear-gradient(180deg, rgba(7, 19, 29, 0.985), rgba(8, 21, 33, 0.975));
+  --cockpit-window-header-bg:
+    linear-gradient(180deg, rgba(10, 26, 38, 0.99), rgba(7, 18, 28, 0.97)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(141, 226, 255, 0.018) 0,
+      rgba(141, 226, 255, 0.018) 1px,
+      transparent 1px,
+      transparent 18px
+    );
+  --cockpit-window-control-bg: rgba(8, 21, 32, 0.9);
+  --cockpit-window-control-hover-bg: rgba(15, 39, 58, 0.9);
+  --cockpit-window-hint-bg: linear-gradient(180deg, rgba(8, 22, 33, 0.88), rgba(8, 20, 31, 0.82));
+  --cockpit-window-hint-text: rgba(180, 208, 227, 0.78);
+  --cockpit-panel-bg:
+    linear-gradient(180deg, rgba(10, 24, 37, 0.96), rgba(7, 20, 31, 0.94)),
+    repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.015) 0,
+      rgba(255, 255, 255, 0.015) 1px,
+      transparent 1px,
+      transparent 20px
+    );
+  --cockpit-panel-response-bg:
+    radial-gradient(circle at top right, rgba(141, 226, 255, 0.12), transparent 45%),
+    linear-gradient(180deg, rgba(14, 36, 58, 0.96), rgba(8, 20, 34, 0.94));
+  --cockpit-panel-embedded-bg:
+    linear-gradient(180deg, rgba(7, 19, 29, 0.8), rgba(8, 21, 32, 0.84)),
+    repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.012) 0,
+      rgba(255, 255, 255, 0.012) 1px,
+      transparent 1px,
+      transparent 20px
+    );
+  --cockpit-sidebar-bg: rgba(7, 20, 31, 0.38);
+  --cockpit-modal-backdrop-bg:
+    linear-gradient(180deg, rgba(2, 8, 15, 0.72), rgba(3, 8, 15, 0.86)),
+    radial-gradient(circle at top, rgba(141, 226, 255, 0.08), transparent 34%);
+  --cockpit-modal-card-bg:
+    linear-gradient(180deg, rgba(7, 21, 32, 0.98), rgba(8, 22, 34, 0.96)),
+    radial-gradient(circle at top right, rgba(141, 226, 255, 0.1), transparent 44%);
+  --cockpit-modal-close-bg: rgba(11, 27, 40, 0.78);
+  --cockpit-settings-inline-bg: rgba(9, 24, 36, 0.44);
+  --cockpit-settings-toggle-bg: rgba(8, 22, 33, 0.82);
+  --cockpit-session-helper-bg: rgba(10, 25, 38, 0.36);
+  font-family: "IBM Plex Mono", "Iosevka", "SFMono-Regular", Menlo, Consolas, monospace;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  isolation: isolate;
+  min-height: 100vh;
+  min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
+  color: var(--cockpit-text);
+  background: var(--cockpit-shell-bg);
+}
+
+:root[data-theme="light"] .cockpit-shell,
+:root[data-theme="light"] .cockpit-modal-shell {
+  --cockpit-bg: #ebf2f6;
+  --cockpit-panel: rgba(251, 253, 255, 0.95);
+  --cockpit-panel-soft: rgba(242, 247, 251, 0.92);
+  --cockpit-border: rgba(41, 96, 126, 0.18);
+  --cockpit-border-strong: rgba(31, 116, 162, 0.38);
+  --cockpit-text: #173245;
+  --cockpit-muted: #5d7688;
+  --cockpit-accent: #1e7fae;
+  --cockpit-accent-strong: #138a72;
+  --cockpit-warning: #b36a00;
+  --cockpit-danger: #c15353;
+  --cockpit-state-selected-border: rgba(30, 127, 174, 0.42);
+  --cockpit-state-selected-fill: rgba(30, 127, 174, 0.08);
+  --cockpit-state-selected-shadow: rgba(30, 127, 174, 0.12);
+  --cockpit-state-success-border: rgba(19, 138, 114, 0.34);
+  --cockpit-state-success-fill: rgba(19, 138, 114, 0.1);
+  --cockpit-state-warning-border: rgba(179, 106, 0, 0.34);
+  --cockpit-state-warning-fill: rgba(179, 106, 0, 0.08);
+  --cockpit-state-danger-border: rgba(193, 83, 83, 0.34);
+  --cockpit-state-danger-fill: rgba(193, 83, 83, 0.08);
+  --cockpit-shell-bg: linear-gradient(180deg, #f4f8fb 0%, #ebf2f6 42%, #e2ebf1 100%);
+  --cockpit-shell-overlay:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.6), transparent 24%),
+    repeating-linear-gradient(
+      0deg,
+      rgba(31, 116, 162, 0.045) 0,
+      rgba(31, 116, 162, 0.045) 1px,
+      transparent 1px,
+      transparent 28px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(31, 116, 162, 0.038) 0,
+      rgba(31, 116, 162, 0.038) 1px,
+      transparent 1px,
+      transparent 28px
+    );
+  --cockpit-topbar-bg:
+    linear-gradient(180deg, rgba(247, 250, 252, 0.98), rgba(239, 245, 249, 0.94)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(31, 116, 162, 0.04) 0,
+      rgba(31, 116, 162, 0.04) 1px,
+      transparent 1px,
+      transparent 14px
+    );
+  --cockpit-hint-strip-bg: linear-gradient(180deg, rgba(245, 249, 252, 0.96), rgba(238, 244, 248, 0.84));
+  --cockpit-hint-chip-bg: rgba(255, 255, 255, 0.78);
+  --cockpit-hint-chip-text: rgba(93, 118, 136, 0.9);
+  --cockpit-pill-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.97), rgba(241, 247, 251, 0.92));
+  --cockpit-pill-success-bg: linear-gradient(180deg, rgba(231, 250, 245, 0.98), rgba(223, 245, 237, 0.94));
+  --cockpit-action-bg: rgba(250, 252, 254, 0.9);
+  --cockpit-action-active-bg: linear-gradient(180deg, rgba(205, 231, 244, 0.98), rgba(187, 222, 239, 0.94));
+  --cockpit-workspace-bg:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(255, 255, 255, 0)),
+    repeating-linear-gradient(
+      0deg,
+      rgba(31, 116, 162, 0.035) 0,
+      rgba(31, 116, 162, 0.035) 1px,
+      transparent 1px,
+      transparent 24px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(31, 116, 162, 0.028) 0,
+      rgba(31, 116, 162, 0.028) 1px,
+      transparent 1px,
+      transparent 24px
+    );
+  --cockpit-menu-bg: rgba(248, 251, 253, 0.99);
+  --cockpit-menu-toolbar-bg: rgba(241, 247, 250, 0.96);
+  --cockpit-menu-header-bg: rgba(238, 244, 248, 0.98);
+  --cockpit-menu-button-bg: rgba(251, 253, 255, 0.96);
+  --cockpit-menu-button-hover-bg: rgba(226, 238, 245, 0.98);
+  --cockpit-menu-scroll-track: linear-gradient(180deg, rgba(232, 239, 244, 0.98), rgba(223, 232, 239, 0.98));
+  --cockpit-menu-scroll-thumb: linear-gradient(180deg, rgba(93, 168, 208, 0.92), rgba(63, 135, 178, 0.9));
+  --cockpit-menu-scroll-thumb-hover: linear-gradient(180deg, rgba(126, 193, 230, 0.98), rgba(57, 164, 133, 0.9));
+  --cockpit-menu-scroll-thumb-border: rgba(231, 239, 245, 0.96);
+  --cockpit-window-bg: linear-gradient(180deg, rgba(253, 254, 255, 0.99), rgba(245, 249, 252, 0.975));
+  --cockpit-window-header-bg:
+    linear-gradient(180deg, rgba(244, 248, 251, 0.99), rgba(236, 243, 248, 0.97)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(31, 116, 162, 0.04) 0,
+      rgba(31, 116, 162, 0.04) 1px,
+      transparent 1px,
+      transparent 18px
+    );
+  --cockpit-window-control-bg: rgba(248, 251, 253, 0.96);
+  --cockpit-window-control-hover-bg: rgba(226, 238, 245, 0.98);
+  --cockpit-window-hint-bg: linear-gradient(180deg, rgba(246, 250, 252, 0.92), rgba(239, 245, 249, 0.86));
+  --cockpit-window-hint-text: rgba(93, 118, 136, 0.88);
+  --cockpit-panel-bg:
+    linear-gradient(180deg, rgba(252, 254, 255, 0.98), rgba(245, 249, 252, 0.96)),
+    repeating-linear-gradient(
+      0deg,
+      rgba(31, 116, 162, 0.03) 0,
+      rgba(31, 116, 162, 0.03) 1px,
+      transparent 1px,
+      transparent 20px
+    );
+  --cockpit-panel-response-bg:
+    radial-gradient(circle at top right, rgba(30, 127, 174, 0.1), transparent 45%),
+    linear-gradient(180deg, rgba(238, 246, 251, 0.98), rgba(230, 241, 248, 0.96));
+  --cockpit-panel-embedded-bg:
+    linear-gradient(180deg, rgba(249, 252, 254, 0.94), rgba(242, 247, 250, 0.92)),
+    repeating-linear-gradient(
+      0deg,
+      rgba(31, 116, 162, 0.024) 0,
+      rgba(31, 116, 162, 0.024) 1px,
+      transparent 1px,
+      transparent 20px
+    );
+  --cockpit-sidebar-bg: rgba(239, 245, 249, 0.82);
+  --cockpit-modal-backdrop-bg:
+    linear-gradient(180deg, rgba(224, 233, 240, 0.72), rgba(217, 228, 236, 0.82)),
+    radial-gradient(circle at top, rgba(30, 127, 174, 0.08), transparent 34%);
+  --cockpit-modal-card-bg:
+    linear-gradient(180deg, rgba(252, 254, 255, 0.99), rgba(244, 248, 251, 0.97)),
+    radial-gradient(circle at top right, rgba(30, 127, 174, 0.08), transparent 44%);
+  --cockpit-modal-close-bg: rgba(248, 251, 253, 0.96);
+  --cockpit-settings-inline-bg: rgba(243, 248, 251, 0.82);
+  --cockpit-settings-toggle-bg: rgba(248, 251, 253, 0.94);
+  --cockpit-session-helper-bg: rgba(240, 246, 249, 0.82);
+}
+
+.cockpit-shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background: var(--cockpit-shell-overlay);
   opacity: 0.58;
 }
 
@@ -188,15 +422,7 @@ body {
   gap: 12px;
   padding: 10px 14px 8px;
   border-bottom: 1px solid rgba(138, 207, 255, 0.18);
-  background:
-    linear-gradient(180deg, rgba(7, 18, 27, 0.98), rgba(7, 18, 27, 0.94)),
-    repeating-linear-gradient(
-      90deg,
-      rgba(141, 226, 255, 0.026) 0,
-      rgba(141, 226, 255, 0.026) 1px,
-      transparent 1px,
-      transparent 14px
-    );
+  background: var(--cockpit-topbar-bg);
   box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.02);
 }
 
@@ -290,8 +516,7 @@ body {
   gap: 6px;
   padding: 6px 14px 8px;
   border-bottom: 1px solid rgba(141, 226, 255, 0.08);
-  background:
-    linear-gradient(180deg, rgba(7, 17, 26, 0.96), rgba(7, 17, 26, 0.84));
+  background: var(--cockpit-hint-strip-bg);
 }
 
 .cockpit-hint-chip {
@@ -300,8 +525,8 @@ body {
   padding: 4px 7px;
   border: 1px solid rgba(141, 226, 255, 0.12);
   border-radius: 0;
-  background: rgba(10, 23, 35, 0.72);
-  color: rgba(180, 208, 227, 0.72);
+  background: var(--cockpit-hint-chip-bg);
+  color: var(--cockpit-hint-chip-text);
   font-size: 10px;
   letter-spacing: 0.04em;
 }
@@ -314,8 +539,7 @@ body {
   line-height: 1;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  background:
-    linear-gradient(180deg, rgba(8, 22, 33, 0.96), rgba(9, 23, 36, 0.9));
+  background: var(--cockpit-pill-bg);
   color: var(--cockpit-muted);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
@@ -323,7 +547,7 @@ body {
 .cockpit-pill--connected {
   color: var(--cockpit-accent-strong);
   border-color: var(--cockpit-state-success-border);
-  background: linear-gradient(180deg, rgba(8, 24, 27, 0.98), rgba(8, 24, 27, 0.92));
+  background: var(--cockpit-pill-success-bg);
 }
 
 .cockpit-pill--connecting {
@@ -341,7 +565,7 @@ body {
   border: 1px solid transparent;
   border-radius: 1px;
   padding: 6px 9px;
-  background: rgba(8, 22, 33, 0.86);
+  background: var(--cockpit-action-bg);
   color: var(--cockpit-text);
   font: inherit;
   font-size: 10px;
@@ -367,8 +591,7 @@ body {
 .cockpit-action--active {
   color: var(--cockpit-text);
   border-color: var(--cockpit-state-selected-border);
-  background:
-    linear-gradient(180deg, rgba(35, 74, 104, 0.92), rgba(18, 46, 69, 0.9));
+  background: var(--cockpit-action-active-bg);
   box-shadow: inset 0 0 0 1px var(--cockpit-state-selected-shadow);
 }
 
@@ -424,22 +647,7 @@ body {
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
-  background:
-    linear-gradient(180deg, rgba(5, 14, 22, 0.56), rgba(5, 14, 22, 0)),
-    repeating-linear-gradient(
-      0deg,
-      rgba(141, 226, 255, 0.018) 0,
-      rgba(141, 226, 255, 0.018) 1px,
-      transparent 1px,
-      transparent 24px
-    ),
-    repeating-linear-gradient(
-      90deg,
-      rgba(141, 226, 255, 0.014) 0,
-      rgba(141, 226, 255, 0.014) 1px,
-      transparent 1px,
-      transparent 24px
-    );
+  background: var(--cockpit-workspace-bg);
 }
 
 .cockpit-menu-anchor {
@@ -461,7 +669,7 @@ body {
   scrollbar-color: rgba(136, 214, 255, 0.7) rgba(10, 24, 36, 0.94);
   border: 1px solid var(--cockpit-border-strong);
   border-radius: 0;
-  background: rgba(6, 16, 25, 0.98);
+  background: var(--cockpit-menu-bg);
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.44);
 }
 
@@ -471,15 +679,13 @@ body {
 }
 
 .cockpit-windows-menu::-webkit-scrollbar-track {
-  background:
-    linear-gradient(180deg, rgba(6, 18, 28, 0.98), rgba(9, 23, 35, 0.98));
+  background: var(--cockpit-menu-scroll-track);
   border-left: 1px solid rgba(141, 226, 255, 0.1);
 }
 
 .cockpit-windows-menu::-webkit-scrollbar-thumb {
-  background:
-    linear-gradient(180deg, rgba(130, 209, 247, 0.92), rgba(89, 171, 215, 0.9));
-  border: 2px solid rgba(8, 22, 34, 0.94);
+  background: var(--cockpit-menu-scroll-thumb);
+  border: 2px solid var(--cockpit-menu-scroll-thumb-border);
   border-radius: 0;
   box-shadow:
     inset 0 0 0 1px rgba(216, 243, 255, 0.12),
@@ -487,12 +693,11 @@ body {
 }
 
 .cockpit-windows-menu::-webkit-scrollbar-thumb:hover {
-  background:
-    linear-gradient(180deg, rgba(164, 229, 255, 0.98), rgba(110, 244, 195, 0.9));
+  background: var(--cockpit-menu-scroll-thumb-hover);
 }
 
 .cockpit-windows-menu::-webkit-scrollbar-corner {
-  background: rgba(7, 20, 31, 0.98);
+  background: var(--cockpit-menu-bg);
 }
 
 .cockpit-windows-menu--brand {
@@ -506,7 +711,7 @@ body {
   gap: 8px;
   padding: 10px 10px 8px;
   border-bottom: 1px solid rgba(141, 226, 255, 0.12);
-  background: rgba(10, 24, 36, 0.96);
+  background: var(--cockpit-menu-header-bg);
 }
 
 .cockpit-window-launcher-title {
@@ -529,7 +734,7 @@ body {
   gap: 6px;
   padding: 8px;
   border-bottom: 1px solid rgba(141, 226, 255, 0.12);
-  background: rgba(10, 24, 36, 0.92);
+  background: var(--cockpit-menu-toolbar-bg);
 }
 
 .cockpit-windows-menu-action,
@@ -537,7 +742,7 @@ body {
 .cockpit-windows-menu-toggle {
   border: 1px solid rgba(141, 226, 255, 0.12);
   border-radius: 1px;
-  background: rgba(8, 21, 32, 0.9);
+  background: var(--cockpit-menu-button-bg);
   color: var(--cockpit-text);
   font: inherit;
 }
@@ -594,7 +799,7 @@ body {
 .cockpit-windows-menu-focus:hover,
 .cockpit-windows-menu-action:hover {
   border-color: var(--cockpit-state-selected-border);
-  background: rgba(15, 39, 58, 0.9);
+  background: var(--cockpit-menu-button-hover-bg);
 }
 
 .cockpit-windows-menu-check,
@@ -610,8 +815,7 @@ body {
   flex-direction: column;
   border: 1px solid var(--cockpit-border-strong);
   border-radius: 0;
-  background:
-    linear-gradient(180deg, rgba(7, 19, 29, 0.985), rgba(8, 21, 33, 0.975));
+  background: var(--cockpit-window-bg);
   box-shadow:
     0 8px 18px rgba(0, 0, 0, 0.22),
     inset 0 1px 0 rgba(255, 255, 255, 0.02);
@@ -645,15 +849,7 @@ body {
   min-height: 34px;
   padding: 6px var(--cockpit-pane-gutter) 5px;
   border-bottom: 1px solid rgba(141, 226, 255, 0.12);
-  background:
-    linear-gradient(180deg, rgba(10, 26, 38, 0.99), rgba(7, 18, 28, 0.97)),
-    repeating-linear-gradient(
-      90deg,
-      rgba(141, 226, 255, 0.018) 0,
-      rgba(141, 226, 255, 0.018) 1px,
-      transparent 1px,
-      transparent 18px
-    );
+  background: var(--cockpit-window-header-bg);
   cursor: grab;
   user-select: none;
 }
@@ -703,14 +899,14 @@ body {
   padding: 0;
   border: 1px solid rgba(141, 226, 255, 0.14);
   border-radius: 0;
-  background: rgba(8, 21, 32, 0.9);
+  background: var(--cockpit-window-control-bg);
   cursor: pointer;
   font: inherit;
 }
 
 .cockpit-window-control:hover {
   border-color: rgba(141, 226, 255, 0.3);
-  background: rgba(15, 39, 58, 0.9);
+  background: var(--cockpit-window-control-hover-bg);
 }
 
 .cockpit-window-control--close:hover {
@@ -733,9 +929,8 @@ body {
 .cockpit-window-hint {
   padding: 7px var(--cockpit-pane-gutter);
   border-bottom: 1px solid rgba(141, 226, 255, 0.08);
-  background:
-    linear-gradient(180deg, rgba(8, 22, 33, 0.88), rgba(8, 20, 31, 0.82));
-  color: rgba(180, 208, 227, 0.78);
+  background: var(--cockpit-window-hint-bg);
+  color: var(--cockpit-window-hint-text);
   font-size: 10px;
   line-height: 1.45;
 }
@@ -809,15 +1004,7 @@ body {
   min-height: 0;
   border: 1px solid var(--cockpit-border);
   border-radius: 0;
-  background:
-    linear-gradient(180deg, rgba(10, 24, 37, 0.96), rgba(7, 20, 31, 0.94)),
-    repeating-linear-gradient(
-      0deg,
-      rgba(255, 255, 255, 0.015) 0,
-      rgba(255, 255, 255, 0.015) 1px,
-      transparent 1px,
-      transparent 20px
-    );
+  background: var(--cockpit-panel-bg);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.02),
     0 10px 24px rgba(0, 0, 0, 0.24);
@@ -830,23 +1017,13 @@ body {
 
 .cockpit-panel--response {
   border-color: rgba(141, 226, 255, 0.18);
-  background:
-    radial-gradient(circle at top right, rgba(141, 226, 255, 0.12), transparent 45%),
-    linear-gradient(180deg, rgba(14, 36, 58, 0.96), rgba(8, 20, 34, 0.94));
+  background: var(--cockpit-panel-response-bg);
 }
 
 .cockpit-panel--embedded {
   border: 0;
   border-radius: 0;
-  background:
-    linear-gradient(180deg, rgba(7, 19, 29, 0.8), rgba(8, 21, 32, 0.84)),
-    repeating-linear-gradient(
-      0deg,
-      rgba(255, 255, 255, 0.012) 0,
-      rgba(255, 255, 255, 0.012) 1px,
-      transparent 1px,
-      transparent 20px
-    );
+  background: var(--cockpit-panel-embedded-bg);
   box-shadow: none;
 }
 
@@ -857,7 +1034,7 @@ body {
 .cockpit-shell .retro-scrollbar,
 .cockpit-modal-shell .retro-scrollbar {
   scrollbar-width: thin;
-  scrollbar-color: rgba(136, 214, 255, 0.7) rgba(10, 24, 36, 0.94);
+  scrollbar-color: rgba(136, 214, 255, 0.7) var(--cockpit-menu-toolbar-bg);
 }
 
 .cockpit-window-body > .cockpit-panel--embedded::-webkit-scrollbar,
@@ -876,8 +1053,7 @@ body {
 .cockpit-modal-body::-webkit-scrollbar-track,
 .cockpit-shell .retro-scrollbar::-webkit-scrollbar-track,
 .cockpit-modal-shell .retro-scrollbar::-webkit-scrollbar-track {
-  background:
-    linear-gradient(180deg, rgba(6, 18, 28, 0.98), rgba(9, 23, 35, 0.98));
+  background: var(--cockpit-menu-scroll-track);
   border-left: 1px solid rgba(141, 226, 255, 0.1);
 }
 
@@ -887,9 +1063,8 @@ body {
 .cockpit-modal-body::-webkit-scrollbar-thumb,
 .cockpit-shell .retro-scrollbar::-webkit-scrollbar-thumb,
 .cockpit-modal-shell .retro-scrollbar::-webkit-scrollbar-thumb {
-  background:
-    linear-gradient(180deg, rgba(130, 209, 247, 0.92), rgba(89, 171, 215, 0.9));
-  border: 2px solid rgba(8, 22, 34, 0.94);
+  background: var(--cockpit-menu-scroll-thumb);
+  border: 2px solid var(--cockpit-menu-scroll-thumb-border);
   border-radius: 0;
   box-shadow:
     inset 0 0 0 1px rgba(216, 243, 255, 0.12),
@@ -902,8 +1077,7 @@ body {
 .cockpit-modal-body::-webkit-scrollbar-thumb:hover,
 .cockpit-shell .retro-scrollbar::-webkit-scrollbar-thumb:hover,
 .cockpit-modal-shell .retro-scrollbar::-webkit-scrollbar-thumb:hover {
-  background:
-    linear-gradient(180deg, rgba(164, 229, 255, 0.98), rgba(110, 244, 195, 0.9));
+  background: var(--cockpit-menu-scroll-thumb-hover);
 }
 
 .cockpit-window-body > .cockpit-panel--embedded::-webkit-scrollbar-corner,
@@ -912,7 +1086,7 @@ body {
 .cockpit-modal-body::-webkit-scrollbar-corner,
 .cockpit-shell .retro-scrollbar::-webkit-scrollbar-corner,
 .cockpit-modal-shell .retro-scrollbar::-webkit-scrollbar-corner {
-  background: rgba(7, 20, 31, 0.98);
+  background: var(--cockpit-menu-bg);
 }
 
 .cockpit-modal-shell {
@@ -985,7 +1159,7 @@ body {
   min-height: 0;
   padding: 14px;
   border-right: 1px solid rgba(141, 226, 255, 0.08);
-  background: rgba(7, 20, 31, 0.38);
+  background: var(--cockpit-sidebar-bg);
 }
 
 .cockpit-studio-sidebar-group {
@@ -1031,9 +1205,7 @@ body {
   position: absolute;
   inset: 0;
   border: 0;
-  background:
-    linear-gradient(180deg, rgba(2, 8, 15, 0.72), rgba(3, 8, 15, 0.86)),
-    radial-gradient(circle at top, rgba(141, 226, 255, 0.08), transparent 34%);
+  background: var(--cockpit-modal-backdrop-bg);
   backdrop-filter: blur(12px);
   cursor: pointer;
 }
@@ -1047,9 +1219,7 @@ body {
   flex-direction: column;
   border: 1px solid var(--cockpit-border-strong);
   border-radius: 0;
-  background:
-    linear-gradient(180deg, rgba(7, 21, 32, 0.98), rgba(8, 22, 34, 0.96)),
-    radial-gradient(circle at top right, rgba(141, 226, 255, 0.1), transparent 44%);
+  background: var(--cockpit-modal-card-bg);
   box-shadow: 0 24px 72px rgba(0, 0, 0, 0.46);
   overflow: hidden;
   line-height: 1.45;
@@ -1093,7 +1263,7 @@ body {
   align-items: center;
   justify-content: center;
   padding: 0;
-  background: rgba(11, 27, 40, 0.78);
+  background: var(--cockpit-modal-close-bg);
   color: var(--cockpit-muted);
   font: inherit;
   font-size: 11px;
@@ -1167,7 +1337,7 @@ body {
   padding: 10px 12px;
   border: 1px solid rgba(141, 226, 255, 0.1);
   border-radius: 0;
-  background: rgba(9, 24, 36, 0.44);
+  background: var(--cockpit-settings-inline-bg);
 }
 
 .cockpit-settings-copy {
@@ -1195,7 +1365,7 @@ body {
   border-radius: 0;
   padding: 6px 10px;
   min-width: 58px;
-  background: rgba(8, 22, 33, 0.82);
+  background: var(--cockpit-settings-toggle-bg);
   color: var(--cockpit-muted);
   font: inherit;
   font-size: 10px;
@@ -1209,6 +1379,41 @@ body {
   border-color: var(--cockpit-state-success-border);
   color: var(--cockpit-accent-strong);
   background: var(--cockpit-state-success-fill);
+}
+
+.cockpit-settings-choice-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.cockpit-settings-choice {
+  border: 1px solid var(--cockpit-border);
+  border-radius: 0;
+  padding: 6px 10px;
+  min-width: 72px;
+  background: var(--cockpit-settings-toggle-bg);
+  color: var(--cockpit-muted);
+  font: inherit;
+  font-size: 10px;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.cockpit-settings-choice:hover {
+  border-color: var(--cockpit-state-selected-border);
+  color: var(--cockpit-text);
+}
+
+.cockpit-settings-choice.is-active {
+  border-color: var(--cockpit-state-selected-border);
+  color: var(--cockpit-text);
+  background: var(--cockpit-state-selected-fill);
+  box-shadow: inset 0 0 0 1px var(--cockpit-state-selected-shadow);
 }
 
 .cockpit-modal-form {
@@ -1382,7 +1587,7 @@ body {
   gap: 8px;
   padding: 8px var(--cockpit-pane-gutter);
   border-bottom: 1px solid rgba(141, 226, 255, 0.08);
-  background: rgba(10, 25, 38, 0.36);
+  background: var(--cockpit-session-helper-bg);
 }
 
 .cockpit-session-helper-row {

--- a/frontend/src/lib/theme.test.ts
+++ b/frontend/src/lib/theme.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { applyThemePreference, readThemePreference, resolveThemePreference } from "./theme";
+
+describe("theme helpers", () => {
+  it("resolves system preference using OS light mode", () => {
+    expect(resolveThemePreference("system", true)).toBe("light");
+    expect(resolveThemePreference("system", false)).toBe("dark");
+    expect(resolveThemePreference("light", false)).toBe("light");
+  });
+
+  it("reads the persisted theme preference safely", () => {
+    const getItem = vi.fn(() => "light");
+    vi.stubGlobal("window", {
+      localStorage: { getItem },
+      matchMedia: vi.fn(),
+    });
+
+    expect(readThemePreference()).toBe("light");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("applies the resolved theme to the document root", () => {
+    const root = document.createElement("div");
+    const matchMedia = vi.fn().mockReturnValue({ matches: true });
+    vi.stubGlobal("window", {
+      localStorage: { getItem: vi.fn(() => "system") },
+      matchMedia,
+    });
+
+    expect(applyThemePreference("system", root)).toBe("light");
+    expect(root.dataset.theme).toBe("light");
+    expect(root.style.colorScheme).toBe("light");
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/frontend/src/lib/theme.test.ts
+++ b/frontend/src/lib/theme.test.ts
@@ -21,6 +21,24 @@ describe("theme helpers", () => {
     vi.unstubAllGlobals();
   });
 
+  it("falls back to system when localStorage access throws", () => {
+    const windowStub = {
+      matchMedia: vi.fn(),
+    } as unknown as Window & typeof globalThis;
+
+    Object.defineProperty(windowStub, "localStorage", {
+      get() {
+        throw new DOMException("blocked", "SecurityError");
+      },
+    });
+
+    vi.stubGlobal("window", windowStub);
+
+    expect(readThemePreference()).toBe("system");
+
+    vi.unstubAllGlobals();
+  });
+
   it("applies the resolved theme to the document root", () => {
     const root = document.createElement("div");
     const matchMedia = vi.fn().mockReturnValue({ matches: true });

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -13,7 +13,12 @@ export function readThemePreference(): ThemePreference {
   if (typeof window === "undefined") {
     return "system";
   }
-  const value = window.localStorage?.getItem("seraph_theme_preference");
+  let value: string | null = null;
+  try {
+    value = window.localStorage?.getItem("seraph_theme_preference") ?? null;
+  } catch {
+    return "system";
+  }
   if (value === "dark" || value === "light" || value === "system") {
     return value;
   }

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,0 +1,34 @@
+import type { ThemePreference } from "../stores/chatStore";
+
+export type ResolvedTheme = "dark" | "light";
+
+export function resolveThemePreference(themePreference: ThemePreference, prefersLight: boolean): ResolvedTheme {
+  if (themePreference === "system") {
+    return prefersLight ? "light" : "dark";
+  }
+  return themePreference;
+}
+
+export function readThemePreference(): ThemePreference {
+  if (typeof window === "undefined") {
+    return "system";
+  }
+  const value = window.localStorage?.getItem("seraph_theme_preference");
+  if (value === "dark" || value === "light" || value === "system") {
+    return value;
+  }
+  return "system";
+}
+
+export function systemPrefersLight(): boolean {
+  return typeof window !== "undefined"
+    && typeof window.matchMedia === "function"
+    && window.matchMedia("(prefers-color-scheme: light)").matches;
+}
+
+export function applyThemePreference(themePreference: ThemePreference, root: HTMLElement = document.documentElement): ResolvedTheme {
+  const resolvedTheme = resolveThemePreference(themePreference, systemPrefersLight());
+  root.dataset.theme = resolvedTheme;
+  root.style.colorScheme = resolvedTheme;
+  return resolvedTheme;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { applyThemePreference, readThemePreference } from "./lib/theme";
 import "./index.css";
+
+applyThemePreference(readThemePreference());
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/frontend/src/stores/chatStore.test.ts
+++ b/frontend/src/stores/chatStore.test.ts
@@ -33,6 +33,7 @@ function resetStore() {
     questPanelOpen: false,
     settingsPanelOpen: false,
     cockpitHintsEnabled: true,
+    themePreference: "system",
     onboardingCompleted: null,
     toolRegistry: [],
   });
@@ -62,6 +63,12 @@ describe("chatStore sync actions", () => {
     useChatStore.getState().setCockpitHintsEnabled(false);
     expect(useChatStore.getState().cockpitHintsEnabled).toBe(false);
     expect(localStorageMock.setItem).toHaveBeenCalledWith("seraph_cockpit_hints_enabled", "0");
+  });
+
+  it("setThemePreference persists the theme preference", () => {
+    useChatStore.getState().setThemePreference("light");
+    expect(useChatStore.getState().themePreference).toBe("light");
+    expect(localStorageMock.setItem).toHaveBeenCalledWith("seraph_theme_preference", "light");
   });
 
   it("setAgentVisual merges partial state", () => {

--- a/frontend/src/stores/chatStore.ts
+++ b/frontend/src/stores/chatStore.ts
@@ -10,6 +10,8 @@ import type {
   ToolMeta,
 } from "../types";
 
+export type ThemePreference = "system" | "dark" | "light";
+
 interface ChatStore {
   messages: ChatMessage[];
   sessionId: string | null;
@@ -25,6 +27,7 @@ interface ChatStore {
   questPanelOpen: boolean;
   settingsPanelOpen: boolean;
   cockpitHintsEnabled: boolean;
+  themePreference: ThemePreference;
   onboardingCompleted: boolean | null;
   toolRegistry: ToolMeta[];
 
@@ -45,6 +48,7 @@ interface ChatStore {
   setQuestPanelOpen: (open: boolean) => void;
   setSettingsPanelOpen: (open: boolean) => void;
   setCockpitHintsEnabled: (enabled: boolean) => void;
+  setThemePreference: (theme: ThemePreference) => void;
   setOnboardingCompleted: (completed: boolean) => void;
   setToolRegistry: (tools: ToolMeta[]) => void;
   fetchToolRegistry: () => Promise<void>;
@@ -62,6 +66,7 @@ interface ChatStore {
 
 const LAST_SESSION_KEY = "seraph_last_session_id";
 const COCKPIT_HINTS_KEY = "seraph_cockpit_hints_enabled";
+const THEME_PREFERENCE_KEY = "seraph_theme_preference";
 const MAX_MESSAGES = 500;
 let restoreLastSessionPromise: Promise<void> | null = null;
 
@@ -104,6 +109,14 @@ function safeStorageBool(key: string, fallback: boolean): boolean {
     return fallback;
   }
   return value !== "0" && value.toLowerCase() !== "false";
+}
+
+function safeStorageTheme(): ThemePreference {
+  const value = safeStorageGet(THEME_PREFERENCE_KEY);
+  if (value === "dark" || value === "light" || value === "system") {
+    return value;
+  }
+  return "system";
 }
 
 function parseDisplayRole(message: Record<string, unknown>): {
@@ -152,6 +165,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   questPanelOpen: false,
   settingsPanelOpen: false,
   cockpitHintsEnabled: safeStorageBool(COCKPIT_HINTS_KEY, true),
+  themePreference: safeStorageTheme(),
   onboardingCompleted: null,
   toolRegistry: [],
 
@@ -215,6 +229,11 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   setCockpitHintsEnabled: (enabled) => {
     safeStorageSet(COCKPIT_HINTS_KEY, enabled ? "1" : "0");
     set({ cockpitHintsEnabled: enabled });
+  },
+
+  setThemePreference: (theme) => {
+    safeStorageSet(THEME_PREFERENCE_KEY, theme);
+    set({ themePreference: theme });
   },
 
   setOnboardingCompleted: (completed) => set({ onboardingCompleted: completed }),


### PR DESCRIPTION
## Done on develop
- [x] Five-wave Hermes/OpenClaw capability import program and the operator-grade dark workspace are already merged on develop.

## Working in this PR
- [x] Add persisted light, dark, and system theme selection with first-paint theme bootstrap so the UI no longer flashes dark before React applies the saved preference.
- [x] Retokenize cockpit and modal surfaces so the light palette reaches workspace windows, overlays, settings controls, and shared scrollbars instead of only the main shell.
- [x] Clarify onboarding copy so the temporary onboarding-limited toolset does not imply Seraph lacks the broader runtime, workflow, connector, and operator surfaces.
- [x] Add frontend and backend regressions for theme persistence, overlay controls, onboarding instructions, and websocket welcome copy.

## Still to do after this PR
- [ ] Do a visual polish pass on high-touch specialty panes like Seraph Presence once the light theme is exercised more broadly in daily use.
- [ ] Run a focused accessibility review for contrast and readability in both dark and light palettes.

## Validation
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_tool_audit.py tests/test_websocket.py -q
- cd frontend && npm test -- src/lib/theme.test.ts src/stores/chatStore.test.ts src/components/cockpit/CockpitOverlays.test.tsx
- cd frontend && npm test
- cd frontend && npm run build
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
- git diff --check
- Subagent review: Mendel found three concrete issues in the first light-theme pass (overlay token scope, first-paint theme flash, light-mode scrollbar theming); all three were fixed and Mendel re-reviewed the updated diff with no findings. Darwin timed out on the final general review.
