### PR TITLE
Batch AD: enforce authenticated workflow source drift

### DIFF
--- a/backend/src/api/workflows.py
+++ b/backend/src/api/workflows.py
@@ -248,21 +248,81 @@ def _normalize_string_list(value: Any) -> list[str]:
     return sorted(normalized)
 
 
+def _normalize_source_systems(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str, bool, tuple[str, ...]]] = set()
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        server_name = str(item.get("server_name") or "").strip()
+        hostname = str(item.get("hostname") or "").strip()
+        source = str(item.get("source") or "").strip()
+        authenticated_source = bool(item.get("authenticated_source", False))
+        credential_sources = tuple(_normalize_string_list(item.get("credential_sources")))
+        key = (
+            server_name,
+            hostname,
+            source,
+            authenticated_source,
+            credential_sources,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(
+            {
+                "server_name": server_name,
+                "hostname": hostname,
+                "source": source,
+                "authenticated_source": authenticated_source,
+                "credential_sources": list(credential_sources),
+            }
+        )
+    normalized.sort(
+        key=lambda item: (
+            str(item.get("server_name") or ""),
+            str(item.get("hostname") or ""),
+            str(item.get("source") or ""),
+            bool(item.get("authenticated_source", False)),
+            tuple(item.get("credential_sources") or []),
+        )
+    )
+    return normalized
+
+
 def _normalize_approval_context(value: Any, *, workflow_name: str | None = None) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
     risk_level = str(value.get("risk_level") or "").strip()
     execution_boundaries = _normalize_string_list(value.get("execution_boundaries"))
     step_tools = _normalize_string_list(value.get("step_tools"))
-    if not any([risk_level, execution_boundaries, step_tools, "accepts_secret_refs" in value]):
+    authenticated_source = bool(value.get("authenticated_source", False))
+    source_systems = _normalize_source_systems(value.get("source_systems"))
+    if not any(
+        [
+            risk_level,
+            execution_boundaries,
+            step_tools,
+            "accepts_secret_refs" in value,
+            authenticated_source,
+            source_systems,
+        ]
+    ):
         return None
-    return {
+    normalized = {
         "workflow_name": str(value.get("workflow_name") or workflow_name or "").strip() or None,
         "risk_level": risk_level or "unknown",
         "execution_boundaries": execution_boundaries,
         "accepts_secret_refs": bool(value.get("accepts_secret_refs", False)),
         "step_tools": step_tools,
     }
+    if authenticated_source:
+        normalized["authenticated_source"] = True
+    if source_systems:
+        normalized["source_systems"] = source_systems
+    return normalized
 
 
 def _workflow_current_approval_context(
@@ -276,7 +336,7 @@ def _workflow_current_approval_context(
     )
     if normalized is not None:
         return normalized
-    return {
+    normalized = {
         "workflow_name": workflow_name,
         "risk_level": str(workflow_meta.get("risk_level") or "high"),
         "execution_boundaries": _normalize_string_list(
@@ -285,6 +345,31 @@ def _workflow_current_approval_context(
         "accepts_secret_refs": bool(workflow_meta.get("accepts_secret_refs", False)),
         "step_tools": _normalize_string_list(workflow_meta.get("step_tools")),
     }
+    if bool(workflow_meta.get("authenticated_source", False)):
+        normalized["authenticated_source"] = True
+    source_systems = _normalize_source_systems(workflow_meta.get("source_systems"))
+    if source_systems:
+        normalized["source_systems"] = source_systems
+    return normalized
+
+
+def _workflow_runtime_approval_contexts() -> dict[str, dict[str, Any]]:
+    base_tools, active_skill_names, _mcp_mode = get_base_tools_and_active_skills()
+    runtime_contexts: dict[str, dict[str, Any]] = {}
+    for tool in workflow_manager.build_workflow_tools(base_tools, active_skill_names):
+        tool_name = getattr(tool, "name", None)
+        if not isinstance(tool_name, str) or not tool_name.startswith("workflow_"):
+            continue
+        hook = getattr(tool, "get_approval_context", None)
+        if not callable(hook):
+            continue
+        normalized = _normalize_approval_context(
+            hook({}),
+            workflow_name=_workflow_name_from_tool(tool_name),
+        )
+        if normalized is not None:
+            runtime_contexts[tool_name] = normalized
+    return runtime_contexts
 
 
 def _workflow_name_from_tool(tool_name: str) -> str:
@@ -931,6 +1016,7 @@ async def _list_workflow_runs(
     completed: list[dict[str, Any]] = []
     pending_approvals = await approval_repository.list_pending(session_id=session_id, limit=100)
     workflow_statuses = _workflow_runtime_statuses()
+    workflow_runtime_contexts = _workflow_runtime_approval_contexts()
     pending_by_tool: dict[tuple[str | None, str], list[dict[str, Any]]] = defaultdict(list)
     pending_by_signature: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for approval in pending_approvals:
@@ -1074,7 +1160,11 @@ async def _list_workflow_runs(
         )
         current_approval_context = _workflow_current_approval_context(
             workflow_name=str(run["workflow_name"]),
-            workflow_meta=workflow_meta,
+            workflow_meta={
+                **workflow_meta,
+                "approval_context": workflow_runtime_contexts.get(tool_name)
+                or workflow_meta.get("approval_context"),
+            },
         )
         effective_approval_context = recorded_approval_context or current_approval_context
         approval_context_mismatch = bool(
@@ -1293,7 +1383,11 @@ async def _list_workflow_runs(
             )
             current_approval_context = _workflow_current_approval_context(
                 workflow_name=str(run["workflow_name"]),
-                workflow_meta=workflow_meta,
+                workflow_meta={
+                    **workflow_meta,
+                    "approval_context": workflow_runtime_contexts.get(str(run["tool_name"]))
+                    or workflow_meta.get("approval_context"),
+                },
             )
             effective_approval_context = recorded_approval_context or current_approval_context
             approval_context_mismatch = bool(

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -2481,6 +2481,285 @@ async def test_workflow_runs_endpoint_ignores_approval_context_list_reordering(c
 
 
 @pytest.mark.asyncio
+async def test_workflow_runs_endpoint_detects_authenticated_source_context_drift(client):
+    recorded_context = {
+        "workflow_name": "web-brief-to-file",
+        "risk_level": "medium",
+        "execution_boundaries": ["external_read", "workspace_write"],
+        "accepts_secret_refs": False,
+        "step_tools": ["web_search", "write_file"],
+        "authenticated_source": False,
+        "source_systems": [],
+    }
+    current_context = {
+        "workflow_name": "web-brief-to-file",
+        "risk_level": "medium",
+        "execution_boundaries": ["external_read", "workspace_write"],
+        "accepts_secret_refs": False,
+        "step_tools": ["web_search", "write_file"],
+        "authenticated_source": True,
+        "source_systems": [
+            {
+                "server_name": "github",
+                "hostname": "api.github.com",
+                "source": "extension",
+                "authenticated_source": True,
+                "credential_sources": ["vault:github_token"],
+            }
+        ],
+    }
+    runtime_workflow_tool = SimpleNamespace(
+        name="workflow_web_brief_to_file",
+        get_approval_context=lambda _arguments: current_context,
+    )
+
+    with (
+        patch(
+            "src.api.workflows.audit_repository.list_events",
+            return_value=[
+                {
+                    "id": "evt-result",
+                    "session_id": "session-1",
+                    "event_type": "tool_result",
+                    "tool_name": "workflow_web_brief_to_file",
+                    "summary": "workflow_web_brief_to_file succeeded (2 steps)",
+                    "created_at": "2026-03-18T12:01:45Z",
+                    "details": {
+                        "workflow_name": "web-brief-to-file",
+                        "run_fingerprint": "web-brief-auth",
+                        "approval_context": recorded_context,
+                        "step_tools": ["web_search", "write_file"],
+                        "step_records": [],
+                        "artifact_paths": ["notes/brief.md"],
+                        "continued_error_steps": [],
+                    },
+                },
+                {
+                    "id": "evt-call",
+                    "session_id": "session-1",
+                    "event_type": "tool_call",
+                    "tool_name": "workflow_web_brief_to_file",
+                    "summary": "Calling workflow",
+                    "created_at": "2026-03-18T12:01:00Z",
+                    "details": {
+                        "run_fingerprint": "web-brief-auth",
+                        "approval_context": recorded_context,
+                        "arguments": {"query": "seraph", "file_path": "notes/brief.md"},
+                    },
+                },
+            ],
+        ),
+        patch("src.api.workflows.approval_repository.list_pending", return_value=[]),
+        patch(
+            "src.api.workflows.workflow_manager.get_tool_metadata",
+            return_value={
+                "risk_level": "medium",
+                "execution_boundaries": ["external_read", "workspace_write"],
+                "accepts_secret_refs": False,
+                "approval_context": {
+                    "workflow_name": "web-brief-to-file",
+                    "risk_level": "medium",
+                    "execution_boundaries": ["external_read", "workspace_write"],
+                    "accepts_secret_refs": False,
+                    "step_tools": ["web_search", "write_file"],
+                    "authenticated_source": False,
+                },
+            },
+        ),
+        patch("src.api.workflows.get_base_tools_and_active_skills", return_value=([], [], "full")),
+        patch("src.api.workflows.workflow_manager.build_workflow_tools", return_value=[runtime_workflow_tool]),
+        patch(
+            "src.api.workflows.workflow_manager.list_workflows",
+            return_value=[
+                {
+                    "name": "web-brief-to-file",
+                    "inputs": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "file_path": {"type": "string", "description": "Output path"},
+                    },
+                    "enabled": True,
+                    "is_available": True,
+                    "missing_tools": [],
+                    "missing_skills": [],
+                }
+            ],
+        ),
+        patch(
+            "src.api.workflows.session_manager.list_sessions",
+            return_value=[{"id": "session-1", "title": "Research thread"}],
+        ),
+        patch("src.api.workflows.get_current_tool_policy_mode", return_value="balanced"),
+    ):
+        response = await client.get("/api/workflows/runs?session_id=session-1")
+
+    assert response.status_code == 200
+    run = response.json()["runs"][0]
+    assert run["approval_context_mismatch"] is True
+    assert run["replay_allowed"] is False
+    assert run["replay_block_reason"] == "approval_context_changed"
+    assert run["current_approval_context"]["authenticated_source"] is True
+    assert run["current_approval_context"]["source_systems"] == [
+        {
+            "server_name": "github",
+            "hostname": "api.github.com",
+            "source": "extension",
+            "authenticated_source": True,
+            "credential_sources": ["vault:github_token"],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_workflow_runs_endpoint_ignores_authenticated_source_system_reordering(client):
+    recorded_context = {
+        "workflow_name": "web-brief-to-file",
+        "risk_level": "medium",
+        "execution_boundaries": ["external_read", "workspace_write"],
+        "accepts_secret_refs": False,
+        "step_tools": ["web_search", "write_file"],
+        "authenticated_source": True,
+        "source_systems": [
+            {
+                "server_name": "github",
+                "hostname": "api.github.com",
+                "source": "extension",
+                "authenticated_source": True,
+                "credential_sources": ["vault:github_token", "env:GITHUB_TOKEN"],
+            },
+            {
+                "server_name": "jira",
+                "hostname": "acme.atlassian.net",
+                "source": "manual",
+                "authenticated_source": True,
+                "credential_sources": ["vault:jira_token"],
+            },
+        ],
+    }
+    current_context = {
+        "workflow_name": "web-brief-to-file",
+        "risk_level": "medium",
+        "execution_boundaries": ["workspace_write", "external_read"],
+        "accepts_secret_refs": False,
+        "step_tools": ["write_file", "web_search"],
+        "authenticated_source": True,
+        "source_systems": [
+            {
+                "server_name": "jira",
+                "hostname": "acme.atlassian.net",
+                "source": "manual",
+                "authenticated_source": True,
+                "credential_sources": ["vault:jira_token"],
+            },
+            {
+                "server_name": "github",
+                "hostname": "api.github.com",
+                "source": "extension",
+                "authenticated_source": True,
+                "credential_sources": ["env:GITHUB_TOKEN", "vault:github_token"],
+            },
+        ],
+    }
+    runtime_workflow_tool = SimpleNamespace(
+        name="workflow_web_brief_to_file",
+        get_approval_context=lambda _arguments: current_context,
+    )
+
+    with (
+        patch(
+            "src.api.workflows.audit_repository.list_events",
+            return_value=[
+                {
+                    "id": "evt-result",
+                    "session_id": "session-1",
+                    "event_type": "tool_result",
+                    "tool_name": "workflow_web_brief_to_file",
+                    "summary": "workflow_web_brief_to_file succeeded (2 steps)",
+                    "created_at": "2026-03-18T12:01:45Z",
+                    "details": {
+                        "workflow_name": "web-brief-to-file",
+                        "run_fingerprint": "web-brief-auth-stable",
+                        "approval_context": recorded_context,
+                        "step_tools": ["web_search", "write_file"],
+                        "step_records": [],
+                        "artifact_paths": ["notes/brief.md"],
+                        "continued_error_steps": [],
+                    },
+                },
+                {
+                    "id": "evt-call",
+                    "session_id": "session-1",
+                    "event_type": "tool_call",
+                    "tool_name": "workflow_web_brief_to_file",
+                    "summary": "Calling workflow",
+                    "created_at": "2026-03-18T12:01:00Z",
+                    "details": {
+                        "run_fingerprint": "web-brief-auth-stable",
+                        "approval_context": recorded_context,
+                        "arguments": {"query": "seraph", "file_path": "notes/brief.md"},
+                    },
+                },
+            ],
+        ),
+        patch("src.api.workflows.approval_repository.list_pending", return_value=[]),
+        patch(
+            "src.api.workflows.workflow_manager.get_tool_metadata",
+            return_value={
+                "risk_level": "medium",
+                "execution_boundaries": ["external_read", "workspace_write"],
+                "accepts_secret_refs": False,
+                "approval_context": recorded_context,
+            },
+        ),
+        patch("src.api.workflows.get_base_tools_and_active_skills", return_value=([], [], "full")),
+        patch("src.api.workflows.workflow_manager.build_workflow_tools", return_value=[runtime_workflow_tool]),
+        patch(
+            "src.api.workflows.workflow_manager.list_workflows",
+            return_value=[
+                {
+                    "name": "web-brief-to-file",
+                    "inputs": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "file_path": {"type": "string", "description": "Output path"},
+                    },
+                    "enabled": True,
+                    "is_available": True,
+                    "missing_tools": [],
+                    "missing_skills": [],
+                }
+            ],
+        ),
+        patch(
+            "src.api.workflows.session_manager.list_sessions",
+            return_value=[{"id": "session-1", "title": "Research thread"}],
+        ),
+        patch("src.api.workflows.get_current_tool_policy_mode", return_value="balanced"),
+    ):
+        response = await client.get("/api/workflows/runs?session_id=session-1")
+
+    assert response.status_code == 200
+    run = response.json()["runs"][0]
+    assert run["approval_context_mismatch"] is False
+    assert run["replay_allowed"] is True
+    assert run["replay_block_reason"] is None
+    assert run["current_approval_context"]["source_systems"] == [
+        {
+            "server_name": "github",
+            "hostname": "api.github.com",
+            "source": "extension",
+            "authenticated_source": True,
+            "credential_sources": ["env:GITHUB_TOKEN", "vault:github_token"],
+        },
+        {
+            "server_name": "jira",
+            "hostname": "acme.atlassian.net",
+            "source": "manual",
+            "authenticated_source": True,
+            "credential_sources": ["vault:jira_token"],
+        },
+    ]
+
+
+@pytest.mark.asyncio
 async def test_workflow_resume_plan_rejects_when_approval_context_changes(client):
     recorded_context = {
         "workflow_name": "web-brief-to-file",

--- a/docs/implementation/01-trust-boundaries.md
+++ b/docs/implementation/01-trust-boundaries.md
@@ -39,6 +39,7 @@
 - [x] this workstream now also ships `catalog-install-lifecycle-approval-v1`
 - [x] this workstream now also ships `privileged-repair-bundle-gating-v1`
 - [x] this workstream now also ships `authenticated-source-boundary-hardening-v1`
+- [x] this workstream now also ships `workflow-authenticated-source-drift-enforcement-v1`
 
 ## Still To Do On `develop`
 
@@ -166,6 +167,23 @@
 - review pass:
   - `Copernicus` found two real live-path gaps after the first implementation pass: `SecretRefResolvingTool` still dropped `get_approval_context`, so authenticated MCP tools lost the narrower boundary before forced approval wrapped them, and it also dropped `get_audit_failure_payload`, so authenticated-source attribution disappeared on failure even when call/result payloads were source-aware
   - fixed by forwarding both hooks through the secret-ref wrapper and adding regressions that pin authenticated approval context persistence plus authenticated MCP failure audit payloads through the real wrapped execution path
+
+### `workflow-authenticated-source-drift-enforcement-v1`
+
+- status: complete on `feat/execution-isolation-batch-ad-v1`, intended for the first Batch AD PR for `#299`
+- root cause addressed:
+  - workflow run projection was normalizing approval context down to risk, boundaries, secret-ref acceptance, and step tools, which silently dropped authenticated-source flags and source-system provenance from recorded runs
+  - the current workflow surface was also derived from static workflow metadata, which cannot see the live wrapped MCP tool surface, so replay and resume drift checks could miss a change from generic external access to authenticated external-source execution
+- scope:
+  - workflow approval-context normalization now preserves authenticated-source truth and normalized source-system provenance when those fields are actually present, while staying backward-compatible for older runs that never recorded them
+  - workflow run projection now derives current workflow approval context from runtime-built workflow tools before falling back to static metadata, so authenticated MCP/source wrappers participate in replay and resume blocking
+  - replay and resume blocking now catches authenticated-source drift deterministically instead of collapsing both sides back to the same generic boundary summary
+- validation:
+  - `python3 -m py_compile backend/src/api/workflows.py backend/tests/test_workflows.py`
+  - `cd backend && .venv/bin/python -m pytest tests/test_workflows.py -q -k "approval_context or authenticated_source_system"`
+- review pass:
+  - direct review against bugs and regressions exposed one real backward-compatibility problem in the first pass: adding default `authenticated_source=false` and empty `source_systems=[]` into normalized approval context changed legacy workflow fingerprints for runs that never carried source metadata
+  - fixed by only persisting authenticated-source fields in normalized approval context when they are materially present, which keeps older approval fingerprints stable while still surfacing real authenticated-source drift
 
 ### `planner-secret-surface-isolation-v1`
 


### PR DESCRIPTION
## Summary
- derive current workflow approval context from runtime-built workflow tools instead of static metadata
- preserve authenticated source and source-system provenance in workflow approval-context normalization without breaking legacy fingerprints
- add workflow regressions for authenticated-source drift detection and stable source-system reordering

## Validation
- python3 -m py_compile backend/src/api/workflows.py backend/tests/test_workflows.py
- cd backend && .venv/bin/python -m pytest tests/test_workflows.py -q -k "approval_context or authenticated_source_system"
- cd docs && npm run build
- git diff --check

Closes #299