### PR TITLE
fix(extensions): gate high-risk removal on lifecycle approval

### DIFF
--- a/backend/src/api/extensions.py
+++ b/backend/src/api/extensions.py
@@ -983,6 +983,7 @@ async def remove_extension_package(extension_id: str):
     preview: dict[str, Any] | None = None
     try:
         preview = get_extension(extension_id)
+        await _require_extension_lifecycle_approval("remove", preview)
         remove_extension(extension_id)
     except KeyError as exc:
         await _log_extension_lifecycle_event(

--- a/backend/tests/test_extensions_api.py
+++ b/backend/tests/test_extensions_api.py
@@ -919,6 +919,92 @@ async def test_install_high_risk_extension_requires_new_approval_if_package_chan
 
 
 @pytest.mark.asyncio
+async def test_remove_high_risk_extension_requires_approval(client, extension_runtime, tmp_path):
+    package_dir = _write_high_risk_extension(tmp_path)
+
+    with patch(
+        "src.extensions.lifecycle.get_base_tools_and_active_skills",
+        return_value=([SimpleNamespace(name="write_file")], [], "approval"),
+    ), patch(
+        "src.api.extensions.log_integration_event",
+        AsyncMock(),
+    ):
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 409
+        install_approval_id = install_response.json()["detail"]["approval_id"]
+
+        approve_install = await client.post(f"/api/approvals/{install_approval_id}/approve")
+        assert approve_install.status_code == 200
+
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 201
+
+        remove_response = await client.delete("/api/extensions/seraph.high-risk-pack")
+        assert remove_response.status_code == 409
+        remove_detail = remove_response.json()["detail"]
+        assert remove_detail["type"] == "approval_required"
+
+        approve_remove = await client.post(f"/api/approvals/{remove_detail['approval_id']}/approve")
+        assert approve_remove.status_code == 200
+
+        remove_response = await client.delete("/api/extensions/seraph.high-risk-pack")
+        assert remove_response.status_code == 200
+        assert not (extension_runtime / "extensions" / "seraph-high-risk-pack").exists()
+
+
+@pytest.mark.asyncio
+async def test_remove_high_risk_extension_requires_new_approval_if_package_changes(client, extension_runtime, tmp_path):
+    package_dir = _write_high_risk_extension(tmp_path)
+
+    with patch(
+        "src.extensions.lifecycle.get_base_tools_and_active_skills",
+        return_value=([SimpleNamespace(name="write_file")], [], "approval"),
+    ), patch(
+        "src.api.extensions.log_integration_event",
+        AsyncMock(),
+    ):
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 409
+        install_approval_id = install_response.json()["detail"]["approval_id"]
+
+        approve_install = await client.post(f"/api/approvals/{install_approval_id}/approve")
+        assert approve_install.status_code == 200
+
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 201
+
+        remove_response = await client.delete("/api/extensions/seraph.high-risk-pack")
+        assert remove_response.status_code == 409
+        first_remove_approval_id = remove_response.json()["detail"]["approval_id"]
+
+        approve_remove = await client.post(f"/api/approvals/{first_remove_approval_id}/approve")
+        assert approve_remove.status_code == 200
+
+        installed_workflow = extension_runtime / "extensions" / "seraph-high-risk-pack" / "workflows" / "write-note.md"
+        installed_workflow.write_text(
+            "---\n"
+            "name: write-note\n"
+            "description: Write a changed note into the workspace\n"
+            "requires:\n"
+            "  tools: [write_file]\n"
+            "steps:\n"
+            "  - id: save\n"
+            "    tool: write_file\n"
+            "    arguments:\n"
+            "      file_path: notes/high-risk.md\n"
+            "      content: changed-before-remove\n"
+            "---\n\n"
+            "Write a changed note.\n",
+            encoding="utf-8",
+        )
+
+        remove_response = await client.delete("/api/extensions/seraph.high-risk-pack")
+        assert remove_response.status_code == 409
+        second_remove_approval_id = remove_response.json()["detail"]["approval_id"]
+        assert second_remove_approval_id != first_remove_approval_id
+
+
+@pytest.mark.asyncio
 async def test_install_configure_toggle_and_remove_workspace_extension(client, extension_runtime, tmp_path):
     package_dir = _write_installable_extension(tmp_path)
 

--- a/docs/implementation/01-trust-boundaries.md
+++ b/docs/implementation/01-trust-boundaries.md
@@ -202,6 +202,22 @@
   - direct review against bugs and regressions found two real implementation problems in the first pass: static vault delegation was still reading a low-risk surface because the specialist graph exposed tools as a dict and the new boundary walk treated it like a list, and the first vault regression overclaimed `accepts_secret_refs` even though the real fail-closed signal is the delegated secret-injection boundary
   - fixed by normalizing specialist tool collections before walking delegated boundaries and by pinning the actual checkpoint-blocking contract instead of inventing a broader secret-ref claim
 
+### `extension-removal-boundary-enforcement-v1`
+
+- status: complete on `feat/extension-removal-boundary-hardening-batch-ad-v3`, intended for the next Batch AD PR for `#299`
+- root cause addressed:
+  - install, update, enable, and secret-bearing configure already route through extension lifecycle approval, but direct removal still mutated the workspace package and runtime state immediately
+  - that meant a high-risk extension could be torn down without the same package-digest-bound approval envelope that already protects the rest of the lifecycle mutation surface
+- scope:
+  - extension removal now reuses the existing lifecycle approval seam before destructive workspace-package teardown
+  - removal approvals bind to the current installed package digest, so a changed package must be re-approved before the delete path can consume the destructive mutation
+  - low-risk workspace removals remain direct because the lifecycle approval profile is still driven by the extension's real declared boundaries instead of turning every uninstall into ceremony
+- validation:
+  - `python3 -m py_compile backend/src/api/extensions.py backend/tests/test_extensions_api.py`
+  - `cd backend && .venv/bin/python -m pytest tests/test_extensions_api.py -q -k "remove_high_risk_extension_requires_approval or remove_high_risk_extension_requires_new_approval_if_package_changes or install_high_risk_extension_requires_new_approval_if_package_changes or install_and_enable_high_risk_extension_require_approval"`
+- review pass:
+  - direct review against regressions found the real risk was not broad uninstall approval in general, but the missing destructive boundary specifically for already-approved high-risk extensions; the fix keeps low-risk removals direct and only tightens the high-risk mutation seam
+
 ### `planner-secret-surface-isolation-v1`
 
 - status: complete on `develop` via PR `#245`


### PR DESCRIPTION
Summary
- require lifecycle approval before removing high-risk workspace extensions
- bind removal approval to the current installed package digest so destructive approval cannot be reused after the package changes
- add focused regression coverage for high-risk removal approval and package-drift reapproval

Validation
- python3 -m py_compile backend/src/api/extensions.py backend/tests/test_extensions_api.py
- cd backend && .venv/bin/python -m pytest tests/test_extensions_api.py -q -k remove_high_risk_extension_requires_approval or remove_high_risk_extension_requires_new_approval_if_package_changes or install_high_risk_extension_requires_new_approval_if_package_changes or install_and_enable_high_risk_extension_require_approval
- cd docs && npm run build
- git diff --check

Notes
- review/fix pass found one real test regression before publish: the first package-drift removal test mutated the wrong installed workspace path, so it was proving nothing about removal fingerprints until that path was corrected
- I am not claiming a broader full extensions suite run here; the PR evidence only includes the focused lifecycle seam exercised by this slice