### PR TITLE
fix(workflows): harden delegated workflow boundaries

### DIFF
--- a/backend/src/tools/delegate_task_tool.py
+++ b/backend/src/tools/delegate_task_tool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from contextvars import ContextVar
 from collections.abc import Iterable
+from typing import Any
 
 from smolagents import tool
 
@@ -42,6 +43,22 @@ AUTO_ROUTE_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
 )
 
 _DELEGATION_DEPTH: ContextVar[int] = ContextVar("delegate_task_depth", default=0)
+_RISK_RANKS = {"low": 0, "medium": 1, "high": 2}
+_DEFAULT_SPECIALIST_NAMES: tuple[str, ...] = (
+    "memory_keeper",
+    "vault_keeper",
+    "goal_planner",
+    "web_researcher",
+    "file_worker",
+    "workflow_runner",
+)
+_SPECIALIST_DEFAULT_TOOL_NAMES: dict[str, tuple[str, ...]] = {
+    "memory_keeper": ("view_soul", "update_soul"),
+    "vault_keeper": ("store_secret", "get_secret", "get_secret_ref", "list_secrets", "delete_secret"),
+    "goal_planner": ("create_goal", "update_goal", "get_goals", "get_goal_progress"),
+    "web_researcher": ("web_search", "browse_webpage", "browser_session", "source_capabilities"),
+    "file_worker": ("read_file", "write_file", "fill_template", "execute_code"),
+}
 
 
 def _normalize_specialist_name(value: str) -> str:
@@ -74,6 +91,130 @@ def _match_specialist(task: str, specialist_names: Iterable[str]) -> str | None:
     return None
 
 
