### PR TITLE
Ship Batch A structured memory foundation

### DIFF
--- a/backend/src/db/engine.py
+++ b/backend/src/db/engine.py
@@ -2,6 +2,7 @@ import os
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
@@ -16,6 +17,15 @@ engine = create_async_engine(
     echo=settings.debug,
     connect_args={"check_same_thread": False},
 )
+
+
+def _configure_sqlite_connection(dbapi_connection, _connection_record) -> None:
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+event.listen(engine.sync_engine, "connect", _configure_sqlite_connection)
 
 async_session_factory = sessionmaker(
     engine, class_=AsyncSession, expire_on_commit=False
@@ -50,6 +60,71 @@ async def _ensure_legacy_columns(conn) -> None:
     if queued_insight_columns and "session_id" not in queued_insight_columns:
         await conn.exec_driver_sql(
             "ALTER TABLE queued_insights ADD COLUMN session_id VARCHAR"
+        )
+
+    memory_columns = await _table_columns("memories")
+    if memory_columns and "kind" not in memory_columns:
+        await conn.exec_driver_sql(
+            "ALTER TABLE memories ADD COLUMN kind VARCHAR DEFAULT 'fact'"
+        )
+    if memory_columns and "kind" in await _table_columns("memories"):
+        await conn.exec_driver_sql(
+            """
+            UPDATE memories
+            SET kind = CASE category
+                WHEN 'preference' THEN 'preference'
+                WHEN 'pattern' THEN 'pattern'
+                WHEN 'goal' THEN 'goal'
+                WHEN 'reflection' THEN 'reflection'
+                ELSE 'fact'
+            END
+            WHERE kind IS NULL
+               OR kind = ''
+               OR (kind = 'fact' AND category IN ('preference', 'pattern', 'goal', 'reflection'))
+            """
+        )
+    if memory_columns and "summary" not in memory_columns:
+        await conn.exec_driver_sql(
+            "ALTER TABLE memories ADD COLUMN summary VARCHAR"
+        )
+    if memory_columns and "confidence" not in memory_columns:
+        await conn.exec_driver_sql(
+            "ALTER TABLE memories ADD COLUMN confidence FLOAT DEFAULT 0.5"
+        )
+    if memory_columns and "importance" not in memory_columns:
+        await conn.exec_driver_sql(
+            "ALTER TABLE memories ADD COLUMN importance FLOAT DEFAULT 0.5"
+        )
+    if memory_columns and "reinforcement" not in memory_columns:
+        await conn.exec_driver_sql(
+            "ALTER TABLE memories ADD COLUMN reinforcement FLOAT DEFAULT 1.0"
+        )
+    if memory_columns and "status" not in memory_columns:
+        await conn.exec_driver_sql(
+            "ALTER TABLE memories ADD COLUMN status VARCHAR DEFAULT 'active'"
+        )
+    if memory_columns and "subject_entity_id" not in memory_columns:
+        await conn.exec_driver_sql(
+            "ALTER TABLE memories ADD COLUMN subject_entity_id VARCHAR"
+        )
+    if memory_columns and "project_entity_id" not in memory_columns:
+        await conn.exec_driver_sql(
+            "ALTER TABLE memories ADD COLUMN project_entity_id VARCHAR"
+        )
+    if memory_columns and "metadata_json" not in memory_columns:
+        await conn.exec_driver_sql(
+            "ALTER TABLE memories ADD COLUMN metadata_json VARCHAR"
+        )
+    if memory_columns and "updated_at" not in memory_columns:
+        await conn.exec_driver_sql(
+            "ALTER TABLE memories ADD COLUMN updated_at DATETIME"
+        )
+        await conn.exec_driver_sql(
+            "UPDATE memories SET updated_at = created_at WHERE updated_at IS NULL"
+        )
+    if memory_columns and "last_confirmed_at" not in memory_columns:
+        await conn.exec_driver_sql(
+            "ALTER TABLE memories ADD COLUMN last_confirmed_at DATETIME"
         )
 
 

--- a/backend/src/db/models.py
+++ b/backend/src/db/models.py
@@ -40,6 +40,47 @@ class MemoryCategory(str, enum.Enum):
     reflection = "reflection"
 
 
+class MemoryKind(str, enum.Enum):
+    fact = "fact"
+    preference = "preference"
+    pattern = "pattern"
+    goal = "goal"
+    reflection = "reflection"
+    project = "project"
+    collaborator = "collaborator"
+    obligation = "obligation"
+    routine = "routine"
+    timeline = "timeline"
+    commitment = "commitment"
+    communication_preference = "communication_preference"
+
+
+class MemoryStatus(str, enum.Enum):
+    active = "active"
+    archived = "archived"
+    superseded = "superseded"
+
+
+class MemoryEntityType(str, enum.Enum):
+    person = "person"
+    project = "project"
+    routine = "routine"
+    obligation = "obligation"
+    organization = "organization"
+    thread = "thread"
+
+
+class MemorySnapshotKind(str, enum.Enum):
+    bounded_guardian_context = "bounded_guardian_context"
+
+
+class MemoryEdgeType(str, enum.Enum):
+    related = "related"
+    supports = "supports"
+    supersedes = "supersedes"
+    contradicts = "contradicts"
+
+
 # ─── Helper ──────────────────────────────────────────────
 
 def _uuid() -> str:
@@ -123,9 +164,67 @@ class Memory(SQLModel, table=True):
 
     id: str = Field(default_factory=_uuid, primary_key=True)
     content: str
-    category: str = Field(default=MemoryCategory.fact)
+    category: MemoryCategory = Field(default=MemoryCategory.fact)
+    kind: MemoryKind = Field(default=MemoryKind.fact, index=True)
+    summary: Optional[str] = Field(default=None)
+    confidence: float = Field(default=0.5)
+    importance: float = Field(default=0.5)
+    reinforcement: float = Field(default=1.0)
+    status: MemoryStatus = Field(default=MemoryStatus.active, index=True)
+    subject_entity_id: Optional[str] = Field(default=None, foreign_key="memory_entities.id", index=True)
+    project_entity_id: Optional[str] = Field(default=None, foreign_key="memory_entities.id", index=True)
     source_session_id: Optional[str] = Field(default=None)
     embedding_id: Optional[str] = Field(default=None)
+    metadata_json: Optional[str] = Field(default=None)
+    created_at: datetime = Field(default_factory=_now)
+    updated_at: datetime = Field(default_factory=_now)
+    last_confirmed_at: Optional[datetime] = Field(default=None)
+
+
+class MemoryEntity(SQLModel, table=True):
+    __tablename__ = "memory_entities"
+
+    id: str = Field(default_factory=_uuid, primary_key=True)
+    canonical_key: str = Field(index=True, unique=True)
+    canonical_name: str = Field(index=True)
+    entity_type: MemoryEntityType = Field(default=MemoryEntityType.person, index=True)
+    aliases_json: Optional[str] = Field(default=None)
+    created_at: datetime = Field(default_factory=_now)
+    updated_at: datetime = Field(default_factory=_now)
+
+
+class MemorySource(SQLModel, table=True):
+    __tablename__ = "memory_sources"
+
+    id: str = Field(default_factory=_uuid, primary_key=True)
+    memory_id: str = Field(foreign_key="memories.id", index=True)
+    source_type: str = Field(default="session", index=True)
+    source_session_id: Optional[str] = Field(default=None, index=True)
+    source_message_id: Optional[str] = Field(default=None, index=True)
+    snippet: Optional[str] = Field(default=None)
+    created_at: datetime = Field(default_factory=_now)
+
+
+class MemorySnapshot(SQLModel, table=True):
+    __tablename__ = "memory_snapshots"
+
+    id: str = Field(default_factory=_uuid, primary_key=True)
+    kind: MemorySnapshotKind = Field(default=MemorySnapshotKind.bounded_guardian_context, index=True, unique=True)
+    content: str = Field(default="")
+    source_hash: Optional[str] = Field(default=None)
+    created_at: datetime = Field(default_factory=_now)
+    updated_at: datetime = Field(default_factory=_now)
+
+
+class MemoryEdge(SQLModel, table=True):
+    __tablename__ = "memory_edges"
+
+    id: str = Field(default_factory=_uuid, primary_key=True)
+    from_memory_id: str = Field(foreign_key="memories.id", index=True)
+    to_memory_id: str = Field(foreign_key="memories.id", index=True)
+    edge_type: MemoryEdgeType = Field(default=MemoryEdgeType.related, index=True)
+    weight: float = Field(default=1.0)
+    metadata_json: Optional[str] = Field(default=None)
     created_at: datetime = Field(default_factory=_now)
 
 

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -60,6 +60,8 @@ from src.audit.repository import audit_repository
 from src.app import create_app
 from src.llm_runtime import FallbackLiteLLMModel, _reset_target_health, completion_with_fallback_sync
 from src.memory.embedder import _reset_embedder_state, embed
+from src.memory.repository import memory_repository
+from src.memory.snapshots import _reset_bounded_guardian_snapshot_cache
 from src.observer.sources.calendar_source import gather_calendar
 from src.observer.sources.goal_source import gather_goals
 from src.observer.sources.git_source import gather_git
@@ -366,7 +368,7 @@ async def _patched_async_db(*patch_targets: str):
 
     try:
         with ExitStack() as stack:
-            for target in patch_targets:
+            for target in dict.fromkeys((*patch_targets, "src.memory.repository.get_session")):
                 stack.enter_context(patch(target, _get_session))
             yield
     finally:
@@ -410,6 +412,7 @@ def _make_sync_client_with_db():
         "src.vault.repository.get_session",
         "src.api.profile.get_db",
         "src.api.settings.get_db",
+        "src.memory.repository.get_session",
     ]
     patches = [patch(target, _get_session) for target in targets]
     patches.append(patch("src.app.init_db", _test_init_db))
@@ -1173,22 +1176,29 @@ def _eval_provider_health_reroute() -> dict[str, Any]:
 
     _reset_target_health()
     try:
-        with (
-            patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4"),
-            patch.object(settings, "fallback_model", ""),
-            patch.object(settings, "fallback_models", "openai/gpt-4o-mini"),
-            patch.object(settings, "llm_api_key", "primary-key"),
-            patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1"),
-            patch.object(settings, "llm_target_cooldown_seconds", 300),
-            patch(
-                "litellm.completion",
-                side_effect=[
-                    RuntimeError("primary down"),
-                    first_fallback_response,
-                    rerouted_response,
-                ],
-            ) as mock_completion,
-        ):
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(settings, "default_model", "openrouter/anthropic/claude-sonnet-4")
+            )
+            stack.enter_context(patch.object(settings, "fallback_model", ""))
+            stack.enter_context(patch.object(settings, "fallback_models", "openai/gpt-4o-mini"))
+            stack.enter_context(patch.object(settings, "llm_api_key", "primary-key"))
+            stack.enter_context(
+                patch.object(settings, "llm_api_base", "https://openrouter.ai/api/v1")
+            )
+            stack.enter_context(
+                patch.object(settings, "llm_target_cooldown_seconds", 300)
+            )
+            mock_completion = stack.enter_context(
+                patch(
+                    "litellm.completion",
+                    side_effect=[
+                        RuntimeError("primary down"),
+                        first_fallback_response,
+                        rerouted_response,
+                    ],
+                )
+            )
             completion_with_fallback_sync(
                 messages=[{"role": "user", "content": "recover once"}],
                 temperature=0.2,
@@ -3211,14 +3221,15 @@ async def _eval_session_consolidation_background_audit() -> dict[str, Any]:
         "soul_updates": {},
     }))
 
-    with (
-        patch.object(session_manager, "get_history_text", AsyncMock(return_value="User: I need reliability.\nAssistant: Let's harden it.")),
-        patch("src.memory.consolidator.read_soul", return_value="# Soul\nName: Hero"),
-        patch("src.memory.consolidator.completion_with_fallback", AsyncMock(return_value=llm_response)),
-        patch("src.memory.consolidator.add_memory"),
-        patch.object(audit_repository, "log_event", mock_log_event),
-    ):
-        await consolidate_session("eval-session")
+    async with _patched_async_db():
+        with (
+            patch.object(session_manager, "get_history_text", AsyncMock(return_value="User: I need reliability.\nAssistant: Let's harden it.")),
+            patch("src.memory.consolidator.read_soul", return_value="# Soul\nName: Hero"),
+            patch("src.memory.consolidator.completion_with_fallback", AsyncMock(return_value=llm_response)),
+            patch("src.memory.consolidator.add_memory", return_value="vec-memory-1"),
+            patch.object(audit_repository, "log_event", mock_log_event),
+        ):
+            await consolidate_session("eval-session")
 
     success = _find_audit_call(
         mock_log_event,
@@ -3242,22 +3253,23 @@ async def _eval_session_consolidation_behavior() -> dict[str, Any]:
         "soul_updates": {"Goals": "- Ship the guardian workspace direction"},
     }))
 
-    with (
-        patch.object(
-            session_manager,
-            "get_history_text",
-            AsyncMock(return_value=(
-                "User: I want Seraph to become a dense guardian workspace.\n"
-                "Assistant: Then we need behavioral evals, stronger state, and better operator UX."
-            )),
-        ),
-        patch("src.memory.consolidator.read_soul", return_value="# Soul\n\n## Goals\n- Keep the system grounded"),
-        patch("src.memory.consolidator.completion_with_fallback", AsyncMock(return_value=llm_response)),
-        patch("src.memory.consolidator.add_memory") as mock_add_memory,
-        patch("src.memory.consolidator.update_soul_section") as mock_update_soul,
-        patch.object(audit_repository, "log_event", mock_log_event),
-    ):
-        await consolidate_session("guardian-session")
+    async with _patched_async_db():
+        with (
+            patch.object(
+                session_manager,
+                "get_history_text",
+                AsyncMock(return_value=(
+                    "User: I want Seraph to become a dense guardian workspace.\n"
+                    "Assistant: Then we need behavioral evals, stronger state, and better operator UX."
+                )),
+            ),
+            patch("src.memory.consolidator.read_soul", return_value="# Soul\n\n## Goals\n- Keep the system grounded"),
+            patch("src.memory.consolidator.completion_with_fallback", AsyncMock(return_value=llm_response)),
+            patch("src.memory.consolidator.add_memory", return_value="vec-memory-1") as mock_add_memory,
+            patch("src.memory.consolidator.update_soul_section") as mock_update_soul,
+            patch.object(audit_repository, "log_event", mock_log_event),
+        ):
+            await consolidate_session("guardian-session")
 
     success = _find_audit_call(
         mock_log_event,
@@ -3271,6 +3283,312 @@ async def _eval_session_consolidation_behavior() -> dict[str, Any]:
         "stored_texts": [call.kwargs["text"] for call in mock_add_memory.call_args_list],
         "updated_soul_section": mock_update_soul.call_args.args[0],
         "updated_soul_mentions_workspace": "guardian workspace" in mock_update_soul.call_args.args[1].lower(),
+    }
+
+
+async def _eval_memory_commitment_continuity_behavior() -> dict[str, Any]:
+    from src.guardian.state import _structured_memory_context_bundle
+
+    async with _patched_async_db(
+        "src.agent.session.get_session",
+        "src.guardian.feedback.get_session",
+    ):
+        await session_manager.get_or_create("memory-current")
+        await session_manager.add_message("memory-current", "user", "What matters for Atlas right now?")
+        await session_manager.add_message("memory-current", "assistant", "Let me ground that in linked memory.")
+
+        atlas = await memory_repository.get_or_create_entity(
+            canonical_name="Project Atlas",
+            entity_type="project",
+            aliases=["Atlas"],
+        )
+        await memory_repository.create_memory(
+            content="Atlas launch is the active release project.",
+            kind="project",
+            summary="Atlas launch",
+            importance=0.9,
+            project_entity_id=atlas.id,
+        )
+        await memory_repository.create_memory(
+            content="Send the Atlas checklist before Friday.",
+            kind="commitment",
+            summary="Send the Atlas checklist before Friday",
+            importance=0.88,
+            project_entity_id=atlas.id,
+        )
+        await memory_repository.create_memory(
+            content="Renew the Nimbus enterprise contract.",
+            kind="commitment",
+            summary="Renew the Nimbus enterprise contract",
+            importance=0.99,
+        )
+        await memory_repository.create_memory(
+            content="Draft the Orion launch stakeholder update.",
+            kind="commitment",
+            summary="Draft the Orion launch stakeholder update",
+            importance=0.97,
+        )
+
+        baseline_context, baseline_buckets = await _structured_memory_context_bundle(active_projects=())
+
+        ctx = _make_context(
+            active_goals_summary="Support Atlas launch",
+            active_window="VS Code",
+            screen_context="Editing Atlas release notes",
+            data_quality="good",
+            observer_confidence="grounded",
+            salience_level="high",
+            salience_reason="active_goals",
+            interruption_cost="low",
+        )
+
+        with (
+            patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+            patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
+            patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+            patch("src.audit.repository.audit_repository.list_events", return_value=[]),
+            patch(
+                "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
+                return_value=["Atlas"],
+            ),
+            patch(
+                "src.guardian.feedback.guardian_feedback_repository.summarize_recent",
+                return_value="",
+            ),
+        ):
+            state = await build_guardian_state(
+                session_id="memory-current",
+                user_message="What matters for Atlas right now?",
+            )
+
+        return {
+            "baseline_bucket_excludes_linked_commitment": "Send the Atlas checklist before Friday"
+            not in baseline_buckets.get("commitment", ()),
+            "baseline_context_excludes_linked_commitment": "[commitment] Send the Atlas checklist before Friday"
+            not in baseline_context,
+            "linked_project_present": "Atlas launch" in state.world_model.active_projects,
+            "memory_context_has_commitment": "[commitment] Send the Atlas checklist before Friday" in state.memory_context,
+        }
+
+
+async def _eval_memory_collaborator_lookup_behavior() -> dict[str, Any]:
+    from src.guardian.state import _structured_memory_context_bundle
+
+    async with _patched_async_db(
+        "src.agent.session.get_session",
+        "src.guardian.feedback.get_session",
+    ):
+        await session_manager.get_or_create("memory-current")
+        await session_manager.add_message("memory-current", "user", "Who owns Atlas communications?")
+        await session_manager.add_message("memory-current", "assistant", "Let me look up the collaborator context.")
+
+        atlas = await memory_repository.get_or_create_entity(
+            canonical_name="Project Atlas",
+            entity_type="project",
+            aliases=["Atlas"],
+        )
+        alice = await memory_repository.get_or_create_entity(
+            canonical_name="Alice",
+            entity_type="person",
+        )
+        await memory_repository.create_memory(
+            content="Atlas launch is the active release project.",
+            kind="project",
+            summary="Atlas launch",
+            importance=0.9,
+            project_entity_id=atlas.id,
+        )
+        await memory_repository.create_memory(
+            content="Alice owns Atlas launch communications.",
+            kind="collaborator",
+            summary="Alice owns Atlas launch communications",
+            importance=0.87,
+            subject_entity_id=alice.id,
+            project_entity_id=atlas.id,
+        )
+        await memory_repository.create_memory(
+            content="Morgan owns the Nimbus customer rollout.",
+            kind="collaborator",
+            summary="Morgan owns the Nimbus customer rollout",
+            importance=0.99,
+        )
+        await memory_repository.create_memory(
+            content="Priya owns the Orion executive brief.",
+            kind="collaborator",
+            summary="Priya owns the Orion executive brief",
+            importance=0.97,
+        )
+
+        baseline_context, baseline_buckets = await _structured_memory_context_bundle(active_projects=())
+
+        ctx = _make_context(
+            active_goals_summary="Support Atlas launch",
+            active_window="VS Code",
+            screen_context="Editing Atlas release notes",
+            data_quality="good",
+            observer_confidence="grounded",
+            salience_level="high",
+            salience_reason="active_goals",
+            interruption_cost="low",
+        )
+
+        with (
+            patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+            patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
+            patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+            patch("src.audit.repository.audit_repository.list_events", return_value=[]),
+            patch(
+                "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
+                return_value=["Atlas"],
+            ),
+            patch(
+                "src.guardian.feedback.guardian_feedback_repository.summarize_recent",
+                return_value="",
+            ),
+        ):
+            state = await build_guardian_state(
+                session_id="memory-current",
+                user_message="Who owns Atlas communications?",
+            )
+
+        return {
+            "baseline_bucket_excludes_linked_collaborator": "Alice owns Atlas launch communications"
+            not in baseline_buckets.get("collaborator", ()),
+            "baseline_context_excludes_linked_collaborator": "[collaborator] Alice owns Atlas launch communications"
+            not in baseline_context,
+            "collaborator_present": "Alice owns Atlas launch communications" in state.world_model.collaborators,
+            "memory_context_has_collaborator": "[collaborator] Alice owns Atlas launch communications" in state.memory_context,
+            "active_projects_has_atlas": "Atlas launch" in state.world_model.active_projects,
+        }
+
+
+async def _eval_bounded_memory_snapshot_behavior() -> dict[str, Any]:
+    from src.memory.snapshots import refresh_bounded_guardian_snapshot
+
+    async with _patched_async_db(
+        "src.agent.session.get_session",
+        "src.guardian.feedback.get_session",
+    ):
+        await session_manager.get_or_create("snapshot-current")
+        await session_manager.add_message("snapshot-current", "user", "What should I focus on next?")
+        await session_manager.add_message("snapshot-current", "assistant", "Let me ground that in bounded recall.")
+        await session_manager.replace_todos(
+            "snapshot-current",
+            [
+                {"content": "Send the Atlas checklist", "completed": False},
+                {"content": "Review launch notes", "completed": True},
+            ],
+        )
+
+        await memory_repository.create_memory(
+            content="Atlas launch is the active release project.",
+            kind="project",
+            summary="Atlas launch",
+            importance=0.9,
+        )
+        await memory_repository.create_memory(
+            content="User prefers concise morning briefings.",
+            kind="communication_preference",
+            summary="Prefers concise morning briefings",
+            importance=0.85,
+        )
+        await refresh_bounded_guardian_snapshot(
+            soul_context="# Soul\n\n## Identity\nBuilder\n\n## Goals\n- Keep the system grounded",
+        )
+
+        ctx = _make_context(
+            active_goals_summary="Support Atlas launch",
+            active_window="VS Code",
+            screen_context="Editing Atlas launch checklist",
+            data_quality="good",
+            observer_confidence="grounded",
+            salience_level="high",
+            salience_reason="active_goals",
+            interruption_cost="low",
+        )
+
+        with (
+            patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+            patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder\n\n## Goals\n- Keep the system grounded"),
+            patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+            patch("src.audit.repository.audit_repository.list_events", return_value=[]),
+            patch(
+                "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
+                return_value=["Atlas"],
+            ),
+            patch(
+                "src.guardian.feedback.guardian_feedback_repository.summarize_recent",
+                return_value="",
+            ),
+        ):
+            first_state = await build_guardian_state(
+                session_id="snapshot-current",
+                user_message="What should I focus on next?",
+            )
+            await memory_repository.create_memory(
+                content="Hermes budget memo is now active.",
+                kind="project",
+                summary="Hermes budget memo",
+                importance=0.95,
+            )
+            await memory_repository.create_memory(
+                content="Neptune planning review is now active.",
+                kind="project",
+                summary="Neptune planning review",
+                importance=0.93,
+            )
+            await session_manager.get_or_create("snapshot-new")
+            await session_manager.add_message("snapshot-new", "user", "What should I focus on next?")
+            await session_manager.add_message("snapshot-new", "assistant", "Ground me in the latest bounded memory.")
+            second_state = await build_guardian_state(
+                session_id="snapshot-current",
+                user_message="What should I focus on next?",
+            )
+            fresh_state = await build_guardian_state(
+                session_id="snapshot-new",
+                user_message="What should I focus on next?",
+            )
+            fresh_session = await session_manager.get("snapshot-new")
+
+        return {
+            "bounded_snapshot_is_stable_within_session": (
+                first_state.bounded_memory_context == second_state.bounded_memory_context
+            ),
+            "bounded_snapshot_includes_todo_overlay": "Send the Atlas checklist" in first_state.bounded_memory_context,
+            "bounded_snapshot_line_count": max(
+                len(second_state.bounded_memory_context.splitlines()),
+                len(fresh_state.bounded_memory_context.splitlines()),
+            ),
+            "same_session_excludes_new_project": "Hermes budget memo" not in second_state.bounded_memory_context,
+            "new_session_sees_new_project": "Hermes budget memo" in fresh_state.bounded_memory_context,
+            "new_session_uses_real_session_record": fresh_session is not None,
+        }
+
+
+async def _eval_memory_supersession_filter_behavior() -> dict[str, Any]:
+    from src.memory.snapshots import render_bounded_guardian_snapshot
+
+    async with _patched_async_db():
+        await memory_repository.create_memory(
+            content="Atlas launch is delayed.",
+            kind="project",
+            summary="Atlas launch delayed",
+            importance=0.95,
+            status="superseded",
+        )
+        await memory_repository.create_memory(
+            content="Atlas launch is on track.",
+            kind="project",
+            summary="Atlas launch on track",
+            importance=0.9,
+        )
+        snapshot_content, _ = await render_bounded_guardian_snapshot(
+            soul_context="# Soul\n\n## Identity\nBuilder",
+        )
+
+    return {
+        "active_project_present": "Atlas launch on track" in snapshot_content,
+        "superseded_project_filtered": "Atlas launch delayed" not in snapshot_content,
     }
 
 
