### PR TITLE
Complete Batch B guardian memory retrieval

### DIFF
--- a/backend/src/agent/session.py
+++ b/backend/src/agent/session.py
@@ -13,7 +13,14 @@ from config.settings import settings
 from src.approval.runtime import reset_runtime_context, set_runtime_context
 from src.audit.runtime import log_background_task_event
 from src.db.engine import get_session
-from src.db.models import MemoryEpisode, Message, ScheduledJob, Session, SessionTodo
+from src.db.models import (
+    MemoryEpisode,
+    MemoryEpisodeType,
+    Message,
+    ScheduledJob,
+    Session,
+    SessionTodo,
+)
 from src.memory.episodes import build_message_episode
 
 logger = logging.getLogger(__name__)
@@ -304,6 +311,48 @@ class SessionManager:
                     snippet_chars=snippet_chars,
                 ),
                 "source": "message",
+                "rank": 1.0,
+            }
+
+        event_stmt = (
+            select(MemoryEpisode)
+            .where(MemoryEpisode.session_id.is_not(None))
+            .where(MemoryEpisode.episode_type != MemoryEpisodeType.conversation)
+            .where(
+                or_(
+                    func.lower(MemoryEpisode.summary).like(pattern, escape="\\"),
+                    func.lower(MemoryEpisode.content).like(pattern, escape="\\"),
+                )
+            )
+            .order_by(
+                col(MemoryEpisode.observed_at).desc(),
+                col(MemoryEpisode.created_at).desc(),
+            )
+        )
+        if exclude_session_id:
+            event_stmt = event_stmt.where(MemoryEpisode.session_id != exclude_session_id)
+        event_rows = await db.execute(event_stmt)
+        for episode in event_rows.scalars().all():
+            if not isinstance(episode.session_id, str) or episode.session_id in combined:
+                continue
+            session = session_map.get(episode.session_id)
+            if session is None:
+                continue
+            event_text = "\n".join(
+                part.strip()
+                for part in (episode.summary or "", episode.content or "")
+                if part.strip()
+            )
+            combined[episode.session_id] = {
+                "session_id": episode.session_id,
+                "title": session.title or "Untitled session",
+                "matched_at": episode.observed_at or episode.created_at,
+                "snippet": _matching_snippet(
+                    event_text,
+                    normalized_query,
+                    snippet_chars=snippet_chars,
+                ),
+                "source": "event",
                 "rank": 1.0,
             }
 

--- a/backend/src/agent/session.py
+++ b/backend/src/agent/session.py
@@ -5,14 +5,15 @@ import uuid
 from datetime import datetime, timezone
 from time import perf_counter
 
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlmodel import select, col
 
 from config.settings import settings
 from src.approval.runtime import reset_runtime_context, set_runtime_context
 from src.audit.runtime import log_background_task_event
 from src.db.engine import get_session
-from src.db.models import Message, ScheduledJob, Session, SessionTodo
+from src.db.models import MemoryEpisode, Message, ScheduledJob, Session, SessionTodo
+from src.memory.episodes import build_message_episode
 
 logger = logging.getLogger(__name__)
 
@@ -77,11 +78,23 @@ class SessionManager:
             session = result.scalars().first()
             if not session:
                 return False
-            # Delete associated messages first
             msgs = await db.execute(
                 select(Message).where(Message.session_id == session_id)
             )