+def _max_risk_level(current: str, candidate: str) -> str:
+    current_rank = _RISK_RANKS.get(current, _RISK_RANKS["high"])
+    candidate_rank = _RISK_RANKS.get(candidate, _RISK_RANKS["high"])
+    return current if current_rank >= candidate_rank else candidate
+
+
+def _build_specialists_by_name(specialists: Iterable[object]) -> dict[str, object]:
+    specialists_by_name: dict[str, object] = {}
+    for specialist in specialists:
+        name = getattr(specialist, "name", None)
+        if isinstance(name, str) and name:
+            specialists_by_name[name] = specialist
+    return specialists_by_name
+
+
+def resolve_specialist_runtime(
+    task: str | None,
+    specialist: str | None = None,
+    *,
+    specialists: Iterable[object] | None = None,
+) -> tuple[str | None, object | None]:
+    """Resolve the effective specialist name/runtime for a delegation call."""
+    if specialists is None:
+        try:
+            from src.agent.specialists import build_all_specialists
+
+            specialists = build_all_specialists()
+        except Exception:
+            specialists = []
+    specialists_by_name = _build_specialists_by_name(specialists or [])
+    candidate_names = specialists_by_name.keys() or _DEFAULT_SPECIALIST_NAMES
+    normalized_name = _normalize_specialist_name(specialist or "")
+    selected_name = normalized_name or _match_specialist(task or "", candidate_names)
+    if not selected_name:
+        return None, None
+    return selected_name, specialists_by_name.get(selected_name)
+
+
+def infer_delegation_approval_context(
+    task: str | None,
+    specialist: str | None = None,
+    *,
+    specialists: Iterable[object] | None = None,
+) -> dict[str, Any]:
+    """Infer the approval-context surface for a delegated specialist route."""
+    from src.native_tools.registry import canonical_tool_name
+    from src.tools.policy import (
+        get_tool_execution_boundaries,
+        get_tool_risk_level,
+        get_tool_source_context,
+        tool_accepts_secret_refs,
+    )
+
+    selected_name, selected_runtime = resolve_specialist_runtime(
+        task,
+        specialist,
+        specialists=specialists,
+    )
+    execution_boundaries = ["delegation"]
+    accepts_secret_refs = False
+    authenticated_source = False
+    source_systems: list[dict[str, Any]] = []
+    risk_level = "low"
+
+    raw_specialist_tools = getattr(selected_runtime, "tools", []) or []
+    if isinstance(raw_specialist_tools, dict):
+        specialist_tools = list(raw_specialist_tools.values())
+    else:
+        specialist_tools = list(raw_specialist_tools)
+    if not specialist_tools and isinstance(selected_name, str):
+        for tool_name in _SPECIALIST_DEFAULT_TOOL_NAMES.get(selected_name, ()):
+            canonical_name = canonical_tool_name(tool_name)
+            for boundary in get_tool_execution_boundaries(canonical_name):
+                if boundary not in execution_boundaries:
+                    execution_boundaries.append(boundary)
+            accepts_secret_refs = accepts_secret_refs or tool_accepts_secret_refs(canonical_name)
+            risk_level = _max_risk_level(risk_level, get_tool_risk_level(canonical_name))
+        if selected_name == "workflow_runner":
+            risk_level = "high"
+        if selected_name and selected_name.startswith("mcp_"):
+            if "external_mcp" not in execution_boundaries:
+                execution_boundaries.append("external_mcp")
+            accepts_secret_refs = True
+            risk_level = "high"
+
+    for tool in specialist_tools:
+        tool_name = getattr(tool, "name", None)
+        if not isinstance(tool_name, str) or not tool_name:
+            continue
+        canonical_name = canonical_tool_name(tool_name)
+        is_mcp = canonical_name.startswith("mcp_")
+        for boundary in get_tool_execution_boundaries(canonical_name, is_mcp=is_mcp, tool=tool):
+            if boundary not in execution_boundaries:
+                execution_boundaries.append(boundary)
+        accepts_secret_refs = accepts_secret_refs or tool_accepts_secret_refs(canonical_name, is_mcp=is_mcp)
+        risk_level = _max_risk_level(risk_level, get_tool_risk_level(canonical_name, is_mcp=is_mcp))
+        source_context = get_tool_source_context(tool)
+        if is_mcp and isinstance(source_context, dict) and bool(source_context.get("authenticated_source")):
+            authenticated_source = True
+            source_system = {
+                "server_name": str(source_context.get("server_name") or ""),
+                "hostname": str(source_context.get("hostname") or ""),
+                "source": str(source_context.get("source") or "manual"),
+                "authenticated_source": True,
+            }
+            if source_system not in source_systems:
+                source_systems.append(source_system)
+
+    unresolved = selected_name is None
+    if unresolved:
+        risk_level = "high"
+        accepts_secret_refs = True
+
+    return {
+        "delegated_specialist": selected_name,
+        "delegation_target_unresolved": unresolved,
+        "risk_level": risk_level,
+        "execution_boundaries": execution_boundaries,
+        "accepts_secret_refs": accepts_secret_refs,
+        "authenticated_source": authenticated_source,
+        "source_systems": source_systems,
+    }
+
+
 @tool
 def delegate_task(task: str, specialist: str = "") -> str:
     """Delegate a bounded subtask to a specialist runtime.
@@ -102,9 +243,8 @@ def delegate_task(task: str, specialist: str = "") -> str:
     if not specialists:
         return "Error: No specialists are currently available for delegation."
 
-    specialists_by_name = {agent.name: agent for agent in specialists}
-    specialist_name = _normalize_specialist_name(specialist)
-    selected_name = specialist_name or _match_specialist(task, specialists_by_name.keys())
+    specialists_by_name = _build_specialists_by_name(specialists)
+    selected_name, selected = resolve_specialist_runtime(task, specialist, specialists=specialists)
     if not selected_name:
         available = ", ".join(sorted(specialists_by_name))
         return (
@@ -112,7 +252,6 @@ def delegate_task(task: str, specialist: str = "") -> str:
             f"Specify one of: {available}"
         )
 
-    selected = specialists_by_name.get(selected_name)
     if selected is None:
         available = ", ".join(sorted(specialists_by_name))
         return f"Error: Unknown specialist '{specialist}'. Available specialists: {available}"

--- a/backend/src/workflows/manager.py
+++ b/backend/src/workflows/manager.py
@@ -235,12 +235,94 @@ def _json_safe_value(value: Any) -> Any:
         return str(value)
 
 
+def _max_risk_level(current: str, candidate: str) -> str:
+    ranks = {"low": 0, "medium": 1, "high": 2}
+    current_rank = ranks.get(current, ranks["high"])
+    candidate_rank = ranks.get(candidate, ranks["high"])
+    return current if current_rank >= candidate_rank else candidate
+
+
+def _append_unique_source_systems(
+    target: list[dict[str, Any]],
+    additions: list[dict[str, Any]],
+) -> None:
+    for source_system in additions:
+        if isinstance(source_system, dict) and source_system not in target:
+            target.append(source_system)
+
+
+def _delegate_step_approval_context(
+    workflow: Workflow,
+    step: Any,
+    workflow_inputs: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    from src.tools.delegate_task_tool import infer_delegation_approval_context
+
+    if canonical_tool_name(getattr(step, "tool", "")) != "delegate_task":
+        return None
+    raw_arguments = getattr(step, "arguments", None)
+    if not isinstance(raw_arguments, dict):
+        return infer_delegation_approval_context(None, None)
+    render_context = {"inputs": dict(workflow_inputs or {})}
+    render_context.update(workflow_inputs or {})
+    try:
+        rendered_arguments = _render_value(raw_arguments, render_context)
+    except KeyError:
+        rendered_arguments = raw_arguments
+    if not isinstance(rendered_arguments, dict):
+        return infer_delegation_approval_context(None, None)
+
+    def _resolved_string(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        if "{{" in value and "}}" in value:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    return infer_delegation_approval_context(
+        _resolved_string(rendered_arguments.get("task")),
+        _resolved_string(rendered_arguments.get("specialist")),
+    )
+
+
+def _policy_modes_for_approval_context(approval_context: dict[str, Any]) -> list[str]:
+    if bool(approval_context.get("delegation_target_unresolved", False)):
+        return ["full"]
+    if bool(approval_context.get("authenticated_source", False)):
+        return ["full"]
+    if bool(approval_context.get("accepts_secret_refs", False)):
+        return ["full"]
+    boundaries = {
+        str(boundary)
+        for boundary in approval_context.get("execution_boundaries", [])
+        if isinstance(boundary, str)
+    }
+    if boundaries & {
+        "authenticated_external_source",
+        "container_process_execution",
+        "container_process_management",
+        "external_mcp",
+        "sandbox_execution",
+        "secret_injection",
+        "secret_read",
+    }:
+        return ["full"]
+    if approval_context.get("risk_level") == "high":
+        return ["full"]
+    if approval_context.get("risk_level") == "medium":
+        return ["balanced", "full"]
+    return ["safe", "balanced", "full"]
+
+
 def _checkpoint_context_allowed(approval_context: dict[str, Any] | None) -> bool:
     if approval_context is None:
         return True
     if bool(approval_context.get("accepts_secret_refs", False)):
         return False
     if bool(approval_context.get("authenticated_source", False)):
+        return False
+    if bool(approval_context.get("delegation_target_unresolved", False)):
         return False
     boundaries = {
         str(boundary)
@@ -293,12 +375,19 @@ async def _load_workflow_checkpoint_payload(run_identity: str) -> dict[str, Any]
     return None
 
 
-def _approval_context_for_workflow(workflow: Workflow, tools_by_name: dict[str, Any] | None = None) -> dict[str, Any]:
+def _approval_context_for_workflow(
+    workflow: Workflow,
+    tools_by_name: dict[str, Any] | None = None,
+    workflow_inputs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     canonical_step_tools = _canonicalize_tool_names(workflow.step_tools)
     execution_boundaries: list[str] = []
     accepts_secret_refs = False
     authenticated_source = False
     source_systems: list[dict[str, Any]] = []
+    delegated_specialists: list[str] = []
+    delegation_target_unresolved = False
+    risk_level = "low"
     for tool_name in workflow.step_tools:
         canonical_name = canonical_tool_name(tool_name)
         runtime_tool = None
@@ -337,8 +426,27 @@ def _approval_context_for_workflow(workflow: Workflow, tools_by_name: dict[str, 
         risk_level = "medium"
     elif any(tool_name in {"execute_code", "get_secret"} for tool_name in canonical_step_tools):
         risk_level = "high"
-    else:
-        risk_level = "low"
+    steps = getattr(workflow, "steps", None)
+    if isinstance(steps, list):
+        for step in steps:
+            delegate_context = _delegate_step_approval_context(workflow, step, workflow_inputs)
+            if not isinstance(delegate_context, dict):
+                continue
+            delegated_specialist = delegate_context.get("delegated_specialist")
+            if isinstance(delegated_specialist, str) and delegated_specialist:
+                delegated_specialists.append(delegated_specialist)
+            if bool(delegate_context.get("delegation_target_unresolved", False)):
+                delegation_target_unresolved = True
+            risk_level = _max_risk_level(risk_level, str(delegate_context.get("risk_level") or "high"))
+            accepts_secret_refs = accepts_secret_refs or bool(delegate_context.get("accepts_secret_refs", False))
+            authenticated_source = authenticated_source or bool(delegate_context.get("authenticated_source", False))
+            for boundary in delegate_context.get("execution_boundaries", []):
+                if isinstance(boundary, str) and boundary not in execution_boundaries:
+                    execution_boundaries.append(boundary)
+            _append_unique_source_systems(
+                source_systems,
+                list(delegate_context.get("source_systems", [])),
+            )
     return {
         "workflow_name": workflow.name,
         "risk_level": risk_level,
@@ -346,6 +454,8 @@ def _approval_context_for_workflow(workflow: Workflow, tools_by_name: dict[str, 
         "accepts_secret_refs": accepts_secret_refs,
         "authenticated_source": authenticated_source,
         "source_systems": source_systems,
+        "delegated_specialists": sorted(dict.fromkeys(delegated_specialists)),
+        "delegation_target_unresolved": delegation_target_unresolved,
         "step_tools": sorted(dict.fromkeys(canonical_step_tools)),
     }
 
@@ -592,8 +702,8 @@ class WorkflowTool(Tool):
             },
         )
 
-    def get_approval_context(self, _arguments: dict[str, Any]) -> dict[str, Any]:
-        return _approval_context_for_workflow(self.workflow, self.tools_by_name)
+    def get_approval_context(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        return _approval_context_for_workflow(self.workflow, self.tools_by_name, arguments)
 
     def _control_audit_details(self, control_inputs: dict[str, Any]) -> dict[str, Any]:
         details: dict[str, Any] = {}
@@ -1231,7 +1341,8 @@ class WorkflowManager:
         workflow = self.get_workflow_by_tool_name(tool_name)
         if workflow is None:
             return None
-        policy_modes = self._infer_policy_modes(workflow)
+        approval_context = _approval_context_for_workflow(workflow)
+        policy_modes = self._infer_policy_modes(workflow, approval_context)
         return {
             "description": workflow.description,
             "inputs": workflow.inputs,
@@ -1244,10 +1355,10 @@ class WorkflowManager:
             "requires_tools": _canonicalize_tool_names(workflow.requires_tools),
             "requires_skills": workflow.requires_skills,
             "step_count": len(workflow.steps),
-            "execution_boundaries": self._infer_execution_boundaries(workflow),
-            "risk_level": self._infer_risk_level(workflow),
-            "accepts_secret_refs": self._accepts_secret_refs(workflow),
-            "approval_context": _approval_context_for_workflow(workflow),
+            "execution_boundaries": self._infer_execution_boundaries(workflow, approval_context),
+            "risk_level": self._infer_risk_level(workflow, approval_context),
+            "accepts_secret_refs": self._accepts_secret_refs(workflow, approval_context),
+            "approval_context": approval_context,
         }
 
     def _get_runtime_availability(
@@ -1309,50 +1420,33 @@ class WorkflowManager:
             "missing_manifest_network": missing_manifest_network,
         }
 
-    def _infer_policy_modes(self, workflow: Workflow) -> list[str]:
-        step_tools = workflow.step_tools
-        canonical_step_tools = [canonical_tool_name(tool_name) for tool_name in step_tools]
-        if any(tool_name.startswith("mcp_") for tool_name in canonical_step_tools):
-            return ["full"]
-        if any(
-            tool_name in {"write_file", "update_goal", "update_soul", "store_secret", "delete_secret"}
-            for tool_name in canonical_step_tools
-        ):
-            return ["balanced", "full"]
-        if any(tool_name in {"execute_code", "get_secret"} for tool_name in canonical_step_tools):
-            return ["full"]
-        return ["safe", "balanced", "full"]
+    def _infer_policy_modes(self, workflow: Workflow, approval_context: dict[str, Any] | None = None) -> list[str]:
+        context = approval_context or _approval_context_for_workflow(workflow)
+        return _policy_modes_for_approval_context(context)
 
-    def _infer_execution_boundaries(self, workflow: Workflow) -> list[str]:
-        boundaries: list[str] = []
-        for tool_name in workflow.step_tools:
-            canonical_name = canonical_tool_name(tool_name)
-            if canonical_name.startswith("mcp_"):
-                boundaries.append("external_mcp")
-                continue
-            tool_meta = TOOL_METADATA.get(canonical_name, {})
-            for boundary in tool_meta.get("execution_boundaries", []):
-                if boundary not in boundaries:
-                    boundaries.append(boundary)
-        return boundaries or ["unknown"]
+    def _infer_execution_boundaries(
+        self,
+        workflow: Workflow,
+        approval_context: dict[str, Any] | None = None,
+    ) -> list[str]:
+        context = approval_context or _approval_context_for_workflow(workflow)
+        boundaries = context.get("execution_boundaries", [])
+        return list(boundaries) if isinstance(boundaries, list) and boundaries else ["unknown"]
 
-    def _infer_risk_level(self, workflow: Workflow) -> str:
-        policy_modes = self._infer_policy_modes(workflow)
+    def _infer_risk_level(self, workflow: Workflow, approval_context: dict[str, Any] | None = None) -> str:
+        context = approval_context or _approval_context_for_workflow(workflow)
+        if isinstance(context.get("risk_level"), str):
+            return str(context["risk_level"])
+        policy_modes = self._infer_policy_modes(workflow, context)
         if policy_modes == ["full"]:
             return "high"
         if policy_modes == ["balanced", "full"]:
             return "medium"
         return "low"
 
-    def _accepts_secret_refs(self, workflow: Workflow) -> bool:
-        for tool_name in workflow.step_tools:
-            canonical_name = canonical_tool_name(tool_name)
-            if canonical_name.startswith("mcp_"):
-                return True
-            tool_meta = TOOL_METADATA.get(canonical_name, {})
-            if bool(tool_meta.get("accepts_secret_refs", False)):
-                return True
-        return False
+    def _accepts_secret_refs(self, workflow: Workflow, approval_context: dict[str, Any] | None = None) -> bool:
+        context = approval_context or _approval_context_for_workflow(workflow)
+        return bool(context.get("accepts_secret_refs", False))
 
 
 workflow_manager = WorkflowManager()

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -3426,6 +3426,115 @@ class TestWorkflowSurfaces:
         ]
         assert _checkpoint_context_allowed(approval_context) is False
 
+    def test_workflow_approval_context_marks_delegated_vault_routes_high_risk(self):
+        workflow = Workflow(
+            name="vault-delegation",
+            description="Delegate secret handling",
+            inputs={},
+            steps=[
+                WorkflowStep(
+                    id="delegate",
+                    tool="delegate_task",
+                    arguments={
+                        "task": "Store this API key in the vault.",
+                        "specialist": "vault",
+                    },
+                )
+            ],
+            requires_tools=["delegate_task"],
+        )
+
+        approval_context = _approval_context_for_workflow(workflow)
+
+        assert approval_context["risk_level"] == "high"
+        assert approval_context["delegated_specialists"] == ["vault_keeper"]
+        assert "delegation" in approval_context["execution_boundaries"]
+        assert "secret_management" in approval_context["execution_boundaries"]
+        assert "secret_injection" in approval_context["execution_boundaries"]
+        assert _checkpoint_context_allowed(approval_context) is False
+
+    def test_workflow_tool_approval_context_includes_authenticated_delegated_source(self):
+        workflow = Workflow(
+            name="delegated-mcp-sync",
+            description="Delegate authenticated source work",
+            inputs={
+                "task": {"type": "string", "required": True},
+                "specialist": {"type": "string", "required": True},
+            },
+            steps=[
+                WorkflowStep(
+                    id="delegate",
+                    tool="delegate_task",
+                    arguments={
+                        "task": "{{ task }}",
+                        "specialist": "{{ specialist }}",
+                    },
+                )
+            ],
+            requires_tools=["delegate_task"],
+        )
+        workflow_tool = WorkflowTool(
+            workflow,
+            {"delegate_task": DummyTool("delegate_task", lambda **_kwargs: "delegated")},
+        )
+        mcp_tool = MagicMock()
+        mcp_tool.name = "mcp_github_issues"
+        mcp_tool.seraph_source_context = {
+            "server_name": "github",
+            "hostname": "api.github.com",
+            "source": "extension",
+            "authenticated_source": True,
+        }
+        github_specialist = SimpleNamespace(name="mcp_github", tools=[mcp_tool])
+
+        with patch("src.agent.specialists.build_all_specialists", return_value=[github_specialist]):
+            approval_context = workflow_tool.get_approval_context(
+                {
+                    "task": "Review the assigned issues.",
+                    "specialist": "mcp_github",
+                }
+            )
+
+        assert approval_context["risk_level"] == "high"
+        assert approval_context["authenticated_source"] is True
+        assert approval_context["delegated_specialists"] == ["mcp_github"]
+        assert "external_mcp" in approval_context["execution_boundaries"]
+        assert "authenticated_external_source" in approval_context["execution_boundaries"]
+        assert approval_context["source_systems"] == [
+            {
+                "server_name": "github",
+                "hostname": "api.github.com",
+                "source": "extension",
+                "authenticated_source": True,
+            }
+        ]
+        assert _checkpoint_context_allowed(approval_context) is False
+
+    def test_workflow_metadata_fails_closed_when_delegate_target_is_dynamic(self):
+        workflow = Workflow(
+            name="dynamic-delegation",
+            description="Dynamic delegation workflow",
+            inputs={"task": {"type": "string", "required": True}},
+            steps=[
+                WorkflowStep(
+                    id="delegate",
+                    tool="delegate_task",
+                    arguments={"task": "{{ task }}"},
+                )
+            ],
+            requires_tools=["delegate_task"],
+        )
+        mgr = WorkflowManager()
+        mgr._workflows = [workflow]
+
+        metadata = mgr.get_tool_metadata(workflow.tool_name)
+
+        assert metadata is not None
+        assert metadata["policy_modes"] == ["full"]
+        assert metadata["risk_level"] == "high"
+        assert metadata["accepts_secret_refs"] is True
+        assert metadata["approval_context"]["delegation_target_unresolved"] is True
+
     def test_build_all_specialists_adds_workflow_runner(self):
         native_tool = MagicMock()
         native_tool.name = "read_file"

--- a/docs/implementation/01-trust-boundaries.md
+++ b/docs/implementation/01-trust-boundaries.md
@@ -185,6 +185,23 @@
   - direct review against bugs and regressions exposed one real backward-compatibility problem in the first pass: adding default `authenticated_source=false` and empty `source_systems=[]` into normalized approval context changed legacy workflow fingerprints for runs that never carried source metadata
   - fixed by only persisting authenticated-source fields in normalized approval context when they are materially present, which keeps older approval fingerprints stable while still surfacing real authenticated-source drift
 
+### `workflow-delegation-boundary-enforcement-v1`
+
+- status: complete on `feat/delegated-workflow-boundary-hardening-batch-ad-v2`, intended for the next Batch AD PR for `#299`
+- root cause addressed:
+  - reusable workflows that used `delegate_task` only advertised the generic `delegation` surface in workflow metadata and runtime approval context, even when the delegated specialist actually crossed vault or authenticated external-source boundaries
+  - that made delegated workflows look safer than the real execution path, which weakened safe/balanced exposure decisions and let checkpoint/replay policy reason about an underspecified trust surface
+- scope:
+  - delegated workflow approval context now resolves the selected specialist when the route is explicit or renderable from runtime inputs, and merges the delegated specialist's real risk, boundary, and authenticated-source signals into the workflow approval snapshot
+  - workflow metadata now derives policy modes, risk, execution boundaries, and secret-ref handling from that richer approval context instead of trusting only the direct step tool list
+  - workflows with unresolved dynamic delegation targets now fail closed as `full` / `high` and block checkpoint reuse instead of staying exposed as generic low-risk delegation
+- validation:
+  - `python3 -m py_compile backend/src/tools/delegate_task_tool.py backend/src/workflows/manager.py backend/tests/test_workflows.py`
+  - `cd backend && .venv/bin/python -m pytest tests/test_workflows.py -q -k "delegated_vault_routes or authenticated_delegated_source or delegate_target_is_dynamic or authenticated_source_context_drift or authenticated_source_system_reordering or approval_context_marks_authenticated_mcp_sources"`
+- review pass:
+  - direct review against bugs and regressions found two real implementation problems in the first pass: static vault delegation was still reading a low-risk surface because the specialist graph exposed tools as a dict and the new boundary walk treated it like a list, and the first vault regression overclaimed `accepts_secret_refs` even though the real fail-closed signal is the delegated secret-injection boundary
+  - fixed by normalizing specialist tool collections before walking delegated boundaries and by pinning the actual checkpoint-blocking contract instead of inventing a broader secret-ref claim
+
 ### `planner-secret-surface-isolation-v1`
 
 - status: complete on `develop` via PR `#245`


### PR DESCRIPTION
Summary
- harden workflow approval and replay context when delegate_task routes into privileged or authenticated specialists
- make workflow metadata fail closed when delegated targets are dynamic or unresolved instead of exposing those workflows as low-risk delegation
- add focused regression coverage for delegated vault routes, authenticated delegated MCP routes, and unresolved delegation metadata

Validation
- python3 -m py_compile backend/src/tools/delegate_task_tool.py backend/src/workflows/manager.py backend/tests/test_workflows.py
- cd backend && .venv/bin/python -m pytest tests/test_workflows.py -q -k delegated_vault_routes or authenticated_delegated_source or delegate_target_is_dynamic or authenticated_source_context_drift or authenticated_source_system_reordering or approval_context_marks_authenticated_mcp_sources
- cd backend && .venv/bin/python -m pytest tests/test_delegate_task_tool.py -q -k routes_to_named_specialist or routes_secret_keywords_to_vault_keeper or blocks_nested_delegation
- cd docs && npm run build
- git diff --check

Notes
- review/fix pass caught two real issues before publish: specialist tool collections from the live graph can be dict-backed instead of list-backed, and the first vault regression overclaimed accepts_secret_refs instead of pinning the real secret-injection boundary contract
- I did not claim the broader delegate_task_tool plus tools_api bundle because it hits this environment's long-tail teardown path even after all assertions print green