@@ -6163,6 +6481,30 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         runner=_eval_session_consolidation_behavior,
     ),
     EvalScenario(
+        name="memory_commitment_continuity_behavior",
+        category="behavior",
+        description="Project-linked commitments are recoverable in guardian-state memory context for active work even when the global structured kind bucket would miss them.",
+        runner=_eval_memory_commitment_continuity_behavior,
+    ),
+    EvalScenario(
+        name="memory_collaborator_lookup_behavior",
+        category="behavior",
+        description="Project-linked collaborator memory is recoverable through guardian state for active work instead of staying as inert text.",
+        runner=_eval_memory_collaborator_lookup_behavior,
+    ),
+    EvalScenario(
+        name="bounded_memory_snapshot_behavior",
+        category="behavior",
+        description="Bounded recall stays session-stable, keeps todo overlay, and remains compact even as later memory changes land.",
+        runner=_eval_bounded_memory_snapshot_behavior,
+    ),
+    EvalScenario(
+        name="memory_supersession_filter_behavior",
+        category="behavior",
+        description="Superseded structured memories stay out of bounded recall so stale project state does not surface as current truth.",
+        runner=_eval_memory_supersession_filter_behavior,
+    ),
+    EvalScenario(
         name="session_title_generation_background_audit",
         category="observability",
         description="Session title generation records background-task audit success without live providers.",
@@ -6234,6 +6576,7 @@ def _select_scenarios(selected_names: Sequence[str] | None) -> list[EvalScenario
 
 async def _run_scenario(scenario: EvalScenario) -> EvalResult:
     started = time.perf_counter()
+    _reset_bounded_guardian_snapshot_cache()
     try:
         output = scenario.runner()
         if asyncio.iscoroutine(output):
@@ -6257,6 +6600,8 @@ async def _run_scenario(scenario: EvalScenario) -> EvalResult:
             duration_ms=int((time.perf_counter() - started) * 1000),
             error=str(exc),
         )
+    finally:
+        _reset_bounded_guardian_snapshot_cache()
 
 
 async def run_runtime_evals(selected_names: Sequence[str] | None = None) -> EvalSummary:

--- a/backend/src/guardian/state.py
+++ b/backend/src/guardian/state.py
@@ -286,8 +286,29 @@ def _summarize_bounded_memory(*, soul_context: str, todos: list[dict[str, object
     return "\n".join(lines)
 
 
-async def _structured_memory_context_bundle() -> tuple[str, dict[str, tuple[str, ...]]]:
-    from src.db.models import MemoryKind
+def _append_structured_memory_line(
+    *,
+    bucketed: dict[str, list[str]],
+    lines: list[str],
+    text: str,
+    bucket_name: str,
+) -> None:
+    normalized = text.strip()
+    if not normalized:
+        return
+    bucket = bucketed.setdefault(bucket_name, [])
+    if normalized not in bucket:
+        bucket.append(normalized)
+    line = f"- [{bucket_name}] {normalized}"
+    if line not in lines:
+        lines.append(line)
+
+
+async def _structured_memory_context_bundle(
+    *,
+    active_projects: tuple[str, ...] = (),
+) -> tuple[str, dict[str, tuple[str, ...]]]:
+    from src.db.models import MemoryEntityType, MemoryKind
     from src.memory.repository import memory_repository
     from src.memory.types import bucket_name_for_kind
 
@@ -313,16 +334,39 @@ async def _structured_memory_context_bundle() -> tuple[str, dict[str, tuple[str,
         bucket_name = bucket_name_for_kind(kind_name)
         for memory in memories:
             text = (memory.summary or memory.content or "").strip()
-            if not text:
-                continue
-            bucket = bucketed.setdefault(bucket_name, [])
-            if text not in bucket:
-                bucket.append(text)
-            line = f"- [{bucket_name}] {text}"
-            if line not in lines:
-                lines.append(line)
+            _append_structured_memory_line(
+                bucketed=bucketed,
+                lines=lines,
+                text=text,
+                bucket_name=bucket_name,
+            )
 
-    return "\n".join(lines[:6]), {key: tuple(values) for key, values in bucketed.items()}
+    linked_project_entities = await memory_repository.find_entities_by_names(
+        names=active_projects,
+        entity_type=MemoryEntityType.project,
+    )
+    if linked_project_entities:
+        linked_memories = await memory_repository.list_memories_for_entities(
+            project_entity_ids=tuple(entity.id for entity in linked_project_entities.values()),
+            kinds=(
+                MemoryKind.commitment,
+                MemoryKind.project,
+                MemoryKind.collaborator,
+                MemoryKind.obligation,
+                MemoryKind.routine,
+                MemoryKind.timeline,
+            ),
+            limit=8,
+        )
+        for memory in linked_memories:
+            _append_structured_memory_line(
+                bucketed=bucketed,
+                lines=lines,
+                text=(memory.summary or memory.content or "").strip(),
+                bucket_name=bucket_name_for_kind(memory.kind),
+            )
+
+    return "\n".join(lines[:8]), {key: tuple(values) for key, values in bucketed.items()}
 
 
 def _merge_memory_contexts(*contexts: str) -> str:
@@ -370,7 +414,6 @@ async def build_guardian_state(
         intervention_type="advisory",
         limit=12,
     )
-    structured_memory_context, structured_memory_buckets = await _structured_memory_context_bundle()
     try:
         recent_execution_summary = _summarize_recent_execution(
             await audit_repository.list_events(limit=20, session_id=session_id)
@@ -384,6 +427,9 @@ async def build_guardian_state(
     except Exception:
         logger.debug("Failed to load recent projects for guardian state", exc_info=True)
         active_projects = ()
+    structured_memory_context, structured_memory_buckets = await _structured_memory_context_bundle(
+        active_projects=active_projects,
+    )
 
     query = user_message or memory_query or ""
     memory_requested = bool(query.strip())

--- a/backend/src/guardian/state.py
+++ b/backend/src/guardian/state.py
@@ -256,11 +256,7 @@ def _extract_soul_section_lines(soul_context: str, section: str, *, limit: int) 
     return tuple(extracted)
 
 
-def _summarize_bounded_memory(*, soul_context: str, todos: list[dict[str, object]]) -> str:
-    identity_bits = _extract_soul_section_lines(soul_context, "Identity", limit=3)
-    goal_bits = _extract_soul_section_lines(soul_context, "Goals", limit=3)
-    personality_bits = _extract_soul_section_lines(soul_context, "Personality Notes", limit=2)
-
+def _summarize_bounded_todos(*, todos: list[dict[str, object]]) -> str:
     open_todos = [
         str(item.get("content", "")).strip()
         for item in todos
@@ -273,12 +269,6 @@ def _summarize_bounded_memory(*, soul_context: str, todos: list[dict[str, object
     ][:2]
 
     lines: list[str] = []
-    if identity_bits:
-        lines.append(f"- Identity: {' | '.join(identity_bits)}")
-    if goal_bits:
-        lines.append(f"- Goal memory: {' | '.join(goal_bits)}")
-    if personality_bits:
-        lines.append(f"- Preferences: {' | '.join(personality_bits)}")
     if open_todos:
         lines.append(f"- Open todos: {' | '.join(open_todos)}")
     if completed_todos:
@@ -389,6 +379,10 @@ async def build_guardian_state(
 ) -> GuardianState:
     """Build one explicit guardian-state object from current repo surfaces."""
     from src.memory.soul import read_soul
+    from src.memory.snapshots import (
+        get_or_create_bounded_guardian_snapshot,
+        render_bounded_guardian_snapshot,
+    )
     from src.memory.vector_store import search_with_status
     from src.audit.repository import audit_repository
     from src.guardian.feedback import guardian_feedback_repository
@@ -399,6 +393,7 @@ async def build_guardian_state(
         await context_manager.refresh() if refresh_observer else context_manager.get_context()
     )
     soul_context = read_soul()
+    session_record = await session_manager.get(session_id) if session_id is not None else None
 
     current_session_history = (
         await session_manager.get_history_text(session_id)
@@ -444,9 +439,28 @@ async def build_guardian_state(
         if isinstance(item.get("category"), str) and isinstance(item.get("text"), str)
     )
     memory_context = _merge_memory_contexts(vector_memory_context, structured_memory_context)
-    bounded_memory_context = _summarize_bounded_memory(
-        soul_context=soul_context,
+    try:
+        snapshot_session_key = None
+        if session_id is not None and session_record is not None:
+            created_at = getattr(session_record, "created_at", None)
+            if created_at is not None:
+                snapshot_session_key = f"{session_id}:{created_at.isoformat()}"
+            else:
+                snapshot_session_key = session_id
+        bounded_snapshot = await get_or_create_bounded_guardian_snapshot(
+            soul_context=soul_context,
+            session_id=snapshot_session_key,
+        )
+    except Exception:
+        logger.debug("Failed to load bounded guardian snapshot", exc_info=True)
+        bounded_snapshot, _ = await render_bounded_guardian_snapshot(
+            soul_context=soul_context,
+        )
+    bounded_memory_context = _merge_memory_contexts(
+        bounded_snapshot,
+        _summarize_bounded_todos(
         todos=session_todos,
+        ),
     )
     grouped_memory: dict[str, list[str]] = {}
     for item in memory_results:

--- a/backend/src/guardian/state.py
+++ b/backend/src/guardian/state.py
@@ -286,6 +286,56 @@ def _summarize_bounded_memory(*, soul_context: str, todos: list[dict[str, object
     return "\n".join(lines)
 
 
+async def _structured_memory_context_bundle() -> tuple[str, dict[str, tuple[str, ...]]]:
+    from src.db.models import MemoryKind
+    from src.memory.repository import memory_repository
+    from src.memory.types import bucket_name_for_kind
+
+    grouped = await memory_repository.list_memories_by_kinds(
+        kinds=(
+            MemoryKind.goal,
+            MemoryKind.commitment,
+            MemoryKind.preference,
+            MemoryKind.communication_preference,
+            MemoryKind.pattern,
+            MemoryKind.project,
+            MemoryKind.collaborator,
+            MemoryKind.obligation,
+            MemoryKind.routine,
+            MemoryKind.timeline,
+        ),
+        limit_per_kind=2,
+    )
+
+    bucketed: dict[str, list[str]] = {}
+    lines: list[str] = []
+    for kind_name, memories in grouped.items():
+        bucket_name = bucket_name_for_kind(kind_name)
+        for memory in memories:
+            text = (memory.summary or memory.content or "").strip()
+            if not text:
+                continue
+            bucket = bucketed.setdefault(bucket_name, [])
+            if text not in bucket:
+                bucket.append(text)
+            line = f"- [{bucket_name}] {text}"
+            if line not in lines:
+                lines.append(line)
+
+    return "\n".join(lines[:6]), {key: tuple(values) for key, values in bucketed.items()}
+
+
+def _merge_memory_contexts(*contexts: str) -> str:
+    lines: list[str] = []
+    for context in contexts:
+        for raw_line in context.splitlines():
+            line = raw_line.strip()
+            if not line or line in lines:
+                continue
+            lines.append(line)
+    return "\n".join(lines)
+
+
 async def build_guardian_state(
     *,
     session_id: str | None = None,
@@ -320,6 +370,7 @@ async def build_guardian_state(
         intervention_type="advisory",
         limit=12,
     )
+    structured_memory_context, structured_memory_buckets = await _structured_memory_context_bundle()
     try:
         recent_execution_summary = _summarize_recent_execution(
             await audit_repository.list_events(limit=20, session_id=session_id)
@@ -341,11 +392,12 @@ async def build_guardian_state(
     memory_buckets: dict[str, tuple[str, ...]] = {}
     if memory_requested:
         memory_results, memory_degraded = await asyncio.to_thread(search_with_status, query)
-    memory_context = "\n".join(
+    vector_memory_context = "\n".join(
         f"- [{item['category']}] {item['text']}"
         for item in memory_results
         if isinstance(item.get("category"), str) and isinstance(item.get("text"), str)
     )
+    memory_context = _merge_memory_contexts(vector_memory_context, structured_memory_context)
     bounded_memory_context = _summarize_bounded_memory(
         soul_context=soul_context,
         todos=session_todos,
@@ -359,6 +411,11 @@ async def build_guardian_state(
         grouped_memory.setdefault(category, [])
         if text not in grouped_memory[category]:
             grouped_memory[category].append(text)
+    for category, texts in structured_memory_buckets.items():
+        grouped_memory.setdefault(category, [])
+        for text in texts:
+            if text not in grouped_memory[category]:
+                grouped_memory[category].append(text)
     memory_buckets = {key: tuple(values) for key, values in grouped_memory.items()}
     world_model = build_guardian_world_model(
         observer_context=observer_context,

--- a/backend/src/guardian/world_model.py
+++ b/backend/src/guardian/world_model.py
@@ -224,19 +224,28 @@ def build_guardian_world_model(
     feedback_lines = _extract_lines(recent_intervention_feedback, limit=2)
     memory_buckets = memory_buckets or {}
     goal_memory = list(memory_buckets.get("goal", ()))[:2] or _extract_tagged_memory(memory_context, "goal", limit=2)
+    commitment_memory = list(memory_buckets.get("commitment", ()))[:2] or _extract_tagged_memory(memory_context, "commitment", limit=2)
     preference_constraints = list(memory_buckets.get("preference", ()))[:2] or _extract_tagged_memory(memory_context, "preference", limit=2)
     recurring_patterns = list(memory_buckets.get("pattern", ()))[:3] or _extract_tagged_memory(memory_context, "pattern", limit=3)
+    project_memory = list(memory_buckets.get("project", ()))[:2] or _extract_tagged_memory(memory_context, "project", limit=2)
     active_routines = list(memory_buckets.get("routine", ()))[:3] or _extract_tagged_memory(memory_context, "routine", limit=3)
     collaborators = list(memory_buckets.get("collaborator", ()))[:3] or _extract_tagged_memory(memory_context, "collaborator", limit=3)
     recurring_obligations = list(memory_buckets.get("obligation", ()))[:3] or _extract_tagged_memory(memory_context, "obligation", limit=3)
     timeline_memory = list(memory_buckets.get("timeline", ()))[:3] or _extract_tagged_memory(memory_context, "timeline", limit=3)
     project_timeline = _dedupe(
         timeline_memory
+        + project_memory
         + list(active_projects[:1])
         + _extract_lines(recent_execution_summary, limit=2)
         + recent_session_lines[:1]
     )
-    memory_signals = _dedupe(goal_memory + recurring_patterns[:1] + preference_constraints[:1] + active_routines[:1])
+    memory_signals = _dedupe(
+        goal_memory
+        + commitment_memory[:1]
+        + recurring_patterns[:1]
+        + preference_constraints[:1]
+        + active_routines[:1]
+    )
     continuity_threads = _dedupe(recent_session_lines + feedback_lines[:1])
 
     current_focus = "No clear focus signal"
@@ -266,6 +275,8 @@ def build_guardian_world_model(
             commitments.append(summary)
     if observer_context.active_goals_summary:
         commitments.append(observer_context.active_goals_summary)
+    commitments.extend(commitment_memory[:2])
+    commitments.extend(project_memory[:1])
     commitments.extend(memory_lines[:1])
     commitments.extend(active_projects[:2])
 
@@ -288,7 +299,9 @@ def build_guardian_world_model(
         + list(preference_constraints[:1])
     )
     next_up = _dedupe(
-        list(active_projects[:1])
+        list(commitment_memory[:1])
+        + project_memory[:1]
+        + list(active_projects[:1])
         + list(goal_memory[:1])
         + list(recent_session_lines[:1])
     )
@@ -306,8 +319,8 @@ def build_guardian_world_model(
     if observer_context.user_state in {"deep_work", "in_meeting", "away"}:
         active_constraints.append(f"Current state is {observer_context.user_state}")
     active_constraints.extend(preference_constraints)
-    project_state = list(active_projects[:3])
-    project_state.extend(execution_pressure[:2])
+    active_project_signals = _dedupe(project_memory[:2] + list(active_projects[:3]))
+    project_state = _dedupe(list(active_project_signals) + execution_pressure[:2])
     has_observer_focus_signal = any(
         (
             observer_context.current_event,
@@ -326,7 +339,7 @@ def build_guardian_world_model(
         corroboration_sources.append("current_session")
     if recent_session_lines:
         corroboration_sources.append("recent_sessions")
-    if active_projects:
+    if active_projects or project_memory:
         corroboration_sources.append("projects")
     if execution_pressure:
         corroboration_sources.append("execution")
@@ -340,12 +353,12 @@ def build_guardian_world_model(
         active_blockers=active_blockers,
         next_up=next_up,
         dominant_thread=dominant_thread,
-        active_projects=_dedupe(list(active_projects)),
+        active_projects=active_project_signals,
         execution_pressure=_dedupe(execution_pressure),
         active_constraints=_dedupe(active_constraints),
         recurring_patterns=_dedupe(recurring_patterns),
         active_routines=_dedupe(active_routines),
-        project_state=_dedupe(project_state),
+        project_state=project_state,
         memory_signals=memory_signals,
         continuity_threads=continuity_threads,
         collaborators=_dedupe(collaborators),

--- a/backend/src/memory/consolidator.py
+++ b/backend/src/memory/consolidator.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from datetime import datetime, timezone
 from time import perf_counter
 
 from config.settings import settings
@@ -9,6 +10,7 @@ from src.audit.runtime import log_background_task_event
 from src.llm_runtime import completion_with_fallback
 from src.memory.repository import memory_repository
 from src.memory.soul import read_soul, update_soul_section
+from src.memory.types import parse_consolidated_memories
 from src.memory.vector_store import add_memory
 
 logger = logging.getLogger(__name__)
@@ -16,10 +18,18 @@ logger = logging.getLogger(__name__)
 _CONSOLIDATION_PROMPT = """Analyze this conversation and extract key information to remember long-term.
 
 Return a JSON object with these fields:
-- "facts": list of factual statements learned about the user (name, role, preferences, etc.)
-- "patterns": list of behavioral patterns observed
-- "goals": list of goals or intentions the user mentioned
-- "reflections": list of insights or decisions made
+- "memories": list of memory objects. Each object should include:
+  - "text": the memory statement
+  - "kind": one of fact, preference, pattern, goal, reflection, project, collaborator, obligation, routine, timeline, commitment, communication_preference
+  - "summary": short compressed form of the memory
+  - "confidence": float from 0 to 1
+  - "importance": float from 0 to 1
+  - optional "subject" and "project" fields when obvious
+  - optional "last_confirmed_at" ISO timestamp if the conversation makes timing explicit
+- "facts": optional legacy list of factual statements learned about the user (keep empty if using typed memories)
+- "patterns": optional legacy list of behavioral patterns observed
+- "goals": optional legacy list of goals or intentions the user mentioned
+- "reflections": optional legacy list of insights or decisions made
 - "soul_updates": dict of soul sections to update (only if significant new identity/goal info). Keys are section names like "Identity", "Values", "Goals". Values are the new content. Return empty dict if no updates needed.
 
 Be selective — only extract things worth remembering across future conversations.
@@ -110,58 +120,69 @@ async def consolidate_session(session_id: str) -> None:
         data = json.loads(text)
 
         # Store memories by category
+        extracted_memories = parse_consolidated_memories(
+            data,
+            fallback_confirmed_at=datetime.now(timezone.utc),
+        )
         stored = 0
         vector_stored = 0
         partial_write_count = 0
         write_failure_count = 0
-        for category in ["facts", "patterns", "goals", "reflections"]:
-            items = data.get(category, [])
-            singular = category.rstrip("s") if category != "reflections" else "reflection"
-            for item in items:
-                if isinstance(item, str) and len(item) > 10:
-                    embedding_id = ""
-                    vector_succeeded = False
-                    structured_succeeded = False
-                    try:
-                        embedding_id = await asyncio.wait_for(
-                            asyncio.to_thread(
-                                add_memory,
-                                text=item,
-                                category=singular,
-                                source_session_id=session_id,
-                            ),
-                            timeout=10,
-                        )
-                        vector_succeeded = isinstance(embedding_id, str) and bool(embedding_id.strip())
-                        if vector_succeeded:
-                            vector_stored += 1
-                    except asyncio.TimeoutError:
-                        logger.warning("add_memory timed out for session %s", session_id[:8])
-                    except Exception:
-                        logger.exception("add_memory failed for session %s", session_id[:8])
-                    try:
-                        await memory_repository.create_memory(
-                            content=item,
-                            category=singular,
-                            kind=singular,
-                            source_session_id=session_id,
-                            embedding_id=embedding_id or None,
-                            summary=_summary_for_memory(item),
-                            metadata={
-                                "writer": "session_consolidation",
-                                "source": "llm_extract",
-                            },
-                        )
-                        structured_succeeded = True
-                        stored += 1
-                    except Exception:
-                        logger.exception(
-                            "structured memory write failed for session %s", session_id[:8]
-                        )
-                    if vector_succeeded != structured_succeeded:
-                        partial_write_count += 1
-                    elif not vector_succeeded and not structured_succeeded:
-                        write_failure_count += 1
+        for item in extracted_memories:
+            embedding_id = ""
+            vector_succeeded = False
+            structured_succeeded = False
+            try:
+                embedding_id = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        add_memory,
+                        text=item.text,
+                        category=item.category.value,
+                        source_session_id=session_id,
+                    ),
+                    timeout=10,
+                )
+                vector_succeeded = isinstance(embedding_id, str) and bool(embedding_id.strip())
+                if vector_succeeded:
+                    vector_stored += 1
+            except asyncio.TimeoutError:
+                logger.warning("add_memory timed out for session %s", session_id[:8])
+            except Exception:
+                logger.exception("add_memory failed for session %s", session_id[:8])
+            metadata = dict(item.metadata or {})
+            metadata.update(
+                {
+                    "writer": "session_consolidation",
+                    "source": "llm_extract",
+                }
+            )
+            if item.subject_name:
+                metadata["subject_name"] = item.subject_name
+            if item.project_name:
+                metadata["project_name"] = item.project_name
+            try:
+                await memory_repository.create_memory(
+                    content=item.text,
+                    category=item.category,
+                    kind=item.kind,
+                    source_session_id=session_id,
+                    embedding_id=embedding_id or None,
+                    summary=item.summary or _summary_for_memory(item.text),
+                    confidence=item.confidence,
+                    importance=item.importance,
+                    metadata=metadata,
+                    last_confirmed_at=item.last_confirmed_at,
+                )
+                structured_succeeded = True
+                stored += 1
+            except Exception:
+                logger.exception(
+                    "structured memory write failed for session %s", session_id[:8]
+                )
+            if vector_succeeded != structured_succeeded:
+                partial_write_count += 1
+            elif not vector_succeeded and not structured_succeeded:
+                write_failure_count += 1
 
         # Apply soul updates if any
         soul_updates = data.get("soul_updates", {})

--- a/backend/src/memory/consolidator.py
+++ b/backend/src/memory/consolidator.py
@@ -7,6 +7,7 @@ from src.approval.runtime import reset_runtime_context, set_runtime_context
 from src.agent.session import session_manager
 from src.audit.runtime import log_background_task_event
 from src.llm_runtime import completion_with_fallback
+from src.memory.repository import memory_repository
 from src.memory.soul import read_soul, update_soul_section
 from src.memory.vector_store import add_memory
 
@@ -31,6 +32,13 @@ Current soul file:
 {soul}
 
 Return ONLY valid JSON, no markdown fences."""
+
+
+def _summary_for_memory(text: str, *, max_chars: int = 140) -> str:
+    normalized = " ".join(text.strip().split())
+    if len(normalized) <= max_chars:
+        return normalized
+    return normalized[: max_chars - 3].rstrip() + "..."
 
 
 async def consolidate_session(session_id: str) -> None:
@@ -103,13 +111,19 @@ async def consolidate_session(session_id: str) -> None:
 
         # Store memories by category
         stored = 0
+        vector_stored = 0
+        partial_write_count = 0
+        write_failure_count = 0
         for category in ["facts", "patterns", "goals", "reflections"]:
             items = data.get(category, [])
             singular = category.rstrip("s") if category != "reflections" else "reflection"
             for item in items:
                 if isinstance(item, str) and len(item) > 10:
+                    embedding_id = ""
+                    vector_succeeded = False
+                    structured_succeeded = False
                     try:
-                        await asyncio.wait_for(
+                        embedding_id = await asyncio.wait_for(
                             asyncio.to_thread(
                                 add_memory,
                                 text=item,
@@ -118,9 +132,36 @@ async def consolidate_session(session_id: str) -> None:
                             ),
                             timeout=10,
                         )
-                        stored += 1
+                        vector_succeeded = isinstance(embedding_id, str) and bool(embedding_id.strip())
+                        if vector_succeeded:
+                            vector_stored += 1
                     except asyncio.TimeoutError:
                         logger.warning("add_memory timed out for session %s", session_id[:8])
+                    except Exception:
+                        logger.exception("add_memory failed for session %s", session_id[:8])
+                    try:
+                        await memory_repository.create_memory(
+                            content=item,
+                            category=singular,
+                            kind=singular,
+                            source_session_id=session_id,
+                            embedding_id=embedding_id or None,
+                            summary=_summary_for_memory(item),
+                            metadata={
+                                "writer": "session_consolidation",
+                                "source": "llm_extract",
+                            },
+                        )
+                        structured_succeeded = True
+                        stored += 1
+                    except Exception:
+                        logger.exception(
+                            "structured memory write failed for session %s", session_id[:8]
+                        )
+                    if vector_succeeded != structured_succeeded:
+                        partial_write_count += 1
+                    elif not vector_succeeded and not structured_succeeded:
+                        write_failure_count += 1
 
         # Apply soul updates if any
         soul_updates = data.get("soul_updates", {})
@@ -130,19 +171,30 @@ async def consolidate_session(session_id: str) -> None:
                 logger.info("Soul updated: section '%s'", section)
 
         logger.info(
-            "Consolidated session %s: %d memories stored, %d soul updates",
+            "Consolidated session %s: %d structured memories, %d vector memories, %d soul updates, %d partial writes, %d failed writes",
             session_id[:8],
             stored,
+            vector_stored,
             len(soul_updates),
+            partial_write_count,
+            write_failure_count,
+        )
+        outcome = (
+            "partially_succeeded"
+            if partial_write_count or write_failure_count
+            else "succeeded"
         )
         await log_background_task_event(
             task_name="session_consolidation",
-            outcome="succeeded",
+            outcome=outcome,
             session_id=session_id,
             details={
                 "duration_ms": int((perf_counter() - started_at) * 1000),
                 "history_length": len(history),
                 "stored_memory_count": stored,
+                "vector_memory_count": vector_stored,
+                "partial_write_count": partial_write_count,
+                "write_failure_count": write_failure_count,
                 "soul_update_count": len(soul_updates),
             },
         )

--- a/backend/src/memory/consolidator.py
+++ b/backend/src/memory/consolidator.py
@@ -10,6 +10,7 @@ from src.audit.runtime import log_background_task_event
 from src.llm_runtime import completion_with_fallback
 from src.memory.linking import resolve_memory_links
 from src.memory.repository import memory_repository
+from src.memory.snapshots import refresh_bounded_guardian_snapshot
 from src.memory.soul import read_soul, update_soul_section
 from src.memory.types import parse_consolidated_memories
 from src.memory.vector_store import add_memory
@@ -129,6 +130,7 @@ async def consolidate_session(session_id: str) -> None:
         vector_stored = 0
         partial_write_count = 0
         write_failure_count = 0
+        snapshot_refresh_failed = False
         for item in extracted_memories:
             embedding_id = ""
             vector_succeeded = False
@@ -195,14 +197,22 @@ async def consolidate_session(session_id: str) -> None:
                 update_soul_section(section, content)
                 logger.info("Soul updated: section '%s'", section)
 
+        try:
+            await refresh_bounded_guardian_snapshot(soul_context=read_soul())
+        except Exception:
+            snapshot_refresh_failed = True
+            partial_write_count += 1
+            logger.exception("bounded memory snapshot refresh failed for session %s", session_id[:8])
+
         logger.info(
-            "Consolidated session %s: %d structured memories, %d vector memories, %d soul updates, %d partial writes, %d failed writes",
+            "Consolidated session %s: %d structured memories, %d vector memories, %d soul updates, %d partial writes, %d failed writes, snapshot_failed=%s",
             session_id[:8],
             stored,
             vector_stored,
             len(soul_updates),
             partial_write_count,
             write_failure_count,
+            snapshot_refresh_failed,
         )
         outcome = (
             "partially_succeeded"
@@ -221,6 +231,7 @@ async def consolidate_session(session_id: str) -> None:
                 "partial_write_count": partial_write_count,
                 "write_failure_count": write_failure_count,
                 "soul_update_count": len(soul_updates),
+                "snapshot_refresh_failed": snapshot_refresh_failed,
             },
         )
 

--- a/backend/src/memory/consolidator.py
+++ b/backend/src/memory/consolidator.py
@@ -8,6 +8,7 @@ from src.approval.runtime import reset_runtime_context, set_runtime_context
 from src.agent.session import session_manager
 from src.audit.runtime import log_background_task_event
 from src.llm_runtime import completion_with_fallback
+from src.memory.linking import resolve_memory_links
 from src.memory.repository import memory_repository
 from src.memory.soul import read_soul, update_soul_section
 from src.memory.types import parse_consolidated_memories
@@ -161,6 +162,7 @@ async def consolidate_session(session_id: str) -> None:
             if item.project_name:
                 metadata["project_name"] = item.project_name
             try:
+                link_resolution = await resolve_memory_links(item)
                 await memory_repository.create_memory(
                     content=item.text,
                     category=item.category,
@@ -170,6 +172,8 @@ async def consolidate_session(session_id: str) -> None:
                     summary=item.summary or _summary_for_memory(item.text),
                     confidence=item.confidence,
                     importance=item.importance,
+                    subject_entity_id=link_resolution.subject_entity_id,
+                    project_entity_id=link_resolution.project_entity_id,
                     metadata=metadata,
                     last_confirmed_at=item.last_confirmed_at,
                 )

--- a/backend/src/memory/linking.py
+++ b/backend/src/memory/linking.py
@@ -48,14 +48,9 @@ async def resolve_memory_links(item: ConsolidatedMemoryItem) -> MemoryLinkResolu
             subject_entity_id = subject_entity.id
 
     if project_name is not None:
-        aliases: list[str] = []
-        summary_name = _canonical_name(item.summary)
-        if summary_name is not None and summary_name != project_name:
-            aliases.append(summary_name)
         project_entity = await memory_repository.get_or_create_entity(
             canonical_name=project_name,
             entity_type=MemoryEntityType.project,
-            aliases=aliases,
         )
         project_entity_id = project_entity.id
 

--- a/backend/src/memory/linking.py
+++ b/backend/src/memory/linking.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.db.models import MemoryEntityType, MemoryKind
+from src.memory.repository import memory_repository
+from src.memory.types import ConsolidatedMemoryItem
+
+
+@dataclass(frozen=True)
+class MemoryLinkResolution:
+    subject_entity_id: str | None = None
+    project_entity_id: str | None = None
+
+
+def _canonical_name(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = " ".join(value.strip().split())
+    return normalized or None
+
+
+async def resolve_memory_links(item: ConsolidatedMemoryItem) -> MemoryLinkResolution:
+    subject_name = _canonical_name(item.subject_name)
+    project_name = _canonical_name(item.project_name)
+
+    if item.kind == MemoryKind.project and project_name is None:
+        project_name = _canonical_name(item.summary) or _canonical_name(item.text)
+    if item.kind == MemoryKind.routine and subject_name is None:
+        subject_name = _canonical_name(item.summary) or _canonical_name(item.text)
+    if item.kind == MemoryKind.obligation and subject_name is None:
+        subject_name = _canonical_name(item.summary) or _canonical_name(item.text)
+
+    subject_entity_id: str | None = None
+    project_entity_id: str | None = None
+
+    if subject_name is not None:
+        subject_entity_type = {
+            MemoryKind.collaborator: MemoryEntityType.person,
+            MemoryKind.routine: MemoryEntityType.routine,
+            MemoryKind.obligation: MemoryEntityType.obligation,
+        }.get(item.kind)
+        if subject_entity_type is not None:
+            subject_entity = await memory_repository.get_or_create_entity(
+                canonical_name=subject_name,
+                entity_type=subject_entity_type,
+            )
+            subject_entity_id = subject_entity.id
+
+    if project_name is not None:
+        aliases: list[str] = []
+        summary_name = _canonical_name(item.summary)
+        if summary_name is not None and summary_name != project_name:
+            aliases.append(summary_name)
+        project_entity = await memory_repository.get_or_create_entity(
+            canonical_name=project_name,
+            entity_type=MemoryEntityType.project,
+            aliases=aliases,
+        )
+        project_entity_id = project_entity.id
+
+    return MemoryLinkResolution(
+        subject_entity_id=subject_entity_id,
+        project_entity_id=project_entity_id,
+    )

--- a/backend/src/memory/repository.py
+++ b/backend/src/memory/repository.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select, col
+
+from src.db.engine import get_session
+from src.db.models import (
+    Memory,
+    MemoryCategory,
+    MemoryEdge,
+    MemoryEdgeType,
+    MemoryEntity,
+    MemoryEntityType,
+    MemoryKind,
+    MemorySnapshot,
+    MemorySnapshotKind,
+    MemorySource,
+    MemoryStatus,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize_entity_key(name: str, entity_type: MemoryEntityType | str) -> str:
+    normalized_type = _coerce_enum(entity_type, MemoryEntityType).value
+    return f"{normalized_type}:{' '.join(name.strip().lower().split())}"
+
+
+def _coerce_enum(
+    value: Any,
+    enum_cls: type[
+        MemoryCategory
+        | MemoryKind
+        | MemoryStatus
+        | MemoryEntityType
+        | MemorySnapshotKind
+        | MemoryEdgeType
+    ],
+):
+    if isinstance(value, enum_cls):
+        return value
+    try:
+        return enum_cls(value)
+    except ValueError as exc:
+        raise ValueError(f"Invalid {enum_cls.__name__}: {value!r}") from exc
+
+
+@dataclass(frozen=True)
+class MemoryWriteResult:
+    memory_id: str
+    subject_entity_id: str | None = None
+    project_entity_id: str | None = None
+
+
+class MemoryRepository:
+    async def get_or_create_entity(
+        self,
+        *,
+        canonical_name: str,
+        entity_type: MemoryEntityType | str = MemoryEntityType.person,
+        aliases: list[str] | None = None,
+    ) -> MemoryEntity:
+        normalized_name = canonical_name.strip()
+        if not normalized_name:
+            raise ValueError("canonical_name must be non-empty")
+        normalized_entity_type = _coerce_enum(entity_type, MemoryEntityType)
+        canonical_key = _normalize_entity_key(normalized_name, normalized_entity_type)
+        requested_aliases = sorted({alias.strip() for alias in aliases or [] if alias.strip()})
+
+        async with get_session() as db:
+            result = await db.execute(
+                select(MemoryEntity)
+                .where(MemoryEntity.canonical_key == canonical_key)
+            )
+            entity = result.scalars().first()
+            if entity is None and requested_aliases:
+                alias_candidates = (
+                    await db.execute(
+                        select(MemoryEntity).where(MemoryEntity.entity_type == normalized_entity_type)
+                    )
+                ).scalars().all()
+                requested_alias_keys = {_normalize_entity_key(alias, normalized_entity_type) for alias in requested_aliases}
+                for candidate in alias_candidates:
+                    candidate_keys = {_normalize_entity_key(candidate.canonical_name, normalized_entity_type)}
+                    candidate_keys.update(
+                        _normalize_entity_key(alias, normalized_entity_type)
+                        for alias in json.loads(candidate.aliases_json or "[]")
+                    )
+                    if requested_alias_keys & candidate_keys or canonical_key in candidate_keys:
+                        entity = candidate
+                        break
+            if entity is not None:
+                updated_aliases = sorted(
+                    {
+                        alias.strip()
+                        for alias in requested_aliases + json.loads(entity.aliases_json or "[]")
+                        if alias.strip()
+                    }
+                )
+                if updated_aliases != json.loads(entity.aliases_json or "[]"):
+                    entity.aliases_json = json.dumps(updated_aliases)
+                    entity.updated_at = _now()
+                    db.add(entity)
+                await db.flush()
+                db.expunge(entity)
+                return entity
+
+            entity = MemoryEntity(
+                canonical_key=canonical_key,
+                canonical_name=normalized_name,
+                entity_type=normalized_entity_type,
+                aliases_json=json.dumps(requested_aliases),
+            )
+            db.add(entity)
+            try:
+                await db.flush()
+            except IntegrityError:
+                await db.rollback()
+                result = await db.execute(
+                    select(MemoryEntity).where(MemoryEntity.canonical_key == canonical_key)
+                )
+                entity = result.scalars().one()
+            db.expunge(entity)
+            return entity
+
+    async def create_memory(
+        self,
+        *,
+        content: str,
+        category: MemoryCategory | str = MemoryCategory.fact,
+        kind: MemoryKind | str = MemoryKind.fact,
+        source_session_id: str | None = None,
+        source_message_id: str | None = None,
+        summary: str | None = None,
+        confidence: float = 0.5,
+        importance: float = 0.5,
+        reinforcement: float = 1.0,
+        subject_entity_id: str | None = None,
+        project_entity_id: str | None = None,
+        embedding_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        status: MemoryStatus | str = MemoryStatus.active,
+        last_confirmed_at: datetime | None = None,
+    ) -> MemoryWriteResult:
+        normalized_content = content.strip()
+        if not normalized_content:
+            raise ValueError("content must be non-empty")
+        normalized_category = _coerce_enum(category, MemoryCategory)
+        normalized_kind = _coerce_enum(kind, MemoryKind)
+        normalized_status = _coerce_enum(status, MemoryStatus)
+        normalized_embedding_id = (
+            embedding_id.strip()
+            if isinstance(embedding_id, str) and embedding_id.strip()
+            else None
+        )
+
+        async with get_session() as db:
+            memory = Memory(
+                content=normalized_content,
+                category=normalized_category,
+                kind=normalized_kind,
+                summary=summary,
+                confidence=confidence,
+                importance=importance,
+                reinforcement=reinforcement,
+                status=normalized_status,
+                subject_entity_id=subject_entity_id,
+                project_entity_id=project_entity_id,
+                source_session_id=source_session_id,
+                embedding_id=normalized_embedding_id,
+                metadata_json=json.dumps(metadata or {}, sort_keys=True),
+                last_confirmed_at=last_confirmed_at,
+                updated_at=_now(),
+            )
+            db.add(memory)
+            await db.flush()
+
+            if source_session_id or source_message_id:
+                db.add(
+                    MemorySource(
+                        memory_id=memory.id,
+                        source_type="session",
+                        source_session_id=source_session_id,
+                        source_message_id=source_message_id,
+                        snippet=(summary or normalized_content)[:240],
+                    )
+                )
+                await db.flush()
+
+            db.expunge(memory)
+            return MemoryWriteResult(
+                memory_id=memory.id,
+                subject_entity_id=subject_entity_id,
+                project_entity_id=project_entity_id,
+            )
+
+    async def list_memories(
+        self,
+        *,
+        kind: MemoryKind | str | None = None,
+        limit: int = 20,
+        status: MemoryStatus | str = MemoryStatus.active,
+    ) -> list[Memory]:
+        normalized_status = _coerce_enum(status, MemoryStatus)
+        async with get_session() as db:
+            stmt = (
+                select(Memory)
+                .where(Memory.status == normalized_status)
+                .order_by(col(Memory.importance).desc(), col(Memory.created_at).desc())
+                .limit(limit)
+            )
+            if kind:
+                stmt = stmt.where(Memory.kind == _coerce_enum(kind, MemoryKind))
+            result = await db.execute(stmt)
+            memories = result.scalars().all()
+            for memory in memories:
+                db.expunge(memory)
+            return list(memories)
+
+    async def list_memories_for_entities(
+        self,
+        *,
+        subject_entity_id: str | None = None,
+        project_entity_id: str | None = None,
+        limit: int = 20,
+    ) -> list[Memory]:
+        async with get_session() as db:
+            stmt = (
+                select(Memory)
+                .where(Memory.status == MemoryStatus.active)
+                .order_by(col(Memory.importance).desc(), col(Memory.created_at).desc())
+                .limit(limit)
+            )
+            if subject_entity_id:
+                stmt = stmt.where(Memory.subject_entity_id == subject_entity_id)
+            if project_entity_id:
+                stmt = stmt.where(Memory.project_entity_id == project_entity_id)
+            result = await db.execute(stmt)
+            memories = result.scalars().all()
+            for memory in memories:
+                db.expunge(memory)
+            return list(memories)
+
+    async def create_edge(
+        self,
+        *,
+        from_memory_id: str,
+        to_memory_id: str,
+        edge_type: MemoryEdgeType | str = MemoryEdgeType.related,
+        weight: float = 1.0,
+        metadata: dict[str, Any] | None = None,
+    ) -> MemoryEdge:
+        if not from_memory_id or not to_memory_id:
+            raise ValueError("from_memory_id and to_memory_id must be non-empty")
+        normalized_edge_type = _coerce_enum(edge_type, MemoryEdgeType)
+        async with get_session() as db:
+            edge = MemoryEdge(
+                from_memory_id=from_memory_id,
+                to_memory_id=to_memory_id,
+                edge_type=normalized_edge_type,
+                weight=weight,
+                metadata_json=json.dumps(metadata or {}, sort_keys=True),
+            )
+            db.add(edge)
+            await db.flush()
+            db.expunge(edge)
+            return edge
+
+    async def save_snapshot(
+        self,
+        *,
+        kind: MemorySnapshotKind | str = MemorySnapshotKind.bounded_guardian_context,
+        content: str,
+        source_hash: str | None = None,
+    ) -> MemorySnapshot:
+        normalized_kind = _coerce_enum(kind, MemorySnapshotKind)
+        async with get_session() as db:
+            result = await db.execute(
+                select(MemorySnapshot).where(MemorySnapshot.kind == normalized_kind)
+            )
+            snapshot = result.scalars().first()
+            if snapshot is None:
+                snapshot = MemorySnapshot(kind=normalized_kind, content=content, source_hash=source_hash)
+            else:
+                snapshot.content = content
+                snapshot.source_hash = source_hash
+                snapshot.updated_at = _now()
+            db.add(snapshot)
+            try:
+                await db.flush()
+            except IntegrityError:
+                await db.rollback()
+                snapshot = (
+                    await db.execute(
+                        select(MemorySnapshot).where(MemorySnapshot.kind == normalized_kind)
+                    )
+                ).scalars().one()
+                snapshot.content = content
+                snapshot.source_hash = source_hash
+                snapshot.updated_at = _now()
+                db.add(snapshot)
+                await db.flush()
+            db.expunge(snapshot)
+            return snapshot
+
+    async def get_snapshot(self, kind: MemorySnapshotKind | str = MemorySnapshotKind.bounded_guardian_context) -> MemorySnapshot | None:
+        normalized_kind = _coerce_enum(kind, MemorySnapshotKind)
+        async with get_session() as db:
+            result = await db.execute(
+                select(MemorySnapshot).where(MemorySnapshot.kind == normalized_kind)
+            )
+            snapshot = result.scalars().first()
+            if snapshot is not None:
+                db.expunge(snapshot)
+            return snapshot
+
+
+memory_repository = MemoryRepository()

--- a/backend/src/memory/repository.py
+++ b/backend/src/memory/repository.py
@@ -248,6 +248,39 @@ class MemoryRepository:
                 db.expunge(memory)
             return list(memories)
 
+    async def list_memories_by_kinds(
+        self,
+        *,
+        kinds: tuple[MemoryKind | str, ...],
+        limit_per_kind: int = 3,
+        status: MemoryStatus | str = MemoryStatus.active,
+    ) -> dict[str, list[Memory]]:
+        normalized_status = _coerce_enum(status, MemoryStatus)
+        normalized_kinds = tuple(dict.fromkeys(_coerce_enum(kind, MemoryKind) for kind in kinds))
+        if not normalized_kinds:
+            return {}
+
+        async with get_session() as db:
+            stmt = (
+                select(Memory)
+                .where(Memory.status == normalized_status)
+                .where(col(Memory.kind).in_(normalized_kinds))
+                .order_by(
+                    col(Memory.importance).desc(),
+                    col(Memory.last_confirmed_at).desc(),
+                    col(Memory.created_at).desc(),
+                )
+            )
+            result = await db.execute(stmt)
+            grouped: dict[str, list[Memory]] = {kind.value: [] for kind in normalized_kinds}
+            for memory in result.scalars().all():
+                bucket = grouped.setdefault(memory.kind.value, [])
+                if len(bucket) >= limit_per_kind:
+                    continue
+                db.expunge(memory)
+                bucket.append(memory)
+            return {key: value for key, value in grouped.items() if value}
+
     async def create_edge(
         self,
         *,

--- a/backend/src/memory/repository.py
+++ b/backend/src/memory/repository.py
@@ -6,7 +6,8 @@ from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import select, col
+from sqlalchemy import or_
+from sqlmodel import col, select
 
 from src.db.engine import get_session
 from src.db.models import (
@@ -31,6 +32,21 @@ def _now() -> datetime:
 def _normalize_entity_key(name: str, entity_type: MemoryEntityType | str) -> str:
     normalized_type = _coerce_enum(entity_type, MemoryEntityType).value
     return f"{normalized_type}:{' '.join(name.strip().lower().split())}"
+
+
+def _normalize_entity_name(name: str) -> str:
+    return " ".join(name.strip().lower().split())
+
+
+def _name_contains_requested_tokens(candidate_name: str, requested_name: str) -> bool:
+    candidate_tokens = _normalize_entity_name(candidate_name).split()
+    requested_tokens = _normalize_entity_name(requested_name).split()
+    if not candidate_tokens or not requested_tokens or len(requested_tokens) > len(candidate_tokens):
+        return False
+    for index in range(len(candidate_tokens) - len(requested_tokens) + 1):
+        if candidate_tokens[index : index + len(requested_tokens)] == requested_tokens:
+            return True
+    return False
 
 
 def _coerce_enum(
@@ -201,6 +217,60 @@ class MemoryRepository:
                 project_entity_id=project_entity_id,
             )
 
+    async def find_entities_by_names(
+        self,
+        *,
+        names: tuple[str, ...],
+        entity_type: MemoryEntityType | str,
+    ) -> dict[str, MemoryEntity]:
+        normalized_entity_type = _coerce_enum(entity_type, MemoryEntityType)
+        requested = {
+            name: _normalize_entity_key(name, normalized_entity_type)
+            for name in dict.fromkeys(name.strip() for name in names if name.strip())
+        }
+        if not requested:
+            return {}
+
+        async with get_session() as db:
+            result = await db.execute(
+                select(MemoryEntity).where(MemoryEntity.entity_type == normalized_entity_type)
+            )
+            entities = result.scalars().all()
+            resolved: dict[str, MemoryEntity] = {}
+            for entity in entities:
+                candidate_keys = {
+                    _normalize_entity_key(entity.canonical_name, normalized_entity_type)
+                }
+                candidate_keys.update(
+                    _normalize_entity_key(alias, normalized_entity_type)
+                    for alias in json.loads(entity.aliases_json or "[]")
+                    if alias
+                )
+                for requested_name, requested_key in requested.items():
+                    if requested_key not in candidate_keys or requested_name in resolved:
+                        continue
+                    resolved[requested_name] = entity
+            unresolved_names = [name for name in requested if name not in resolved]
+            if unresolved_names and normalized_entity_type == MemoryEntityType.project:
+                for requested_name in unresolved_names:
+                    matches: list[MemoryEntity] = []
+                    for entity in entities:
+                        candidate_names = [entity.canonical_name]
+                        candidate_names.extend(
+                            alias for alias in json.loads(entity.aliases_json or "[]") if alias
+                        )
+                        if any(
+                            _name_contains_requested_tokens(candidate_name, requested_name)
+                            for candidate_name in candidate_names
+                        ):
+                            matches.append(entity)
+                    unique_matches = {entity.id: entity for entity in matches}
+                    if len(unique_matches) == 1:
+                        resolved[requested_name] = next(iter(unique_matches.values()))
+            for entity in {id(entity): entity for entity in resolved.values()}.values():
+                db.expunge(entity)
+            return resolved
+
     async def list_memories(
         self,
         *,
@@ -227,21 +297,43 @@ class MemoryRepository:
     async def list_memories_for_entities(
         self,
         *,
-        subject_entity_id: str | None = None,
-        project_entity_id: str | None = None,
+        subject_entity_ids: tuple[str, ...] = (),
+        project_entity_ids: tuple[str, ...] = (),
+        kinds: tuple[MemoryKind | str, ...] = (),
         limit: int = 20,
+        status: MemoryStatus | str = MemoryStatus.active,
     ) -> list[Memory]:
+        normalized_status = _coerce_enum(status, MemoryStatus)
+        normalized_subject_ids = tuple(
+            dict.fromkeys(entity_id.strip() for entity_id in subject_entity_ids if entity_id.strip())
+        )
+        normalized_project_ids = tuple(
+            dict.fromkeys(entity_id.strip() for entity_id in project_entity_ids if entity_id.strip())
+        )
+        normalized_kinds = tuple(
+            dict.fromkeys(_coerce_enum(kind, MemoryKind) for kind in kinds)
+        )
+        if not normalized_subject_ids and not normalized_project_ids:
+            return []
         async with get_session() as db:
             stmt = (
                 select(Memory)
-                .where(Memory.status == MemoryStatus.active)
-                .order_by(col(Memory.importance).desc(), col(Memory.created_at).desc())
+                .where(Memory.status == normalized_status)
+                .order_by(
+                    col(Memory.importance).desc(),
+                    col(Memory.last_confirmed_at).desc(),
+                    col(Memory.created_at).desc(),
+                )
                 .limit(limit)
             )
-            if subject_entity_id:
-                stmt = stmt.where(Memory.subject_entity_id == subject_entity_id)
-            if project_entity_id:
-                stmt = stmt.where(Memory.project_entity_id == project_entity_id)
+            filters = []
+            if normalized_subject_ids:
+                filters.append(col(Memory.subject_entity_id).in_(normalized_subject_ids))
+            if normalized_project_ids:
+                filters.append(col(Memory.project_entity_id).in_(normalized_project_ids))
+            stmt = stmt.where(or_(*filters))
+            if normalized_kinds:
+                stmt = stmt.where(col(Memory.kind).in_(normalized_kinds))
             result = await db.execute(stmt)
             memories = result.scalars().all()
             for memory in memories:

--- a/backend/src/memory/snapshots.py
+++ b/backend/src/memory/snapshots.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+from src.db.models import MemoryKind, MemorySnapshotKind
+from src.memory.repository import memory_repository
+from src.memory.soul import read_soul
+
+_SESSION_BOUNDED_SNAPSHOT_CACHE: dict[str, str] = {}
+
+
+def _extract_soul_section_lines(soul_context: str, section: str, *, limit: int) -> tuple[str, ...]:
+    header = f"## {section}".lower()
+    lines = soul_context.splitlines()
+    in_section = False
+    extracted: list[str] = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if line.lower().startswith("## "):
+            if line.lower() == header:
+                in_section = True
+                continue
+            if in_section:
+                break
+        if not in_section or not line or line.startswith("("):
+            continue
+        if line.startswith("- "):
+            extracted.append(line[2:].strip())
+        else:
+            extracted.append(line)
+        if len(extracted) >= limit:
+            break
+    return tuple(extracted)
+
+
+def _dedupe_preserve(items: list[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        normalized = " ".join(item.strip().split())
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        ordered.append(normalized)
+    return tuple(ordered)
+
+
+async def render_bounded_guardian_snapshot(
+    *,
+    soul_context: str | None = None,
+) -> tuple[str, str]:
+    resolved_soul = soul_context if isinstance(soul_context, str) else read_soul()
+    grouped = await memory_repository.list_memories_by_kinds(
+        kinds=(
+            MemoryKind.goal,
+            MemoryKind.commitment,
+            MemoryKind.preference,
+            MemoryKind.communication_preference,
+            MemoryKind.project,
+            MemoryKind.collaborator,
+            MemoryKind.obligation,
+            MemoryKind.routine,
+        ),
+        limit_per_kind=2,
+    )
+
+    identity_bits = _extract_soul_section_lines(resolved_soul, "Identity", limit=3)
+    goal_bits = _dedupe_preserve(
+        list(_extract_soul_section_lines(resolved_soul, "Goals", limit=3))
+        + [
+            (memory.summary or memory.content or "").strip()
+            for kind in ("goal", "commitment")
+            for memory in grouped.get(kind, [])
+        ]
+    )
+    preference_bits = _dedupe_preserve(
+        list(_extract_soul_section_lines(resolved_soul, "Personality Notes", limit=2))
+        + [
+            (memory.summary or memory.content or "").strip()
+            for kind in ("preference", "communication_preference")
+            for memory in grouped.get(kind, [])
+        ]
+    )
+    project_bits = _dedupe_preserve(
+        [(memory.summary or memory.content or "").strip() for memory in grouped.get("project", [])]
+    )
+    collaborator_bits = _dedupe_preserve(
+        [(memory.summary or memory.content or "").strip() for memory in grouped.get("collaborator", [])]
+    )
+    cadence_bits = _dedupe_preserve(
+        [
+            (memory.summary or memory.content or "").strip()
+            for kind in ("obligation", "routine")
+            for memory in grouped.get(kind, [])
+        ]
+    )
+
+    lines: list[str] = []
+    if identity_bits:
+        lines.append(f"- Identity: {' | '.join(identity_bits)}")
+    if goal_bits:
+        lines.append(f"- Goal memory: {' | '.join(goal_bits)}")
+    if preference_bits:
+        lines.append(f"- Preferences: {' | '.join(preference_bits)}")
+    if project_bits:
+        lines.append(f"- Active projects: {' | '.join(project_bits)}")
+    if collaborator_bits:
+        lines.append(f"- Collaborators: {' | '.join(collaborator_bits)}")
+    if cadence_bits:
+        lines.append(f"- Routines and obligations: {' | '.join(cadence_bits)}")
+
+    payload = {
+        "identity": list(identity_bits),
+        "goal_memory": list(goal_bits),
+        "preferences": list(preference_bits),
+        "active_projects": list(project_bits),
+        "collaborators": list(collaborator_bits),
+        "routines_and_obligations": list(cadence_bits),
+    }
+    content = "\n".join(lines[:6])
+    source_hash = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, ensure_ascii=True).encode("utf-8")
+    ).hexdigest()
+    return content, source_hash
+
+
+async def refresh_bounded_guardian_snapshot(
+    *,
+    soul_context: str | None = None,
+):
+    content, source_hash = await render_bounded_guardian_snapshot(soul_context=soul_context)
+    current = await memory_repository.get_snapshot(MemorySnapshotKind.bounded_guardian_context)
+    if current is not None and current.source_hash == source_hash and current.content == content:
+        return current
+    return await memory_repository.save_snapshot(
+        kind=MemorySnapshotKind.bounded_guardian_context,
+        content=content,
+        source_hash=source_hash,
+    )
+
+
+async def get_or_create_bounded_guardian_snapshot(
+    *,
+    soul_context: str | None = None,
+    session_id: str | None = None,
+) -> str:
+    if session_id is not None:
+        cached = _SESSION_BOUNDED_SNAPSHOT_CACHE.get(session_id)
+        if isinstance(cached, str) and cached.strip():
+            return cached
+
+    content, source_hash = await render_bounded_guardian_snapshot(soul_context=soul_context)
+    current = await memory_repository.get_snapshot(MemorySnapshotKind.bounded_guardian_context)
+    if current is None or current.source_hash != source_hash or current.content != content:
+        current = await memory_repository.save_snapshot(
+            kind=MemorySnapshotKind.bounded_guardian_context,
+            content=content,
+            source_hash=source_hash,
+        )
+    if session_id is not None and current.content.strip():
+        _SESSION_BOUNDED_SNAPSHOT_CACHE[session_id] = current.content
+        return current.content
+    if current is not None and current.content.strip():
+        return current.content
+    snapshot = await refresh_bounded_guardian_snapshot(soul_context=soul_context)
+    if session_id is not None and snapshot.content.strip():
+        _SESSION_BOUNDED_SNAPSHOT_CACHE[session_id] = snapshot.content
+    return snapshot.content
+
+
+def _reset_bounded_guardian_snapshot_cache() -> None:
+    _SESSION_BOUNDED_SNAPSHOT_CACHE.clear()

--- a/backend/src/memory/types.py
+++ b/backend/src/memory/types.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from src.db.models import MemoryCategory, MemoryKind
+
+
+_LEGACY_FIELD_TO_KIND = {
+    "facts": MemoryKind.fact,
+    "patterns": MemoryKind.pattern,
+    "goals": MemoryKind.goal,
+    "reflections": MemoryKind.reflection,
+}
+
+_KIND_TO_CATEGORY = {
+    MemoryKind.fact: MemoryCategory.fact,
+    MemoryKind.pattern: MemoryCategory.pattern,
+    MemoryKind.goal: MemoryCategory.goal,
+    MemoryKind.commitment: MemoryCategory.goal,
+    MemoryKind.preference: MemoryCategory.preference,
+    MemoryKind.communication_preference: MemoryCategory.preference,
+    MemoryKind.reflection: MemoryCategory.reflection,
+    MemoryKind.project: MemoryCategory.fact,
+    MemoryKind.collaborator: MemoryCategory.fact,
+    MemoryKind.obligation: MemoryCategory.fact,
+    MemoryKind.routine: MemoryCategory.fact,
+    MemoryKind.timeline: MemoryCategory.fact,
+}
+
+
+@dataclass(frozen=True)
+class ConsolidatedMemoryItem:
+    text: str
+    kind: MemoryKind
+    category: MemoryCategory
+    summary: str | None = None
+    confidence: float = 0.5
+    importance: float = 0.5
+    last_confirmed_at: datetime | None = None
+    subject_name: str | None = None
+    project_name: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+def _normalize_text(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.strip().split())
+
+
+def _clamp_score(value: Any, *, default: float) -> float:
+    if isinstance(value, (int, float)):
+        return max(0.0, min(1.0, float(value)))
+    return default
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def normalize_memory_kind(value: MemoryKind | str) -> MemoryKind:
+    if isinstance(value, MemoryKind):
+        return value
+    return MemoryKind(value)
+
+
+def kind_to_category(kind: MemoryKind | str) -> MemoryCategory:
+    return _KIND_TO_CATEGORY[normalize_memory_kind(kind)]
+
+
+def bucket_name_for_kind(kind: MemoryKind | str) -> str:
+    normalized = normalize_memory_kind(kind)
+    if normalized == MemoryKind.communication_preference:
+        return MemoryKind.preference.value
+    return normalized.value
+
+
+def parse_consolidated_memories(
+    payload: dict[str, Any],
+    *,
+    fallback_confirmed_at: datetime | None = None,
+) -> list[ConsolidatedMemoryItem]:
+    parsed: list[ConsolidatedMemoryItem] = []
+    seen: set[tuple[str, str]] = set()
+
+    def _append(item: ConsolidatedMemoryItem) -> None:
+        key = (bucket_name_for_kind(item.kind), item.text.lower())
+        if key in seen:
+            return
+        seen.add(key)
+        parsed.append(item)
+
+    raw_memories = payload.get("memories", [])
+    if isinstance(raw_memories, list):
+        for raw_item in raw_memories:
+            if not isinstance(raw_item, dict):
+                continue
+            text = _normalize_text(raw_item.get("text"))
+            if len(text) <= 10:
+                continue
+            kind_value = raw_item.get("kind")
+            if not isinstance(kind_value, str):
+                continue
+            try:
+                kind = normalize_memory_kind(kind_value)
+            except ValueError:
+                continue
+            _append(
+                ConsolidatedMemoryItem(
+                    text=text,
+                    kind=kind,
+                    category=kind_to_category(kind),
+                    summary=_normalize_text(raw_item.get("summary")) or None,
+                    confidence=_clamp_score(raw_item.get("confidence"), default=0.65),
+                    importance=_clamp_score(raw_item.get("importance"), default=0.65),
+                    last_confirmed_at=(
+                        _parse_timestamp(raw_item.get("last_confirmed_at"))
+                        or fallback_confirmed_at
+                    ),
+                    subject_name=_normalize_text(
+                        raw_item.get("subject") or raw_item.get("subject_name")
+                    ) or None,
+                    project_name=_normalize_text(
+                        raw_item.get("project") or raw_item.get("project_name")
+                    ) or None,
+                    metadata={
+                        "input_schema": "typed",
+                    },
+                )
+            )
+
+    for field_name, kind in _LEGACY_FIELD_TO_KIND.items():
+        items = payload.get(field_name, [])
+        if not isinstance(items, list):
+            continue
+        for raw_text in items:
+            text = _normalize_text(raw_text)
+            if len(text) <= 10:
+                continue
+            _append(
+                ConsolidatedMemoryItem(
+                    text=text,
+                    kind=kind,
+                    category=kind_to_category(kind),
+                    confidence=0.6,
+                    importance=0.6,
+                    last_confirmed_at=fallback_confirmed_at,
+                    metadata={"input_schema": "legacy", "legacy_field": field_name},
+                )
+            )
+
+    return parsed

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,6 +16,7 @@ os.environ.setdefault("WORKSPACE_DIR", "/tmp/seraph-test")
 
 from src.app import create_app
 from src.llm_runtime import _reset_target_health
+from src.memory.snapshots import _reset_bounded_guardian_snapshot_cache
 
 # Every place get_session is imported — use the local attribute name.
 _PATCH_TARGETS = [
@@ -112,3 +113,10 @@ def reset_llm_target_health():
     _reset_target_health()
     yield
     _reset_target_health()
+
+
+@pytest.fixture(autouse=True)
+def reset_bounded_snapshot_cache():
+    _reset_bounded_guardian_snapshot_cache()
+    yield
+    _reset_bounded_guardian_snapshot_cache()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -31,6 +32,7 @@ _PATCH_TARGETS = [
     "src.guardian.feedback.get_session",
     "src.vault.repository.get_session",
     "src.observer.screen_repository.get_session",
+    "src.memory.repository.get_session",
 ]
 
 
@@ -48,6 +50,13 @@ async def async_db():
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_sqlite_foreign_keys(dbapi_connection, _connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
     factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with engine.begin() as conn:

--- a/backend/tests/test_consolidation_reliability.py
+++ b/backend/tests/test_consolidation_reliability.py
@@ -1,7 +1,7 @@
 """Memory consolidation reliability — deleted sessions, embedding failures, malformed LLM output."""
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -23,13 +23,13 @@ class TestConsolidationAfterSessionDelete:
         await sm.delete("s1")
 
         # Should not raise — history will be empty
-        with patch("litellm.completion") as mock_llm:
+        with patch("src.memory.consolidator.completion_with_fallback") as mock_llm:
             await consolidate_session("s1")
             mock_llm.assert_not_called()  # short/empty history → early return
 
     async def test_nonexistent_session_returns_silently(self, async_db, sm):
         """Consolidation on a session that never existed should not raise."""
-        with patch("litellm.completion") as mock_llm:
+        with patch("src.memory.consolidator.completion_with_fallback") as mock_llm:
             await consolidate_session("never-existed")
             mock_llm.assert_not_called()
 
@@ -52,8 +52,13 @@ class TestEmbeddingFailures:
         mock_resp.choices = [MagicMock()]
         mock_resp.choices[0].message.content = llm_response
 
-        with patch("litellm.completion", return_value=mock_resp), \
-             patch("src.memory.consolidator.add_memory", side_effect=RuntimeError("Embedding crashed")):
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ), patch(
+            "src.memory.consolidator.add_memory",
+            side_effect=RuntimeError("Embedding crashed"),
+        ):
             # Should not raise — consolidator catches all exceptions
             await consolidate_session("s1")
 
@@ -69,7 +74,10 @@ class TestMalformedLLMOutput:
         mock_resp.choices = [MagicMock()]
         mock_resp.choices[0].message.content = "This is not JSON at all"
 
-        with patch("litellm.completion", return_value=mock_resp):
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ):
             await consolidate_session("s1")  # should not raise
 
     async def test_missing_fields_handled(self, async_db, sm):
@@ -83,8 +91,10 @@ class TestMalformedLLMOutput:
         mock_resp.choices = [MagicMock()]
         mock_resp.choices[0].message.content = llm_response
 
-        with patch("litellm.completion", return_value=mock_resp), \
-             patch("src.memory.consolidator.add_memory") as mock_add:
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ), patch("src.memory.consolidator.add_memory") as mock_add:
             await consolidate_session("s1")
             mock_add.assert_not_called()  # no valid categories → no memories stored
 
@@ -105,7 +115,9 @@ class TestMalformedLLMOutput:
         mock_resp.choices = [MagicMock()]
         mock_resp.choices[0].message.content = llm_response
 
-        with patch("litellm.completion", return_value=mock_resp), \
-             patch("src.memory.consolidator.add_memory") as mock_add:
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ), patch("src.memory.consolidator.add_memory") as mock_add:
             await consolidate_session("s1")
             mock_add.assert_not_called()

--- a/backend/tests/test_consolidator.py
+++ b/backend/tests/test_consolidator.py
@@ -7,6 +7,7 @@ import pytest
 
 from src.agent.session import SessionManager
 from src.memory.consolidator import consolidate_session
+from src.memory.repository import memory_repository
 
 
 @pytest.fixture
@@ -39,8 +40,10 @@ class TestConsolidateSession:
         mock_resp.choices = [MagicMock()]
         mock_resp.choices[0].message.content = llm_response
 
-        with patch("litellm.completion", return_value=mock_resp), \
-             patch("src.memory.consolidator.add_memory") as mock_add:
+        with patch("litellm.completion", return_value=mock_resp), patch(
+            "src.memory.consolidator.add_memory",
+            side_effect=["vec-1", "vec-2"],
+        ) as mock_add:
             await consolidate_session("s1")
             assert mock_add.call_count == 2
 
@@ -52,6 +55,8 @@ class TestConsolidateSession:
             and event["tool_name"] == "session_consolidation"
             and event["session_id"] == "s1"
             and event["details"]["stored_memory_count"] == 2
+            and event["details"]["vector_memory_count"] == 2
+            and event["details"]["partial_write_count"] == 0
             for event in events
         )
         assert any(
@@ -62,6 +67,36 @@ class TestConsolidateSession:
             and event["details"]["request_id"]
             for event in events
         )
+
+    async def test_extracts_facts_also_persists_structured_memory(self, async_db, sm):
+        await sm.get_or_create("s1")
+        await sm.add_message("s1", "user", "My name is Alice and I prefer concise daily summaries.")
+        await sm.add_message("s1", "assistant", "I will keep that in mind.")
+
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = json.dumps({
+            "facts": ["User's name is Alice"],
+            "patterns": [],
+            "goals": [],
+            "reflections": [],
+            "soul_updates": {},
+        })
+
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ), patch("src.memory.consolidator.add_memory", return_value="vec-1"):
+            await consolidate_session("s1")
+
+        memories = await memory_repository.list_memories(limit=5)
+
+        assert len(memories) == 1
+        assert memories[0].content == "User's name is Alice"
+        assert memories[0].kind.value == "fact"
+        assert memories[0].embedding_id == "vec-1"
+        assert memories[0].source_session_id == "s1"
+        assert memories[0].metadata_json == '{"source": "llm_extract", "writer": "session_consolidation"}'
 
     async def test_extracts_facts_uses_session_consolidation_runtime_path(self, async_db, sm):
         await sm.get_or_create("s1")
@@ -78,10 +113,10 @@ class TestConsolidateSession:
             "soul_updates": {},
         })
 
-        with (
-            patch("src.memory.consolidator.completion_with_fallback", AsyncMock(return_value=mock_resp)) as mock_completion,
-            patch("src.memory.consolidator.add_memory"),
-        ):
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ) as mock_completion, patch("src.memory.consolidator.add_memory"):
             await consolidate_session("s1")
 
         assert mock_completion.await_args.kwargs["runtime_path"] == "session_consolidation"
@@ -102,9 +137,12 @@ class TestConsolidateSession:
         mock_resp.choices = [MagicMock()]
         mock_resp.choices[0].message.content = llm_response
 
-        with patch("litellm.completion", return_value=mock_resp), \
-             patch("src.memory.consolidator.add_memory"), \
-             patch("src.memory.consolidator.update_soul_section") as mock_soul:
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ), patch("src.memory.consolidator.add_memory"), patch(
+            "src.memory.consolidator.update_soul_section"
+        ) as mock_soul:
             await consolidate_session("s1")
             mock_soul.assert_called_once_with("Goals", "- Build an AI startup")
 
@@ -124,8 +162,10 @@ class TestConsolidateSession:
         mock_resp.choices = [MagicMock()]
         mock_resp.choices[0].message.content = fenced
 
-        with patch("litellm.completion", return_value=mock_resp), \
-             patch("src.memory.consolidator.add_memory") as mock_add:
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ), patch("src.memory.consolidator.add_memory", return_value="vec-1") as mock_add:
             await consolidate_session("s1")
             assert mock_add.call_count == 1
 
@@ -134,7 +174,10 @@ class TestConsolidateSession:
         await sm.add_message("s1", "user", "Tell me about the weather in San Francisco this week.")
         await sm.add_message("s1", "assistant", "The weather in SF is typically mild with some fog.")
 
-        with patch("litellm.completion", side_effect=RuntimeError("LLM down")):
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(side_effect=RuntimeError("LLM down")),
+        ):
             # Should not raise
             await consolidate_session("s1")
 
@@ -146,5 +189,77 @@ class TestConsolidateSession:
             and event["tool_name"] == "session_consolidation"
             and event["session_id"] == "s1"
             and event["details"]["error"] == "LLM down"
+            for event in events
+        )
+
+    async def test_vector_failure_does_not_block_structured_memory_write(self, async_db, sm):
+        await sm.get_or_create("s1")
+        await sm.add_message("s1", "user", "I need to finish the Atlas launch brief this week.")
+        await sm.add_message("s1", "assistant", "I can remember that commitment.")
+
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = json.dumps({
+            "facts": [],
+            "patterns": [],
+            "goals": ["Finish the Atlas launch brief this week"],
+            "reflections": [],
+            "soul_updates": {},
+        })
+
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ), patch(
+            "src.memory.consolidator.add_memory",
+            side_effect=RuntimeError("Embedding crashed"),
+        ):
+            await consolidate_session("s1")
+
+        memories = await memory_repository.list_memories(limit=5)
+
+        assert len(memories) == 1
+        assert memories[0].content == "Finish the Atlas launch brief this week"
+        assert memories[0].kind.value == "goal"
+        assert memories[0].embedding_id is None
+
+    async def test_structured_failure_is_reported_as_partial_success(self, async_db, sm):
+        await sm.get_or_create("s1")
+        await sm.add_message("s1", "user", "Remember that I need to review the Atlas brief tomorrow.")
+        await sm.add_message("s1", "assistant", "I will keep that reminder.")
+
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = json.dumps({
+            "facts": [],
+            "patterns": [],
+            "goals": ["Review the Atlas brief tomorrow"],
+            "reflections": [],
+            "soul_updates": {},
+        })
+
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ), patch(
+            "src.memory.consolidator.add_memory",
+            return_value="vec-1",
+        ), patch.object(
+            memory_repository,
+            "create_memory",
+            AsyncMock(side_effect=RuntimeError("sqlite write failed")),
+        ):
+            await consolidate_session("s1")
+
+        from src.audit.repository import audit_repository
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "background_task_partially_succeeded"
+            and event["tool_name"] == "session_consolidation"
+            and event["session_id"] == "s1"
+            and event["details"]["stored_memory_count"] == 0
+            and event["details"]["vector_memory_count"] == 1
+            and event["details"]["partial_write_count"] == 1
             for event in events
         )

--- a/backend/tests/test_consolidator.py
+++ b/backend/tests/test_consolidator.py
@@ -96,7 +96,69 @@ class TestConsolidateSession:
         assert memories[0].kind.value == "fact"
         assert memories[0].embedding_id == "vec-1"
         assert memories[0].source_session_id == "s1"
-        assert memories[0].metadata_json == '{"source": "llm_extract", "writer": "session_consolidation"}'
+        assert memories[0].metadata_json == (
+            '{"input_schema": "legacy", "legacy_field": "facts", "source": "llm_extract", '
+            '"writer": "session_consolidation"}'
+        )
+
+    async def test_extracts_typed_memory_objects_with_provenance(self, async_db, sm):
+        await sm.get_or_create("s1")
+        await sm.add_message("s1", "user", "Alice owns investor updates, and I want concise morning briefings.")
+        await sm.add_message("s1", "assistant", "I will remember both the collaborator and your preference.")
+
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = json.dumps({
+            "memories": [
+                {
+                    "text": "Alice owns the investor update thread.",
+                    "kind": "collaborator",
+                    "summary": "Alice owns investor updates",
+                    "confidence": 0.92,
+                    "importance": 0.88,
+                    "subject": "Alice",
+                    "project": "Investor updates",
+                    "last_confirmed_at": "2026-03-25T08:30:00Z",
+                },
+                {
+                    "text": "User prefers concise morning briefings.",
+                    "kind": "communication_preference",
+                    "summary": "Prefers concise morning briefings",
+                    "confidence": 0.95,
+                    "importance": 0.85,
+                },
+            ],
+            "facts": [],
+            "patterns": [],
+            "goals": [],
+            "reflections": [],
+            "soul_updates": {},
+        })
+
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ), patch(
+            "src.memory.consolidator.add_memory",
+            side_effect=["vec-1", "vec-2"],
+        ):
+            await consolidate_session("s1")
+
+        memories = await memory_repository.list_memories(limit=5)
+        memories_by_kind = {memory.kind.value: memory for memory in memories}
+
+        assert memories_by_kind["collaborator"].summary == "Alice owns investor updates"
+        assert memories_by_kind["collaborator"].confidence == pytest.approx(0.92)
+        assert memories_by_kind["collaborator"].importance == pytest.approx(0.88)
+        assert memories_by_kind["collaborator"].metadata_json == (
+            '{"input_schema": "typed", "project_name": "Investor updates", '
+            '"source": "llm_extract", "subject_name": "Alice", "writer": "session_consolidation"}'
+        )
+        assert memories_by_kind["communication_preference"].summary == (
+            "Prefers concise morning briefings"
+        )
+        assert memories_by_kind["communication_preference"].confidence == pytest.approx(0.95)
+        assert memories_by_kind["communication_preference"].importance == pytest.approx(0.85)
 
     async def test_extracts_facts_uses_session_consolidation_runtime_path(self, async_db, sm):
         await sm.get_or_create("s1")

--- a/backend/tests/test_consolidator.py
+++ b/backend/tests/test_consolidator.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.db.models import MemoryKind
+from src.db.models import MemoryKind, MemorySnapshotKind
 from src.agent.session import SessionManager
 from src.memory.consolidator import consolidate_session
 from src.memory.repository import memory_repository
@@ -272,8 +272,49 @@ class TestConsolidateSession:
             and event["details"]["vector_memory_count"] == 1
             and event["details"]["partial_write_count"] == 1
             and event["details"]["write_failure_count"] == 0
+            and event["details"]["snapshot_refresh_failed"] is False
             for event in events
         )
+
+    async def test_consolidation_refreshes_bounded_snapshot(self, async_db, sm):
+        await sm.get_or_create("s1")
+        await sm.add_message("s1", "user", "Atlas launch is the active release project.")
+        await sm.add_message("s1", "assistant", "I will keep that project context in bounded recall.")
+
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = json.dumps({
+            "memories": [
+                {
+                    "text": "Atlas launch is the active release project.",
+                    "kind": "project",
+                    "summary": "Atlas launch",
+                    "confidence": 0.9,
+                    "importance": 0.88,
+                    "project": "Atlas",
+                }
+            ],
+            "facts": [],
+            "patterns": [],
+            "goals": [],
+            "reflections": [],
+            "soul_updates": {},
+        })
+
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ), patch("src.memory.consolidator.add_memory", return_value="vec-1"), patch(
+            "src.memory.consolidator.read_soul",
+            return_value="# Soul\n\n## Identity\nBuilder",
+        ):
+            await consolidate_session("s1")
+
+        snapshot = await memory_repository.get_snapshot(MemorySnapshotKind.bounded_guardian_context)
+
+        assert snapshot is not None
+        assert "Identity: Builder" in snapshot.content
+        assert "Atlas launch" in snapshot.content
 
     async def test_extracts_facts_uses_session_consolidation_runtime_path(self, async_db, sm):
         await sm.get_or_create("s1")

--- a/backend/tests/test_consolidator.py
+++ b/backend/tests/test_consolidator.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.db.models import MemoryKind
 from src.agent.session import SessionManager
 from src.memory.consolidator import consolidate_session
 from src.memory.repository import memory_repository
@@ -150,6 +151,8 @@ class TestConsolidateSession:
         assert memories_by_kind["collaborator"].summary == "Alice owns investor updates"
         assert memories_by_kind["collaborator"].confidence == pytest.approx(0.92)
         assert memories_by_kind["collaborator"].importance == pytest.approx(0.88)
+        assert memories_by_kind["collaborator"].subject_entity_id is not None
+        assert memories_by_kind["collaborator"].project_entity_id is not None
         assert memories_by_kind["collaborator"].metadata_json == (
             '{"input_schema": "typed", "project_name": "Investor updates", '
             '"source": "llm_extract", "subject_name": "Alice", "writer": "session_consolidation"}'
@@ -159,6 +162,118 @@ class TestConsolidateSession:
         )
         assert memories_by_kind["communication_preference"].confidence == pytest.approx(0.95)
         assert memories_by_kind["communication_preference"].importance == pytest.approx(0.85)
+
+    async def test_typed_project_and_commitment_keep_structured_kinds_but_link_vector_categories(self, async_db, sm):
+        await sm.get_or_create("s1")
+        await sm.add_message("s1", "user", "Atlas launch needs a project memory and a clear commitment.")
+        await sm.add_message("s1", "assistant", "I will store both the project and the commitment.")
+
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = json.dumps({
+            "memories": [
+                {
+                    "text": "Atlas launch is the current release project.",
+                    "kind": "project",
+                    "summary": "Atlas launch",
+                    "confidence": 0.91,
+                    "importance": 0.9,
+                    "project": "Atlas",
+                },
+                {
+                    "text": "Send the Atlas launch checklist before Friday.",
+                    "kind": "commitment",
+                    "summary": "Send Atlas checklist before Friday",
+                    "confidence": 0.88,
+                    "importance": 0.87,
+                    "project": "Atlas",
+                },
+            ],
+            "facts": [],
+            "patterns": [],
+            "goals": [],
+            "reflections": [],
+            "soul_updates": {},
+        })
+
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ), patch(
+            "src.memory.consolidator.add_memory",
+            side_effect=["vec-project", "vec-commitment"],
+        ) as mock_add_memory:
+            await consolidate_session("s1")
+
+        memories = await memory_repository.list_memories_by_kinds(
+            kinds=(MemoryKind.project, MemoryKind.commitment),
+            limit_per_kind=2,
+        )
+
+        project_memory = memories["project"][0]
+        commitment_memory = memories["commitment"][0]
+
+        assert project_memory.kind == MemoryKind.project
+        assert commitment_memory.kind == MemoryKind.commitment
+        assert project_memory.project_entity_id == commitment_memory.project_entity_id
+        assert project_memory.project_entity_id is not None
+        assert [call.kwargs["category"] for call in mock_add_memory.call_args_list] == ["fact", "goal"]
+
+    async def test_entity_link_failure_does_not_abort_consolidation(self, async_db, sm):
+        await sm.get_or_create("s1")
+        await sm.add_message("s1", "user", "Alice owns Atlas launch communications.")
+        await sm.add_message("s1", "assistant", "I will keep that collaborator memory.")
+
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = json.dumps({
+            "memories": [
+                {
+                    "text": "Alice owns Atlas launch communications.",
+                    "kind": "collaborator",
+                    "summary": "Alice owns Atlas launch communications",
+                    "confidence": 0.92,
+                    "importance": 0.85,
+                    "subject": "Alice",
+                    "project": "Atlas",
+                }
+            ],
+            "facts": [],
+            "patterns": [],
+            "goals": [],
+            "reflections": [],
+            "soul_updates": {},
+        })
+
+        with patch(
+            "src.memory.consolidator.completion_with_fallback",
+            AsyncMock(return_value=mock_resp),
+        ), patch(
+            "src.memory.consolidator.add_memory",
+            return_value="vec-1",
+        ), patch(
+            "src.memory.consolidator.resolve_memory_links",
+            AsyncMock(side_effect=RuntimeError("entity linking down")),
+        ):
+            await consolidate_session("s1")
+
+        memories = await memory_repository.list_memories(limit=5)
+
+        assert memories == []
+
+        from src.audit.repository import audit_repository
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "background_task_partially_succeeded"
+            and event["tool_name"] == "session_consolidation"
+            and event["session_id"] == "s1"
+            and event["details"]["stored_memory_count"] == 0
+            and event["details"]["vector_memory_count"] == 1
+            and event["details"]["partial_write_count"] == 1
+            and event["details"]["write_failure_count"] == 0
+            for event in events
+        )
 
     async def test_extracts_facts_uses_session_consolidation_runtime_path(self, async_db, sm):
         await sm.get_or_create("s1")

--- a/backend/tests/test_db_engine.py
+++ b/backend/tests/test_db_engine.py
@@ -1,28 +1,57 @@
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from src.db.engine import _ensure_legacy_columns
+from src.db.engine import _configure_sqlite_connection, _ensure_legacy_columns
 
 
-async def test_ensure_legacy_columns_adds_queued_insight_columns():
-    engine = create_async_engine("sqlite+aiosqlite://")
-    async with engine.begin() as conn:
-        await conn.exec_driver_sql(
-            """
-            CREATE TABLE queued_insights (
-                id VARCHAR PRIMARY KEY,
-                content VARCHAR NOT NULL,
-                intervention_type VARCHAR DEFAULT 'advisory',
-                urgency INTEGER DEFAULT 3,
-                reasoning VARCHAR DEFAULT '',
-                created_at VARCHAR
+async def test_ensure_legacy_columns_backfills_kind_from_category(tmp_path):
+    db_path = tmp_path / "legacy-memory.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    event.listen(engine.sync_engine, "connect", _configure_sqlite_connection)
+
+    try:
+        async with engine.begin() as conn:
+            await conn.exec_driver_sql(
+                """
+                CREATE TABLE memories (
+                    id VARCHAR PRIMARY KEY,
+                    content VARCHAR,
+                    category VARCHAR,
+                    source_session_id VARCHAR,
+                    embedding_id VARCHAR,
+                    created_at DATETIME
+                )
+                """
             )
-            """
-        )
-        await _ensure_legacy_columns(conn)
-        result = await conn.exec_driver_sql("PRAGMA table_info(queued_insights)")
-        columns = {row[1] for row in result.fetchall()}
+            await conn.exec_driver_sql(
+                """
+                INSERT INTO memories (id, content, category, source_session_id, embedding_id, created_at)
+                VALUES ('goal-1', 'Ship batch A', 'goal', 's1', NULL, '2026-03-25T00:00:00Z')
+                """
+            )
 
-    await engine.dispose()
+            await _ensure_legacy_columns(conn)
 
-    assert "intervention_id" in columns
-    assert "session_id" in columns
+            row = (
+                await conn.exec_driver_sql(
+                    "SELECT kind FROM memories WHERE id = 'goal-1'"
+                )
+            ).fetchone()
+            assert row is not None
+            assert row[0] == "goal"
+    finally:
+        await engine.dispose()
+
+
+async def test_sqlite_connection_enables_foreign_keys(tmp_path):
+    db_path = tmp_path / "fk-check.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    event.listen(engine.sync_engine, "connect", _configure_sqlite_connection)
+
+    try:
+        async with engine.connect() as conn:
+            row = (await conn.exec_driver_sql("PRAGMA foreign_keys")).fetchone()
+            assert row is not None
+            assert row[0] == 1
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -96,6 +96,10 @@ def test_main_lists_available_scenarios(capsys):
     assert "provider_routing_decision_audit" in captured.out
     assert "session_bound_llm_trace" in captured.out
     assert "session_consolidation_behavior" in captured.out
+    assert "memory_commitment_continuity_behavior" in captured.out
+    assert "memory_collaborator_lookup_behavior" in captured.out
+    assert "bounded_memory_snapshot_behavior" in captured.out
+    assert "memory_supersession_filter_behavior" in captured.out
     assert "scheduled_local_runtime_profile" in captured.out
     assert "daily_briefing_delivery_behavior" in captured.out
     assert "shell_tool_runtime_audit" in captured.out
@@ -200,6 +204,10 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "provider_routing_decision_audit",
                 "session_bound_llm_trace",
                 "session_consolidation_behavior",
+                "memory_commitment_continuity_behavior",
+                "memory_collaborator_lookup_behavior",
+                "bounded_memory_snapshot_behavior",
+                "memory_supersession_filter_behavior",
                 "scheduled_local_runtime_profile",
                 "daily_briefing_delivery_behavior",
                 "shell_tool_runtime_audit",
@@ -919,6 +927,23 @@ def test_runtime_eval_scenarios_expose_expected_details():
     ]
     assert details_by_name["session_consolidation_behavior"]["updated_soul_section"] == "Goals"
     assert details_by_name["session_consolidation_behavior"]["updated_soul_mentions_workspace"] is True
+    assert details_by_name["memory_commitment_continuity_behavior"]["baseline_bucket_excludes_linked_commitment"] is True
+    assert details_by_name["memory_commitment_continuity_behavior"]["baseline_context_excludes_linked_commitment"] is True
+    assert details_by_name["memory_commitment_continuity_behavior"]["linked_project_present"] is True
+    assert details_by_name["memory_commitment_continuity_behavior"]["memory_context_has_commitment"] is True
+    assert details_by_name["memory_collaborator_lookup_behavior"]["baseline_bucket_excludes_linked_collaborator"] is True
+    assert details_by_name["memory_collaborator_lookup_behavior"]["baseline_context_excludes_linked_collaborator"] is True
+    assert details_by_name["memory_collaborator_lookup_behavior"]["collaborator_present"] is True
+    assert details_by_name["memory_collaborator_lookup_behavior"]["memory_context_has_collaborator"] is True
+    assert details_by_name["memory_collaborator_lookup_behavior"]["active_projects_has_atlas"] is True
+    assert details_by_name["bounded_memory_snapshot_behavior"]["bounded_snapshot_is_stable_within_session"] is True
+    assert details_by_name["bounded_memory_snapshot_behavior"]["bounded_snapshot_includes_todo_overlay"] is True
+    assert details_by_name["bounded_memory_snapshot_behavior"]["bounded_snapshot_line_count"] <= 8
+    assert details_by_name["bounded_memory_snapshot_behavior"]["same_session_excludes_new_project"] is True
+    assert details_by_name["bounded_memory_snapshot_behavior"]["new_session_sees_new_project"] is True
+    assert details_by_name["bounded_memory_snapshot_behavior"]["new_session_uses_real_session_record"] is True
+    assert details_by_name["memory_supersession_filter_behavior"]["active_project_present"] is True
+    assert details_by_name["memory_supersession_filter_behavior"]["superseded_project_filtered"] is True
     assert details_by_name["scheduled_local_runtime_profile"]["runtime_profile"] == "local"
     assert details_by_name["scheduled_local_runtime_profile"]["routed_models"] == {
         "daily_briefing": "ollama/llama3.2",

--- a/backend/tests/test_guardian_state.py
+++ b/backend/tests/test_guardian_state.py
@@ -7,8 +7,10 @@ import pytest
 from src.agent.factory import create_agent
 from src.agent.session import SessionManager
 from src.agent.strategist import create_strategist_agent
+from src.db.models import MemoryKind
 from src.guardian.state import GuardianState, GuardianStateConfidence, build_guardian_state
 from src.guardian.world_model import GuardianWorldModel, build_guardian_world_model
+from src.memory.repository import memory_repository
 from src.observer.context import CurrentContext
 
 
@@ -195,6 +197,89 @@ async def test_build_guardian_state_lowers_overall_confidence_when_memory_is_deg
 
     assert state.confidence.memory == "degraded"
     assert state.confidence.overall == "partial"
+
+
+@pytest.mark.asyncio
+async def test_build_guardian_state_uses_structured_memory_kinds(async_db):
+    sm = SessionManager()
+    await sm.get_or_create("current")
+    await sm.add_message("current", "user", "What should I focus on next?")
+    await sm.add_message("current", "assistant", "Let me ground that in recent memory.")
+
+    await memory_repository.create_memory(
+        content="Review the Atlas brief tomorrow morning.",
+        kind=MemoryKind.commitment,
+        summary="Review the Atlas brief tomorrow morning",
+        importance=0.95,
+    )
+    await memory_repository.create_memory(
+        content="Atlas investor brief",
+        kind=MemoryKind.project,
+        summary="Atlas investor brief",
+        importance=0.9,
+    )
+    await memory_repository.create_memory(
+        content="Alice owns the investor update thread.",
+        kind=MemoryKind.collaborator,
+        summary="Alice owns investor updates",
+        importance=0.85,
+    )
+    await memory_repository.create_memory(
+        content="Weekly investor note goes out on Friday.",
+        kind=MemoryKind.obligation,
+        summary="Weekly investor note goes out on Friday",
+        importance=0.82,
+    )
+    await memory_repository.create_memory(
+        content="Atlas launch timeline ends on Friday.",
+        kind=MemoryKind.timeline,
+        summary="Atlas launch timeline ends on Friday",
+        importance=0.8,
+    )
+    await memory_repository.create_memory(
+        content="User prefers concise morning briefings.",
+        kind=MemoryKind.communication_preference,
+        summary="Prefers concise morning briefings",
+        importance=0.78,
+    )
+
+    ctx = CurrentContext(
+        time_of_day="morning",
+        day_of_week="Monday",
+        is_working_hours=True,
+        active_goals_summary="Prepare investor brief",
+        active_window="VS Code",
+        screen_context="Editing Atlas brief",
+        data_quality="good",
+        observer_confidence="grounded",
+        salience_level="high",
+        salience_reason="active_goals",
+        interruption_cost="low",
+    )
+
+    with (
+        patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+        patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
+        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.audit.repository.audit_repository.list_events", return_value=[]),
+        patch(
+            "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
+            return_value=["Guardian cockpit"],
+        ),
+        patch(
+            "src.guardian.feedback.guardian_feedback_repository.summarize_recent",
+            return_value="",
+        ),
+    ):
+        state = await build_guardian_state(session_id="current", user_message="What should I focus on next?")
+
+    assert "Review the Atlas brief tomorrow morning" in state.world_model.active_commitments
+    assert "Atlas investor brief" in state.world_model.active_projects
+    assert "Alice owns investor updates" in state.world_model.collaborators
+    assert "Weekly investor note goes out on Friday" in state.world_model.recurring_obligations
+    assert "Atlas launch timeline ends on Friday" in state.world_model.project_timeline
+    assert "Prefers concise morning briefings" in state.memory_context
+    assert "[commitment] Review the Atlas brief tomorrow morning" in state.memory_context
 
 
 def test_guardian_state_prompt_block_exposes_confidence_and_recent_sessions():

--- a/backend/tests/test_guardian_state.py
+++ b/backend/tests/test_guardian_state.py
@@ -1,6 +1,6 @@
 """Tests for explicit guardian-state synthesis."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -423,6 +423,210 @@ async def test_build_guardian_state_uses_unique_project_token_fallback_for_linke
 
     assert "Atlas launch" in state.world_model.active_projects
     assert "Send the Atlas checklist before Friday" in state.world_model.active_commitments
+
+
+@pytest.mark.asyncio
+async def test_build_guardian_state_uses_bounded_snapshot_with_todo_overlay(async_db):
+    sm = SessionManager()
+    await sm.get_or_create("current")
+    await sm.add_message("current", "user", "What should I focus on next?")
+    await sm.add_message("current", "assistant", "Let me ground that in bounded recall.")
+    await sm.replace_todos(
+        "current",
+        [
+            {"content": "Send the Atlas checklist", "completed": False},
+            {"content": "Review launch notes", "completed": True},
+        ],
+    )
+
+    await memory_repository.create_memory(
+        content="Atlas launch is the active release project.",
+        kind=MemoryKind.project,
+        summary="Atlas launch",
+        importance=0.9,
+    )
+    await memory_repository.create_memory(
+        content="User prefers concise morning briefings.",
+        kind=MemoryKind.communication_preference,
+        summary="Prefers concise morning briefings",
+        importance=0.8,
+    )
+
+    from src.memory.snapshots import refresh_bounded_guardian_snapshot
+
+    await refresh_bounded_guardian_snapshot(
+        soul_context="# Soul\n\n## Identity\nBuilder\n\n## Goals\n- Keep the system grounded",
+    )
+
+    ctx = CurrentContext(
+        time_of_day="morning",
+        day_of_week="Monday",
+        is_working_hours=True,
+        active_goals_summary="Support Atlas launch",
+        active_window="VS Code",
+        screen_context="Editing Atlas launch checklist",
+        data_quality="good",
+        observer_confidence="grounded",
+        salience_level="high",
+        salience_reason="active_goals",
+        interruption_cost="low",
+    )
+
+    with (
+        patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+        patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder\n\n## Goals\n- Keep the system grounded"),
+        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.audit.repository.audit_repository.list_events", return_value=[]),
+        patch(
+            "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
+            return_value=["Atlas"],
+        ),
+        patch(
+            "src.guardian.feedback.guardian_feedback_repository.summarize_recent",
+            return_value="",
+        ),
+    ):
+        state = await build_guardian_state(session_id="current", user_message="What should I focus on next?")
+
+    assert "Identity: Builder" in state.bounded_memory_context
+    assert "Atlas launch" in state.bounded_memory_context
+    assert "Prefers concise morning briefings" in state.bounded_memory_context
+    assert "Send the Atlas checklist" in state.bounded_memory_context
+    assert "Review launch notes" in state.bounded_memory_context
+
+
+@pytest.mark.asyncio
+async def test_build_guardian_state_recomputes_structured_bounded_memory_when_snapshot_load_fails(async_db):
+    sm = SessionManager()
+    await sm.get_or_create("current")
+    await sm.add_message("current", "user", "What should I focus on next?")
+    await sm.add_message("current", "assistant", "Let me ground that in bounded recall.")
+
+    await memory_repository.create_memory(
+        content="Atlas launch is the active release project.",
+        kind=MemoryKind.project,
+        summary="Atlas launch",
+        importance=0.9,
+    )
+    await memory_repository.create_memory(
+        content="User prefers concise morning briefings.",
+        kind=MemoryKind.communication_preference,
+        summary="Prefers concise morning briefings",
+        importance=0.8,
+    )
+
+    ctx = CurrentContext(
+        time_of_day="morning",
+        day_of_week="Monday",
+        is_working_hours=True,
+        active_goals_summary="Support Atlas launch",
+        active_window="VS Code",
+        screen_context="Editing Atlas launch checklist",
+        data_quality="good",
+        observer_confidence="grounded",
+        salience_level="high",
+        salience_reason="active_goals",
+        interruption_cost="low",
+    )
+
+    with (
+        patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+        patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
+        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.audit.repository.audit_repository.list_events", return_value=[]),
+        patch(
+            "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
+            return_value=["Atlas"],
+        ),
+        patch(
+            "src.guardian.feedback.guardian_feedback_repository.summarize_recent",
+            return_value="",
+        ),
+        patch(
+            "src.memory.snapshots.get_or_create_bounded_guardian_snapshot",
+            AsyncMock(side_effect=RuntimeError("snapshot unavailable")),
+        ),
+    ):
+        state = await build_guardian_state(session_id="current", user_message="What should I focus on next?")
+
+    assert "Identity: Builder" in state.bounded_memory_context
+    assert "Atlas launch" in state.bounded_memory_context
+    assert "Prefers concise morning briefings" in state.bounded_memory_context
+
+
+@pytest.mark.asyncio
+async def test_build_guardian_state_invalidates_bounded_snapshot_when_session_id_is_reused(async_db):
+    sm = SessionManager()
+    await sm.get_or_create("current")
+    await sm.add_message("current", "user", "What should I focus on next?")
+    await sm.add_message("current", "assistant", "Let me ground that in bounded recall.")
+
+    await memory_repository.create_memory(
+        content="Atlas launch is the active release project.",
+        kind=MemoryKind.project,
+        summary="Atlas launch",
+        importance=0.9,
+    )
+
+    ctx = CurrentContext(
+        time_of_day="morning",
+        day_of_week="Monday",
+        is_working_hours=True,
+        active_goals_summary="Support Atlas launch",
+        active_window="VS Code",
+        screen_context="Editing Atlas launch checklist",
+        data_quality="good",
+        observer_confidence="grounded",
+        salience_level="high",
+        salience_reason="active_goals",
+        interruption_cost="low",
+    )
+
+    with (
+        patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+        patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
+        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.audit.repository.audit_repository.list_events", return_value=[]),
+        patch(
+            "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
+            return_value=["Atlas"],
+        ),
+        patch(
+            "src.guardian.feedback.guardian_feedback_repository.summarize_recent",
+            return_value="",
+        ),
+    ):
+        first_state = await build_guardian_state(session_id="current", user_message="What should I focus on next?")
+
+    await memory_repository.create_memory(
+        content="Hermes budget memo is now active.",
+        kind=MemoryKind.project,
+        summary="Hermes budget memo",
+        importance=0.95,
+    )
+    await sm.delete("current")
+    await sm.get_or_create("current")
+    await sm.add_message("current", "user", "What should I focus on next?")
+    await sm.add_message("current", "assistant", "Let me ground that in bounded recall.")
+
+    with (
+        patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+        patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
+        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.audit.repository.audit_repository.list_events", return_value=[]),
+        patch(
+            "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
+            return_value=["Atlas"],
+        ),
+        patch(
+            "src.guardian.feedback.guardian_feedback_repository.summarize_recent",
+            return_value="",
+        ),
+    ):
+        second_state = await build_guardian_state(session_id="current", user_message="What should I focus on next?")
+
+    assert "Hermes budget memo" not in first_state.bounded_memory_context
+    assert "Hermes budget memo" in second_state.bounded_memory_context
 
 
 def test_guardian_state_prompt_block_exposes_confidence_and_recent_sessions():

--- a/backend/tests/test_guardian_state.py
+++ b/backend/tests/test_guardian_state.py
@@ -282,6 +282,149 @@ async def test_build_guardian_state_uses_structured_memory_kinds(async_db):
     assert "[commitment] Review the Atlas brief tomorrow morning" in state.memory_context
 
 
+@pytest.mark.asyncio
+async def test_build_guardian_state_pulls_project_linked_memories_for_active_project(async_db):
+    sm = SessionManager()
+    await sm.get_or_create("current")
+    await sm.add_message("current", "user", "What matters for Atlas right now?")
+    await sm.add_message("current", "assistant", "Let me ground that in active project memory.")
+
+    atlas = await memory_repository.get_or_create_entity(
+        canonical_name="Project Atlas",
+        entity_type="project",
+        aliases=["Atlas"],
+    )
+    alice = await memory_repository.get_or_create_entity(
+        canonical_name="Alice",
+        entity_type="person",
+    )
+
+    await memory_repository.create_memory(
+        content="Prepare the Hermes budget memo.",
+        kind=MemoryKind.commitment,
+        summary="Prepare the Hermes budget memo",
+        importance=0.99,
+    )
+    await memory_repository.create_memory(
+        content="Atlas launch is the active release project.",
+        kind=MemoryKind.project,
+        summary="Atlas launch",
+        importance=0.35,
+        project_entity_id=atlas.id,
+    )
+    await memory_repository.create_memory(
+        content="Send the Atlas checklist before Friday.",
+        kind=MemoryKind.commitment,
+        summary="Send the Atlas checklist before Friday",
+        importance=0.3,
+        project_entity_id=atlas.id,
+    )
+    await memory_repository.create_memory(
+        content="Alice owns Atlas launch communications.",
+        kind=MemoryKind.collaborator,
+        summary="Alice owns Atlas launch communications",
+        importance=0.25,
+        subject_entity_id=alice.id,
+        project_entity_id=atlas.id,
+    )
+
+    ctx = CurrentContext(
+        time_of_day="morning",
+        day_of_week="Monday",
+        is_working_hours=True,
+        active_goals_summary="Support Atlas launch",
+        active_window="VS Code",
+        screen_context="Editing Atlas release notes",
+        data_quality="good",
+        observer_confidence="grounded",
+        salience_level="high",
+        salience_reason="active_goals",
+        interruption_cost="low",
+    )
+
+    with (
+        patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+        patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
+        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.audit.repository.audit_repository.list_events", return_value=[]),
+        patch(
+            "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
+            return_value=["Atlas"],
+        ),
+        patch(
+            "src.guardian.feedback.guardian_feedback_repository.summarize_recent",
+            return_value="",
+        ),
+    ):
+        state = await build_guardian_state(session_id="current", user_message="What matters for Atlas right now?")
+
+    assert "Atlas launch" in state.world_model.active_projects
+    assert "Send the Atlas checklist before Friday" in state.world_model.active_commitments
+    assert "Alice owns Atlas launch communications" in state.world_model.collaborators
+    assert "[project] Atlas launch" in state.memory_context
+    assert "[commitment] Send the Atlas checklist before Friday" in state.memory_context
+
+
+@pytest.mark.asyncio
+async def test_build_guardian_state_uses_unique_project_token_fallback_for_linked_recall(async_db):
+    sm = SessionManager()
+    await sm.get_or_create("current")
+    await sm.add_message("current", "user", "What matters for Atlas today?")
+    await sm.add_message("current", "assistant", "Let me pull the Atlas-linked memory.")
+
+    atlas = await memory_repository.get_or_create_entity(
+        canonical_name="Atlas launch",
+        entity_type="project",
+    )
+    await memory_repository.create_memory(
+        content="Atlas launch is the active release project.",
+        kind=MemoryKind.project,
+        summary="Atlas launch",
+        importance=0.4,
+        project_entity_id=atlas.id,
+    )
+    await memory_repository.create_memory(
+        content="Send the Atlas checklist before Friday.",
+        kind=MemoryKind.commitment,
+        summary="Send the Atlas checklist before Friday",
+        importance=0.35,
+        project_entity_id=atlas.id,
+    )
+
+    ctx = CurrentContext(
+        time_of_day="morning",
+        day_of_week="Monday",
+        is_working_hours=True,
+        active_goals_summary="Support Atlas launch",
+        active_window="VS Code",
+        screen_context="Editing Atlas release notes",
+        data_quality="good",
+        observer_confidence="grounded",
+        salience_level="high",
+        salience_reason="active_goals",
+        interruption_cost="low",
+    )
+
+    with (
+        patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+        patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
+        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.audit.repository.audit_repository.list_events", return_value=[]),
+        patch(
+            "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
+            return_value=["Atlas"],
+        ),
+        patch(
+            "src.guardian.feedback.guardian_feedback_repository.summarize_recent",
+            return_value="",
+        ),
+    ):
+        state = await build_guardian_state(session_id="current", user_message="What matters for Atlas today?")
+
+    assert "Atlas launch" in state.world_model.active_projects
+    assert "Send the Atlas checklist before Friday" in state.world_model.active_commitments
+
+
 def test_guardian_state_prompt_block_exposes_confidence_and_recent_sessions():
     block = _make_guardian_state().to_prompt_block()
 

--- a/backend/tests/test_memory_linking.py
+++ b/backend/tests/test_memory_linking.py
@@ -1,0 +1,31 @@
+import pytest
+
+from src.db.models import MemoryKind
+from src.memory.linking import resolve_memory_links
+from src.memory.types import ConsolidatedMemoryItem, kind_to_category
+
+
+@pytest.mark.asyncio
+async def test_resolve_memory_links_does_not_merge_projects_on_shared_summary(async_db):
+    first = await resolve_memory_links(
+        ConsolidatedMemoryItem(
+            text="Send the weekly update for Mercury.",
+            kind=MemoryKind.commitment,
+            category=kind_to_category(MemoryKind.commitment),
+            summary="Send weekly update",
+            project_name="Project Mercury",
+        )
+    )
+    second = await resolve_memory_links(
+        ConsolidatedMemoryItem(
+            text="Send the weekly update for Apollo.",
+            kind=MemoryKind.commitment,
+            category=kind_to_category(MemoryKind.commitment),
+            summary="Send weekly update",
+            project_name="Project Apollo",
+        )
+    )
+
+    assert first.project_entity_id is not None
+    assert second.project_entity_id is not None
+    assert first.project_entity_id != second.project_entity_id

--- a/backend/tests/test_memory_repository.py
+++ b/backend/tests/test_memory_repository.py
@@ -1,0 +1,132 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from src.db.models import MemoryEdgeType, MemoryEntityType, MemoryKind, MemorySnapshotKind
+from src.memory.repository import memory_repository
+
+
+@pytest.mark.asyncio
+async def test_create_memory_persists_structured_fields(async_db):
+    result = await memory_repository.create_memory(
+        content="User prefers concise status updates.",
+        category="preference",
+        kind=MemoryKind.communication_preference,
+        source_session_id="sess-1",
+        summary="Prefers concise updates",
+        confidence=0.9,
+        importance=0.8,
+        reinforcement=1.2,
+        metadata={"writer": "test"},
+    )
+
+    memories = await memory_repository.list_memories(limit=5)
+
+    assert result.memory_id
+    assert len(memories) == 1
+    assert memories[0].kind == MemoryKind.communication_preference
+    assert memories[0].summary == "Prefers concise updates"
+    assert memories[0].confidence == pytest.approx(0.9)
+    assert memories[0].importance == pytest.approx(0.8)
+    assert memories[0].reinforcement == pytest.approx(1.2)
+    assert memories[0].source_session_id == "sess-1"
+    assert memories[0].metadata_json == '{"writer": "test"}'
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_entity_merges_aliases(async_db):
+    first = await memory_repository.get_or_create_entity(
+        canonical_name="Project Atlas",
+        entity_type=MemoryEntityType.project,
+        aliases=["Atlas"],
+    )
+    second = await memory_repository.get_or_create_entity(
+        canonical_name="Project Atlas",
+        entity_type=MemoryEntityType.project,
+        aliases=["Atlas", "The Atlas rewrite"],
+    )
+
+    assert first.id == second.id
+    assert second.aliases_json == '["Atlas", "The Atlas rewrite"]'
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_entity_normalizes_case_and_alias_matches(async_db):
+    first = await memory_repository.get_or_create_entity(
+        canonical_name="Project Atlas",
+        entity_type=MemoryEntityType.project,
+        aliases=["Atlas"],
+    )
+    second = await memory_repository.get_or_create_entity(
+        canonical_name="project atlas",
+        entity_type=MemoryEntityType.project,
+    )
+    third = await memory_repository.get_or_create_entity(
+        canonical_name="Atlas",
+        entity_type=MemoryEntityType.project,
+        aliases=["Project Atlas"],
+    )
+
+    assert first.id == second.id == third.id
+
+
+@pytest.mark.asyncio
+async def test_create_memory_rejects_invalid_kind(async_db):
+    with pytest.raises(ValueError, match="Invalid MemoryKind"):
+        await memory_repository.create_memory(
+            content="Broken kind",
+            kind="commmitment",
+        )
+
+
+@pytest.mark.asyncio
+async def test_save_snapshot_upserts_by_kind(async_db):
+    first = await memory_repository.save_snapshot(
+        kind=MemorySnapshotKind.bounded_guardian_context,
+        content="- Identity: Builder",
+        source_hash="abc",
+    )
+    second = await memory_repository.save_snapshot(
+        kind=MemorySnapshotKind.bounded_guardian_context,
+        content="- Identity: Builder\n- Goal memory: Ship batch A",
+        source_hash="def",
+    )
+    stored = await memory_repository.get_snapshot(MemorySnapshotKind.bounded_guardian_context)
+
+    assert first.id == second.id
+    assert stored is not None
+    assert stored.content.endswith("Ship batch A")
+    assert stored.source_hash == "def"
+
+
+@pytest.mark.asyncio
+async def test_create_edge_persists_structured_relationship(async_db):
+    first = await memory_repository.create_memory(
+        content="Prepare the Atlas investor brief.",
+        kind=MemoryKind.commitment,
+    )
+    second = await memory_repository.create_memory(
+        content="Investor brief belongs to Project Atlas.",
+        kind=MemoryKind.project,
+    )
+
+    edge = await memory_repository.create_edge(
+        from_memory_id=first.memory_id,
+        to_memory_id=second.memory_id,
+        edge_type=MemoryEdgeType.supports,
+        metadata={"writer": "test"},
+    )
+
+    assert edge.from_memory_id == first.memory_id
+    assert edge.to_memory_id == second.memory_id
+    assert edge.edge_type == MemoryEdgeType.supports
+    assert edge.metadata_json == '{"writer": "test"}'
+
+
+@pytest.mark.asyncio
+async def test_create_memory_rejects_unknown_entity_links(async_db):
+    with pytest.raises(IntegrityError):
+        await memory_repository.create_memory(
+            content="Orphan collaborator link",
+            kind=MemoryKind.collaborator,
+            subject_entity_id="missing-entity",
+        )

--- a/backend/tests/test_memory_repository.py
+++ b/backend/tests/test_memory_repository.py
@@ -162,3 +162,68 @@ async def test_list_memories_by_kinds_groups_richer_memory_types(async_db):
     assert grouped["commitment"][0].content == "Review the Atlas brief tomorrow morning."
     assert grouped["collaborator"][0].content == "Alice owns the investor update thread."
     assert grouped["communication_preference"][0].content == "Prefers concise morning briefings."
+
+
+@pytest.mark.asyncio
+async def test_find_entities_by_names_matches_aliases(async_db):
+    atlas = await memory_repository.get_or_create_entity(
+        canonical_name="Project Atlas",
+        entity_type=MemoryEntityType.project,
+        aliases=["Atlas"],
+    )
+
+    resolved = await memory_repository.find_entities_by_names(
+        names=("Atlas", "Project Atlas", "Unknown"),
+        entity_type=MemoryEntityType.project,
+    )
+
+    assert resolved["Atlas"].id == atlas.id
+    assert resolved["Project Atlas"].id == atlas.id
+    assert "Unknown" not in resolved
+
+
+@pytest.mark.asyncio
+async def test_find_entities_by_names_supports_unique_project_token_fallback(async_db):
+    atlas = await memory_repository.get_or_create_entity(
+        canonical_name="Atlas launch",
+        entity_type=MemoryEntityType.project,
+    )
+
+    resolved = await memory_repository.find_entities_by_names(
+        names=("Atlas",),
+        entity_type=MemoryEntityType.project,
+    )
+
+    assert resolved["Atlas"].id == atlas.id
+
+
+@pytest.mark.asyncio
+async def test_list_memories_for_entities_supports_project_filters(async_db):
+    atlas = await memory_repository.get_or_create_entity(
+        canonical_name="Project Atlas",
+        entity_type=MemoryEntityType.project,
+        aliases=["Atlas"],
+    )
+    other = await memory_repository.get_or_create_entity(
+        canonical_name="Project Hermes",
+        entity_type=MemoryEntityType.project,
+    )
+    await memory_repository.create_memory(
+        content="Review the Atlas brief tomorrow morning.",
+        kind=MemoryKind.commitment,
+        project_entity_id=atlas.id,
+        importance=0.9,
+    )
+    await memory_repository.create_memory(
+        content="Review the Hermes brief next week.",
+        kind=MemoryKind.commitment,
+        project_entity_id=other.id,
+        importance=0.95,
+    )
+
+    linked = await memory_repository.list_memories_for_entities(
+        project_entity_ids=(atlas.id,),
+        kinds=(MemoryKind.commitment,),
+    )
+
+    assert [memory.content for memory in linked] == ["Review the Atlas brief tomorrow morning."]

--- a/backend/tests/test_memory_repository.py
+++ b/backend/tests/test_memory_repository.py
@@ -130,3 +130,35 @@ async def test_create_memory_rejects_unknown_entity_links(async_db):
             kind=MemoryKind.collaborator,
             subject_entity_id="missing-entity",
         )
+
+
+@pytest.mark.asyncio
+async def test_list_memories_by_kinds_groups_richer_memory_types(async_db):
+    await memory_repository.create_memory(
+        content="Review the Atlas brief tomorrow morning.",
+        kind=MemoryKind.commitment,
+        importance=0.9,
+    )
+    await memory_repository.create_memory(
+        content="Alice owns the investor update thread.",
+        kind=MemoryKind.collaborator,
+        importance=0.8,
+    )
+    await memory_repository.create_memory(
+        content="Prefers concise morning briefings.",
+        kind=MemoryKind.communication_preference,
+        importance=0.7,
+    )
+
+    grouped = await memory_repository.list_memories_by_kinds(
+        kinds=(
+            MemoryKind.commitment,
+            MemoryKind.collaborator,
+            MemoryKind.communication_preference,
+        ),
+        limit_per_kind=1,
+    )
+
+    assert grouped["commitment"][0].content == "Review the Atlas brief tomorrow morning."
+    assert grouped["collaborator"][0].content == "Alice owns the investor update thread."
+    assert grouped["communication_preference"][0].content == "Prefers concise morning briefings."

--- a/backend/tests/test_memory_snapshots.py
+++ b/backend/tests/test_memory_snapshots.py
@@ -1,0 +1,102 @@
+import pytest
+
+from src.db.models import MemoryKind, MemorySnapshotKind
+from src.memory.repository import memory_repository
+from src.memory.snapshots import (
+    get_or_create_bounded_guardian_snapshot,
+    refresh_bounded_guardian_snapshot,
+)
+
+
+@pytest.mark.asyncio
+async def test_refresh_bounded_guardian_snapshot_persists_structured_summary(async_db):
+    await memory_repository.create_memory(
+        content="Ship Batch A memory upgrades.",
+        kind=MemoryKind.goal,
+        summary="Ship Batch A memory upgrades",
+        importance=0.95,
+    )
+    await memory_repository.create_memory(
+        content="Atlas launch is the active release project.",
+        kind=MemoryKind.project,
+        summary="Atlas launch",
+        importance=0.9,
+    )
+    await memory_repository.create_memory(
+        content="User prefers concise morning briefings.",
+        kind=MemoryKind.communication_preference,
+        summary="Prefers concise morning briefings",
+        importance=0.85,
+    )
+
+    snapshot = await refresh_bounded_guardian_snapshot(
+        soul_context=(
+            "# Soul\n\n## Identity\nBuilder\n\n## Goals\n- Keep the system grounded\n\n"
+            "## Personality Notes\n- Prefer direct wording"
+        ),
+    )
+    stored = await memory_repository.get_snapshot(MemorySnapshotKind.bounded_guardian_context)
+
+    assert snapshot.content == stored.content
+    assert "Identity: Builder" in snapshot.content
+    assert "Ship Batch A memory upgrades" in snapshot.content
+    assert "Atlas launch" in snapshot.content
+    assert "Prefers concise morning briefings" in snapshot.content
+    assert snapshot.source_hash == stored.source_hash
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_bounded_guardian_snapshot_reuses_stored_snapshot(async_db):
+    await memory_repository.create_memory(
+        content="Atlas launch is the active release project.",
+        kind=MemoryKind.project,
+        summary="Atlas launch",
+        importance=0.9,
+    )
+    await memory_repository.save_snapshot(
+        kind=MemorySnapshotKind.bounded_guardian_context,
+        content="- Identity: Stale snapshot",
+        source_hash="cached-hash",
+    )
+
+    content = await get_or_create_bounded_guardian_snapshot(
+        soul_context="# Soul\n\n## Identity\nBuilder\n\n## Goals\n- Keep the system grounded",
+    )
+
+    assert "Identity: Builder" in content
+    assert "Atlas launch" in content
+    assert "Stale snapshot" not in content
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_bounded_guardian_snapshot_freezes_content_per_session(async_db):
+    await memory_repository.create_memory(
+        content="Atlas launch is the active release project.",
+        kind=MemoryKind.project,
+        summary="Atlas launch",
+        importance=0.9,
+    )
+
+    initial = await get_or_create_bounded_guardian_snapshot(
+        soul_context="# Soul\n\n## Identity\nBuilder",
+        session_id="session-a",
+    )
+    await memory_repository.create_memory(
+        content="Hermes budget memo is now active.",
+        kind=MemoryKind.project,
+        summary="Hermes budget memo",
+        importance=0.95,
+    )
+
+    frozen = await get_or_create_bounded_guardian_snapshot(
+        soul_context="# Soul\n\n## Identity\nBuilder",
+        session_id="session-a",
+    )
+    fresh = await get_or_create_bounded_guardian_snapshot(
+        soul_context="# Soul\n\n## Identity\nBuilder",
+        session_id="session-b",
+    )
+
+    assert frozen == initial
+    assert "Hermes budget memo" not in frozen
+    assert "Hermes budget memo" in fresh

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -438,6 +438,56 @@ See [Capability Import Wave 2](./12-capability-import-wave-2.md) for the impleme
 36. [x] `capability-cleanup-and-legacy-path-removal-v1`:
     remove transitional seams and legacy compatibility paths once the imported capability families are first-class, stable parts of Seraph’s architecture
 
+## Next Guardian Memory Upgrade Program
+
+This is the next major Guardian Intelligence execution program after the current first-pass world-model fusion, bounded memory layer, and learning-policy foundations.
+
+- the target product shape is defined in [14. Seraph Memory SOTA Roadmap](/research/seraph-memory-sota-roadmap)
+- [Workstream 05](./05-guardian-intelligence.md) summarizes the shipped-state gap and the same batch structure from the workstream perspective
+- each numbered item below is a PR-sized slice
+- the program is intentionally organized into dependency-ordered batches instead of one flat queue because the substrate, retrieval, and learning layers should land in sequence
+
+### Batch A: Structured memory foundation
+
+1. [x] `memory-eval-harness-v1`:
+   add deterministic memory eval coverage for recall, contradiction, commitment continuity, collaborator lookup, and bounded-cost memory behavior before major architecture rewrites begin
+2. [x] `typed-memory-schema-v1`:
+   introduce structured SQLite-backed memory tables for typed memory items, entities, sources, edges, and snapshots while keeping LanceDB as the vector backend
+3. [x] `memory-kinds-and-provenance-v1`:
+   replace coarse memory categories with richer typed kinds plus confidence, importance, and last-confirmed provenance metadata so durable memory becomes more than text blobs
+4. [x] `entity-and-project-linking-v1`:
+   add conservative collaborator, project, routine, obligation, and commitment linking so guardian continuity stops depending on plain-text matching alone
+5. [x] `bounded-memory-snapshots-v1`:
+   generate compact session-start memory snapshots from structured state so always-on guardian context stays cheap, stable, and explicit
+
+### Batch B: Episodic and observer-driven retrieval
+
+6. [ ] `episodic-memory-events-v1`:
+   store typed episodic records for important conversation, workflow, tool, and decision boundaries so recall can reason over time instead of only semantic similarity
+7. [ ] `observer-episodic-fusion-v1`:
+   write observer project, focus, and activity transitions into episodic memory with conservative salience rules and clear provenance
+8. [ ] `session-search-fts-and-event-index-v1`:
+   upgrade session recall from plain text matching to FTS-backed session and event search with better bounded summaries
+9. [ ] `hybrid-memory-retrieval-v1`:
+   add lexical plus vector retrieval, reranking, recency weighting, and project or entity boosts across structured semantic memory and episodic memory
+10. [ ] `guardian-state-retrieval-planner-v1`:
+    route guardian-state synthesis between bounded, episodic, semantic, and procedural retrieval lanes instead of issuing one generic memory search
+
+### Batch C: Learning, consolidation, and decay
+
+11. [ ] `memory-flush-lifecycle-hooks-v1`:
+    add durable-memory flush triggers at session end, near compaction, and key workflow boundaries so important context is promoted before it collapses
+12. [ ] `multi-stage-memory-consolidation-v1`:
+    replace one-shot extraction with staged capture, extract, merge, strengthen, and source-backed write logic so long-term memory becomes updateable
+13. [ ] `soul-projection-and-structured-profile-v1`:
+    move durable identity state underneath the current soul surface so `soul.md` becomes a human-readable projection rather than the only identity substrate
+14. [ ] `procedural-memory-from-outcomes-v1`:
+    store timing, phrasing, channel, and interruption lessons from intervention outcomes as explicit procedural memory instead of leaving them as thin policy heuristics
+15. [ ] `memory-decay-contradiction-and-archive-v1`:
+    add reinforcement, contradiction, supersession, and archive rules so stale or invalid memory stops accumulating forever
+16. [ ] `guardian-memory-behavioral-evals-v1`:
+    prove the new memory behavior with deterministic tests covering contradiction cleanup, adaptation quality, retrieval planning, and bounded-cost recall
+
 ## Delivery Order
 
 1. Trust Boundaries

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -209,6 +209,12 @@ This section records the internal Batch A slices on the feature branch before th
   - deferred to later slices:
     - guardian-state recall still does not consume subject-side entity ids, only project-linked ids
     - richer entity-driven retrieval beyond active-project boosts belongs in the later hybrid retrieval planner work
+  - aggregate PR follow-up:
+    - external PR review caught that project linking was also injecting memory summaries as project aliases, which could merge unrelated projects that share generic summaries
+    - fixed on the branch by removing summary-derived aliases from project entity creation and adding a regression test that proves two projects with the same summary still resolve to different project entities
+    - subagent recheck:
+      - reviewer: `Volta` (`019d24d3-df48-7700-9943-e69cbfaf93aa`)
+      - result: no material findings after the alias-removal fix, regression test, and wording update
 
 ### `bounded-memory-snapshots-v1`
 

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -6,7 +6,7 @@
 
 ## Paired Research
 
-- primary design docs: [01. Guardian Thesis](/research/guardian-thesis), [02. Human Model And Memory](/research/human-model-and-memory), and [11. Superiority Program](/research/superiority-program)
+- primary design docs: [01. Guardian Thesis](/research/guardian-thesis), [02. Human Model And Memory](/research/human-model-and-memory), [11. Superiority Program](/research/superiority-program), and [14. Seraph Memory SOTA Roadmap](/research/seraph-memory-sota-roadmap)
 - synthesis context: [00. Research Synthesis](/research)
 
 ## Shipped On `develop`
@@ -42,6 +42,82 @@
 - [ ] stronger learning loops based on intervention outcomes beyond the first multi-signal delivery/channel/escalation plus phrasing/cadence/timing/suppression/blocked-state/thread layer
 - [ ] stronger salience calibration and confidence quality beyond the first aligned-work/high-salience pass
 - [ ] stronger linkage between guardian state, execution choices, and feedback-driven policy adaptation
+
+## Next Memory Upgrade Program
+
+The canonical PR queue for the upgraded memory system lives in [00. Master Roadmap](./00-master-roadmap.md).
+
+The delivery shape should stay split into three implementation batches:
+
+### Batch A: Structured memory foundation
+
+- `memory-eval-harness-v1`
+- `typed-memory-schema-v1`
+- `memory-kinds-and-provenance-v1`
+- `entity-and-project-linking-v1`
+- `bounded-memory-snapshots-v1`
+
+### Batch B: Episodic and observer-driven retrieval
+
+- `episodic-memory-events-v1`
+- `observer-episodic-fusion-v1`
+- `session-search-fts-and-event-index-v1`
+- `hybrid-memory-retrieval-v1`
+- `guardian-state-retrieval-planner-v1`
+
+### Batch C: Learning, consolidation, and decay
+
+- `memory-flush-lifecycle-hooks-v1`
+- `multi-stage-memory-consolidation-v1`
+- `soul-projection-and-structured-profile-v1`
+- `procedural-memory-from-outcomes-v1`
+- `memory-decay-contradiction-and-archive-v1`
+- `guardian-memory-behavioral-evals-v1`
+
+The batch split is the right implementation shape because the dependencies are real:
+
+- Batch A creates the durable typed substrate
+- Batch B turns sessions and observer signals into usable episodic recall
+- Batch C makes that memory updateable, policy-relevant, and behaviorally testable
+
+Each Batch A internal slice should close with:
+
+- targeted validation commands
+- a subagent review pass for bugs, regressions, and misleading claims
+- a short implementation log entry in this document before the slice is treated as complete
+
+## Batch A Branch Review Log
+
+This section records the internal Batch A slices on the feature branch before the aggregate GitHub PR is opened.
+
+### `typed-memory-schema-v1`
+
+- status: complete on `feat/memory-batch-a-v1`, pending inclusion in the aggregate Batch A PR
+- scope:
+  - added structured SQLite memory tables and enums for typed memories, entities, sources, edges, and snapshots
+  - added `memory_repository` CRUD helpers for entities, memories, edges, and snapshots
+  - made session consolidation dual-write into the structured store while keeping the existing vector path alive
+  - enabled SQLite foreign-key enforcement in both runtime and test engines
+- validation:
+  - `python3 -m py_compile backend/src/db/engine.py backend/src/db/models.py backend/src/memory/repository.py backend/src/memory/consolidator.py backend/tests/conftest.py backend/tests/test_db_engine.py backend/tests/test_memory_repository.py backend/tests/test_consolidator.py backend/tests/test_consolidation_reliability.py`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_consolidator.py -q`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_db_engine.py backend/tests/test_memory_repository.py backend/tests/test_consolidation_reliability.py backend/tests/test_vector_store.py backend/tests/test_guardian_state.py -q`
+- subagent review:
+  - reviewer: `Euclid` (`019d24ad-f0fa-7700-af86-85b79cd7aea5`)
+  - initial findings:
+    - legacy `category -> kind` backfill was missing
+    - dual-write inconsistencies were reported as clean success
+    - SQLite foreign keys were declared but not enforced
+    - the substrate exposed richer kinds and links than the live writer actually used
+  - fixed before commit:
+    - backfilled legacy `kind` values from `category`
+    - changed consolidation audit outcome to `background_task_partially_succeeded` when vector and structured writes diverge
+    - added foreign-key PRAGMA setup to runtime and tests
+    - added tests for legacy backfill, partial-success audit reporting, and enforced entity links
+  - deferred to later Batch A slices:
+    - richer memory kinds beyond the legacy four writer buckets
+    - entity and project linking in the live writer
+    - bounded snapshot generation and consumption
 
 ## Non-Goals
 

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -134,13 +134,53 @@ This section records the internal Batch A slices on the feature branch before th
 - review notes:
   - local regression caught and fixed before commit:
     - project-memory enrichment briefly leaked execution-pressure lines into `world_model.active_projects`; the final slice keeps those lines in `project_state` while `active_projects` stays project-only
-  - subagent review attempts:
-    - requested from `Ptolemy` (`019d24c7-9a43-7860-8b66-b5d77adc3187`)
-    - requested from `Dalton` (`019d24c9-0610-7102-a84f-a58874fb38f9`)
-    - both review agents timed out within the turn window, so this slice currently relies on local validation plus the explicit regression fix above
+  - subagent review:
+    - reviewer: `Ptolemy` (`019d24c7-9a43-7860-8b66-b5d77adc3187`)
+    - findings:
+      - caught the `project_state` / `active_projects` regression while guardian-state tests were failing
+      - flagged that richer kinds still collapse through the vector category lane, so only the structured bundle preserves typed recall behavior for now
+    - fixed before the slice stayed marked complete:
+      - separated `active_project_signals` from `project_state` so execution-pressure lines stay out of `active_projects`
+  - secondary review:
+    - reviewer: `Dalton` (`019d24c9-0610-7102-a84f-a58874fb38f9`)
+    - findings:
+      - confirmed the structured-memory bundle does change runtime behavior even though the vector layer still uses coarse categories
+      - requested a typed `commitment` / `project` test to prove structured kinds survive while vector writes keep coarse categories
+    - fixed after review:
+      - added a typed project-and-commitment consolidation test that proves structured `kind` values are preserved while vector writes still route through coarse `fact` / `goal` categories
   - deferred to later Batch A slices:
     - project/entity linking still relies on names embedded in metadata, not real entity ids
+    - the vector recall path still uses coarse categories until Batch B hybrid retrieval work lands
     - bounded snapshot generation still does not project this richer memory into a stable session-start snapshot
+
+### `entity-and-project-linking-v1`
+
+- status: complete on `feat/memory-batch-a-v1`, pending inclusion in the aggregate Batch A PR
+- scope:
+  - added `backend/src/memory/linking.py` to resolve conservative subject and project entity links during typed consolidation writes
+  - extended `memory_repository` with exact or alias entity resolution plus linked-memory lookup by project or subject ids
+  - upgraded guardian-state synthesis to boost project-linked structured memories for currently active projects instead of relying only on global importance ordering
+  - kept the runtime claim narrow: subject-side entity ids are now stored, but live guardian recall currently consumes project-linked recall only
+- validation:
+  - `python3 -m py_compile backend/src/memory/linking.py backend/src/memory/repository.py backend/src/memory/consolidator.py backend/src/guardian/state.py backend/tests/test_memory_repository.py backend/tests/test_consolidator.py backend/tests/test_guardian_state.py`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_memory_repository.py backend/tests/test_consolidator.py backend/tests/test_guardian_state.py -q`
+- subagent review:
+  - reviewer: `Volta` (`019d24d3-df48-7700-9943-e69cbfaf93aa`)
+  - initial findings:
+    - entity linking had moved outside the per-item structured-write fault boundary, which would have let a single link failure abort the whole consolidation run
+    - the runtime slice only consumes project-linked recall today, so broader “entity recall” wording would overstate what is live
+    - the original tests proved project-link persistence but not the collaborator subject-link path
+    - project-linked recall could still fragment when a project memory landed without an explicit `project` field and the observer only exposed a shorter active-project token
+  - fixed before the slice stayed marked complete:
+    - moved `resolve_memory_links(...)` back inside the per-item structured-write `try` block so link failures are counted as partial writes instead of aborting the whole run
+    - added a consolidation test that forces entity-link failure and proves the audit outcome stays `background_task_partially_succeeded`
+    - added collaborator-link assertions so subject and project ids are both exercised in tests
+    - added a conservative unique project-token fallback in entity resolution plus a guardian-state test that proves `Atlas` can still resolve linked memories stored under `Atlas launch` when that match is unique
+  - final recheck:
+    - no remaining high-severity issue was found after the fault-isolation and unique-project-fallback fixes
+  - deferred to later slices:
+    - guardian-state recall still does not consume subject-side entity ids, only project-linked ids
+    - richer entity-driven retrieval beyond active-project boosts belongs in the later hybrid retrieval planner work
 
 ## Non-Goals
 

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -182,6 +182,34 @@ This section records the internal Batch A slices on the feature branch before th
     - guardian-state recall still does not consume subject-side entity ids, only project-linked ids
     - richer entity-driven retrieval beyond active-project boosts belongs in the later hybrid retrieval planner work
 
+### `bounded-memory-snapshots-v1`
+
+- status: complete on `feat/memory-batch-a-v1`, pending inclusion in the aggregate Batch A PR
+- scope:
+  - added `backend/src/memory/snapshots.py` to build a compact bounded guardian snapshot from soul identity plus structured memory kinds
+  - refreshes that snapshot after consolidation so durable semantic changes project into the always-on guardian prefix without rebuilding it ad hoc every call
+  - changed guardian-state synthesis to use a session-frozen bounded snapshot plus a live todo overlay, with structured-memory recomputation as the degraded fallback if snapshot load or save fails
+  - keyed the in-process session freeze by session lifecycle (`session_id + created_at`) so reused session ids do not keep serving stale bounded recall
+- validation:
+  - `python3 -m py_compile backend/src/memory/snapshots.py backend/src/memory/consolidator.py backend/src/guardian/state.py backend/tests/conftest.py backend/tests/test_memory_snapshots.py backend/tests/test_consolidator.py backend/tests/test_guardian_state.py`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_memory_snapshots.py backend/tests/test_consolidator.py backend/tests/test_guardian_state.py -q`
+- subagent review:
+  - reviewer: `Laplace` (`019d24da-bfeb-7360-8b3a-6e9bcef8fcb7`)
+  - initial findings:
+    - the first cut reused one global snapshot blindly, so it was neither fresh on new sessions nor stable against unrelated snapshot churn
+    - the degraded path fell back to soul-only lines and silently dropped structured bounded recall when snapshot IO failed
+    - the first session-freeze pass still needed an invalidation path for reused session ids in the same process
+  - fixed before the slice stayed marked complete:
+    - `get_or_create_bounded_guardian_snapshot(...)` now recomputes source hash against live soul and structured memory, refreshes stale global snapshots, and freezes the resolved content per session
+    - guardian-state fallback now recomputes bounded recall from structured memory via `render_bounded_guardian_snapshot(...)` instead of collapsing to soul-only memory
+    - the session cache key now includes the session lifecycle (`created_at`) so deleting and recreating the same session id invalidates the frozen snapshot
+    - added tests for stale snapshot refresh, per-session freeze, session-id reuse invalidation, consolidation-triggered snapshot refresh, and structured-memory fallback when snapshot load fails
+  - final recheck:
+    - no remaining high-severity or medium-severity issue was reported after the session-lifecycle and degraded-fallback fixes
+  - deferred to later slices:
+    - snapshot promotion still runs from consolidation boundaries; broader lifecycle hooks near compaction and workflow boundaries belong in the later flush-lifecycle slice
+    - bounded snapshot contents are still semantic-only and do not yet include procedural memory or episodic recall planning
+
 ## Non-Goals
 
 - marketing “guardian intelligence” before the learning loop is real

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -90,6 +90,34 @@ Each Batch A internal slice should close with:
 
 This section records the internal Batch A slices on the feature branch before the aggregate GitHub PR is opened.
 
+### `memory-eval-harness-v1`
+
+- status: complete on `feat/memory-batch-a-v1`, pending inclusion in the aggregate Batch A PR
+- scope:
+  - expanded `backend/src/evals/harness.py` with deterministic memory-behavior scenarios for linked commitment recall, linked collaborator recall, bounded snapshot stability, and supersession filtering
+  - taught the eval harness DB patch helpers about `src.memory.repository.get_session` and cleared the bounded snapshot cache around each scenario so the new memory scenarios run in isolated process state
+  - updated the existing session-consolidation evals so they still represent a clean successful dual-write path under the new structured-memory substrate instead of tripping `partially_succeeded` from mock-only vector writes
+  - extended `backend/tests/test_eval_harness.py` so the aggregate runtime-eval contracts now assert the new memory scenario details directly
+- validation:
+  - `backend/.venv/bin/python -m py_compile backend/src/evals/harness.py backend/tests/test_eval_harness.py`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_eval_harness.py::test_run_runtime_evals_passes_all_scenarios -q`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_eval_harness.py::test_runtime_eval_scenarios_expose_expected_details -q`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_eval_harness.py -q`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_memory_repository.py backend/tests/test_consolidator.py backend/tests/test_guardian_state.py backend/tests/test_memory_snapshots.py backend/tests/test_eval_harness.py -q`
+- subagent review:
+  - reviewer: `Zeno` (`019d24e8-51f8-7402-b24e-82c872dd4813`)
+  - initial findings:
+    - the first linked commitment and collaborator scenarios could still pass from the generic structured kind buckets, so they did not actually prove the project-linked recall path
+    - the first bounded snapshot scenario built the “new session” state without creating that session first, so it could fall back to the global snapshot lane instead of exercising real per-session freezing
+    - the compactness check was measured before later memory changes landed, which made the “remains compact after later changes” claim weaker than intended
+  - fixed before the slice stayed marked complete:
+    - seeded higher-importance unrelated commitments and collaborators, captured a baseline no-active-project structured bundle, and then asserted the Atlas-linked items only reappear once active-project linking is in play
+    - created a real `snapshot-new` session before the fresh-state build and asserted that the scenario uses an actual session record
+    - moved the bounded line-count check to the post-change states so the compactness contract is evaluated after later memory writes land
+    - narrowed the commitment-continuity scenario description so it now claims only the memory-context recall behavior that the eval actually proves
+  - final recheck:
+    - no remaining material issue was found after the linked-recall proof, real-session snapshot path, and wording fixes
+
 ### `typed-memory-schema-v1`
 
 - status: complete on `feat/memory-batch-a-v1`, pending inclusion in the aggregate Batch A PR

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -119,6 +119,29 @@ This section records the internal Batch A slices on the feature branch before th
     - entity and project linking in the live writer
     - bounded snapshot generation and consumption
 
+### `memory-kinds-and-provenance-v1`
+
+- status: complete on `feat/memory-batch-a-v1`, pending inclusion in the aggregate Batch A PR
+- scope:
+  - added `backend/src/memory/types.py` to normalize kind/category mapping, bucket mapping, and consolidation payload parsing
+  - upgraded session consolidation to accept typed memory objects with kind, summary, confidence, importance, and last-confirmed provenance while remaining backward-compatible with the legacy four lists
+  - started feeding richer structured memory kinds into guardian state and the world model instead of dropping everything back to coarse vector categories
+- validation:
+  - `python3 -m py_compile backend/src/memory/types.py backend/src/memory/consolidator.py backend/src/memory/repository.py backend/src/guardian/state.py backend/src/guardian/world_model.py backend/tests/test_memory_repository.py backend/tests/test_consolidator.py backend/tests/test_guardian_state.py`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_memory_repository.py backend/tests/test_consolidator.py backend/tests/test_guardian_state.py -q`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_consolidation_reliability.py -q`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_guardian_state.py backend/tests/test_consolidator.py backend/tests/test_memory_repository.py backend/tests/test_consolidation_reliability.py -q`
+- review notes:
+  - local regression caught and fixed before commit:
+    - project-memory enrichment briefly leaked execution-pressure lines into `world_model.active_projects`; the final slice keeps those lines in `project_state` while `active_projects` stays project-only
+  - subagent review attempts:
+    - requested from `Ptolemy` (`019d24c7-9a43-7860-8b66-b5d77adc3187`)
+    - requested from `Dalton` (`019d24c9-0610-7102-a84f-a58874fb38f9`)
+    - both review agents timed out within the turn window, so this slice currently relies on local validation plus the explicit regression fix above
+  - deferred to later Batch A slices:
+    - project/entity linking still relies on names embedded in metadata, not real entity ids
+    - bounded snapshot generation still does not project this richer memory into a stable session-start snapshot
+
 ## Non-Goals
 
 - marketing “guardian intelligence” before the learning loop is real

--- a/docs/research/14-seraph-memory-sota-roadmap.md
+++ b/docs/research/14-seraph-memory-sota-roadmap.md
@@ -1,0 +1,952 @@
+---
+title: 14. Seraph Memory SOTA Roadmap
+---
+
+# 14. Seraph Memory SOTA Roadmap
+
+## Goal
+
+Define a research-backed plan for turning Seraph's memory system from a solid foundation into a genuinely best-in-class guardian memory stack.
+
+This document answers:
+
+- what Hermes and OpenClaw each get right about memory
+- what recent memory research changes the design target
+- where Seraph's current memory stack is structurally limited
+- what target architecture Seraph should build instead
+- how to implement that target in realistic phases inside this repo
+
+## Scope And Clarification
+
+In this document, `Hermes` means the **Nous Research Hermes Agent** memory system documented in early 2026, not Seraph's internal `Hermes Session Memory` extension pack.
+
+This file is about **memory architecture**, not only retrieval quality. For Seraph, the real objective is:
+
+- better recall
+- better continuity
+- better intervention timing
+- better adaptation to the human
+- lower online token cost
+- stronger provenance and safer forgetting
+
+## Executive Summary
+
+Seraph should not try to beat Hermes by making one bigger prompt block, and it should not try to beat OpenClaw by only adding better search knobs.
+
+The winning design is:
+
+1. keep a **Hermes-like bounded memory layer** for cheap, always-on context
+2. add an **OpenClaw-like hybrid retrieval layer** for precise recall
+3. adopt a **LightMem-style layered pipeline** with online filtering and offline consolidation
+4. add a **MemoryBank-style reinforcement and decay model** so memory quality improves over time instead of only growing
+5. add a **MemGPT-style tiered memory manager** so Seraph explicitly decides what stays in prompt, what stays searchable, and what stays archived
+6. make the core memory unit a **typed, source-backed claim/event/entity record**, not a flat text blob
+
+If Seraph does that well, it can surpass both reference systems because it has one advantage they do not use as deeply: observer context, project state, intervention outcomes, and guardian policy can all feed the memory system.
+
+## Evidence Base
+
+### Official product/system references
+
+- Hermes Agent memory docs:
+  - https://hermes-agent.nousresearch.com/docs/user-guide/features/memory/
+- OpenClaw memory docs:
+  - https://github.com/openclaw/openclaw/blob/main/docs/concepts/memory.md
+
+### Primary research sources
+
+- MemoryBank: Enhancing Large Language Models with Long-Term Memory
+  - arXiv:2305.10250
+  - https://arxiv.org/abs/2305.10250
+- MemGPT: Towards LLMs as Operating Systems
+  - submitted October 12, 2023; revised February 12, 2024
+  - arXiv:2310.08560
+  - https://arxiv.org/abs/2310.08560
+- Evaluating Very Long-Term Conversational Memory of LLM Agents
+  - submitted February 27, 2024
+  - arXiv:2402.17753
+  - https://arxiv.org/abs/2402.17753
+- LightMem: Lightweight and Efficient Memory-Augmented Generation
+  - submitted October 21, 2025; revised February 28, 2026
+  - arXiv:2510.18866
+  - https://arxiv.org/abs/2510.18866
+
+### Current Seraph implementation surfaces reviewed
+
+- `backend/src/memory/vector_store.py`
+- `backend/src/memory/consolidator.py`
+- `backend/src/memory/soul.py`
+- `backend/src/guardian/state.py`
+- `backend/src/guardian/world_model.py`
+- `backend/src/tools/session_search_tool.py`
+- `backend/src/agent/session.py`
+- `backend/config/settings.py`
+- `docs/research/02-human-model-and-memory.md`
+
+## What Hermes Gets Right
+
+Hermes is not trying to build the deepest possible memory graph. It is trying to build **fast, bounded, useful memory that actually stays in use**.
+
+Key strengths:
+
+- two sharply defined stores:
+  - `MEMORY.md` for environment, project, and agent notes
+  - `USER.md` for user identity and preferences
+- both stores are small enough to remain prompt-friendly
+- the memory block is frozen at session start, which preserves prefix-cache efficiency
+- memory edits are agent-managed and persisted immediately
+- `session_search` is clearly separated from persistent memory
+- the docs are explicit about what should be saved versus skipped
+- the memory layer is security-scanned because it is prompt-injected
+
+The important lesson for Seraph is not "copy two markdown files." The lesson is:
+
+- bounded memory should be a first-class product surface
+- always-on memory should be curated, not auto-expanded without limit
+- active-session performance matters
+- memory and session recall should be separate tools with separate cost profiles
+
+## What OpenClaw Gets Right
+
+OpenClaw's memory direction is stronger on retrieval engineering than Hermes.
+
+Key strengths called out in the official docs:
+
+- semantic vector index over memory notes
+- optional hybrid search combining lexical and vector retrieval
+- MMR diversity reranking
+- temporal decay
+- optional advanced sidecar retrieval backends
+- pre-compaction "memory flush" so durable memory is written before context collapses
+
+The important lesson for Seraph is:
+
+- memory quality depends on write timing as much as retrieval
+- semantic recall alone is not enough
+- lexical, temporal, and diversity-aware signals materially help
+- memory should be updated at lifecycle boundaries, not only after the whole session
+
+## What Recent Research Changes
+
+### MemoryBank
+
+MemoryBank's lasting contribution is not the exact architecture. It is the idea that long-term memory should be **reinforced, forgotten, and updated over time**.
+
+What matters for Seraph:
+
+- memory entries should have reinforcement strength
+- stale, unconfirmed, or contradicted memory should decay
+- memory should not be treated as permanent truth once written
+
+### MemGPT
+
+MemGPT frames memory as **explicit tier management**. That is highly relevant to Seraph.
+
+What matters for Seraph:
+
+- fast prompt memory and slow external memory must be treated as different tiers
+- the system should decide what gets promoted or paged into context
+- context pressure is a memory-management problem, not only a summarization problem
+
+### LoCoMo
+
+LoCoMo is useful because it shows that long-context and naive RAG are still weak on:
+
+- temporal reasoning
+- causal reasoning
+- multi-session continuity
+- remembering who did what when
+
+For Seraph, this means "bigger context" is not the answer. Seraph needs structured episodic memory with time, source, and entity links.
+
+### LightMem
+
+LightMem is the most directly applicable current template.
+
+What matters for Seraph:
+
+- three-stage memory is effective:
+  - sensory filtering
+  - short-term topical organization
+  - long-term offline consolidation
+- offline consolidation dramatically lowers online cost
+- memory architecture should be measured on both quality and efficiency
+
+## Current Seraph Assessment
+
+Seraph already has a real memory stack, but it is still a first-generation one.
+
+### What exists today
+
+- a `soul.md` identity record
+- a LanceDB vector table for long-term text memories
+- a background consolidation pass after sessions
+- a token-aware conversation summarizer
+- a bounded recall summary built from soul plus todos
+- session search over prior conversations
+- a guardian world model that tries to consume memory-derived signals
+
+### Current strengths
+
+- Seraph already thinks in terms of guardian state and world model, not only retrieval
+- Seraph has observer context and intervention feedback, which are excellent future memory inputs
+- Seraph already distinguishes some memory categories
+- Seraph already has a place where memory affects downstream decision-making
+
+### Current architectural limitations
+
+#### 1. Flat memory records
+
+The vector store schema is only:
+
+- `id`
+- `text`
+- `category`
+- `source_session_id`
+- `vector`
+- `created_at`
+
+That is too thin for SOTA memory. It cannot represent:
+
+- confidence
+- provenance beyond one session id
+- affected entity or project
+- whether the item is an event or stable fact
+- contradiction state
+- importance or reinforcement
+- validity interval
+- user-facing privacy sensitivity
+
+#### 2. One-shot extraction writer
+
+The main writer path is one extraction prompt over the last 30 messages. It returns lists of strings in a few coarse categories. That is better than nothing, but it is not enough for durable high-quality memory.
+
+Current missing steps:
+
+- entity linking
+- merge/update logic
+- contradiction detection
+- reinforcement scoring
+- project/thread assignment
+- event extraction
+- observer/tool-output fusion
+
+#### 3. Soul is not a structured model
+
+The soul file is useful as a product artifact, but it is currently a markdown overwrite surface rather than a structured user-model projection.
+
+The target should be:
+
+- structured underlying model
+- markdown or prompt view generated from that model
+
+#### 4. Retrieval is mostly single-shot semantic recall
+
+`build_guardian_state()` mainly issues one memory search from the current user message and turns the result into lines of text.
+
+That misses several important retrieval modes:
+
+- "what happened last week?"
+- "what do we know about this collaborator?"
+- "what commitments are still open?"
+- "what intervention style has worked recently?"
+- "what project is this likely about?"
+
+#### 5. Session search is still a narrow text search lane
+
+The current session search is useful, but it is not yet:
+
+- FTS-based
+- hybrid lexical/semantic
+- event-aware
+- summarization-aware
+- thread- or entity-aware
+
+#### 6. World-model slots are underfed
+
+The world model already has slots like:
+
+- `collaborators`
+- `recurring_obligations`
+- `project_timeline`
+- `active_routines`
+
+But the memory writer does not reliably generate those categories, so the world model is often trying to reason from sparse hints instead of well-formed structured memory.
+
+## Design Principles For Seraph Memory V2
+
+### 1. Memory should optimize behavior, not storage volume
+
+The right test is not "did Seraph store more things?" The right test is:
+
+- did Seraph interrupt better?
+- did Seraph remember commitments correctly?
+- did Seraph adapt to the user's real preferences?
+- did Seraph make fewer repeated mistakes?
+
+### 2. Every memory should have a type
+
+At minimum, Seraph should distinguish:
+
+- `episodic_event`
+- `semantic_fact`
+- `preference`
+- `goal_or_commitment`
+- `routine`
+- `constraint`
+- `collaborator`
+- `project`
+- `timeline_milestone`
+- `intervention_outcome`
+- `communication_preference`
+- `tool_or_workflow_lesson`
+
+### 3. Every durable memory should have provenance
+
+No durable item should exist without:
+
+- source session/message ids or source event ids
+- creation time
+- last confirmation time
+- writer path
+- confidence
+
+### 4. Memory should support update, not only append
+
+Seraph needs first-class:
+
+- create
+- merge
+- strengthen
+- weaken
+- contradict
+- supersede
+- archive
+- forget
+
+### 5. Online and offline memory work should be separated
+
+Online path:
+
+- fast
+- bounded
+- low-latency
+- focused on current thread and immediate recall
+
+Offline path:
+
+- richer extraction
+- cross-session synthesis
+- contradiction cleanup
+- timeline building
+- pattern learning
+
+## Target Architecture
+
+## Layer 1: Bounded Working Memory
+
+This is Seraph's always-on session-start snapshot.
+
+It should include only the highest-value, low-volatility state:
+
+- user identity summary
+- stable communication preferences
+- active projects
+- active collaborators
+- open commitments
+- known recurring constraints
+- current thread summary
+- top routines and intervention guidance
+
+This layer should stay compact and deterministic. Hermes is right here.
+
+Implementation rule:
+
+- build this snapshot from structured state
+- do not make it the source of truth
+- regenerate it at session start and on explicit refresh boundaries
+
+## Layer 2: Episodic Memory
+
+This stores timestamped events and observations:
+
+- conversation events
+- commitments made
+- decisions made
+- tasks completed
+- meetings referenced
+- observed screen/project transitions
+- important tool outcomes
+- interventions sent and feedback received
+
+This layer must be:
+
+- time-aware
+- source-aware
+- queryable by entity, project, and thread
+
+This is what LoCoMo exposes as difficult and what Seraph needs for real continuity.
+
+## Layer 3: Semantic Memory
+
+This stores generalized stable knowledge about the human and their environment:
+
+- preferences
+- project facts
+- collaborator relationships
+- recurring obligations
+- routines
+- known constraints
+- durable values and goals
+
+This layer should be synthesized from episodic evidence plus direct user statements.
+
+## Layer 4: Procedural Memory
+
+This stores what kinds of actions work.
+
+Examples:
+
+- direct interruption during meetings is poorly received
+- async native delivery works better for blocked-state nudges
+- daily planning nudges are effective in the morning but not late evening
+- user responds better to brief literal phrasing than reflective framing
+
+Seraph already has the beginning of this in guardian feedback learning. That should become a first-class memory layer instead of an isolated signal.
+
+## Layer 5: Soul / Narrative Projection
+
+Keep `soul.md`, but change its role.
+
+The soul should become:
+
+- a human-readable narrative projection of the structured model
+- editable with review controls
+- not the only durable source of identity data
+
+In other words:
+
+- structured user model underneath
+- soul as curated export and operator-facing reflection layer
+
+## Retrieval Architecture
+
+Seraph should stop doing one generic memory search for every situation.
+
+### Retrieval planner
+
+Before retrieval, classify the request:
+
+- thread continuity
+- factual user preference
+- project continuity
+- historical event lookup
+- commitment status
+- intervention policy
+- general recall
+
+Then route to one or more retrievers.
+
+### Retrieval modes
+
+#### 1. Bounded snapshot retrieval
+
+Use for:
+
+- most normal turns
+- low-latency response setup
+- prefix-cache friendly context
+
+#### 2. Episodic search
+
+Use:
+
+- FTS5 lexical search over prior sessions and extracted events
+- vector retrieval over episodic summaries
+- time filters
+- project/entity filters
+- recency decay
+
+#### 3. Semantic retrieval
+
+Use:
+
+- entity- and category-aware retrieval
+- confidence-aware ranking
+- contradiction-aware filtering
+- reinforcement-weighted ranking
+
+#### 4. Procedural retrieval
+
+Use:
+
+- guardian feedback outcomes
+- successful and unsuccessful intervention history
+- context-conditioned policy hints
+
+### Ranking formula
+
+Seraph does not need the exact same formula as OpenClaw, but it should combine:
+
+- semantic relevance
+- lexical relevance
+- recency
+- reinforcement strength
+- confidence
+- source diversity
+- entity/project match
+- contradiction penalty
+
+MMR should be used to avoid returning five near-duplicates.
+
+## Write / Consolidation Pipeline
+
+### Stage A: Sensory filtering
+
+On each important turn or event boundary, create cheap candidate memory units from:
+
+- user messages
+- assistant commitments
+- tool outputs
+- observer snapshots
+- intervention outcomes
+
+Discard low-value noise quickly.
+
+This is the LightMem lesson.
+
+### Stage B: Online short-term organization
+
+Maintain a rolling session-local working set:
+
+- active thread summary
+- current project guesses
+- named entities mentioned this session
+- candidate commitments
+- candidate preferences
+
+This layer is not yet durable unless promoted.
+
+### Stage C: Offline long-term consolidation
+
+At session end, near compaction, and on periodic background jobs:
+
+- merge related candidates
+- detect contradictions
+- create or update semantic records
+- write episodic timeline entries
+- update procedural memory from intervention outcomes
+- regenerate bounded snapshot sources
+- refresh the soul projection if needed
+
+### Stage D: Reinforcement and decay
+
+Every time a memory is:
+
+- reused successfully
+- reconfirmed by the user
+- contradicted
+- ignored for a long period
+
+update its strength score.
+
+This prevents immortal low-quality memory.
+
+## Proposed Data Model
+
+Seraph should keep SQLite plus LanceDB, but give them clearer roles.
+
+### SQLite as source of truth
+
+Use SQLite and SQLModel tables for:
+
+- typed memory metadata
+- entities
+- edges/relationships
+- episodic events
+- source links
+- FTS indexes
+- reinforcement and contradiction state
+
+### LanceDB as vector index
+
+Use LanceDB only for:
+
+- vector embeddings
+- ANN search
+- optional multimodal embeddings later
+
+### Recommended tables
+
+- `memory_entities`
+  - people, projects, orgs, routines, locations, channels
+- `memory_items`
+  - one typed durable memory record
+- `memory_item_sources`
+  - links from each durable item to sessions, messages, observer events, audit events
+- `memory_events`
+  - episodic timeline units
+- `memory_edges`
+  - relations such as `works_on`, `blocked_by`, `collaborates_with`, `prefers`, `supersedes`
+- `memory_feedback`
+  - reinforcement, contradiction, confirmation, archival actions
+- `memory_snapshots`
+  - generated bounded prompt snapshots and soul projections
+
+### Recommended `memory_items` fields
+
+- `id`
+- `kind`
+- `subject_entity_id`
+- `project_entity_id`
+- `thread_id`
+- `canonical_text`
+- `summary_text`
+- `confidence`
+- `importance`
+- `reinforcement`
+- `contradicted`
+- `superseded_by`
+- `valid_from`
+- `valid_to`
+- `first_seen_at`
+- `last_seen_at`
+- `last_confirmed_at`
+- `privacy_level`
+- `status`
+- `embedding_id`
+
+## Concrete Implementation Plan
+
+## Phase 0: Measurement First
+
+Before major rewrites, define memory evals.
+
+Add:
+
+- recall QA over prior sessions
+- commitment continuity evals
+- collaborator and project recall evals
+- contradiction cleanup evals
+- intervention adaptation evals
+- latency and token-cost measurements
+
+Suggested location:
+
+- `backend/src/evals/memory/`
+- `backend/tests/test_memory_*.py`
+
+Without this, Seraph can add complexity without proving improvement.
+
+## Phase 1: Introduce structured memory metadata
+
+Keep current vector search alive, but add structured tables.
+
+Implementation steps:
+
+1. Add new SQLModel tables in `backend/src/db/models.py`
+2. Add migration support for the new tables
+3. Create `backend/src/memory/repository.py` for CRUD and query logic
+4. Keep `vector_store.py` temporarily as the vector backend
+5. Make every new memory insert write both:
+   - structured row in SQLite
+   - vector row in LanceDB
+
+Exit criteria:
+
+- old flows still work
+- new memory can carry provenance, confidence, and typed kind
+
+## Phase 2: Replace coarse categories with typed memory kinds
+
+Expand beyond the current categories.
+
+Implementation steps:
+
+1. Define enums or string constants in a new `backend/src/memory/types.py`
+2. Update consolidation output schema
+3. Update retrieval filters and guardian-state grouping
+4. Map old `fact/preference/pattern/goal/reflection` into richer kinds during migration
+
+Important note:
+
+The current world model already expects richer categories. This phase should align the writer and the consumer.
+
+## Phase 3: Build entity extraction and linking
+
+Seraph needs explicit entities.
+
+Implementation steps:
+
+1. Add `backend/src/memory/entity_linker.py`
+2. Extract people, projects, organizations, routines, and channels from:
+   - user messages
+   - session summaries
+   - observer project signals
+   - audit/tool outcomes
+3. Link memory items to these entities
+4. Add conservative merge rules so "OpenAI API project" and "the API project" can resolve to one entity when confidence is high
+
+Exit criteria:
+
+- project continuity and collaborator recall stop relying on plain text matching
+
+## Phase 4: Build hybrid retrieval
+
+This is the OpenClaw lesson applied to Seraph's richer model.
+
+Implementation steps:
+
+1. Add FTS5-backed lexical search for:
+   - session messages
+   - episodic event summaries
+   - semantic memory texts
+2. Add a retrieval planner in `backend/src/memory/retrieval_planner.py`
+3. Add specialized retrievers:
+   - `episodic_retriever.py`
+   - `semantic_retriever.py`
+   - `procedural_retriever.py`
+   - `bounded_snapshot_retriever.py`
+4. Add reranking with:
+   - recency decay
+   - MMR
+   - entity/project match boosts
+   - contradiction penalty
+
+Exit criteria:
+
+- `build_guardian_state()` uses retrieval plans instead of one generic query
+
+## Phase 5: Rebuild consolidation around multi-stage memory writing
+
+The current `consolidator.py` should evolve into a pipeline.
+
+Recommended split:
+
+- `backend/src/memory/pipeline/capture.py`
+- `backend/src/memory/pipeline/extract.py`
+- `backend/src/memory/pipeline/link.py`
+- `backend/src/memory/pipeline/merge.py`
+- `backend/src/memory/pipeline/strengthen.py`
+- `backend/src/memory/pipeline/projectors.py`
+
+Implementation behavior:
+
+- capture candidate facts, events, commitments, preferences, routines
+- attach provenance
+- compare against existing memory
+- merge or supersede when appropriate
+- update reinforcement and contradiction state
+- only then write durable memory
+
+Exit criteria:
+
+- durable memory becomes updatable, not append-only
+
+## Phase 6: Move soul to a projected view
+
+Do not delete `soul.md`. Change its role.
+
+Implementation steps:
+
+1. Add structured identity/profile records to SQLite
+2. Generate `soul.md` from those records plus curated narrative sections
+3. Preserve manual editing, but add review or reconciliation logic so manual edits become structured updates rather than raw overwrite
+
+Exit criteria:
+
+- soul remains human-readable
+- structured memory becomes the canonical substrate
+
+## Phase 7: Add compaction and milestone memory flushes
+
+This is the OpenClaw lesson that Seraph should adopt quickly.
+
+Trigger flushes on:
+
+- near context compression
+- workflow completion
+- explicit task completion
+- session end
+- significant observer state transitions
+
+Implementation steps:
+
+1. add flush hooks around conversation compaction and workflow lifecycle
+2. run a lightweight durable-write pass
+3. write only high-salience items
+
+Exit criteria:
+
+- important commitments are less likely to be lost before session end
+
+## Phase 8: Add procedural memory from intervention outcomes
+
+This is Seraph's biggest chance to be better than the reference systems.
+
+Implementation steps:
+
+1. turn existing guardian feedback signals into explicit procedural memory rows
+2. condition them on context:
+   - user state
+   - interruption mode
+   - channel
+   - urgency
+   - time of day
+3. retrieve them in guardian-state synthesis and delivery planning
+
+Exit criteria:
+
+- timing and phrasing decisions improve from actual outcomes, not only hand-written rules
+
+## Phase 9: Add decay, contradiction, and archive policies
+
+Implementation steps:
+
+1. define memory strengths and thresholds
+2. lower strength when a memory goes stale or is contradicted
+3. archive low-confidence or superseded memory
+4. keep archived items searchable for forensic debugging but excluded from default recall
+
+Exit criteria:
+
+- Seraph stops accumulating unbounded stale memory debt
+
+## Recommended File-Level Changes
+
+### Existing files to refactor
+
+- `backend/src/memory/vector_store.py`
+  - narrow this into a pure vector backend
+- `backend/src/memory/consolidator.py`
+  - replace one large prompt path with staged pipeline calls
+- `backend/src/memory/soul.py`
+  - convert into read/write projection helpers plus reconciliation logic
+- `backend/src/guardian/state.py`
+  - replace single generic retrieval with retrieval planner and structured bundle assembly
+- `backend/src/tools/session_search_tool.py`
+  - switch from plain SQL `LIKE` search to FTS5 plus semantic summary path
+- `backend/src/agent/session.py`
+  - add richer session/event indexing helpers
+
+### New modules to add
+
+- `backend/src/memory/types.py`
+- `backend/src/memory/repository.py`
+- `backend/src/memory/entity_linker.py`
+- `backend/src/memory/retrieval_planner.py`
+- `backend/src/memory/retrievers/`
+- `backend/src/memory/pipeline/`
+- `backend/src/memory/snapshots.py`
+- `backend/src/memory/decay.py`
+- `backend/src/memory/merge.py`
+
+## Retrieval Context Shape For Agents
+
+Instead of only injecting:
+
+- `Relevant memories:`
+
+Seraph should inject a structured bundle like:
+
+- bounded snapshot
+- active commitments
+- active collaborators
+- project continuity
+- recent relevant episodes
+- known user preferences
+- learned communication guidance
+- confidence and contradiction warnings
+
+This should make the agent's prompt less noisy and more legible.
+
+## Safety, Privacy, And Trust
+
+To be world-class, the memory system must also be safer.
+
+Requirements:
+
+- memory sensitivity labels
+- prompt-injection scanning for prompt-injected memory surfaces
+- secret-pattern scanning before durable writes
+- explicit rules for what should never enter long-term memory
+- user-facing inspection and deletion tools
+- audit trail for memory creation and mutation
+
+Missing today:
+
+- first-class delete/update/forget surface for long-term vector memory
+- contradiction state
+- privacy classes on memory records
+
+## Evaluation Plan
+
+Seraph should not call the new memory system better until it wins on measured outcomes.
+
+### Core eval buckets
+
+- recall accuracy
+  - preferences, collaborators, projects, routines, commitments
+- temporal accuracy
+  - who/what/when questions over prior sessions
+- contradiction handling
+  - outdated preference replacement
+- guardian adaptation
+  - phrasing/timing/channel adjustments after feedback
+- efficiency
+  - prompt token cost
+  - retrieval latency
+  - consolidation cost
+
+### Suggested benchmark mix
+
+- external:
+  - LoCoMo-style long-conversation memory tasks
+- internal:
+  - Seraph-native guardian continuity tasks
+  - project handoff tasks
+  - repeated interrupted-work tasks
+  - intervention acceptance and rejection loops
+
+## Non-Goals
+
+This roadmap does not recommend:
+
+- storing every message forever in prompt-visible memory
+- replacing all existing Seraph memory with one giant knowledge graph immediately
+- relying only on embeddings as the solution
+- trying to solve multimodal memory before typed textual memory is solid
+
+## Proposed Build Order
+
+If implementation starts now, the highest-leverage order is:
+
+1. evals
+2. structured metadata tables
+3. richer memory kinds
+4. entity linking
+5. hybrid retrieval
+6. multi-stage consolidation
+7. soul projection
+8. compaction flush
+9. procedural memory learning
+10. decay and contradiction cleanup
+
+This order preserves current functionality while moving toward a much stronger architecture.
+
+## Bottom Line
+
+Hermes shows that bounded curated memory is right.
+OpenClaw shows that hybrid retrieval and lifecycle-triggered writes are right.
+MemoryBank, MemGPT, LoCoMo, and LightMem show that tiering, decay, episodic structure, and offline consolidation are necessary.
+
+Seraph can beat all of them if it builds:
+
+- bounded prompt memory
+- typed episodic and semantic memory
+- procedural guardian memory from outcomes
+- retrieval planning instead of one generic search
+- reinforcement, contradiction, and decay
+- evals tied to real guardian behavior
+
+That is the path from "persistent memory" to real guardian intelligence.

--- a/docs/sidebars.research.ts
+++ b/docs/sidebars.research.ts
@@ -13,6 +13,7 @@ const sidebars: SidebarsConfig = {
     'ecosystem-and-delegation',
     'plugin-system-and-mcp-strategy',
     'hermes-and-openclaw-capability-import-plan',
+    'seraph-memory-sota-roadmap',
     'reference-systems-and-evidence',
     'competitive-benchmark',
     'superiority-program',


### PR DESCRIPTION
## Done on develop
- [x] first-pass guardian state and world-model synthesis are already live
- [x] legacy session consolidation plus LanceDB-backed semantic memory recall are already live
- [x] first-pass bounded guardian context scaffolding exists and this PR upgrades it into a typed, session-frozen layer

## Working in this PR
- [x] add the structured SQLite memory substrate for typed memories, entities, sources, edges, and snapshots while keeping vector writes alive
- [x] add richer memory kinds, provenance metadata, and guardian-state consumption of structured memory
- [x] add conservative project and subject linking plus active-project linked recall
- [x] add bounded guardian snapshots with session freezing and structured degraded fallback
- [x] add deterministic Batch A memory eval coverage and record every internal slice review in the implementation docs

## Still to do after this PR
- [ ] Batch B: episodic events, observer fusion, FTS session search, hybrid retrieval, and the guardian retrieval planner
- [ ] Batch C: lifecycle flush hooks, consolidation and decay, contradiction handling, and procedural-memory learning loops
- [ ] broader subject-driven retrieval beyond the current active-project linked recall path

## Validation
- backend/.venv/bin/python -m py_compile backend/src/evals/harness.py backend/tests/test_eval_harness.py
- backend/.venv/bin/python -m pytest backend/tests/test_eval_harness.py::test_run_runtime_evals_passes_all_scenarios -q
- backend/.venv/bin/python -m pytest backend/tests/test_eval_harness.py::test_runtime_eval_scenarios_expose_expected_details -q
- backend/.venv/bin/python -m pytest backend/tests/test_eval_harness.py -q
- backend/.venv/bin/python -m pytest backend/tests/test_memory_repository.py backend/tests/test_consolidator.py backend/tests/test_guardian_state.py backend/tests/test_memory_snapshots.py backend/tests/test_eval_harness.py -q
- cd docs && npm run build
- internal slice subagent review completed for Euclid, Ptolemy, Dalton, Volta, Laplace, and Zeno; detailed review log is in docs/implementation/05-guardian-intelligence.md
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v -> 1191 passed, 34 failed in non-Batch-A areas (approvals, runtime-audit/context propagation, scheduler/jobs, and related workflow surfaces); representative failures include tests/test_agent.py::TestAgentFactory::test_get_tools_wraps_execute_code_for_approval, tests/test_chat_api.py::TestChatAPI::test_chat_approval_required, tests/test_context_window.py::TestSummaryCache::test_cache_miss_logs_runtime_audit_success, and tests/test_scheduled_jobs.py::test_execute_scheduled_job_delivers_message