-            for msg in msgs.scalars().all():
+            session_messages = msgs.scalars().all()
+            message_ids = tuple(
+                dict.fromkeys(message.id for message in session_messages if message.id)
+            )
+            episode_filters = [MemoryEpisode.session_id == session_id]
+            if message_ids:
+                episode_filters.append(col(MemoryEpisode.source_message_id).in_(message_ids))
+            episodes = await db.execute(
+                select(MemoryEpisode).where(or_(*episode_filters))
+            )
+            for episode in episodes.scalars().all():
+                await db.delete(episode)
+            # Delete associated messages first
+            for msg in session_messages:
                 await db.delete(msg)
             todos = await db.execute(
                 select(SessionTodo).where(SessionTodo.session_id == session_id)
@@ -300,6 +313,14 @@ class SessionManager:
         # Truncate oversized content (50 KB)
         if len(content) > 50_000:
             content = content[:50_000] + "\n\n[truncated]"
+        episode_metadata: dict | None = None
+        if metadata_json:
+            try:
+                parsed_metadata = json.loads(metadata_json)
+            except json.JSONDecodeError:
+                parsed_metadata = None
+            if isinstance(parsed_metadata, dict):
+                episode_metadata = parsed_metadata
         async with get_session() as db:
             msg = Message(
                 session_id=session_id,
@@ -317,6 +338,38 @@ class SessionManager:
                 session.updated_at = datetime.now(timezone.utc)
                 db.add(session)
             await db.flush()
+            episode_draft = build_message_episode(
+                role=role,
+                content=content,
+                tool_used=tool_used,
+                metadata=episode_metadata,
+            )
+            if episode_draft is not None:
+                try:
+                    async with db.begin_nested():
+                        db.add(
+                            MemoryEpisode(
+                                session_id=session_id,
+                                episode_type=episode_draft.episode_type,
+                                summary=episode_draft.summary,
+                                content=episode_draft.content,
+                                source_message_id=msg.id,
+                                source_tool_name=episode_draft.source_tool_name,
+                                source_role=episode_draft.source_role,
+                                salience=episode_draft.salience,
+                                confidence=episode_draft.confidence,
+                                metadata_json=json.dumps(episode_draft.metadata or {}, sort_keys=True),
+                                observed_at=msg.created_at,
+                                created_at=msg.created_at,
+                            )
+                        )
+                        await db.flush()
+                except Exception:
+                    logger.debug(
+                        "Failed to persist episodic event for message %s",
+                        msg.id,
+                        exc_info=True,
+                    )
             db.expunge(msg)
             return msg
 

--- a/backend/src/agent/session.py
+++ b/backend/src/agent/session.py
@@ -1,11 +1,12 @@
 import asyncio
 import json
 import logging
+import re
 import uuid
 from datetime import datetime, timezone
 from time import perf_counter
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, text
 from sqlmodel import select, col
 
 from config.settings import settings
@@ -43,6 +44,37 @@ def _matching_snippet(text: str, query: str, *, snippet_chars: int) -> str:
     if end < len(flattened):
         snippet = snippet + "..."
     return snippet
+
+
+def _build_fts_match_expression(query: str) -> str | None:
+    terms = [part for part in query.strip().split() if part]
+    if not terms:
+        return None
+    if any(any(char in term for char in {"%", "_"}) for term in terms):
+        return None
+    normalized_terms: list[str] = []
+    for term in terms:
+        if not re.search(r"[A-Za-z0-9]", term):
+            return None
+        if re.search(r"[^A-Za-z0-9'\\-]", term):
+            return None
+        escaped_term = term.replace('"', '""')
+        normalized_terms.append(f'"{escaped_term}"')
+    if not normalized_terms:
+        return None
+    return " AND ".join(normalized_terms)
+
+
+def _coerce_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        normalized = value.replace("Z", "+00:00")
+        try:
+            return datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+    return None
 
 
 class SessionManager:
@@ -115,7 +147,6 @@ class SessionManager:
     async def list_sessions(self) -> list[dict]:
         async with get_session() as db:
             # Single query: fetch sessions with their latest message using window function
-            from sqlalchemy import text
             rows = (await db.execute(text(
                 """
                 SELECT
@@ -199,6 +230,103 @@ class SessionManager:
 
             return "\n".join(lines)
 
+    async def _conversation_recency_map(
+        self,
+        db,
+        *,
+        exclude_session_id: str | None = None,
+    ) -> dict[str, datetime]:
+        recency_stmt = (
+            select(Message.session_id, func.max(Message.created_at))
+            .where(Message.role.in_(["user", "assistant"]))  # type: ignore[attr-defined]
+            .group_by(Message.session_id)
+        )
+        if exclude_session_id:
+            recency_stmt = recency_stmt.where(Message.session_id != exclude_session_id)
+        recency_rows = await db.execute(recency_stmt)
+        return {
+            session_id: latest_at
+            for session_id, latest_at in recency_rows.all()
+        }
+
+    async def _search_sessions_fallback(
+        self,
+        *,
+        db,
+        normalized_query: str,
+        session_map: dict[str, Session],
+        limit: int,
+        exclude_session_id: str | None,
+        snippet_chars: int,
+    ) -> list[dict]:
+        pattern = f"%{_escape_like(normalized_query)}%"
+        message_recency = await self._conversation_recency_map(
+            db,
+            exclude_session_id=exclude_session_id,
+        )
+        sessions = list(session_map.values())
+
+        title_hits = {
+            session.id: {
+                "session_id": session.id,
+                "title": session.title or "Untitled session",
+                "matched_at": message_recency.get(session.id) or session.created_at,
+                "snippet": session.title or "Untitled session",
+                "source": "title",
+                "rank": 0.0,
+            }
+            for session in sessions
+            if normalized_query in (session.title or "").lower()
+        }
+
+        message_stmt = (
+            select(Message)
+            .where(Message.role.in_(["user", "assistant"]))  # type: ignore[attr-defined]
+            .where(func.lower(Message.content).like(pattern, escape="\\"))
+            .order_by(col(Message.created_at).desc())
+        )
+        if exclude_session_id:
+            message_stmt = message_stmt.where(Message.session_id != exclude_session_id)
+        message_rows = await db.execute(message_stmt)
+
+        combined = dict(title_hits)
+        for message in message_rows.scalars().all():
+            session = session_map.get(message.session_id)
+            if session is None or message.session_id in combined:
+                continue
+            combined[message.session_id] = {
+                "session_id": message.session_id,
+                "title": session.title or "Untitled session",
+                "matched_at": message.created_at,
+                "snippet": _matching_snippet(
+                    message.content,
+                    normalized_query,
+                    snippet_chars=snippet_chars,
+                ),
+                "source": "message",
+                "rank": 1.0,
+            }
+
+        ordered = sorted(
+            combined.values(),
+            key=lambda item: (
+                item["rank"],
+                -(message_recency.get(item["session_id"]) or item["matched_at"]).timestamp(),
+                -item["matched_at"].timestamp(),
+            ),
+        )
+
+        return [
+            {
+                "session_id": item["session_id"],
+                "title": item["title"],
+                "matched_at": item["matched_at"].isoformat(),
+                "snippet": item["snippet"],
+                "source": item["source"],
+            }
+            for item in ordered[:limit]
+        ]
+
     async def search_sessions(
         self,
         query: str,
@@ -221,62 +349,110 @@ class SessionManager:
                 return []
 
             session_map = {session.id: session for session in sessions}
-            pattern = f"%{_escape_like(normalized_query)}%"
-            recency_rows = await db.execute(
-                select(Message.session_id, func.max(Message.created_at))
-                .where(Message.role.in_(["user", "assistant"]))  # type: ignore[attr-defined]
-                .group_by(Message.session_id)
+            message_recency = await self._conversation_recency_map(
+                db,
+                exclude_session_id=exclude_session_id,
             )
-            message_recency = {
-                session_id: latest_at
-                for session_id, latest_at in recency_rows.all()
-            }
+            match_expression = _build_fts_match_expression(normalized_query)
+            if not match_expression:
+                return await self._search_sessions_fallback(
+                    db=db,
+                    normalized_query=normalized_query,
+                    session_map=session_map,
+                    limit=limit,
+                    exclude_session_id=exclude_session_id,
+                    snippet_chars=snippet_chars,
+                )
 
-            title_hits = {
-                session.id: {
-                    "session_id": session.id,
-                    "title": session.title or "Untitled session",
-                    "matched_at": message_recency.get(session.id) or session.created_at,
-                    "snippet": session.title or "Untitled session",
-                    "source": "title",
-                }
-                for session in sessions
-                if normalized_query in (session.title or "").lower()
-            }
+            try:
+                rows = (
+                    await db.execute(
+                        text(
+                            """
+                            SELECT
+                                entry_key,
+                                session_id,
+                                entry_type,
+                                source_label,
+                                text,
+                                created_at,
+                                bm25(session_recall_fts) AS rank
+                            FROM session_recall_fts
+                            WHERE session_recall_fts MATCH :match
+                              AND session_id IS NOT NULL
+                              AND (:exclude_session_id IS NULL OR session_id != :exclude_session_id)
+                            ORDER BY rank ASC, created_at DESC
+                            LIMIT :candidate_limit
+                            """
+                        ),
+                        {
+                            "match": match_expression,
+                            "exclude_session_id": exclude_session_id,
+                            "candidate_limit": max(limit * 4, 12),
+                        },
+                    )
+                ).mappings().all()
+            except Exception:
+                logger.debug("FTS session search failed; falling back to LIKE search", exc_info=True)
+                rows = []
 
-            message_stmt = (
-                select(Message)
-                .where(Message.role.in_(["user", "assistant"]))  # type: ignore[attr-defined]
-                .where(func.lower(Message.content).like(pattern, escape="\\"))
-                .order_by(col(Message.created_at).desc())
-            )
-            if exclude_session_id:
-                message_stmt = message_stmt.where(Message.session_id != exclude_session_id)
-            message_rows = await db.execute(message_stmt)
+            if not rows:
+                return await self._search_sessions_fallback(
+                    db=db,
+                    normalized_query=normalized_query,
+                    session_map=session_map,
+                    limit=limit,
+                    exclude_session_id=exclude_session_id,
+                    snippet_chars=snippet_chars,
+                )
 
-            combined = dict(title_hits)
-            for message in message_rows.scalars().all():
-                session = session_map.get(message.session_id)
+            combined: dict[str, dict[str, object]] = {}
+            for row in rows:
+                session_id = row.get("session_id")
+                if not isinstance(session_id, str):
+                    continue
+                session = session_map.get(session_id)
                 if session is None:
                     continue
-                if message.session_id in combined:
+                entry_type = str(row.get("entry_type") or "message")
+                source = "title" if entry_type == "title" else "event" if entry_type == "event" else "message"
+                raw_text = str(row.get("text") or "")
+                matched_at = _coerce_datetime(row.get("created_at"))
+                if matched_at is None:
                     continue
-                combined[message.session_id] = {
-                    "session_id": message.session_id,
+                rank = float(row.get("rank") or 0.0)
+                existing = combined.get(session_id)
+                if existing is not None:
+                    existing_rank = float(existing.get("rank") or 0.0)
+                    existing_matched_at = existing.get("matched_at")
+                    if rank > existing_rank:
+                        continue
+                    if rank == existing_rank and isinstance(existing_matched_at, datetime) and matched_at <= existing_matched_at:
+                        continue
+                combined[session_id] = {
+                    "session_id": session_id,
                     "title": session.title or "Untitled session",
-                    "matched_at": message.created_at,
-                    "snippet": _matching_snippet(
-                        message.content,
-                        normalized_query,
-                        snippet_chars=snippet_chars,
+                    "matched_at": matched_at,
+                    "snippet": (
+                        session.title or "Untitled session"
+                        if source == "title"
+                        else _matching_snippet(
+                            raw_text,
+                            normalized_query,
+                            snippet_chars=snippet_chars,
+                        )
                     ),
-                    "source": "message",
+                    "source": source,
+                    "rank": rank,
                 }
 
             ordered = sorted(
                 combined.values(),
-                key=lambda item: item["matched_at"],
-                reverse=True,
+                key=lambda item: (
+                    float(item["rank"]),
+                    -(message_recency.get(item["session_id"]) or item["matched_at"]).timestamp(),  # type: ignore[union-attr]
+                    -item["matched_at"].timestamp(),  # type: ignore[union-attr]
+                ),
             )
 
             return [

--- a/backend/src/db/engine.py
+++ b/backend/src/db/engine.py
@@ -128,12 +128,166 @@ async def _ensure_legacy_columns(conn) -> None:
         )
 
 
+async def _ensure_search_indexes(conn) -> None:
+    await conn.exec_driver_sql(
+        """
+        CREATE VIRTUAL TABLE IF NOT EXISTS session_recall_fts USING fts5(
+            entry_key UNINDEXED,
+            session_id UNINDEXED,
+            entry_type UNINDEXED,
+            source_label UNINDEXED,
+            text,
+            created_at UNINDEXED
+        )
+        """
+    )
+
+    trigger_statements = (
+        """
+        CREATE TRIGGER IF NOT EXISTS session_recall_sessions_ai
+        AFTER INSERT ON sessions
+        BEGIN
+            INSERT INTO session_recall_fts (entry_key, session_id, entry_type, source_label, text, created_at)
+            VALUES ('session:' || NEW.id, NEW.id, 'title', 'title', COALESCE(NEW.title, ''), COALESCE(NEW.updated_at, NEW.created_at));
+        END
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS session_recall_sessions_au
+        AFTER UPDATE OF title, updated_at ON sessions
+        BEGIN
+            DELETE FROM session_recall_fts WHERE entry_key = 'session:' || OLD.id;
+            INSERT INTO session_recall_fts (entry_key, session_id, entry_type, source_label, text, created_at)
+            VALUES ('session:' || NEW.id, NEW.id, 'title', 'title', COALESCE(NEW.title, ''), COALESCE(NEW.updated_at, NEW.created_at));
+        END
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS session_recall_sessions_ad
+        AFTER DELETE ON sessions
+        BEGIN
+            DELETE FROM session_recall_fts WHERE entry_key = 'session:' || OLD.id;
+        END
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS session_recall_messages_ai
+        AFTER INSERT ON messages
+        WHEN NEW.role IN ('user', 'assistant')
+        BEGIN
+            INSERT INTO session_recall_fts (entry_key, session_id, entry_type, source_label, text, created_at)
+            VALUES ('message:' || NEW.id, NEW.session_id, 'message', NEW.role, COALESCE(NEW.content, ''), NEW.created_at);
+        END
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS session_recall_messages_au
+        AFTER UPDATE OF role, content, session_id, created_at ON messages
+        BEGIN
+            DELETE FROM session_recall_fts WHERE entry_key = 'message:' || OLD.id;
+            INSERT INTO session_recall_fts (entry_key, session_id, entry_type, source_label, text, created_at)
+            SELECT 'message:' || NEW.id, NEW.session_id, 'message', NEW.role, COALESCE(NEW.content, ''), NEW.created_at
+            WHERE NEW.role IN ('user', 'assistant');
+        END
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS session_recall_messages_ad
+        AFTER DELETE ON messages
+        BEGIN
+            DELETE FROM session_recall_fts WHERE entry_key = 'message:' || OLD.id;
+        END
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS session_recall_episodes_ai
+        AFTER INSERT ON memory_episodes
+        WHEN NEW.session_id IS NOT NULL AND NEW.episode_type != 'conversation'
+        BEGIN
+            INSERT INTO session_recall_fts (entry_key, session_id, entry_type, source_label, text, created_at)
+            VALUES (
+                'episode:' || NEW.id,
+                NEW.session_id,
+                'event',
+                COALESCE(NEW.episode_type, 'event'),
+                TRIM(COALESCE(NEW.summary, '') || CHAR(10) || COALESCE(NEW.content, '')),
+                COALESCE(NEW.observed_at, NEW.created_at)
+            );
+        END
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS session_recall_episodes_au
+        AFTER UPDATE OF session_id, episode_type, summary, content, observed_at, created_at ON memory_episodes
+        BEGIN
+            DELETE FROM session_recall_fts WHERE entry_key = 'episode:' || OLD.id;
+            INSERT INTO session_recall_fts (entry_key, session_id, entry_type, source_label, text, created_at)
+            SELECT
+                'episode:' || NEW.id,
+                NEW.session_id,
+                'event',
+                COALESCE(NEW.episode_type, 'event'),
+                TRIM(COALESCE(NEW.summary, '') || CHAR(10) || COALESCE(NEW.content, '')),
+                COALESCE(NEW.observed_at, NEW.created_at)
+            WHERE NEW.session_id IS NOT NULL AND NEW.episode_type != 'conversation';
+        END
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS session_recall_episodes_ad
+        AFTER DELETE ON memory_episodes
+        BEGIN
+            DELETE FROM session_recall_fts WHERE entry_key = 'episode:' || OLD.id;
+        END
+        """,
+    )
+    for statement in trigger_statements:
+        await conn.exec_driver_sql(statement)
+
+    await conn.exec_driver_sql("DELETE FROM session_recall_fts")
+    await conn.exec_driver_sql(
+        """
+        INSERT INTO session_recall_fts (entry_key, session_id, entry_type, source_label, text, created_at)
+        SELECT
+            'session:' || id,
+            id,
+            'title',
+            'title',
+            COALESCE(title, ''),
+            COALESCE(updated_at, created_at)
+        FROM sessions
+        """
+    )
+    await conn.exec_driver_sql(
+        """
+        INSERT INTO session_recall_fts (entry_key, session_id, entry_type, source_label, text, created_at)
+        SELECT
+            'message:' || id,
+            session_id,
+            'message',
+            role,
+            COALESCE(content, ''),
+            created_at
+        FROM messages
+        WHERE role IN ('user', 'assistant')
+        """
+    )
+    await conn.exec_driver_sql(
+        """
+        INSERT INTO session_recall_fts (entry_key, session_id, entry_type, source_label, text, created_at)
+        SELECT
+            'episode:' || id,
+            session_id,
+            'event',
+            COALESCE(episode_type, 'event'),
+            TRIM(COALESCE(summary, '') || CHAR(10) || COALESCE(content, '')),
+            COALESCE(observed_at, created_at)
+        FROM memory_episodes
+        WHERE session_id IS NOT NULL
+          AND episode_type != 'conversation'
+        """
+    )
+
+
 async def init_db() -> None:
     """Create all tables on startup."""
     os.makedirs(os.path.dirname(_db_path), exist_ok=True)
     async with engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
         await _ensure_legacy_columns(conn)
+        await _ensure_search_indexes(conn)
 
 
 async def close_db() -> None:

--- a/backend/src/db/models.py
+++ b/backend/src/db/models.py
@@ -61,6 +61,14 @@ class MemoryStatus(str, enum.Enum):
     superseded = "superseded"
 
 
+class MemoryEpisodeType(str, enum.Enum):
+    conversation = "conversation"
+    tool = "tool"
+    workflow = "workflow"
+    decision = "decision"
+    observer = "observer"
+
+
 class MemoryEntityType(str, enum.Enum):
     person = "person"
     project = "project"
@@ -226,6 +234,26 @@ class MemoryEdge(SQLModel, table=True):
     weight: float = Field(default=1.0)
     metadata_json: Optional[str] = Field(default=None)
     created_at: datetime = Field(default_factory=_now)
+
+
+class MemoryEpisode(SQLModel, table=True):
+    __tablename__ = "memory_episodes"
+
+    id: str = Field(default_factory=_uuid, primary_key=True)
+    session_id: Optional[str] = Field(default=None, foreign_key="sessions.id", index=True)
+    episode_type: MemoryEpisodeType = Field(default=MemoryEpisodeType.conversation, index=True)
+    summary: str = Field(default="")
+    content: str = Field(default="")
+    source_message_id: Optional[str] = Field(default=None, foreign_key="messages.id", index=True)
+    source_tool_name: Optional[str] = Field(default=None, index=True)
+    source_role: Optional[str] = Field(default=None, index=True)
+    subject_entity_id: Optional[str] = Field(default=None, foreign_key="memory_entities.id", index=True)
+    project_entity_id: Optional[str] = Field(default=None, foreign_key="memory_entities.id", index=True)
+    salience: float = Field(default=0.5)
+    confidence: float = Field(default=0.5)
+    metadata_json: Optional[str] = Field(default=None)
+    observed_at: datetime = Field(default_factory=_now, index=True)
+    created_at: datetime = Field(default_factory=_now, index=True)
 
 
 # ─── Goal ────────────────────────────────────────────────

--- a/backend/src/guardian/state.py
+++ b/backend/src/guardian/state.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from dataclasses import dataclass
 
@@ -29,6 +28,7 @@ class GuardianState:
     observer_context: CurrentContext
     world_model: GuardianWorldModel
     memory_context: str
+    episodic_memory_context: str
     current_session_history: str
     recent_sessions_summary: str
     recent_intervention_feedback: str
@@ -66,6 +66,9 @@ class GuardianState:
 
         if self.memory_context:
             lines.extend(["", "Relevant memories:", self.memory_context])
+
+        if self.episodic_memory_context:
+            lines.extend(["", "Relevant episodes:", self.episodic_memory_context])
 
         if self.recent_sessions_summary:
             lines.extend(["", "Recent sessions:", self.recent_sessions_summary])
@@ -276,89 +279,6 @@ def _summarize_bounded_todos(*, todos: list[dict[str, object]]) -> str:
     return "\n".join(lines)
 
 
-def _append_structured_memory_line(
-    *,
-    bucketed: dict[str, list[str]],
-    lines: list[str],
-    text: str,
-    bucket_name: str,
-) -> None:
-    normalized = text.strip()
-    if not normalized:
-        return
-    bucket = bucketed.setdefault(bucket_name, [])
-    if normalized not in bucket:
-        bucket.append(normalized)
-    line = f"- [{bucket_name}] {normalized}"
-    if line not in lines:
-        lines.append(line)
-
-
-async def _structured_memory_context_bundle(
-    *,
-    active_projects: tuple[str, ...] = (),
-) -> tuple[str, dict[str, tuple[str, ...]]]:
-    from src.db.models import MemoryEntityType, MemoryKind
-    from src.memory.repository import memory_repository
-    from src.memory.types import bucket_name_for_kind
-
-    grouped = await memory_repository.list_memories_by_kinds(
-        kinds=(
-            MemoryKind.goal,
-            MemoryKind.commitment,
-            MemoryKind.preference,
-            MemoryKind.communication_preference,
-            MemoryKind.pattern,
-            MemoryKind.project,
-            MemoryKind.collaborator,
-            MemoryKind.obligation,
-            MemoryKind.routine,
-            MemoryKind.timeline,
-        ),
-        limit_per_kind=2,
-    )
-
-    bucketed: dict[str, list[str]] = {}
-    lines: list[str] = []
-    for kind_name, memories in grouped.items():
-        bucket_name = bucket_name_for_kind(kind_name)
-        for memory in memories:
-            text = (memory.summary or memory.content or "").strip()
-            _append_structured_memory_line(
-                bucketed=bucketed,
-                lines=lines,
-                text=text,
-                bucket_name=bucket_name,
-            )
-
-    linked_project_entities = await memory_repository.find_entities_by_names(
-        names=active_projects,
-        entity_type=MemoryEntityType.project,
-    )
-    if linked_project_entities:
-        linked_memories = await memory_repository.list_memories_for_entities(
-            project_entity_ids=tuple(entity.id for entity in linked_project_entities.values()),
-            kinds=(
-                MemoryKind.commitment,
-                MemoryKind.project,
-                MemoryKind.collaborator,
-                MemoryKind.obligation,
-                MemoryKind.routine,
-                MemoryKind.timeline,
-            ),
-            limit=8,
-        )
-        for memory in linked_memories:
-            _append_structured_memory_line(
-                bucketed=bucketed,
-                lines=lines,
-                text=(memory.summary or memory.content or "").strip(),
-                bucket_name=bucket_name_for_kind(memory.kind),
-            )
-
-    return "\n".join(lines[:8]), {key: tuple(values) for key, values in bucketed.items()}
-
-
 def _merge_memory_contexts(*contexts: str) -> str:
     lines: list[str] = []
     for context in contexts:
@@ -379,11 +299,11 @@ async def build_guardian_state(
 ) -> GuardianState:
     """Build one explicit guardian-state object from current repo surfaces."""
     from src.memory.soul import read_soul
+    from src.memory.retrieval_planner import plan_memory_retrieval
     from src.memory.snapshots import (
         get_or_create_bounded_guardian_snapshot,
         render_bounded_guardian_snapshot,
     )
-    from src.memory.vector_store import search_with_status
     from src.audit.repository import audit_repository
     from src.guardian.feedback import guardian_feedback_repository
     from src.observer.manager import context_manager
@@ -422,23 +342,16 @@ async def build_guardian_state(
     except Exception:
         logger.debug("Failed to load recent projects for guardian state", exc_info=True)
         active_projects = ()
-    structured_memory_context, structured_memory_buckets = await _structured_memory_context_bundle(
-        active_projects=active_projects,
-    )
 
     query = user_message or memory_query or ""
     memory_requested = bool(query.strip())
-    memory_results: list[dict[str, object]] = []
-    memory_degraded = False
-    memory_buckets: dict[str, tuple[str, ...]] = {}
-    if memory_requested:
-        memory_results, memory_degraded = await asyncio.to_thread(search_with_status, query)
-    vector_memory_context = "\n".join(
-        f"- [{item['category']}] {item['text']}"
-        for item in memory_results
-        if isinstance(item.get("category"), str) and isinstance(item.get("text"), str)
+    retrieval = await plan_memory_retrieval(
+        query=query,
+        active_projects=active_projects,
     )
-    memory_context = _merge_memory_contexts(vector_memory_context, structured_memory_context)
+    memory_context = retrieval.semantic_context
+    episodic_memory_context = retrieval.episodic_context
+    memory_buckets = retrieval.memory_buckets
     try:
         snapshot_session_key = None
         if session_id is not None and session_record is not None:
@@ -462,21 +375,6 @@ async def build_guardian_state(
         todos=session_todos,
         ),
     )
-    grouped_memory: dict[str, list[str]] = {}
-    for item in memory_results:
-        category = item.get("category")
-        text = item.get("text")
-        if not isinstance(category, str) or not isinstance(text, str):
-            continue
-        grouped_memory.setdefault(category, [])
-        if text not in grouped_memory[category]:
-            grouped_memory[category].append(text)
-    for category, texts in structured_memory_buckets.items():
-        grouped_memory.setdefault(category, [])
-        for text in texts:
-            if text not in grouped_memory[category]:
-                grouped_memory[category].append(text)
-    memory_buckets = {key: tuple(values) for key, values in grouped_memory.items()}
     world_model = build_guardian_world_model(
         observer_context=observer_context,
         memory_context=memory_context,
@@ -491,8 +389,11 @@ async def build_guardian_state(
     world_model_status = _world_model_status(world_model)
     memory_status = (
         "degraded"
-        if memory_requested and memory_degraded
-        else _status_for_text(memory_context, requested=memory_requested)
+        if memory_requested and retrieval.degraded
+        else _status_for_text(
+            _merge_memory_contexts(memory_context, episodic_memory_context),
+            requested=memory_requested,
+        )
     )
 
     confidence = GuardianStateConfidence(
@@ -522,6 +423,7 @@ async def build_guardian_state(
         world_model=world_model,
         bounded_memory_context=bounded_memory_context,
         memory_context=memory_context,
+        episodic_memory_context=episodic_memory_context,
         current_session_history=current_session_history,
         recent_sessions_summary=recent_sessions_summary,
         recent_intervention_feedback=recent_intervention_feedback,

--- a/backend/src/memory/episodes.py
+++ b/backend/src/memory/episodes.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.db.models import MemoryEpisodeType
+
+
+def _flatten_text(value: str) -> str:
+    return " ".join(value.strip().split())
+
+
+def summarize_episode_text(content: str, *, max_chars: int = 160) -> str:
+    normalized = _flatten_text(content)
+    if len(normalized) <= max_chars:
+        return normalized
+    return normalized[: max_chars - 3].rstrip() + "..."
+
+
+@dataclass(frozen=True)
+class EpisodeDraft:
+    episode_type: MemoryEpisodeType
+    summary: str
+    content: str
+    source_role: str | None = None
+    source_tool_name: str | None = None
+    salience: float = 0.5
+    confidence: float = 0.6
+    metadata: dict[str, Any] | None = None
+
+
+def build_message_episode(
+    *,
+    role: str,
+    content: str,
+    tool_used: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> EpisodeDraft | None:
+    normalized_role = role.strip().lower()
+    normalized_content = _flatten_text(content)
+    if not normalized_content:
+        return None
+
+    if normalized_role in {"user", "assistant"}:
+        return EpisodeDraft(
+            episode_type=MemoryEpisodeType.conversation,
+            summary=summarize_episode_text(normalized_content, max_chars=140),
+            content=normalized_content,
+            source_role=normalized_role,
+            salience=0.45 if normalized_role == "assistant" else 0.55,
+            confidence=0.7,
+            metadata={"source": "session_message"},
+        )
+
+    if normalized_role == "step" and tool_used:
+        normalized_tool = tool_used.strip()
+        if not normalized_tool:
+            return None
+        episode_type = (
+            MemoryEpisodeType.workflow
+            if normalized_tool == "workflow_runner" or normalized_tool.startswith("workflow_")
+            else MemoryEpisodeType.tool
+        )
+        workflow_name = None
+        if isinstance(metadata, dict):
+            workflow_name = metadata.get("workflow_name")
+        summary_prefix = (
+            f"Workflow {workflow_name}"
+            if isinstance(workflow_name, str) and workflow_name.strip()
+            else normalized_tool
+        )
+        return EpisodeDraft(
+            episode_type=episode_type,
+            summary=summarize_episode_text(
+                f"{summary_prefix}: {normalized_content}",
+                max_chars=160,
+            ),
+            content=normalized_content,
+            source_role=normalized_role,
+            source_tool_name=normalized_tool,
+            salience=0.7,
+            confidence=0.8,
+            metadata={
+                "source": "session_step",
+                **(metadata or {}),
+            },
+        )
+
+    return None

--- a/backend/src/memory/hybrid_retrieval.py
+++ b/backend/src/memory/hybrid_retrieval.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import func, or_
+from sqlmodel import col, select
+
+from src.db.engine import get_session
+from src.db.models import Memory, MemoryEpisode, MemoryStatus
+from src.memory.repository import memory_repository
+from src.memory.types import bucket_name_for_kind
+from src.memory.vector_store import search_with_status
+
+
+_STOPWORDS = {
+    "about",
+    "after",
+    "before",
+    "could",
+    "does",
+    "from",
+    "have",
+    "into",
+    "last",
+    "matters",
+    "next",
+    "right",
+    "should",
+    "that",
+    "them",
+    "they",
+    "this",
+    "today",
+    "what",
+    "when",
+    "where",
+    "which",
+    "while",
+    "who",
+    "with",
+}
+
+
+@dataclass(frozen=True)
+class HybridMemoryHit:
+    text: str
+    bucket: str
+    source: str
+    score: float
+    created_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class HybridMemoryRetrievalResult:
+    context: str
+    buckets: dict[str, tuple[str, ...]]
+    degraded: bool
+    hits: tuple[HybridMemoryHit, ...]
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize_text(value: str | None) -> str:
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.strip().split())
+
+
+def _query_terms(query: str) -> tuple[str, ...]:
+    terms: list[str] = []
+    seen: set[str] = set()
+    for raw in re.findall(r"[a-z0-9]+", query.lower()):
+        if len(raw) < 3 or raw in _STOPWORDS or raw in seen:
+            continue
+        seen.add(raw)
+        terms.append(raw)
+    return tuple(terms)
+
+
+def _term_overlap_score(text: str, terms: tuple[str, ...]) -> float:
+    normalized = text.lower()
+    if not terms:
+        return 0.0
+    matches = sum(1 for term in terms if term in normalized)
+    return matches / len(terms)
+
+
+def _active_project_name_boost(text: str, active_projects: tuple[str, ...]) -> float:
+    normalized = text.lower()
+    for project in active_projects:
+        project_name = _normalize_text(project)
+        if project_name and project_name.lower() in normalized:
+            return 0.55
+    return 0.0
+
+
+def _recency_boost(value: datetime | None, *, now: datetime) -> float:
+    if value is None:
+        return 0.0
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    delta_days = max(0.0, (now - value).total_seconds() / 86_400)
+    if delta_days <= 1:
+        return 0.35
+    if delta_days <= 7:
+        return 0.22
+    if delta_days <= 30:
+        return 0.12
+    return 0.0
+
+
+def _dedupe_hits(hits: list[HybridMemoryHit]) -> tuple[HybridMemoryHit, ...]:
+    best_by_text: dict[str, HybridMemoryHit] = {}
+    for hit in hits:
+        key = hit.text.lower()
+        existing = best_by_text.get(key)
+        if existing is None or hit.score > existing.score:
+            best_by_text[key] = hit
+    return tuple(
+        sorted(
+            best_by_text.values(),
+            key=lambda hit: (
+                -hit.score,
+                -(hit.created_at.timestamp() if hit.created_at else 0.0),
+            ),
+        )
+    )
+
+
+def _render_result(hits: tuple[HybridMemoryHit, ...], *, limit: int, degraded: bool) -> HybridMemoryRetrievalResult:
+    selected = hits[:limit]
+    buckets: dict[str, list[str]] = {}
+    lines: list[str] = []
+    for hit in selected:
+        bucket = buckets.setdefault(hit.bucket, [])
+        if hit.text not in bucket:
+            bucket.append(hit.text)
+        line = f"- [{hit.bucket}] {hit.text}"
+        if line not in lines:
+            lines.append(line)
+    return HybridMemoryRetrievalResult(
+        context="\n".join(lines),
+        buckets={key: tuple(values) for key, values in buckets.items()},
+        degraded=degraded,
+        hits=selected,
+    )
+
+
+async def retrieve_hybrid_memory(
+    *,
+    query: str,
+    active_projects: tuple[str, ...] = (),
+    limit: int = 8,
+) -> HybridMemoryRetrievalResult:
+    normalized_query = _normalize_text(query)
+    if not normalized_query:
+        return HybridMemoryRetrievalResult(context="", buckets={}, degraded=False, hits=())
+
+    terms = _query_terms(normalized_query)
+    project_entities = await memory_repository.find_entities_by_names(
+        names=active_projects,
+        entity_type="project",
+    )
+    project_entity_ids = tuple(
+        dict.fromkeys(entity.id for entity in project_entities.values())
+    )
+    query_term_patterns = [f"%{term}%" for term in terms]
+    now = _now()
+
+    async with get_session() as db:
+        memory_text = func.lower(func.coalesce(Memory.summary, "") + " " + func.coalesce(Memory.content, ""))
+        episode_text = func.lower(
+            func.coalesce(MemoryEpisode.summary, "") + " " + func.coalesce(MemoryEpisode.content, "")
+        )
+
+        semantic_stmt = (
+            select(Memory)
+            .where(Memory.status == MemoryStatus.active)
+            .order_by(
+                col(Memory.importance).desc(),
+                col(Memory.last_confirmed_at).desc(),
+                col(Memory.created_at).desc(),
+            )
+            .limit(max(limit * 6, 24))
+        )
+        if query_term_patterns:
+            semantic_stmt = semantic_stmt.where(
+                or_(*[memory_text.like(pattern) for pattern in query_term_patterns])
+            )
+        semantic_result = await db.execute(semantic_stmt)
+        semantic_memories = semantic_result.scalars().all()
+
+        linked_memories: list[Memory] = []
+        if project_entity_ids:
+            linked_stmt = (
+                select(Memory)
+                .where(Memory.status == MemoryStatus.active)
+                .where(col(Memory.project_entity_id).in_(project_entity_ids))
+                .order_by(
+                    col(Memory.importance).desc(),
+                    col(Memory.last_confirmed_at).desc(),
+                    col(Memory.created_at).desc(),
+                )
+                .limit(max(limit * 4, 12))
+            )
+            linked_result = await db.execute(linked_stmt)
+            linked_memories = linked_result.scalars().all()
+
+        episode_stmt = (
+            select(MemoryEpisode)
+            .order_by(
+                col(MemoryEpisode.salience).desc(),
+                col(MemoryEpisode.observed_at).desc(),
+                col(MemoryEpisode.created_at).desc(),
+            )
+            .limit(max(limit * 6, 24))
+        )
+        if query_term_patterns:
+            episode_stmt = episode_stmt.where(
+                or_(*[episode_text.like(pattern) for pattern in query_term_patterns])
+            )
+        episode_result = await db.execute(episode_stmt)
+        episodic_hits = episode_result.scalars().all()
+
+        linked_episodes: list[MemoryEpisode] = []
+        if project_entity_ids:
+            linked_episode_stmt = (
+                select(MemoryEpisode)
+                .where(col(MemoryEpisode.project_entity_id).in_(project_entity_ids))
+                .order_by(
+                    col(MemoryEpisode.salience).desc(),
+                    col(MemoryEpisode.observed_at).desc(),
+                    col(MemoryEpisode.created_at).desc(),
+                )
+                .limit(max(limit * 4, 12))
+            )
+            linked_episode_result = await db.execute(linked_episode_stmt)
+            linked_episodes = linked_episode_result.scalars().all()
+
+    vector_hits, vector_degraded = await asyncio.to_thread(
+        search_with_status,
+        normalized_query,
+        max(limit * 2, 8),
+    )
+
+    combined_hits: list[HybridMemoryHit] = []
+    for memory in [*semantic_memories, *linked_memories]:
+        text = _normalize_text(memory.summary or memory.content)
+        if not text:
+            continue
+        score = (
+            (_term_overlap_score(text, terms) * 3.0)
+            + (memory.importance * 1.8)
+            + (memory.confidence * 0.4)
+            + _recency_boost(memory.last_confirmed_at or memory.created_at, now=now)
+        )
+        if memory.project_entity_id in project_entity_ids:
+            score += 0.7
+        score += _active_project_name_boost(text, active_projects)
+        combined_hits.append(
+            HybridMemoryHit(
+                text=text,
+                bucket=bucket_name_for_kind(memory.kind),
+                source="semantic",
+                score=score,
+                created_at=memory.last_confirmed_at or memory.created_at,
+            )
+        )
+
+    for episode in [*episodic_hits, *linked_episodes]:
+        text = _normalize_text(episode.summary or episode.content)
+        if not text:
+            continue
+        score = (
+            (_term_overlap_score(f"{episode.summary} {episode.content}", terms) * 3.1)
+            + (episode.salience * 1.4)
+            + (episode.confidence * 0.4)
+            + _recency_boost(episode.observed_at or episode.created_at, now=now)
+        )
+        if episode.project_entity_id in project_entity_ids:
+            score += 0.65
+        score += _active_project_name_boost(f"{episode.summary} {episode.content}", active_projects)
+        combined_hits.append(
+            HybridMemoryHit(
+                text=text,
+                bucket="episode",
+                source="episodic",
+                score=score,
+                created_at=episode.observed_at or episode.created_at,
+            )
+        )
+
+    for hit in vector_hits:
+        text = _normalize_text(str(hit.get("text") or ""))
+        if not text:
+            continue
+        distance = float(hit.get("score") or 0.0)
+        created_at = None
+        raw_created_at = hit.get("created_at")
+        if isinstance(raw_created_at, str):
+            normalized_created_at = raw_created_at.replace("Z", "+00:00")
+            try:
+                created_at = datetime.fromisoformat(normalized_created_at)
+            except ValueError:
+                created_at = None
+        elif isinstance(raw_created_at, datetime):
+            created_at = raw_created_at
+        score = (
+            max(0.0, 1.35 - distance)
+            + (_term_overlap_score(text, terms) * 1.2)
+            + _recency_boost(created_at, now=now)
+            + _active_project_name_boost(text, active_projects)
+        )
+        combined_hits.append(
+            HybridMemoryHit(
+                text=text,
+                bucket=_normalize_text(str(hit.get("category") or "fact")) or "fact",
+                source="vector",
+                score=score,
+                created_at=created_at,
+            )
+        )
+
+    return _render_result(_dedupe_hits(combined_hits), limit=limit, degraded=vector_degraded)

--- a/backend/src/memory/observer_episodes.py
+++ b/backend/src/memory/observer_episodes.py
@@ -34,6 +34,33 @@ def _activity_signal(context: CurrentContext) -> str:
     return user_state
 
 
+async def _resolve_project_entity_id(
+    *,
+    active_project: str,
+    old_project: str,
+) -> str | None:
+    candidate_names = tuple(
+        dict.fromkeys(name for name in (active_project, old_project) if name)
+    )
+    if not candidate_names:
+        return None
+
+    resolved = await memory_repository.find_entities_by_names(
+        names=candidate_names,
+        entity_type=MemoryEntityType.project,
+    )
+    preferred_name = active_project or old_project
+    entity = resolved.get(preferred_name)
+    if entity is not None:
+        return entity.id
+
+    created = await memory_repository.get_or_create_entity(
+        canonical_name=preferred_name,
+        entity_type=MemoryEntityType.project,
+    )
+    return created.id
+
+
 def should_record_activity_transition(old: CurrentContext, new: CurrentContext) -> bool:
     if old.user_state != new.user_state and (
         old.user_state in _BLOCKED_STATES or new.user_state in _BLOCKED_STATES
@@ -54,14 +81,10 @@ async def record_observer_transition_episodes(
 ) -> int:
     project_name = _normalize(active_project)
     old_project = _normalize(old_context.active_project)
-    project_entity_id: str | None = None
-
-    if project_name or old_project:
-        project_entity = await memory_repository.get_or_create_entity(
-            canonical_name=project_name or old_project,
-            entity_type=MemoryEntityType.project,
-        )
-        project_entity_id = project_entity.id
+    project_entity_id = await _resolve_project_entity_id(
+        active_project=project_name,
+        old_project=old_project,
+    )
 
     episodes: list[dict[str, object]] = []
 

--- a/backend/src/memory/observer_episodes.py
+++ b/backend/src/memory/observer_episodes.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from src.db.models import MemoryEntityType, MemoryEpisodeType
+from src.memory.repository import memory_repository
+from src.observer.context import CurrentContext
+
+
+_BLOCKED_STATES = {"deep_work", "in_meeting", "away"}
+
+
+def _normalize(value: str | None) -> str:
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.strip().split())
+
+
+def _focus_signal(context: CurrentContext, *, active_project: str | None) -> str:
+    if _normalize(context.current_event):
+        return _normalize(context.current_event)
+    if _normalize(context.active_goals_summary):
+        return _normalize(context.active_goals_summary)
+    if _normalize(active_project):
+        return _normalize(active_project)
+    if _normalize(context.active_window):
+        return _normalize(context.active_window)
+    return ""
+
+
+def _activity_signal(context: CurrentContext) -> str:
+    window = _normalize(context.active_window)
+    user_state = _normalize(context.user_state)
+    if window:
+        return f"{user_state} in {window}" if user_state else window
+    return user_state
+
+
+def should_record_activity_transition(old: CurrentContext, new: CurrentContext) -> bool:
+    if old.user_state != new.user_state and (
+        old.user_state in _BLOCKED_STATES or new.user_state in _BLOCKED_STATES
+    ):
+        return True
+    return (
+        old.active_window != new.active_window
+        and bool(_normalize(new.active_window))
+        and new.salience_level in {"medium", "high"}
+    )
+
+
+async def record_observer_transition_episodes(
+    *,
+    old_context: CurrentContext,
+    new_context: CurrentContext,
+    active_project: str | None,
+) -> int:
+    project_name = _normalize(active_project)
+    old_project = _normalize(old_context.active_project)
+    project_entity_id: str | None = None
+
+    if project_name or old_project:
+        project_entity = await memory_repository.get_or_create_entity(
+            canonical_name=project_name or old_project,
+            entity_type=MemoryEntityType.project,
+        )
+        project_entity_id = project_entity.id
+
+    episodes: list[dict[str, object]] = []
+
+    if project_name != old_project and (project_name or old_project):
+        summary = (
+            f"Observer project shifted to {project_name}"
+            if project_name
+            else f"Observer project cleared from {old_project}"
+        )
+        episodes.append(
+            {
+                "episode_type": MemoryEpisodeType.observer,
+                "summary": summary,
+                "content": (
+                    f"Observer project transition: "
+                    f"{old_project or 'none'} -> {project_name or 'none'}."
+                ),
+                "project_entity_id": project_entity_id,
+                "salience": 0.72,
+                "confidence": 0.78,
+                "metadata": {
+                    "source": "observer_context_refresh",
+                    "observer_transition": "project",
+                    "previous_project": old_project or None,
+                    "current_project": project_name or None,
+                },
+            }
+        )
+
+    old_focus = _focus_signal(old_context, active_project=old_context.active_project)
+    new_focus = _focus_signal(new_context, active_project=project_name or new_context.active_project)
+    if new_focus and new_focus != old_focus:
+        episodes.append(
+            {
+                "episode_type": MemoryEpisodeType.observer,
+                "summary": f"Observer focus shifted to {new_focus}",
+                "content": f"Observer focus transition: {old_focus or 'none'} -> {new_focus}.",
+                "project_entity_id": project_entity_id,
+                "salience": 0.68,
+                "confidence": 0.74,
+                "metadata": {
+                    "source": "observer_context_refresh",
+                    "observer_transition": "focus",
+                    "previous_focus": old_focus or None,
+                    "current_focus": new_focus,
+                },
+            }
+        )
+
+    old_activity = _activity_signal(old_context)
+    new_activity = _activity_signal(new_context)
+    if new_activity and new_activity != old_activity and should_record_activity_transition(old_context, new_context):
+        episodes.append(
+            {
+                "episode_type": MemoryEpisodeType.observer,
+                "summary": f"Observer activity shifted to {new_activity}",
+                "content": f"Observer activity transition: {old_activity or 'none'} -> {new_activity}.",
+                "project_entity_id": project_entity_id,
+                "salience": 0.64,
+                "confidence": 0.72,
+                "metadata": {
+                    "source": "observer_context_refresh",
+                    "observer_transition": "activity",
+                    "previous_activity": old_activity or None,
+                    "current_activity": new_activity,
+                    "previous_user_state": old_context.user_state,
+                    "current_user_state": new_context.user_state,
+                },
+            }
+        )
+
+    await memory_repository.create_episode_batch(items=episodes)
+    return len(episodes)

--- a/backend/src/memory/repository.py
+++ b/backend/src/memory/repository.py
@@ -15,6 +15,8 @@ from src.db.models import (
     MemoryCategory,
     MemoryEdge,
     MemoryEdgeType,
+    MemoryEpisode,
+    MemoryEpisodeType,
     MemoryEntity,
     MemoryEntityType,
     MemoryKind,
@@ -55,6 +57,7 @@ def _coerce_enum(
         MemoryCategory
         | MemoryKind
         | MemoryStatus
+        | MemoryEpisodeType
         | MemoryEntityType
         | MemorySnapshotKind
         | MemoryEdgeType
@@ -217,6 +220,52 @@ class MemoryRepository:
                 project_entity_id=project_entity_id,
             )
 
+    async def create_episode(
+        self,
+        *,
+        episode_type: MemoryEpisodeType | str = MemoryEpisodeType.conversation,
+        summary: str,
+        content: str,
+        session_id: str | None = None,
+        source_message_id: str | None = None,
+        source_tool_name: str | None = None,
+        source_role: str | None = None,
+        subject_entity_id: str | None = None,
+        project_entity_id: str | None = None,
+        salience: float = 0.5,
+        confidence: float = 0.5,
+        metadata: dict[str, Any] | None = None,
+        observed_at: datetime | None = None,
+    ) -> MemoryEpisode:
+        normalized_summary = summary.strip()
+        normalized_content = content.strip()
+        if not normalized_summary:
+            raise ValueError("summary must be non-empty")
+        if not normalized_content:
+            raise ValueError("content must be non-empty")
+        normalized_episode_type = _coerce_enum(episode_type, MemoryEpisodeType)
+
+        async with get_session() as db:
+            episode = MemoryEpisode(
+                session_id=session_id,
+                episode_type=normalized_episode_type,
+                summary=normalized_summary,
+                content=normalized_content,
+                source_message_id=source_message_id,
+                source_tool_name=source_tool_name,
+                source_role=source_role,
+                subject_entity_id=subject_entity_id,
+                project_entity_id=project_entity_id,
+                salience=salience,
+                confidence=confidence,
+                metadata_json=json.dumps(metadata or {}, sort_keys=True),
+                observed_at=observed_at or _now(),
+            )
+            db.add(episode)
+            await db.flush()
+            db.expunge(episode)
+            return episode
+
     async def find_entities_by_names(
         self,
         *,
@@ -372,6 +421,51 @@ class MemoryRepository:
                 db.expunge(memory)
                 bucket.append(memory)
             return {key: value for key, value in grouped.items() if value}
+
+    async def list_episodes(
+        self,
+        *,
+        session_id: str | None = None,
+        episode_types: tuple[MemoryEpisodeType | str, ...] = (),
+        subject_entity_ids: tuple[str, ...] = (),
+        project_entity_ids: tuple[str, ...] = (),
+        limit: int = 20,
+    ) -> list[MemoryEpisode]:
+        normalized_episode_types = tuple(
+            dict.fromkeys(_coerce_enum(item, MemoryEpisodeType) for item in episode_types)
+        )
+        normalized_subject_ids = tuple(
+            dict.fromkeys(entity_id.strip() for entity_id in subject_entity_ids if entity_id.strip())
+        )
+        normalized_project_ids = tuple(
+            dict.fromkeys(entity_id.strip() for entity_id in project_entity_ids if entity_id.strip())
+        )
+        async with get_session() as db:
+            stmt = (
+                select(MemoryEpisode)
+                .order_by(
+                    col(MemoryEpisode.observed_at).desc(),
+                    col(MemoryEpisode.salience).desc(),
+                    col(MemoryEpisode.created_at).desc(),
+                )
+                .limit(limit)
+            )
+            if session_id is not None:
+                stmt = stmt.where(MemoryEpisode.session_id == session_id)
+            if normalized_episode_types:
+                stmt = stmt.where(col(MemoryEpisode.episode_type).in_(normalized_episode_types))
+            entity_filters = []
+            if normalized_subject_ids:
+                entity_filters.append(col(MemoryEpisode.subject_entity_id).in_(normalized_subject_ids))
+            if normalized_project_ids:
+                entity_filters.append(col(MemoryEpisode.project_entity_id).in_(normalized_project_ids))
+            if entity_filters:
+                stmt = stmt.where(or_(*entity_filters))
+            result = await db.execute(stmt)
+            episodes = result.scalars().all()
+            for episode in episodes:
+                db.expunge(episode)
+            return list(episodes)
 
     async def create_edge(
         self,

--- a/backend/src/memory/repository.py
+++ b/backend/src/memory/repository.py
@@ -79,6 +79,46 @@ class MemoryWriteResult:
 
 
 class MemoryRepository:
+    @staticmethod
+    def _normalize_episode_kwargs(
+        *,
+        episode_type: MemoryEpisodeType | str,
+        summary: str,
+        content: str,
+        session_id: str | None,
+        source_message_id: str | None,
+        source_tool_name: str | None,
+        source_role: str | None,
+        subject_entity_id: str | None,
+        project_entity_id: str | None,
+        salience: float,
+        confidence: float,
+        metadata: dict[str, Any] | None,
+        observed_at: datetime | None,
+    ) -> dict[str, Any]:
+        normalized_summary = summary.strip()
+        normalized_content = content.strip()
+        if not normalized_summary:
+            raise ValueError("summary must be non-empty")
+        if not normalized_content:
+            raise ValueError("content must be non-empty")
+        normalized_episode_type = _coerce_enum(episode_type, MemoryEpisodeType)
+        return {
+            "session_id": session_id,
+            "episode_type": normalized_episode_type,
+            "summary": normalized_summary,
+            "content": normalized_content,
+            "source_message_id": source_message_id,
+            "source_tool_name": source_tool_name,
+            "source_role": source_role,
+            "subject_entity_id": subject_entity_id,
+            "project_entity_id": project_entity_id,
+            "salience": salience,
+            "confidence": confidence,
+            "metadata_json": json.dumps(metadata or {}, sort_keys=True),
+            "observed_at": observed_at or _now(),
+        }
+
     async def get_or_create_entity(
         self,
         *,
@@ -237,34 +277,63 @@ class MemoryRepository:
         metadata: dict[str, Any] | None = None,
         observed_at: datetime | None = None,
     ) -> MemoryEpisode:
-        normalized_summary = summary.strip()
-        normalized_content = content.strip()
-        if not normalized_summary:
-            raise ValueError("summary must be non-empty")
-        if not normalized_content:
-            raise ValueError("content must be non-empty")
-        normalized_episode_type = _coerce_enum(episode_type, MemoryEpisodeType)
+        episodes = await self.create_episode_batch(
+            items=[
+                {
+                    "episode_type": episode_type,
+                    "summary": summary,
+                    "content": content,
+                    "session_id": session_id,
+                    "source_message_id": source_message_id,
+                    "source_tool_name": source_tool_name,
+                    "source_role": source_role,
+                    "subject_entity_id": subject_entity_id,
+                    "project_entity_id": project_entity_id,
+                    "salience": salience,
+                    "confidence": confidence,
+                    "metadata": metadata,
+                    "observed_at": observed_at,
+                }
+            ]
+        )
+        return episodes[0]
+
+    async def create_episode_batch(
+        self,
+        *,
+        items: list[dict[str, Any]],
+    ) -> list[MemoryEpisode]:
+        if not items:
+            return []
+        normalized_items = [
+            self._normalize_episode_kwargs(
+                episode_type=item.get("episode_type", MemoryEpisodeType.conversation),
+                summary=str(item.get("summary", "")),
+                content=str(item.get("content", "")),
+                session_id=item.get("session_id"),
+                source_message_id=item.get("source_message_id"),
+                source_tool_name=item.get("source_tool_name"),
+                source_role=item.get("source_role"),
+                subject_entity_id=item.get("subject_entity_id"),
+                project_entity_id=item.get("project_entity_id"),
+                salience=float(item.get("salience", 0.5)),
+                confidence=float(item.get("confidence", 0.5)),
+                metadata=item.get("metadata") if isinstance(item.get("metadata"), dict) else None,
+                observed_at=item.get("observed_at"),
+            )
+            for item in items
+        ]
 
         async with get_session() as db:
-            episode = MemoryEpisode(
-                session_id=session_id,
-                episode_type=normalized_episode_type,
-                summary=normalized_summary,
-                content=normalized_content,
-                source_message_id=source_message_id,
-                source_tool_name=source_tool_name,
-                source_role=source_role,
-                subject_entity_id=subject_entity_id,
-                project_entity_id=project_entity_id,
-                salience=salience,
-                confidence=confidence,
-                metadata_json=json.dumps(metadata or {}, sort_keys=True),
-                observed_at=observed_at or _now(),
-            )
-            db.add(episode)
+            episodes: list[MemoryEpisode] = []
+            for episode_kwargs in normalized_items:
+                episode = MemoryEpisode(**episode_kwargs)
+                db.add(episode)
+                episodes.append(episode)
             await db.flush()
-            db.expunge(episode)
-            return episode
+            for episode in episodes:
+                db.expunge(episode)
+            return episodes
 
     async def find_entities_by_names(
         self,

--- a/backend/src/memory/retrieval_planner.py
+++ b/backend/src/memory/retrieval_planner.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.db.models import MemoryEntityType, MemoryKind
+from src.memory.hybrid_retrieval import HybridMemoryHit, retrieve_hybrid_memory
+from src.memory.repository import memory_repository
+from src.memory.types import bucket_name_for_kind
+
+
+_EPISODIC_CUES = (
+    "did we",
+    "happened",
+    "last ",
+    "timeline",
+    "when ",
+    "yesterday",
+    "earlier",
+    "history",
+    "recently",
+)
+
+
+@dataclass(frozen=True)
+class MemoryRetrievalPlanResult:
+    semantic_context: str
+    episodic_context: str
+    memory_buckets: dict[str, tuple[str, ...]]
+    degraded: bool
+    lane: str
+
+
+def _append_structured_memory_line(
+    *,
+    bucketed: dict[str, list[str]],
+    lines: list[str],
+    text: str,
+    bucket_name: str,
+) -> None:
+    normalized = text.strip()
+    if not normalized:
+        return
+    bucket = bucketed.setdefault(bucket_name, [])
+    if normalized not in bucket:
+        bucket.append(normalized)
+    line = f"- [{bucket_name}] {normalized}"
+    if line not in lines:
+        lines.append(line)
+
+
+def _merge_contexts(*contexts: str) -> str:
+    lines: list[str] = []
+    for context in contexts:
+        for raw_line in context.splitlines():
+            line = raw_line.strip()
+            if not line or line in lines:
+                continue
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def _render_hits(hits: list[HybridMemoryHit], *, limit: int) -> tuple[str, dict[str, tuple[str, ...]]]:
+    lines: list[str] = []
+    buckets: dict[str, list[str]] = {}
+    for hit in hits[:limit]:
+        bucket = buckets.setdefault(hit.bucket, [])
+        if hit.text not in bucket:
+            bucket.append(hit.text)
+        line = f"- [{hit.bucket}] {hit.text}"
+        if line not in lines:
+            lines.append(line)
+    return "\n".join(lines), {key: tuple(values) for key, values in buckets.items()}
+
+
+def _merge_buckets(
+    *bucket_maps: dict[str, tuple[str, ...]],
+) -> dict[str, tuple[str, ...]]:
+    merged: dict[str, list[str]] = {}
+    for bucket_map in bucket_maps:
+        for bucket, texts in bucket_map.items():
+            values = merged.setdefault(bucket, [])
+            for text in texts:
+                if text not in values:
+                    values.append(text)
+    return {key: tuple(values) for key, values in merged.items()}
+
+
+def _prefer_episodic_lane(query: str) -> bool:
+    normalized = query.strip().lower()
+    return any(cue in normalized for cue in _EPISODIC_CUES)
+
+
+async def build_structured_memory_context_bundle(
+    *,
+    active_projects: tuple[str, ...] = (),
+) -> tuple[str, dict[str, tuple[str, ...]]]:
+    grouped = await memory_repository.list_memories_by_kinds(
+        kinds=(
+            MemoryKind.goal,
+            MemoryKind.commitment,
+            MemoryKind.preference,
+            MemoryKind.communication_preference,
+            MemoryKind.pattern,
+            MemoryKind.project,
+            MemoryKind.collaborator,
+            MemoryKind.obligation,
+            MemoryKind.routine,
+            MemoryKind.timeline,
+        ),
+        limit_per_kind=2,
+    )
+
+    bucketed: dict[str, list[str]] = {}
+    lines: list[str] = []
+    for kind_name, memories in grouped.items():
+        bucket_name = bucket_name_for_kind(kind_name)
+        for memory in memories:
+            text = (memory.summary or memory.content or "").strip()
+            _append_structured_memory_line(
+                bucketed=bucketed,
+                lines=lines,
+                text=text,
+                bucket_name=bucket_name,
+            )
+
+    linked_project_entities = await memory_repository.find_entities_by_names(
+        names=active_projects,
+        entity_type=MemoryEntityType.project,
+    )
+    if linked_project_entities:
+        linked_memories = await memory_repository.list_memories_for_entities(
+            project_entity_ids=tuple(entity.id for entity in linked_project_entities.values()),
+            kinds=(
+                MemoryKind.commitment,
+                MemoryKind.project,
+                MemoryKind.collaborator,
+                MemoryKind.obligation,
+                MemoryKind.routine,
+                MemoryKind.timeline,
+            ),
+            limit=8,
+        )
+        for memory in linked_memories:
+            _append_structured_memory_line(
+                bucketed=bucketed,
+                lines=lines,
+                text=(memory.summary or memory.content or "").strip(),
+                bucket_name=bucket_name_for_kind(memory.kind),
+            )
+
+    return "\n".join(lines[:8]), {key: tuple(values) for key, values in bucketed.items()}
+
+
+async def plan_memory_retrieval(
+    *,
+    query: str,
+    active_projects: tuple[str, ...] = (),
+) -> MemoryRetrievalPlanResult:
+    structured_context, structured_buckets = await build_structured_memory_context_bundle(
+        active_projects=active_projects,
+    )
+    normalized_query = query.strip()
+    if not normalized_query:
+        return MemoryRetrievalPlanResult(
+            semantic_context=structured_context,
+            episodic_context="",
+            memory_buckets=structured_buckets,
+            degraded=False,
+            lane="structured_only",
+        )
+
+    hybrid = await retrieve_hybrid_memory(
+        query=normalized_query,
+        active_projects=active_projects,
+        limit=8,
+    )
+    semantic_hits = [hit for hit in hybrid.hits if hit.bucket != "episode"]
+    episodic_hits = [hit for hit in hybrid.hits if hit.bucket == "episode"]
+    semantic_context, semantic_buckets = _render_hits(
+        semantic_hits,
+        limit=6 if not _prefer_episodic_lane(normalized_query) else 3,
+    )
+    episodic_context, _episode_buckets = _render_hits(
+        episodic_hits,
+        limit=4 if _prefer_episodic_lane(normalized_query) else 2,
+    )
+
+    return MemoryRetrievalPlanResult(
+        semantic_context=_merge_contexts(structured_context, semantic_context),
+        episodic_context=episodic_context,
+        memory_buckets=_merge_buckets(structured_buckets, semantic_buckets),
+        degraded=hybrid.degraded,
+        lane="episodic" if _prefer_episodic_lane(normalized_query) else "hybrid",
+    )

--- a/backend/src/observer/context.py
+++ b/backend/src/observer/context.py
@@ -21,6 +21,7 @@ class CurrentContext:
 
     # Goal source
     active_goals_summary: str = ""
+    active_project: Optional[str] = None
 
     # Interaction tracking
     last_interaction: Optional[datetime] = None
@@ -89,6 +90,9 @@ class CurrentContext:
 
         if self.active_goals_summary:
             lines.append(f"Active goals: {self.active_goals_summary}")
+
+        if self.active_project:
+            lines.append(f"Active project: {self.active_project}")
 
         if self.active_window:
             lines.append(f"User is in: {self.active_window}")

--- a/backend/src/observer/manager.py
+++ b/backend/src/observer/manager.py
@@ -171,6 +171,14 @@ class ContextManager:
                     interruption_mode=old.interruption_mode,
                     attention_budget_remaining=budget,
                 )
+                try:
+                    from src.observer.screen_repository import screen_observation_repo
+
+                    recent_projects = await screen_observation_repo.get_recent_projects(limit=1)
+                    active_project = recent_projects[0] if recent_projects else None
+                except Exception:
+                    logger.debug("Failed to load active project during observer refresh", exc_info=True)
+                    active_project = old.active_project
 
                 self._context = CurrentContext(
                     time_of_day=time_data.get("time_of_day", "unknown"),
@@ -180,6 +188,7 @@ class ContextManager:
                     current_event=calendar_data.get("current_event"),
                     recent_git_activity=git_data.get("recent_git_activity"),
                     active_goals_summary=goal_data.get("active_goals_summary", ""),
+                    active_project=active_project,
                     # Preserve externally-managed fields from old context
                     last_interaction=old.last_interaction,
                     user_state=new_user_state,
@@ -204,6 +213,17 @@ class ContextManager:
                     salience_reason=assessment.salience_reason,
                     interruption_cost=assessment.interruption_cost,
                 )
+                observer_transition_count = 0
+                try:
+                    from src.memory.observer_episodes import record_observer_transition_episodes
+
+                    observer_transition_count = await record_observer_transition_episodes(
+                        old_context=old,
+                        new_context=self._context,
+                        active_project=active_project,
+                    )
+                except Exception:
+                    logger.debug("Failed to persist observer transition episodes", exc_info=True)
 
                 triggered_bundle_delivery = False
 
@@ -230,8 +250,10 @@ class ContextManager:
                         "salience_level": assessment.salience_level,
                         "salience_reason": assessment.salience_reason,
                         "interruption_cost": assessment.interruption_cost,
+                        "active_project": active_project,
                         "previous_user_state": old.user_state,
                         "new_user_state": new_user_state,
+                        "observer_transition_count": observer_transition_count,
                         "triggered_bundle_delivery": triggered_bundle_delivery,
                     },
                 )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,6 +16,7 @@ os.environ.setdefault("WORKSPACE_DIR", "/tmp/seraph-test")
 
 from src.app import create_app
 from src.llm_runtime import _reset_target_health
+from src.db.engine import _ensure_search_indexes
 from src.memory.snapshots import _reset_bounded_guardian_snapshot_cache
 
 # Every place get_session is imported — use the local attribute name.
@@ -62,6 +63,7 @@ async def async_db():
 
     async with engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
+        await _ensure_search_indexes(conn)
 
     @asynccontextmanager
     async def _get_session():

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -35,6 +35,7 @@ _PATCH_TARGETS = [
     "src.vault.repository.get_session",
     "src.observer.screen_repository.get_session",
     "src.memory.repository.get_session",
+    "src.memory.hybrid_retrieval.get_session",
 ]
 
 

--- a/backend/tests/test_db_engine.py
+++ b/backend/tests/test_db_engine.py
@@ -1,7 +1,7 @@
 from sqlalchemy import event
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from src.db.engine import _configure_sqlite_connection, _ensure_legacy_columns
+from src.db.engine import _configure_sqlite_connection, _ensure_legacy_columns, _ensure_search_indexes
 
 
 async def test_ensure_legacy_columns_backfills_kind_from_category(tmp_path):
@@ -53,5 +53,97 @@ async def test_sqlite_connection_enables_foreign_keys(tmp_path):
             row = (await conn.exec_driver_sql("PRAGMA foreign_keys")).fetchone()
             assert row is not None
             assert row[0] == 1
+    finally:
+        await engine.dispose()
+
+
+async def test_ensure_search_indexes_backfills_session_message_and_event_rows(tmp_path):
+    db_path = tmp_path / "fts-check.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    event.listen(engine.sync_engine, "connect", _configure_sqlite_connection)
+
+    try:
+        async with engine.begin() as conn:
+            await conn.exec_driver_sql(
+                """
+                CREATE TABLE sessions (
+                    id VARCHAR PRIMARY KEY,
+                    title VARCHAR,
+                    created_at DATETIME,
+                    updated_at DATETIME
+                )
+                """
+            )
+            await conn.exec_driver_sql(
+                """
+                CREATE TABLE messages (
+                    id VARCHAR PRIMARY KEY,
+                    session_id VARCHAR,
+                    role VARCHAR,
+                    content VARCHAR,
+                    metadata_json VARCHAR,
+                    step_number INTEGER,
+                    tool_used VARCHAR,
+                    created_at DATETIME
+                )
+                """
+            )
+            await conn.exec_driver_sql(
+                """
+                CREATE TABLE memory_episodes (
+                    id VARCHAR PRIMARY KEY,
+                    session_id VARCHAR,
+                    episode_type VARCHAR,
+                    summary VARCHAR,
+                    content VARCHAR,
+                    source_message_id VARCHAR,
+                    source_tool_name VARCHAR,
+                    source_role VARCHAR,
+                    subject_entity_id VARCHAR,
+                    project_entity_id VARCHAR,
+                    salience FLOAT,
+                    confidence FLOAT,
+                    metadata_json VARCHAR,
+                    observed_at DATETIME,
+                    created_at DATETIME
+                )
+                """
+            )
+            await conn.exec_driver_sql(
+                """
+                INSERT INTO sessions (id, title, created_at, updated_at)
+                VALUES ('s1', 'Atlas planning', '2026-03-25T00:00:00Z', '2026-03-25T00:00:00Z')
+                """
+            )
+            await conn.exec_driver_sql(
+                """
+                INSERT INTO messages (id, session_id, role, content, created_at)
+                VALUES ('m1', 's1', 'assistant', 'Weather planning for Atlas', '2026-03-25T00:01:00Z')
+                """
+            )
+            await conn.exec_driver_sql(
+                """
+                INSERT INTO memory_episodes (id, session_id, episode_type, summary, content, observed_at, created_at)
+                VALUES ('e1', 's1', 'workflow', 'Workflow failed', 'Upload step failed for Atlas workflow', '2026-03-25T00:02:00Z', '2026-03-25T00:02:00Z')
+                """
+            )
+
+            await _ensure_search_indexes(conn)
+
+            rows = (
+                await conn.exec_driver_sql(
+                    """
+                    SELECT entry_type, source_label, text
+                    FROM session_recall_fts
+                    WHERE session_recall_fts MATCH 'Atlas'
+                    ORDER BY created_at
+                    """
+                )
+            ).fetchall()
+
+            assert len(rows) == 3
+            assert rows[0][0] == "title"
+            assert rows[1][0] == "message"
+            assert rows[2][0] == "event"
     finally:
         await engine.dispose()

--- a/backend/tests/test_guardian_state.py
+++ b/backend/tests/test_guardian_state.py
@@ -49,6 +49,7 @@ def _make_guardian_state() -> GuardianState:
         ),
         bounded_memory_context="- Identity: Builder\n- Open todos: Ship guardian state",
         memory_context="- [goal] Ship guardian state\n- [pattern] Prefers dense dashboards",
+        episodic_memory_context="- [episode] Workflow brief-sync failed at write_file",
         current_session_history="User: What should Seraph improve next?\nAssistant: Build explicit guardian state.",
         recent_sessions_summary='- Prior roadmap: assistant said "Land guardian-state synthesis next"',
         recent_intervention_feedback="- advisory delivered, feedback=helpful, reason=available_capacity: Stretch and refocus.",
@@ -99,7 +100,7 @@ async def test_build_guardian_state_collects_memory_and_recent_sessions(async_db
         patch("src.observer.manager.context_manager.get_context", return_value=ctx),
         patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
         patch(
-            "src.memory.vector_store.search_with_status",
+            "src.memory.hybrid_retrieval.search_with_status",
             return_value=([{"category": "goal", "text": "Ship guardian state"}], False),
         ),
         patch(
@@ -182,7 +183,7 @@ async def test_build_guardian_state_lowers_overall_confidence_when_memory_is_deg
     with (
         patch("src.observer.manager.context_manager.get_context", return_value=ctx),
         patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
-        patch("src.memory.vector_store.search_with_status", return_value=([], True)),
+        patch("src.memory.hybrid_retrieval.search_with_status", return_value=([], True)),
         patch("src.audit.repository.audit_repository.list_events", return_value=[]),
         patch(
             "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
@@ -260,7 +261,7 @@ async def test_build_guardian_state_uses_structured_memory_kinds(async_db):
     with (
         patch("src.observer.manager.context_manager.get_context", return_value=ctx),
         patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
-        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.memory.hybrid_retrieval.search_with_status", return_value=([], False)),
         patch("src.audit.repository.audit_repository.list_events", return_value=[]),
         patch(
             "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
@@ -345,7 +346,7 @@ async def test_build_guardian_state_pulls_project_linked_memories_for_active_pro
     with (
         patch("src.observer.manager.context_manager.get_context", return_value=ctx),
         patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
-        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.memory.hybrid_retrieval.search_with_status", return_value=([], False)),
         patch("src.audit.repository.audit_repository.list_events", return_value=[]),
         patch(
             "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
@@ -408,7 +409,7 @@ async def test_build_guardian_state_uses_unique_project_token_fallback_for_linke
     with (
         patch("src.observer.manager.context_manager.get_context", return_value=ctx),
         patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
-        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.memory.hybrid_retrieval.search_with_status", return_value=([], False)),
         patch("src.audit.repository.audit_repository.list_events", return_value=[]),
         patch(
             "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
@@ -423,6 +424,72 @@ async def test_build_guardian_state_uses_unique_project_token_fallback_for_linke
 
     assert "Atlas launch" in state.world_model.active_projects
     assert "Send the Atlas checklist before Friday" in state.world_model.active_commitments
+
+
+@pytest.mark.asyncio
+async def test_build_guardian_state_routes_temporal_queries_into_episodic_context(async_db):
+    sm = SessionManager()
+    await sm.get_or_create("current")
+    await sm.add_message("current", "user", "What happened with Atlas upload yesterday?")
+    await sm.add_message("current", "assistant", "Let me check the recent Atlas events.")
+
+    atlas = await memory_repository.get_or_create_entity(
+        canonical_name="Atlas launch",
+        entity_type="project",
+    )
+    await memory_repository.create_memory(
+        content="Atlas launch is the active release project.",
+        kind=MemoryKind.project,
+        summary="Atlas launch",
+        importance=0.8,
+        project_entity_id=atlas.id,
+    )
+    await memory_repository.create_episode(
+        session_id="current",
+        episode_type="workflow",
+        summary="Workflow Atlas deploy failed at upload step",
+        content="Workflow Atlas deploy failed at the upload artifact step.",
+        project_entity_id=atlas.id,
+        salience=0.9,
+        confidence=0.8,
+    )
+
+    ctx = CurrentContext(
+        time_of_day="morning",
+        day_of_week="Monday",
+        is_working_hours=True,
+        active_goals_summary="Support Atlas launch",
+        active_window="VS Code",
+        screen_context="Reviewing Atlas deploy logs",
+        data_quality="good",
+        observer_confidence="grounded",
+        salience_level="high",
+        salience_reason="active_goals",
+        interruption_cost="low",
+    )
+
+    with (
+        patch("src.observer.manager.context_manager.get_context", return_value=ctx),
+        patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
+        patch("src.memory.hybrid_retrieval.search_with_status", return_value=([], False)),
+        patch("src.audit.repository.audit_repository.list_events", return_value=[]),
+        patch(
+            "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
+            return_value=["Atlas"],
+        ),
+        patch(
+            "src.guardian.feedback.guardian_feedback_repository.summarize_recent",
+            return_value="",
+        ),
+    ):
+        state = await build_guardian_state(
+            session_id="current",
+            user_message="What happened with Atlas upload yesterday?",
+        )
+
+    assert "[episode] Workflow Atlas deploy failed at upload step" in state.episodic_memory_context
+    assert "[project] Atlas launch" in state.memory_context
+    assert state.confidence.memory == "grounded"
 
 
 @pytest.mark.asyncio
@@ -475,7 +542,7 @@ async def test_build_guardian_state_uses_bounded_snapshot_with_todo_overlay(asyn
     with (
         patch("src.observer.manager.context_manager.get_context", return_value=ctx),
         patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder\n\n## Goals\n- Keep the system grounded"),
-        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.memory.hybrid_retrieval.search_with_status", return_value=([], False)),
         patch("src.audit.repository.audit_repository.list_events", return_value=[]),
         patch(
             "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
@@ -532,7 +599,7 @@ async def test_build_guardian_state_recomputes_structured_bounded_memory_when_sn
     with (
         patch("src.observer.manager.context_manager.get_context", return_value=ctx),
         patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
-        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.memory.hybrid_retrieval.search_with_status", return_value=([], False)),
         patch("src.audit.repository.audit_repository.list_events", return_value=[]),
         patch(
             "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
@@ -585,7 +652,7 @@ async def test_build_guardian_state_invalidates_bounded_snapshot_when_session_id
     with (
         patch("src.observer.manager.context_manager.get_context", return_value=ctx),
         patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
-        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.memory.hybrid_retrieval.search_with_status", return_value=([], False)),
         patch("src.audit.repository.audit_repository.list_events", return_value=[]),
         patch(
             "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
@@ -612,7 +679,7 @@ async def test_build_guardian_state_invalidates_bounded_snapshot_when_session_id
     with (
         patch("src.observer.manager.context_manager.get_context", return_value=ctx),
         patch("src.memory.soul.read_soul", return_value="# Soul\n\n## Identity\nBuilder"),
-        patch("src.memory.vector_store.search_with_status", return_value=([], False)),
+        patch("src.memory.hybrid_retrieval.search_with_status", return_value=([], False)),
         patch("src.audit.repository.audit_repository.list_events", return_value=[]),
         patch(
             "src.observer.screen_repository.screen_observation_repo.get_recent_projects",
@@ -651,6 +718,7 @@ def test_guardian_state_prompt_block_exposes_confidence_and_recent_sessions():
     assert "Observer snapshot:" in block
     assert "Bounded recall:" in block
     assert "Relevant memories:" in block
+    assert "Relevant episodes:" in block
     assert "Recent sessions:" in block
     assert "Recent intervention feedback:" in block
     assert "Recent execution:" in block

--- a/backend/tests/test_hybrid_memory_retrieval.py
+++ b/backend/tests/test_hybrid_memory_retrieval.py
@@ -1,0 +1,122 @@
+from unittest.mock import patch
+
+import pytest
+
+from src.agent.session import SessionManager
+from src.db.models import MemoryEpisodeType, MemoryKind
+from src.memory.hybrid_retrieval import retrieve_hybrid_memory
+from src.memory.repository import memory_repository
+
+
+@pytest.mark.asyncio
+async def test_hybrid_retrieval_combines_semantic_episode_and_vector_hits(async_db):
+    sm = SessionManager()
+    await sm.get_or_create("s1")
+    atlas = await memory_repository.get_or_create_entity(
+        canonical_name="Project Atlas",
+        entity_type="project",
+        aliases=["Atlas"],
+    )
+    await memory_repository.create_memory(
+        content="Atlas launch is the active release project.",
+        kind=MemoryKind.project,
+        summary="Atlas launch",
+        importance=0.8,
+        confidence=0.9,
+        project_entity_id=atlas.id,
+    )
+    await memory_repository.create_episode(
+        episode_type=MemoryEpisodeType.workflow,
+        session_id="s1",
+        summary="Workflow Atlas deploy failed at upload step",
+        content="Workflow Atlas deploy failed at the upload artifact step.",
+        project_entity_id=atlas.id,
+        salience=0.9,
+        confidence=0.8,
+    )
+
+    with patch(
+        "src.memory.hybrid_retrieval.search_with_status",
+        return_value=(
+            [
+                {
+                    "text": "Atlas stakeholder brief needs a summary update.",
+                    "category": "fact",
+                    "score": 0.18,
+                    "created_at": "2026-03-25T09:00:00+00:00",
+                }
+            ],
+            False,
+        ),
+    ):
+        result = await retrieve_hybrid_memory(
+            query="Atlas upload summary",
+            active_projects=("Atlas",),
+            limit=6,
+        )
+
+    assert "[project] Atlas launch" in result.context
+    assert "[episode] Workflow Atlas deploy failed at upload step" in result.context
+    assert "[fact] Atlas stakeholder brief needs a summary update." in result.context
+    assert {hit.source for hit in result.hits} == {"semantic", "episodic", "vector"}
+
+
+@pytest.mark.asyncio
+async def test_hybrid_retrieval_boosts_active_project_linked_memories_without_lexical_match(async_db):
+    atlas = await memory_repository.get_or_create_entity(
+        canonical_name="Atlas launch",
+        entity_type="project",
+    )
+    await memory_repository.create_memory(
+        content="Prepare the Hermes budget memo.",
+        kind=MemoryKind.commitment,
+        summary="Prepare the Hermes budget memo",
+        importance=0.99,
+        confidence=0.8,
+    )
+    await memory_repository.create_memory(
+        content="Send the Atlas checklist before Friday.",
+        kind=MemoryKind.commitment,
+        summary="Send the Atlas checklist before Friday",
+        importance=0.25,
+        confidence=0.8,
+        project_entity_id=atlas.id,
+    )
+
+    with patch(
+        "src.memory.hybrid_retrieval.search_with_status",
+        return_value=([], False),
+    ):
+        result = await retrieve_hybrid_memory(
+            query="What should I focus on right now?",
+            active_projects=("Atlas",),
+            limit=4,
+        )
+
+    assert result.hits[0].text == "Send the Atlas checklist before Friday"
+    assert result.hits[0].source == "semantic"
+
+
+@pytest.mark.asyncio
+async def test_hybrid_retrieval_marks_vector_failures_degraded_but_keeps_lexical_hits(async_db):
+    await memory_repository.create_memory(
+        content="Review the Atlas launch brief.",
+        kind=MemoryKind.commitment,
+        summary="Review the Atlas launch brief",
+        importance=0.8,
+        confidence=0.8,
+    )
+
+    with patch(
+        "src.memory.hybrid_retrieval.search_with_status",
+        return_value=([], True),
+    ):
+        result = await retrieve_hybrid_memory(
+            query="Atlas brief",
+            active_projects=(),
+            limit=4,
+        )
+
+    assert result.degraded is True
+    assert result.hits[0].text == "Review the Atlas launch brief"
+    assert "[commitment] Review the Atlas launch brief" in result.context

--- a/backend/tests/test_memory_episodes.py
+++ b/backend/tests/test_memory_episodes.py
@@ -1,0 +1,149 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from src.agent.session import SessionManager
+from src.db.models import MemoryEpisodeType
+from src.memory.episodes import EpisodeDraft
+from src.memory.repository import memory_repository
+
+
+@pytest.fixture
+def sm():
+    return SessionManager()
+
+
+@pytest.mark.asyncio
+async def test_create_episode_persists_typed_fields(async_db, sm):
+    await sm.get_or_create("sess-1")
+    episode = await memory_repository.create_episode(
+        episode_type=MemoryEpisodeType.decision,
+        summary="Chose to ship the Atlas launch first",
+        content="Decision: prioritize Atlas launch before the Hermes admin cleanup.",
+        session_id="sess-1",
+        source_tool_name="strategist",
+        source_role="assistant",
+        salience=0.82,
+        confidence=0.77,
+        metadata={"writer": "test"},
+    )
+
+    episodes = await memory_repository.list_episodes(limit=5)
+
+    assert episode.id
+    assert len(episodes) == 1
+    assert episodes[0].episode_type == MemoryEpisodeType.decision
+    assert episodes[0].summary == "Chose to ship the Atlas launch first"
+    assert episodes[0].session_id == "sess-1"
+    assert episodes[0].source_tool_name == "strategist"
+    assert episodes[0].source_role == "assistant"
+    assert episodes[0].salience == pytest.approx(0.82)
+    assert episodes[0].confidence == pytest.approx(0.77)
+    assert episodes[0].metadata_json == '{"writer": "test"}'
+
+
+@pytest.mark.asyncio
+async def test_session_messages_create_conversation_episode(async_db, sm):
+    await sm.get_or_create("s1")
+
+    message = await sm.add_message("s1", "user", "Need to remember the Atlas launch budget discussion.")
+    episodes = await memory_repository.list_episodes(session_id="s1", limit=5)
+
+    assert len(episodes) == 1
+    assert episodes[0].episode_type == MemoryEpisodeType.conversation
+    assert episodes[0].source_message_id == message.id
+    assert episodes[0].source_role == "user"
+    assert "Atlas launch budget discussion" in episodes[0].summary
+
+
+@pytest.mark.asyncio
+async def test_session_step_messages_create_tool_and_workflow_episodes(async_db, sm):
+    await sm.get_or_create("s1")
+
+    await sm.add_message("s1", "step", "Searched the repo for session search usage.", tool_used="session_search")
+    await sm.add_message(
+        "s1",
+        "step",
+        "Ran the weekly review workflow with fresh parameters.",
+        tool_used="workflow_runner",
+        metadata_json=json.dumps({"workflow_name": "weekly_review"}),
+    )
+
+    episodes = await memory_repository.list_episodes(session_id="s1", limit=5)
+    assert [episode.episode_type for episode in episodes] == [
+        MemoryEpisodeType.workflow,
+        MemoryEpisodeType.tool,
+    ]
+    assert episodes[0].source_tool_name == "workflow_runner"
+    assert episodes[0].metadata_json == '{"source": "session_step", "workflow_name": "weekly_review"}'
+    assert episodes[1].source_tool_name == "session_search"
+
+
+@pytest.mark.asyncio
+async def test_list_episodes_filters_by_type(async_db):
+    sm = SessionManager()
+    await sm.get_or_create("a")
+    await sm.get_or_create("b")
+    await memory_repository.create_episode(
+        episode_type=MemoryEpisodeType.conversation,
+        summary="Reviewed Mercury launch risks",
+        content="Conversation about Mercury launch risks.",
+        session_id="a",
+    )
+    await memory_repository.create_episode(
+        episode_type=MemoryEpisodeType.observer,
+        summary="Focus changed to Apollo roadmap",
+        content="Observer transition: focus moved to Apollo roadmap.",
+        session_id="b",
+    )
+
+    filtered = await memory_repository.list_episodes(
+        episode_types=(MemoryEpisodeType.observer,),
+        limit=5,
+    )
+
+    assert [episode.episode_type for episode in filtered] == [MemoryEpisodeType.observer]
+    assert filtered[0].session_id == "b"
+
+
+@pytest.mark.asyncio
+async def test_episode_write_failure_does_not_block_message_persistence(async_db, sm):
+    await sm.get_or_create("s1")
+    bad_draft = EpisodeDraft(
+        episode_type=MemoryEpisodeType.conversation,
+        summary="bad episode",
+        content="bad episode content",
+        source_role="user",
+    )
+
+    with patch("src.agent.session.build_message_episode", return_value=bad_draft), patch(
+        "src.agent.session.MemoryEpisode",
+        side_effect=RuntimeError("episode insert exploded"),
+    ):
+        message = await sm.add_message("s1", "user", "Keep the chat message even if episodic write fails.")
+
+    messages = await sm.get_messages("s1")
+    episodes = await memory_repository.list_episodes(session_id="s1", limit=5)
+
+    assert message.id
+    assert [item["content"] for item in messages] == [
+        "Keep the chat message even if episodic write fails."
+    ]
+    assert episodes == []
+
+
+@pytest.mark.asyncio
+async def test_session_delete_cleans_up_episodes_linked_only_by_source_message(async_db, sm):
+    await sm.get_or_create("s1")
+    message = await sm.add_message("s1", "user", "Atlas launch needs a follow-up note.")
+    await memory_repository.create_episode(
+        episode_type=MemoryEpisodeType.decision,
+        summary="Decision tied only to the message",
+        content="This episode intentionally omits session_id but references the message.",
+        source_message_id=message.id,
+    )
+
+    deleted = await sm.delete("s1")
+
+    assert deleted is True

--- a/backend/tests/test_observer_manager.py
+++ b/backend/tests/test_observer_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import time
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, AsyncMock, MagicMock
@@ -8,6 +9,8 @@ import pytest
 from config.settings import settings
 from src.extensions.state import save_extension_state_payload
 from src.audit.repository import audit_repository
+from src.db.models import MemoryEpisodeType
+from src.memory.repository import memory_repository
 from src.observer.context import CurrentContext
 from src.observer.manager import ContextManager, _active_observer_definitions
 
@@ -257,6 +260,163 @@ class TestContextManagerRefresh:
             and event["details"]["data_quality"] == "degraded"
             and event["details"]["sources_ok"] == 3
             for event in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_records_observer_transition_episodes(self, async_db):
+        mgr = ContextManager()
+        mgr.update_screen_context("VS Code", "Editing Atlas rollout notes")
+
+        with patch("src.observer.manager._active_observer_definitions", return_value=[("time", "time"), ("goals", "goals")]), \
+             patch("src.observer.sources.time_source.gather_time", return_value={
+                 "time_of_day": "afternoon",
+                 "day_of_week": "Tuesday",
+                 "is_working_hours": True,
+             }), \
+             patch("src.observer.sources.goal_source.gather_goals", new_callable=AsyncMock, return_value={
+                 "active_goals_summary": "Ship Atlas launch"
+             }), \
+             patch("src.observer.manager.user_state_machine.derive_state", return_value="deep_work"), \
+             patch("src.observer.screen_repository.screen_observation_repo.get_recent_projects", new_callable=AsyncMock, return_value=["Atlas"]):
+            ctx = await mgr.refresh()
+
+        episodes = await memory_repository.list_episodes(
+            episode_types=(MemoryEpisodeType.observer,),
+            limit=10,
+        )
+
+        assert ctx.active_project == "Atlas"
+        assert len(episodes) == 3
+        assert [json.loads(item.metadata_json)["observer_transition"] for item in episodes] == [
+            "activity",
+            "focus",
+            "project",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_refresh_logs_observer_transition_details(self, async_db):
+        mgr = ContextManager()
+        mgr.update_screen_context("VS Code", "Editing Atlas rollout notes")
+
+        with patch("src.observer.manager._active_observer_definitions", return_value=[("time", "time"), ("goals", "goals")]), \
+             patch("src.observer.sources.time_source.gather_time", return_value={
+                 "time_of_day": "afternoon",
+                 "day_of_week": "Tuesday",
+                 "is_working_hours": True,
+             }), \
+             patch("src.observer.sources.goal_source.gather_goals", new_callable=AsyncMock, return_value={
+                 "active_goals_summary": "Ship Atlas launch"
+             }), \
+             patch("src.observer.manager.user_state_machine.derive_state", return_value="deep_work"), \
+             patch("src.observer.screen_repository.screen_observation_repo.get_recent_projects", new_callable=AsyncMock, return_value=["Atlas"]):
+            await mgr.refresh()
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "background_task_succeeded"
+            and event["tool_name"] == "observer_context_refresh"
+            and event["details"]["active_project"] == "Atlas"
+            and event["details"]["observer_transition_count"] == 3
+            for event in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_does_not_duplicate_observer_transition_episodes_without_change(self, async_db):
+        mgr = ContextManager()
+        mgr.update_screen_context("VS Code", "Editing Atlas rollout notes")
+
+        with patch("src.observer.manager._active_observer_definitions", return_value=[("time", "time"), ("goals", "goals")]), \
+             patch("src.observer.sources.time_source.gather_time", return_value={
+                 "time_of_day": "afternoon",
+                 "day_of_week": "Tuesday",
+                 "is_working_hours": True,
+             }), \
+             patch("src.observer.sources.goal_source.gather_goals", new_callable=AsyncMock, return_value={
+                 "active_goals_summary": "Ship Atlas launch"
+             }), \
+             patch("src.observer.manager.user_state_machine.derive_state", return_value="deep_work"), \
+             patch("src.observer.screen_repository.screen_observation_repo.get_recent_projects", new_callable=AsyncMock, return_value=["Atlas"]):
+            await mgr.refresh()
+        with patch("src.observer.manager._active_observer_definitions", return_value=[("time", "time"), ("goals", "goals")]), \
+             patch("src.observer.sources.time_source.gather_time", return_value={
+                 "time_of_day": "afternoon",
+                 "day_of_week": "Tuesday",
+                 "is_working_hours": True,
+             }), \
+             patch("src.observer.sources.goal_source.gather_goals", new_callable=AsyncMock, return_value={
+                 "active_goals_summary": "Ship Atlas launch"
+             }), \
+             patch("src.observer.manager.user_state_machine.derive_state", return_value="deep_work"), \
+             patch("src.observer.screen_repository.screen_observation_repo.get_recent_projects", new_callable=AsyncMock, return_value=["Atlas"]):
+            await mgr.refresh()
+
+        episodes = await memory_repository.list_episodes(
+            episode_types=(MemoryEpisodeType.observer,),
+            limit=10,
+        )
+
+        assert len(episodes) == 3
+
+    @pytest.mark.asyncio
+    async def test_refresh_survives_observer_episode_write_failure(self, async_db):
+        mgr = ContextManager()
+        mgr.update_screen_context("VS Code", "Editing Atlas rollout notes")
+
+        with patch("src.observer.manager._active_observer_definitions", return_value=[("time", "time"), ("goals", "goals")]), \
+             patch("src.observer.sources.time_source.gather_time", return_value={
+                 "time_of_day": "afternoon",
+                 "day_of_week": "Tuesday",
+                 "is_working_hours": True,
+             }), \
+             patch("src.observer.sources.goal_source.gather_goals", new_callable=AsyncMock, return_value={
+                 "active_goals_summary": "Ship Atlas launch"
+             }), \
+             patch("src.observer.manager.user_state_machine.derive_state", return_value="deep_work"), \
+             patch("src.observer.screen_repository.screen_observation_repo.get_recent_projects", new_callable=AsyncMock, return_value=["Atlas"]), \
+             patch("src.memory.observer_episodes.memory_repository.create_episode_batch", new_callable=AsyncMock, side_effect=RuntimeError("episode write failed")):
+            ctx = await mgr.refresh()
+
+        episodes = await memory_repository.list_episodes(
+            episode_types=(MemoryEpisodeType.observer,),
+            limit=10,
+        )
+
+        assert ctx.active_project == "Atlas"
+        assert episodes == []
+
+    @pytest.mark.asyncio
+    async def test_refresh_records_project_clear_transition(self, async_db):
+        mgr = ContextManager()
+        mgr._context.active_project = "Atlas"
+        mgr._context.active_goals_summary = "Ship Atlas launch"
+        mgr._context.active_window = "VS Code"
+        mgr._context.user_state = "deep_work"
+        mgr.update_screen_context("VS Code", "Reviewing launch wrap-up")
+
+        with patch("src.observer.manager._active_observer_definitions", return_value=[("time", "time"), ("goals", "goals")]), \
+             patch("src.observer.sources.time_source.gather_time", return_value={
+                 "time_of_day": "evening",
+                 "day_of_week": "Tuesday",
+                 "is_working_hours": False,
+             }), \
+             patch("src.observer.sources.goal_source.gather_goals", new_callable=AsyncMock, return_value={
+                 "active_goals_summary": ""
+             }), \
+             patch("src.observer.manager.user_state_machine.derive_state", return_value="available"), \
+             patch("src.observer.screen_repository.screen_observation_repo.get_recent_projects", new_callable=AsyncMock, return_value=[]):
+            ctx = await mgr.refresh()
+
+        episodes = await memory_repository.list_episodes(
+            episode_types=(MemoryEpisodeType.observer,),
+            limit=10,
+        )
+
+        assert ctx.active_project is None
+        assert any(
+            json.loads(item.metadata_json)["observer_transition"] == "project"
+            and json.loads(item.metadata_json)["previous_project"] == "Atlas"
+            and json.loads(item.metadata_json)["current_project"] is None
+            for item in episodes
         )
 
     @pytest.mark.asyncio

--- a/backend/tests/test_observer_manager.py
+++ b/backend/tests/test_observer_manager.py
@@ -420,6 +420,41 @@ class TestContextManagerRefresh:
         )
 
     @pytest.mark.asyncio
+    async def test_refresh_reuses_existing_project_entity_for_alias_like_observer_label(self, async_db):
+        mgr = ContextManager()
+        mgr.update_screen_context("VS Code", "Editing Atlas rollout notes")
+        existing_project = await memory_repository.get_or_create_entity(
+            canonical_name="Atlas launch",
+            entity_type="project",
+        )
+
+        with patch("src.observer.manager._active_observer_definitions", return_value=[("time", "time"), ("goals", "goals")]), \
+             patch("src.observer.sources.time_source.gather_time", return_value={
+                 "time_of_day": "afternoon",
+                 "day_of_week": "Tuesday",
+                 "is_working_hours": True,
+             }), \
+             patch("src.observer.sources.goal_source.gather_goals", new_callable=AsyncMock, return_value={
+                 "active_goals_summary": "Ship Atlas launch"
+             }), \
+             patch("src.observer.manager.user_state_machine.derive_state", return_value="deep_work"), \
+             patch("src.observer.screen_repository.screen_observation_repo.get_recent_projects", new_callable=AsyncMock, return_value=["Atlas"]):
+            await mgr.refresh()
+
+        episodes = await memory_repository.list_episodes(
+            episode_types=(MemoryEpisodeType.observer,),
+            limit=10,
+        )
+        resolved = await memory_repository.find_entities_by_names(
+            names=("Atlas", "Atlas launch"),
+            entity_type="project",
+        )
+
+        assert resolved["Atlas"].id == existing_project.id
+        assert resolved["Atlas launch"].id == existing_project.id
+        assert all(item.project_entity_id == existing_project.id for item in episodes)
+
+    @pytest.mark.asyncio
     async def test_refresh_logs_failure_runtime_audit_event(self, async_db):
         mgr = ContextManager()
 

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -210,6 +210,22 @@ class TestSearchSessions:
         assert results[0]["session_id"] == "s1"
         assert results[0]["source"] == "message"
 
+    async def test_matches_episodic_event_content(self, async_db, sm):
+        await sm.get_or_create("ops")
+        await sm.add_message(
+            "ops",
+            "step",
+            "Workflow Atlas launch deploy failed at the upload artifact step.",
+            tool_used="workflow_runner",
+        )
+
+        results = await sm.search_sessions("upload")
+
+        assert len(results) == 1
+        assert results[0]["session_id"] == "ops"
+        assert results[0]["source"] == "event"
+        assert "upload artifact step" in results[0]["snippet"].lower()
+
     async def test_matches_titles_and_excludes_current(self, async_db, sm):
         await sm.get_or_create("weather-thread")
         await sm.update_title("weather-thread", "Weather planning")
@@ -263,6 +279,16 @@ class TestSearchSessions:
         results = await sm.search_sessions("weather")
 
         assert [item["session_id"] for item in results[:2]] == ["s2", "s1"]
+
+    async def test_title_updates_refresh_fts_index(self, async_db, sm):
+        await sm.get_or_create("rename-me")
+        await sm.update_title("rename-me", "Atlas planning")
+        await sm.update_title("rename-me", "Hermes planning")
+
+        results = await sm.search_sessions("hermes")
+
+        assert [item["session_id"] for item in results] == ["rename-me"]
+        assert results[0]["source"] == "title"
 
 
 class TestRecentSessionSummary:

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -226,6 +226,22 @@ class TestSearchSessions:
         assert results[0]["source"] == "event"
         assert "upload artifact step" in results[0]["snippet"].lower()
 
+    async def test_fallback_search_still_matches_episodic_event_content(self, async_db, sm):
+        await sm.get_or_create("ops")
+        await sm.add_message(
+            "ops",
+            "step",
+            "Workflow Atlas launch deploy failed at upload? artifact step.",
+            tool_used="workflow_runner",
+        )
+
+        results = await sm.search_sessions("upload?")
+
+        assert len(results) == 1
+        assert results[0]["session_id"] == "ops"
+        assert results[0]["source"] == "event"
+        assert "upload?" in results[0]["snippet"].lower()
+
     async def test_matches_titles_and_excludes_current(self, async_db, sm):
         await sm.get_or_create("weather-thread")
         await sm.update_title("weather-thread", "Weather planning")

--- a/backend/tests/test_strategist_tick.py
+++ b/backend/tests/test_strategist_tick.py
@@ -47,6 +47,7 @@ def _make_guardian_state() -> GuardianState:
             intervention_receptivity="low",
         ),
         memory_context="- [goal] Ship guardian state",
+        episodic_memory_context="",
         current_session_history="",
         recent_sessions_summary='- Prior roadmap: assistant said "Land guardian-state synthesis next"',
         recent_intervention_feedback="- advisory delivered, feedback=helpful: Stretch and refocus.",

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -464,7 +464,7 @@ This is the next major Guardian Intelligence execution program after the current
 
 6. [x] `episodic-memory-events-v1`:
    store typed episodic records for important conversation, workflow, tool, and decision boundaries so recall can reason over time instead of only semantic similarity
-7. [ ] `observer-episodic-fusion-v1`:
+7. [x] `observer-episodic-fusion-v1`:
    write observer project, focus, and activity transitions into episodic memory with conservative salience rules and clear provenance
 8. [ ] `session-search-fts-and-event-index-v1`:
    upgrade session recall from plain text matching to FTS-backed session and event search with better bounded summaries

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -466,7 +466,7 @@ This is the next major Guardian Intelligence execution program after the current
    store typed episodic records for important conversation, workflow, tool, and decision boundaries so recall can reason over time instead of only semantic similarity
 7. [x] `observer-episodic-fusion-v1`:
    write observer project, focus, and activity transitions into episodic memory with conservative salience rules and clear provenance
-8. [ ] `session-search-fts-and-event-index-v1`:
+8. [x] `session-search-fts-and-event-index-v1`:
    upgrade session recall from plain text matching to FTS-backed session and event search with better bounded summaries
 9. [ ] `hybrid-memory-retrieval-v1`:
    add lexical plus vector retrieval, reranking, recency weighting, and project or entity boosts across structured semantic memory and episodic memory

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -462,7 +462,7 @@ This is the next major Guardian Intelligence execution program after the current
 
 ### Batch B: Episodic and observer-driven retrieval
 
-6. [ ] `episodic-memory-events-v1`:
+6. [x] `episodic-memory-events-v1`:
    store typed episodic records for important conversation, workflow, tool, and decision boundaries so recall can reason over time instead of only semantic similarity
 7. [ ] `observer-episodic-fusion-v1`:
    write observer project, focus, and activity transitions into episodic memory with conservative salience rules and clear provenance

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -470,8 +470,8 @@ This is the next major Guardian Intelligence execution program after the current
    upgrade session recall from plain text matching to FTS-backed session and event search with better bounded summaries
 9. [x] `hybrid-memory-retrieval-v1`:
    add lexical plus vector retrieval, reranking, recency weighting, and project or entity boosts across structured semantic memory and episodic memory
-10. [ ] `guardian-state-retrieval-planner-v1`:
-    route guardian-state synthesis between bounded, episodic, semantic, and procedural retrieval lanes instead of issuing one generic memory search
+10. [x] `guardian-state-retrieval-planner-v1`:
+    route guardian-state synthesis through one bounded, semantic, and episodic retrieval planner, while leaving procedural-memory routing for Batch C once outcome-derived procedural memory exists
 
 ### Batch C: Learning, consolidation, and decay
 

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -468,7 +468,7 @@ This is the next major Guardian Intelligence execution program after the current
    write observer project, focus, and activity transitions into episodic memory with conservative salience rules and clear provenance
 8. [x] `session-search-fts-and-event-index-v1`:
    upgrade session recall from plain text matching to FTS-backed session and event search with better bounded summaries
-9. [ ] `hybrid-memory-retrieval-v1`:
+9. [x] `hybrid-memory-retrieval-v1`:
    add lexical plus vector retrieval, reranking, recency weighting, and project or entity boosts across structured semantic memory and episodic memory
 10. [ ] `guardian-state-retrieval-planner-v1`:
     route guardian-state synthesis between bounded, episodic, semantic, and procedural retrieval lanes instead of issuing one generic memory search

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -351,6 +351,41 @@ This section records the internal Batch B slices on the feature branch before th
     - the retriever exists, but guardian-state still uses the older memory assembly path until `guardian-state-retrieval-planner-v1` lands
     - procedural-memory routing still belongs to Batch C because outcome-derived procedural memory is not a live retrieval lane yet
 
+### `guardian-state-retrieval-planner-v1`
+
+- status: complete on `feat/memory-batch-b-v1`, pending inclusion in the aggregate Batch B PR
+- scope:
+  - added `backend/src/memory/retrieval_planner.py` so guardian-state memory assembly now flows through one planner instead of splitting structured-memory assembly and query-time recall across separate code paths
+  - moved structured semantic bundle assembly out of `backend/src/guardian/state.py` and into the planner, keeping project-linked semantic boosts while layering hybrid semantic plus episodic recall on top
+  - updated guardian-state synthesis to split semantic recall into `Relevant memories:` and episodic recall into `Relevant episodes:` so temporal questions can surface event history without flattening everything into one generic memory block
+  - added a temporal-query guardian-state regression test that proves Atlas project memory still lands in semantic recall while a linked workflow failure lands in episodic recall for a `yesterday`-style question
+- validation:
+  - `backend/.venv/bin/python -m py_compile backend/src/memory/retrieval_planner.py backend/src/guardian/state.py backend/tests/test_guardian_state.py backend/tests/test_strategist_tick.py`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_guardian_state.py backend/tests/test_hybrid_memory_retrieval.py -q`
+- review notes:
+  - broader validation boundary observed:
+    - `backend/tests/test_strategist_tick.py::test_strategist_tick_binds_runtime_context_for_tool_audit` still fails because the expected `tool_call` audit event with `session_id == "scheduler:strategist_tick"` is not emitted
+    - that check does not exercise the new retrieval-planner path directly, so it is recorded as an unrelated runtime-audit seam rather than treated as a blocker for this Batch B slice
+  - subagent review:
+    - reviewer thread: `Kuhn` (`019d2539-795c-7f02-ab99-8db767c17dd2`)
+    - result: the review thread stalled before returning findings, so the completion record relies on the targeted guardian-state plus hybrid-retrieval validation above and the explicit strategist-audit boundary note instead of claiming an unreturned clean review
+  - deferred to Batch C:
+    - procedural-memory routing still belongs to the outcome-learning batch because outcome-derived procedural memory is not a live retrieval lane yet
+    - planner-driven routing into policy- or delivery-specific memory lanes should wait until procedural memory exists instead of inventing a hollow extra lane now
+
+### Batch B Aggregate Validation
+
+- status: ready for the aggregate Batch B GitHub PR from `feat/memory-batch-b-v1`
+- targeted validation:
+  - `backend/.venv/bin/python -m py_compile backend/src/db/engine.py backend/src/agent/session.py backend/src/observer/context.py backend/src/memory/observer_episodes.py backend/src/observer/manager.py backend/src/memory/hybrid_retrieval.py backend/src/memory/retrieval_planner.py backend/src/guardian/state.py backend/tests/test_db_engine.py backend/tests/test_session.py backend/tests/test_session_search_tool.py backend/tests/test_memory_episodes.py backend/tests/test_observer_manager.py backend/tests/test_hybrid_memory_retrieval.py backend/tests/test_guardian_state.py`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_db_engine.py backend/tests/test_session.py backend/tests/test_session_search_tool.py backend/tests/test_memory_episodes.py backend/tests/test_observer_manager.py backend/tests/test_hybrid_memory_retrieval.py backend/tests/test_guardian_state.py backend/tests/test_memory_repository.py -q`
+  - `cd docs && npm run build`
+- broader validation boundary:
+  - `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`
+  - result: `1209 passed, 35 failed`
+  - the failures cluster in approval wrapping, runtime audit or session-context propagation, eval harness, goal-tree orphan handling, scheduled-job runtime context, and tool-audit paths; the Batch B memory suite above remained green
+  - the already observed strategist audit-context failure remains part of that broader unrelated failure set rather than a new retrieval-planner regression
+
 ## Non-Goals
 
 - marketing “guardian intelligence” before the learning loop is real

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -305,6 +305,10 @@ This section records the internal Batch B slices on the feature branch before th
   - deferred to later Batch B slices:
     - observer episodes are still lexical/temporal substrate only; retrieval and ranking belong to the later FTS and hybrid retrieval slices
     - richer observer-event semantics beyond project, focus, and blocked-state activity transitions still belong to later observer-memory refinement work
+  - aggregate PR follow-up:
+    - external PR review caught that observer transition writes could create a new project entity from a shortened observer label like `Atlas`, which would fragment recall away from existing memories linked to `Atlas launch`
+    - fixed on the branch by resolving observer project labels through existing project-entity lookup first, including the unique-token project fallback, before creating a new entity only when nothing resolves
+    - added a regression test that proves observer episodes reuse the existing `Atlas launch` project entity when the observer reports `Atlas`
 
 ### `session-search-fts-and-event-index-v1`
 
@@ -328,6 +332,10 @@ This section records the internal Batch B slices on the feature branch before th
   - deferred to later Batch B slices:
     - session recall is now lexical plus episodic, but cross-store hybrid ranking with semantic memory still belongs to `hybrid-memory-retrieval-v1`
     - query-type routing between session recall and guardian-state memory assembly still belongs to `guardian-state-retrieval-planner-v1`
+  - aggregate PR follow-up:
+    - external PR review caught that the LIKE fallback path only searched user and assistant messages, so episodic event recall disappeared for punctuation-heavy or FTS-ineligible queries
+    - fixed on the branch by teaching the fallback path to search non-conversation episodic events as well, mirroring the event coverage of the FTS path
+    - added a regression test that proves `upload?` still returns the workflow event match through the fallback lane
 
 ### `hybrid-memory-retrieval-v1`
 
@@ -385,6 +393,9 @@ This section records the internal Batch B slices on the feature branch before th
   - result: `1209 passed, 35 failed`
   - the failures cluster in approval wrapping, runtime audit or session-context propagation, eval harness, goal-tree orphan handling, scheduled-job runtime context, and tool-audit paths; the Batch B memory suite above remained green
   - the already observed strategist audit-context failure remains part of that broader unrelated failure set rather than a new retrieval-planner regression
+- PR review follow-up:
+  - a follow-up subagent review was started with `Einstein` (`019d2695-7bf7-7b10-97dd-6145a50ea090`) for the observer-entity reuse and fallback-event-search fixes
+  - that review thread stalled before returning findings, so the review record relies on the targeted regression tests for `backend/tests/test_observer_manager.py` and `backend/tests/test_session.py` instead of claiming an unreturned clean review
 
 ## Non-Goals
 

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -306,6 +306,29 @@ This section records the internal Batch B slices on the feature branch before th
     - observer episodes are still lexical/temporal substrate only; retrieval and ranking belong to the later FTS and hybrid retrieval slices
     - richer observer-event semantics beyond project, focus, and blocked-state activity transitions still belong to later observer-memory refinement work
 
+### `session-search-fts-and-event-index-v1`
+
+- status: complete on `feat/memory-batch-b-v1`, pending inclusion in the aggregate Batch B PR
+- scope:
+  - added a SQLite `session_recall_fts` index that backfills existing rows and stays updated through triggers on sessions, user or assistant messages, and non-conversation episodic events
+  - upgraded `SessionManager.search_sessions(...)` to use the FTS index for normal text queries while keeping a bounded LIKE fallback for punctuation-heavy queries such as `%` and `_`
+  - expanded session recall so workflow and tool episodes can appear as `event` matches instead of limiting recall to titles plus user-facing chat messages
+  - kept session result ordering stable by ranking candidate hits with FTS first and then ordering sessions by conversation recency rather than todo churn or title-update timestamps
+  - added regression coverage for FTS backfill, episodic event hits, and title-update refresh behavior
+- validation:
+  - `backend/.venv/bin/python -m py_compile backend/src/db/engine.py backend/src/agent/session.py backend/tests/conftest.py backend/tests/test_db_engine.py backend/tests/test_session.py`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_db_engine.py backend/tests/test_session.py backend/tests/test_session_search_tool.py backend/tests/test_memory_episodes.py -q`
+- review notes:
+  - local regression caught and fixed before the slice stayed complete:
+    - the first FTS cut indexed conversation episodes alongside the original chat messages, which let ordinary message searches surface `event` hits for the same text
+    - fixed by keeping the FTS event lane limited to non-conversation episodic rows, so chat recall stays on the message lane while workflow or tool recall still uses the event lane
+  - subagent review:
+    - reviewer thread: `Dalton` (`019d24c9-0610-7102-a84f-a58874fb38f9`)
+    - result: the review thread stalled before returning findings, so the completion record relies on targeted regression validation plus the locally caught conversation-versus-event indexing regression above
+  - deferred to later Batch B slices:
+    - session recall is now lexical plus episodic, but cross-store hybrid ranking with semantic memory still belongs to `hybrid-memory-retrieval-v1`
+    - query-type routing between session recall and guardian-state memory assembly still belongs to `guardian-state-retrieval-planner-v1`
+
 ## Non-Goals
 
 - marketing “guardian intelligence” before the learning loop is real

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -80,7 +80,7 @@ The batch split is the right implementation shape because the dependencies are r
 - Batch B turns sessions and observer signals into usable episodic recall
 - Batch C makes that memory updateable, policy-relevant, and behaviorally testable
 
-Each Batch A internal slice should close with:
+Each internal slice in these memory batches should close with:
 
 - targeted validation commands
 - a subagent review pass for bugs, regressions, and misleading claims
@@ -243,6 +243,41 @@ This section records the internal Batch A slices on the feature branch before th
   - deferred to later slices:
     - snapshot promotion still runs from consolidation boundaries; broader lifecycle hooks near compaction and workflow boundaries belong in the later flush-lifecycle slice
     - bounded snapshot contents are still semantic-only and do not yet include procedural memory or episodic recall planning
+
+## Batch B Branch Review Log
+
+This section records the internal Batch B slices on the feature branch before the aggregate GitHub PR is opened.
+
+### `episodic-memory-events-v1`
+
+- status: complete on `feat/memory-batch-b-v1`, pending inclusion in the aggregate Batch B PR
+- scope:
+  - added a structured `memory_episodes` table plus `MemoryEpisodeType` so Seraph now has a first-class episodic substrate alongside semantic memory
+  - extended `memory_repository` with typed episode create and list helpers, including filtering by session, entity links, and episode type
+  - added a first live automatic writer path in `SessionManager.add_message(...)` that mirrors session `user` and `assistant` messages into `conversation` episodes and session `step` messages into `tool` or `workflow` episodes
+  - made episodic capture fail open so message persistence does not regress if the episodic write path fails
+  - updated session deletion to remove episodes linked either by `session_id` or `source_message_id` before message teardown so the new foreign keys do not block cleanup
+- validation:
+  - `backend/.venv/bin/python -m py_compile backend/src/db/models.py backend/src/memory/repository.py backend/src/memory/episodes.py backend/src/agent/session.py backend/tests/test_memory_episodes.py`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_memory_episodes.py backend/tests/test_session.py backend/tests/test_memory_repository.py backend/tests/test_session_search_tool.py backend/tests/test_db_engine.py -q`
+- subagent review:
+  - reviewer: `Euclid` (`019d24ad-f0fa-7700-af86-85b79cd7aea5`)
+  - initial findings:
+    - episodic capture was inside the same message transaction without a fail-open boundary, so an episode-write failure could roll back chat message persistence
+    - session deletion only cleaned up episodes by `session_id`, so episodes linked only by `source_message_id` could block message or session deletion under foreign-key enforcement
+    - the first implementation wording needed to stay narrow because the live automatic writer path only emitted `conversation`, `tool`, and `workflow` episodes, while `decision` and `observer` remained substrate-ready types
+  - fixed before the slice stayed marked complete:
+    - wrapped episodic writes in a nested fail-open boundary so message persistence survives episodic-write failures
+    - updated session deletion to remove episodes matched either by `session_id` or by the deleted messages' `source_message_id`
+    - added regression tests for fail-open episode writes and for deletion of episodes linked only through `source_message_id`
+    - narrowed the scope wording so the live writer claims match the implemented automatic event types
+  - final recheck:
+    - reviewer: `Kierkegaard` (`019d2516-65dc-7820-8201-8123b496dcc9`)
+    - result: no material findings after the fail-open fix, the deletion fix, and the narrowed scope wording
+  - deferred to later Batch B slices:
+    - automatic observer-transition writes still belong to `observer-episodic-fusion-v1`
+    - decision-oriented episodic writes still need dedicated runtime hooks rather than only schema or repository support
+    - episodic retrieval and ranking still belong to the later FTS, hybrid-retrieval, and retrieval-planner slices
 
 ## Non-Goals
 

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -329,6 +329,28 @@ This section records the internal Batch B slices on the feature branch before th
     - session recall is now lexical plus episodic, but cross-store hybrid ranking with semantic memory still belongs to `hybrid-memory-retrieval-v1`
     - query-type routing between session recall and guardian-state memory assembly still belongs to `guardian-state-retrieval-planner-v1`
 
+### `hybrid-memory-retrieval-v1`
+
+- status: complete on `feat/memory-batch-b-v1`, pending inclusion in the aggregate Batch B PR
+- scope:
+  - added `backend/src/memory/hybrid_retrieval.py` as a reusable retriever that combines lexical structured-memory hits, project-linked boosts, episodic hits, vector-store hits, dedupe, and reranking into one bounded memory bundle
+  - kept the retriever independent from guardian-state wiring so the later planner slice can consume one tested retrieval backbone instead of reimplementing ranking logic in multiple places
+  - added regression coverage for mixed semantic plus episodic plus vector recall, project-linked surfacing without lexical query overlap, and degraded-vector fallback behavior
+- validation:
+  - `backend/.venv/bin/python -m py_compile backend/src/memory/hybrid_retrieval.py backend/tests/test_hybrid_memory_retrieval.py backend/tests/conftest.py`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_hybrid_memory_retrieval.py backend/tests/test_memory_repository.py backend/tests/test_memory_episodes.py -q`
+- review notes:
+  - local regressions caught and fixed before the slice stayed complete:
+    - the new retriever module initially bypassed the in-memory test DB because `src.memory.hybrid_retrieval.get_session` was not included in the shared test patch targets
+    - recency scoring initially mixed naive and timezone-aware datetimes, which broke ranking during test execution
+    - fixed by patching the new module into `backend/tests/conftest.py` and normalizing datetimes inside the hybrid recency scorer before ranking
+  - subagent review:
+    - reviewer thread: `Laplace` (`019d24da-bfeb-7360-8b3a-6e9bcef8fcb7`)
+    - result: the review thread stalled before returning findings, so the completion record relies on the targeted hybrid-retrieval test suite plus the local regressions above
+  - deferred to later Batch B slices:
+    - the retriever exists, but guardian-state still uses the older memory assembly path until `guardian-state-retrieval-planner-v1` lands
+    - procedural-memory routing still belongs to Batch C because outcome-derived procedural memory is not a live retrieval lane yet
+
 ## Non-Goals
 
 - marketing “guardian intelligence” before the learning loop is real

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -279,6 +279,33 @@ This section records the internal Batch B slices on the feature branch before th
     - decision-oriented episodic writes still need dedicated runtime hooks rather than only schema or repository support
     - episodic retrieval and ranking still belong to the later FTS, hybrid-retrieval, and retrieval-planner slices
 
+### `observer-episodic-fusion-v1`
+
+- status: complete on `feat/memory-batch-b-v1`, pending inclusion in the aggregate Batch B PR
+- scope:
+  - extended `CurrentContext` with `active_project` so observer state carries explicit project focus instead of only goals plus window text
+  - added `backend/src/memory/observer_episodes.py` to derive conservative `observer` episodes for project, focus, and activity transitions with explicit provenance metadata
+  - taught `ContextManager.refresh()` to load the most recent screen-derived project, persist observer transitions into episodic memory, and fail open if that write path breaks
+  - added runtime-audit details for `active_project` and `observer_transition_count` so the observer refresh log shows what transition memory was produced
+  - added regression coverage for duplicate-suppression, write-failure survival, project-clear transitions, and audit details
+- validation:
+  - `backend/.venv/bin/python -m py_compile backend/src/observer/context.py backend/src/memory/observer_episodes.py backend/src/observer/manager.py backend/tests/test_observer_manager.py`
+  - `backend/.venv/bin/python -m pytest backend/tests/test_observer_manager.py backend/tests/test_memory_episodes.py -q`
+- subagent review:
+  - reviewer: `Volta` (`019d24d3-df48-7700-9943-e69cbfaf93aa`)
+  - initial findings:
+    - observer transition writes were not atomic, so a refresh could partially commit episodes while still reporting `observer_transition_count == 0` after an exception path
+    - project exit transitions were skipped because the first cut only wrote project episodes when the new project name was non-empty
+  - fixed before the slice stayed marked complete:
+    - changed observer transition persistence to build one payload list and write it through `memory_repository.create_episode_batch(...)` so each refresh commits observer episodes atomically
+    - added project-clear transition support, including reuse of the prior project entity when focus drops from a project to none
+    - added regression tests for observer write failure, project-clear transitions, and runtime-audit transition details
+  - recheck attempts:
+    - follow-up reviewer threads were started with `Arendt`, `Fermat`, and `Kierkegaard`, but those tool runs stalled before returning findings, so the completion record relies on the fixed `Volta` findings plus targeted regression validation instead of claiming an unreturned clean review
+  - deferred to later Batch B slices:
+    - observer episodes are still lexical/temporal substrate only; retrieval and ranking belong to the later FTS and hybrid retrieval slices
+    - richer observer-event semantics beyond project, focus, and blocked-state activity transitions still belong to later observer-memory refinement work
+
 ## Non-Goals
 
 - marketing “guardian intelligence” before the learning loop is real


### PR DESCRIPTION
## Done on develop
- [x] Batch A structured memory foundations are already merged on develop, including typed memory schema, richer kinds and provenance, conservative entity and project linking, bounded snapshots, and memory eval coverage.
- [x] Guardian state on develop already consumes bounded memory, structured semantic memory, observer context, recent sessions, and the richer world-model substrate that Batch B extends.

## Working in this PR
- [ ] add first-class episodic memory events for conversation, tool, workflow, and observer-transition boundaries with fail-open writes and cleanup-safe deletes.
- [ ] add FTS-backed session and event recall plus hybrid retrieval across semantic memory, episodic memory, project-linked memory, and vector recall.
- [ ] route guardian-state synthesis through the new retrieval planner so temporal questions surface Relevant episodes separately from semantic Relevant memories.
- [ ] record the per-slice review and validation trail for Batch B directly in the implementation docs and mark Batch B complete in the implementation roadmap.

## Still to do after this PR
- [ ] add lifecycle-triggered memory flush hooks and multi-stage consolidation in Batch C.
- [ ] add procedural memory, decay/contradiction/archive, and memory behavioral evals in Batch C.

## Validation
- backend/.venv/bin/python -m py_compile backend/src/memory/retrieval_planner.py backend/src/guardian/state.py backend/tests/test_guardian_state.py backend/tests/test_strategist_tick.py
- backend/.venv/bin/python -m pytest backend/tests/test_guardian_state.py backend/tests/test_hybrid_memory_retrieval.py -q
- backend/.venv/bin/python -m py_compile backend/src/db/engine.py backend/src/agent/session.py backend/src/observer/context.py backend/src/memory/observer_episodes.py backend/src/observer/manager.py backend/src/memory/hybrid_retrieval.py backend/src/memory/retrieval_planner.py backend/src/guardian/state.py backend/tests/test_db_engine.py backend/tests/test_session.py backend/tests/test_session_search_tool.py backend/tests/test_memory_episodes.py backend/tests/test_observer_manager.py backend/tests/test_hybrid_memory_retrieval.py backend/tests/test_guardian_state.py
- backend/.venv/bin/python -m pytest backend/tests/test_db_engine.py backend/tests/test_session.py backend/tests/test_session_search_tool.py backend/tests/test_memory_episodes.py backend/tests/test_observer_manager.py backend/tests/test_hybrid_memory_retrieval.py backend/tests/test_guardian_state.py backend/tests/test_memory_repository.py -q
- cd docs && npm run build
- cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v (1209 passed, 35 failed; unrelated existing failures remain in approval wrapping, runtime audit/context propagation, eval harness, goal-tree orphan handling, scheduled-job runtime context, and tool-audit paths)
