### PR TITLE
fix(extensions): harden disable and connector approvals

### DIFF
--- a/backend/src/api/extensions.py
+++ b/backend/src/api/extensions.py
@@ -37,6 +37,7 @@ from src.extensions.lifecycle import (
     update_extension_path,
     validate_extension_path,
 )
+from src.extensions.permissions import LIFECYCLE_APPROVAL_BOUNDARIES
 from src.extensions.registry import ExtensionRegistry, default_manifest_roots_for_workspace
 from src.extensions.scaffold import scaffold_extension_package
 from src.extensions.state import (
@@ -44,6 +45,8 @@ from src.extensions.state import (
     load_extension_state_payload,
     save_extension_state_payload,
 )
+from src.native_tools.registry import canonical_tool_name
+from src.tools.policy import get_tool_execution_boundaries, get_tool_risk_level
 from src.tools.mcp_manager import mcp_manager
 
 router = APIRouter()
@@ -63,6 +66,59 @@ _BUILTIN_CHANNEL_ADAPTERS = (
     },
 )
 _REDACTED_CONFIG_SENTINEL = "__SERAPH_STORED_SECRET__"
+
+
+def _lifecycle_fallback_preview(preview: dict[str, Any]) -> dict[str, Any]:
+    approval_profile = preview.get("approval_profile")
+    if isinstance(approval_profile, dict) and approval_profile.get("requires_lifecycle_approval"):
+        return preview
+
+    permissions = preview.get("permissions")
+    if not isinstance(permissions, dict):
+        return preview
+
+    boundaries: list[str] = []
+    for boundary in permissions.get("execution_boundaries", []) or []:
+        if isinstance(boundary, str) and boundary.strip() and boundary not in boundaries:
+            boundaries.append(boundary.strip())
+
+    risk_level = "low"
+    for raw_tool_name in permissions.get("tools", []) or []:
+        if not isinstance(raw_tool_name, str) or not raw_tool_name.strip():
+            continue
+        tool_name = canonical_tool_name(raw_tool_name)
+        if not tool_name:
+            continue
+        is_mcp = tool_name.startswith("mcp_")
+        for boundary in get_tool_execution_boundaries(tool_name, is_mcp=is_mcp):
+            if boundary not in boundaries:
+                boundaries.append(boundary)
+        tool_risk = get_tool_risk_level(tool_name, is_mcp=is_mcp)
+        if tool_risk == "high" or (tool_risk == "medium" and risk_level == "low"):
+            risk_level = tool_risk
+
+    lifecycle_boundaries = [
+        boundary
+        for boundary in boundaries
+        if boundary in LIFECYCLE_APPROVAL_BOUNDARIES
+    ]
+    if not lifecycle_boundaries:
+        return preview
+
+    if risk_level != "high":
+        risk_level = "high"
+    runtime_behavior = "mcp_policy" if "external_mcp" in boundaries else "high_risk"
+    requires_runtime_approval = runtime_behavior in {"mcp_policy", "high_risk"}
+    return {
+        **preview,
+        "approval_profile": {
+            "requires_runtime_approval": requires_runtime_approval,
+            "runtime_behavior": runtime_behavior,
+            "requires_lifecycle_approval": True,
+            "lifecycle_boundaries": lifecycle_boundaries,
+            "risk_level": risk_level,
+        },
+    }
 
 
 class ExtensionPathRequest(BaseModel):
@@ -306,6 +362,7 @@ async def _require_extension_lifecycle_approval(
     *,
     consume: bool = True,
 ) -> None:
+    preview = _lifecycle_fallback_preview(preview)
     approval_profile = preview.get("approval_profile")
     if not isinstance(approval_profile, dict) or not approval_profile.get("requires_lifecycle_approval"):
         return
@@ -327,6 +384,9 @@ async def _require_extension_lifecycle_approval(
 
     extension_id = str(preview.get("id") or preview.get("extension_id") or "")
     display_name = str(preview.get("display_name") or extension_id or "extension")
+    target_reference = str(preview.get("target_reference") or preview.get("reference") or "")
+    target_name = str(preview.get("target_name") or preview.get("name") or "")
+    target_type = str(preview.get("target_type") or preview.get("type") or "")
     tool_name = f"extension_{action}"
     arguments = {
         "extension_id": extension_id,
@@ -336,6 +396,12 @@ async def _require_extension_lifecycle_approval(
         "boundaries": lifecycle_boundaries,
         "permissions": preview.get("permissions"),
     }
+    if target_reference:
+        arguments["target_reference"] = target_reference
+    if target_name:
+        arguments["target_name"] = target_name
+    if target_type:
+        arguments["target_type"] = target_type
     fingerprint = fingerprint_tool_call(tool_name, arguments)
     approval_satisfied = (
         await approval_repository.consume_approved(
@@ -354,8 +420,23 @@ async def _require_extension_lifecycle_approval(
         return
 
     summary = (
-        f"{action.replace('_', ' ').title()} extension '{display_name}' "
-        f"with access to {', '.join(lifecycle_boundaries) or 'high-risk capabilities'}"
+        f"{action.replace('_', ' ').title()} extension "
+        f"'{display_name}'"
+    )
+    if target_reference or target_name:
+        target_label = " / ".join(
+            part
+            for part in (
+                target_type.replace("_", " ").strip(),
+                target_name,
+                target_reference,
+            )
+            if part
+        )
+        summary = f"{summary} target '{target_label}'"
+    summary = (
+        f"{summary} with access to "
+        f"{', '.join(lifecycle_boundaries) or 'high-risk capabilities'}"
     )
     request = await approval_repository.get_or_create_pending(
         session_id=None,
@@ -367,6 +448,9 @@ async def _require_extension_lifecycle_approval(
             "extension_id": extension_id,
             "extension_display_name": display_name,
             "action": action,
+            "target_reference": target_reference or None,
+            "target_name": target_name or None,
+            "target_type": target_type or None,
             "package_path": preview.get("root_path") or preview.get("path"),
             "package_digest": preview.get("package_digest"),
             "permissions": preview.get("permissions"),
@@ -635,50 +719,55 @@ async def set_extension_package_connector_enabled(extension_id: str, req: Extens
     preview: dict[str, Any] | None = None
     try:
         preview = get_extension(extension_id)
+        target_connector = next(
+            (
+                contribution
+                for contribution in preview.get("contributions", [])
+                if isinstance(contribution, dict) and contribution.get("reference") == req.reference
+            ),
+            None,
+        )
+        if target_connector is None:
+            raise KeyError(req.reference)
+        permission_profile = target_connector.get("permission_profile")
+        connector_preview = {
+            **preview,
+            "target_reference": req.reference,
+            "target_name": target_connector.get("name"),
+            "target_type": target_connector.get("type"),
+            "approval_profile": {
+                "requires_runtime_approval": bool(
+                    isinstance(permission_profile, dict) and permission_profile.get("requires_approval")
+                ),
+                "runtime_behavior": (
+                    str(permission_profile.get("approval_behavior") or "never")
+                    if isinstance(permission_profile, dict)
+                    else "never"
+                ),
+                "requires_lifecycle_approval": bool(
+                    isinstance(permission_profile, dict)
+                    and permission_profile.get("lifecycle_approval_boundaries")
+                ),
+                "lifecycle_boundaries": (
+                    list(permission_profile.get("lifecycle_approval_boundaries", []))
+                    if isinstance(permission_profile, dict)
+                    else []
+                ),
+                "risk_level": (
+                    str(permission_profile.get("risk_level") or "low")
+                    if isinstance(permission_profile, dict)
+                    else "low"
+                ),
+            },
+        }
         if req.enabled:
             if preview.get("status") != "ready":
                 raise ValueError(
                     f"extension '{extension_id}' is degraded and cannot enable packaged connectors until validation issues are fixed"
                 )
-            target_connector = next(
-                (
-                    contribution
-                    for contribution in preview.get("contributions", [])
-                    if isinstance(contribution, dict) and contribution.get("reference") == req.reference
-                ),
-                None,
-            )
-            if target_connector is None:
-                raise KeyError(req.reference)
-            permission_profile = target_connector.get("permission_profile")
-            connector_preview = {
-                **preview,
-                "approval_profile": {
-                    "requires_runtime_approval": bool(
-                        isinstance(permission_profile, dict) and permission_profile.get("requires_approval")
-                    ),
-                    "runtime_behavior": (
-                        str(permission_profile.get("approval_behavior") or "never")
-                        if isinstance(permission_profile, dict)
-                        else "never"
-                    ),
-                    "requires_lifecycle_approval": bool(
-                        isinstance(permission_profile, dict)
-                        and permission_profile.get("lifecycle_approval_boundaries")
-                    ),
-                    "lifecycle_boundaries": (
-                        list(permission_profile.get("lifecycle_approval_boundaries", []))
-                        if isinstance(permission_profile, dict)
-                        else []
-                    ),
-                    "risk_level": (
-                        str(permission_profile.get("risk_level") or "low")
-                        if isinstance(permission_profile, dict)
-                        else "low"
-                    ),
-                },
-            }
             await _require_extension_lifecycle_approval("enable", connector_preview)
+        else:
+            await _require_extension_lifecycle_approval("disable", connector_preview)
         result = set_extension_connector_enabled(extension_id, req.reference, enabled=req.enabled)
     except KeyError as exc:
         detail = (
@@ -919,7 +1008,10 @@ async def enable_extension_package(extension_id: str):
 
 @router.post("/extensions/{extension_id}/disable")
 async def disable_extension_package(extension_id: str):
+    preview: dict[str, Any] | None = None
     try:
+        preview = get_extension(extension_id)
+        await _require_extension_lifecycle_approval("disable", preview)
         result = disable_extension(extension_id)
     except KeyError as exc:
         await _log_extension_lifecycle_event(

--- a/backend/tests/test_extensions_api.py
+++ b/backend/tests/test_extensions_api.py
@@ -183,6 +183,52 @@ def _write_mcp_connector_extension(
     return package_dir
 
 
+def _write_multi_mcp_connector_extension(root: Path) -> Path:
+    package_dir = root / "multi-connector-pack"
+    (package_dir / "mcp").mkdir(parents=True)
+    (package_dir / "manifest.yaml").write_text(
+        "id: seraph.multi-connector-pack\n"
+        "version: 2026.3.21\n"
+        "display_name: Multi Connector Pack\n"
+        "kind: connector-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  mcp_servers:\n"
+        "    - mcp/github-primary.json\n"
+        "    - mcp/github-secondary.json\n"
+        "permissions:\n"
+        "  network: true\n",
+        encoding="utf-8",
+    )
+    (package_dir / "mcp" / "github-primary.json").write_text(
+        "{\n"
+        '  "name": "github-primary",\n'
+        '  "url": "https://example.test/mcp-primary",\n'
+        '  "description": "Primary packaged GitHub MCP",\n'
+        '  "headers": {"Authorization": "Bearer ${GITHUB_PRIMARY_TOKEN}"},\n'
+        '  "auth_hint": "Set GITHUB_PRIMARY_TOKEN before enabling the connector",\n'
+        '  "transport": "streamable-http"\n'
+        "}\n",
+        encoding="utf-8",
+    )
+    (package_dir / "mcp" / "github-secondary.json").write_text(
+        "{\n"
+        '  "name": "github-secondary",\n'
+        '  "url": "https://example.test/mcp-secondary",\n'
+        '  "description": "Secondary packaged GitHub MCP",\n'
+        '  "headers": {"Authorization": "Bearer ${GITHUB_SECONDARY_TOKEN}"},\n'
+        '  "auth_hint": "Set GITHUB_SECONDARY_TOKEN before enabling the connector",\n'
+        '  "transport": "streamable-http"\n'
+        "}\n",
+        encoding="utf-8",
+    )
+    return package_dir
+
+
 def _write_managed_connector_extension(root: Path) -> Path:
     package_dir = root / "managed-connector-pack"
     (package_dir / "connectors" / "managed").mkdir(parents=True)
@@ -862,6 +908,14 @@ async def test_install_and_enable_high_risk_extension_require_approval(client, e
         assert "workspace_write" in installed["approval_profile"]["lifecycle_boundaries"]
 
         disable_response = await client.post("/api/extensions/seraph.high-risk-pack/disable")
+        assert disable_response.status_code == 409
+        disable_detail = disable_response.json()["detail"]
+        assert disable_detail["type"] == "approval_required"
+
+        approve_disable = await client.post(f"/api/approvals/{disable_detail['approval_id']}/approve")
+        assert approve_disable.status_code == 200
+
+        disable_response = await client.post("/api/extensions/seraph.high-risk-pack/disable")
         assert disable_response.status_code == 200
 
         enable_response = await client.post("/api/extensions/seraph.high-risk-pack/enable")
@@ -1002,6 +1056,58 @@ async def test_remove_high_risk_extension_requires_new_approval_if_package_chang
         assert remove_response.status_code == 409
         second_remove_approval_id = remove_response.json()["detail"]["approval_id"]
         assert second_remove_approval_id != first_remove_approval_id
+
+
+@pytest.mark.asyncio
+async def test_disable_high_risk_extension_requires_new_approval_if_package_changes(client, extension_runtime, tmp_path):
+    package_dir = _write_high_risk_extension(tmp_path)
+
+    with patch(
+        "src.extensions.lifecycle.get_base_tools_and_active_skills",
+        return_value=([SimpleNamespace(name="write_file")], [], "approval"),
+    ), patch(
+        "src.api.extensions.log_integration_event",
+        AsyncMock(),
+    ):
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 409
+        install_approval_id = install_response.json()["detail"]["approval_id"]
+
+        approve_install = await client.post(f"/api/approvals/{install_approval_id}/approve")
+        assert approve_install.status_code == 200
+
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 201
+
+        disable_response = await client.post("/api/extensions/seraph.high-risk-pack/disable")
+        assert disable_response.status_code == 409
+        first_disable_approval_id = disable_response.json()["detail"]["approval_id"]
+
+        approve_disable = await client.post(f"/api/approvals/{first_disable_approval_id}/approve")
+        assert approve_disable.status_code == 200
+
+        installed_root = extension_runtime / "extensions" / "seraph-high-risk-pack"
+        (installed_root / "workflows" / "write-note.md").write_text(
+            "---\n"
+            "name: write-note\n"
+            "description: Write a changed note into the workspace\n"
+            "requires:\n"
+            "  tools: [write_file]\n"
+            "steps:\n"
+            "  - id: save\n"
+            "    tool: write_file\n"
+            "    arguments:\n"
+            "      file_path: notes/high-risk.md\n"
+            "      content: changed-after-disable-approval\n"
+            "---\n\n"
+            "Write a changed note.\n",
+            encoding="utf-8",
+        )
+
+        disable_response = await client.post("/api/extensions/seraph.high-risk-pack/disable")
+        assert disable_response.status_code == 409
+        second_disable_approval_id = disable_response.json()["detail"]["approval_id"]
+        assert second_disable_approval_id != first_disable_approval_id
 
 
 @pytest.mark.asyncio
@@ -1266,6 +1372,13 @@ async def test_enable_rejects_degraded_extension_with_invalid_workflow_before_ap
         )
 
         disable_response = await client.post("/api/extensions/seraph.high-risk-pack/disable")
+        assert disable_response.status_code == 409
+        disable_approval_id = disable_response.json()["detail"]["approval_id"]
+
+        approve_disable = await client.post(f"/api/approvals/{disable_approval_id}/approve")
+        assert approve_disable.status_code == 200
+
+        disable_response = await client.post("/api/extensions/seraph.high-risk-pack/disable")
         assert disable_response.status_code == 200
 
         enable_response = await client.post("/api/extensions/seraph.high-risk-pack/enable")
@@ -1326,10 +1439,24 @@ async def test_install_toggle_and_remove_workspace_connector_extension(client, e
         connect_mock.assert_called_once()
 
         disable_response = await client.post("/api/extensions/seraph.test-connector/disable")
+        assert disable_response.status_code == 409
+        disable_approval_id = disable_response.json()["detail"]["approval_id"]
+
+        approve_disable = await client.post(f"/api/approvals/{disable_approval_id}/approve")
+        assert approve_disable.status_code == 200
+
+        disable_response = await client.post("/api/extensions/seraph.test-connector/disable")
         assert disable_response.status_code == 200
         assert disable_response.json()["extension"]["enabled"] is False
         assert mcp_manager._config["github-packaged"]["enabled"] is False
         disconnect_mock.assert_called_once()
+
+        remove_response = await client.delete("/api/extensions/seraph.test-connector")
+        assert remove_response.status_code == 409
+        remove_approval_id = remove_response.json()["detail"]["approval_id"]
+
+        approve_remove = await client.post(f"/api/approvals/{remove_approval_id}/approve")
+        assert approve_remove.status_code == 200
 
         remove_response = await client.delete("/api/extensions/seraph.test-connector")
         assert remove_response.status_code == 200
@@ -1903,10 +2030,110 @@ async def test_extension_connector_enable_endpoint_controls_packaged_mcp_runtime
             "/api/extensions/seraph.test-connector/connectors/enabled",
             json={"reference": "mcp/github.json", "enabled": False},
         )
+        assert disable_response.status_code == 409
+        disable_approval_id = disable_response.json()["detail"]["approval_id"]
+
+        approve_disable = await client.post(f"/api/approvals/{disable_approval_id}/approve")
+        assert approve_disable.status_code == 200
+
+        disable_response = await client.post(
+            "/api/extensions/seraph.test-connector/connectors/enabled",
+            json={"reference": "mcp/github.json", "enabled": False},
+        )
         assert disable_response.status_code == 200
         assert disable_response.json()["status"] == "disabled"
         assert mcp_manager._config["github-packaged"]["enabled"] is False
         assert disconnect_mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_connector_lifecycle_approval_is_scoped_to_each_packaged_connector_target(client, extension_runtime, tmp_path):
+    package_dir = _write_multi_mcp_connector_extension(tmp_path)
+
+    with patch(
+        "src.extensions.lifecycle.get_base_tools_and_active_skills",
+        return_value=([SimpleNamespace(name="read_file")], [], "approval"),
+    ), patch(
+        "src.api.extensions.log_integration_event",
+        AsyncMock(),
+    ), patch.object(
+        mcp_manager,
+        "connect",
+    ) as connect_mock, patch.object(
+        mcp_manager,
+        "disconnect",
+    ) as disconnect_mock:
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 409
+        install_approval_id = install_response.json()["detail"]["approval_id"]
+
+        approve_install = await client.post(f"/api/approvals/{install_approval_id}/approve")
+        assert approve_install.status_code == 200
+
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 201
+
+        enable_primary = await client.post(
+            "/api/extensions/seraph.multi-connector-pack/connectors/enabled",
+            json={"reference": "mcp/github-primary.json", "enabled": True},
+        )
+        assert enable_primary.status_code == 409
+        primary_approval_id = enable_primary.json()["detail"]["approval_id"]
+
+        approve_primary = await client.post(f"/api/approvals/{primary_approval_id}/approve")
+        assert approve_primary.status_code == 200
+
+        enable_primary = await client.post(
+            "/api/extensions/seraph.multi-connector-pack/connectors/enabled",
+            json={"reference": "mcp/github-primary.json", "enabled": True},
+        )
+        assert enable_primary.status_code == 200
+        assert enable_primary.json()["connector"]["name"] == "github-primary"
+        assert connect_mock.call_count == 1
+
+        enable_secondary = await client.post(
+            "/api/extensions/seraph.multi-connector-pack/connectors/enabled",
+            json={"reference": "mcp/github-secondary.json", "enabled": True},
+        )
+        assert enable_secondary.status_code == 409
+        secondary_approval_id = enable_secondary.json()["detail"]["approval_id"]
+        assert secondary_approval_id != primary_approval_id
+
+        approve_secondary = await client.post(f"/api/approvals/{secondary_approval_id}/approve")
+        assert approve_secondary.status_code == 200
+
+        enable_secondary = await client.post(
+            "/api/extensions/seraph.multi-connector-pack/connectors/enabled",
+            json={"reference": "mcp/github-secondary.json", "enabled": True},
+        )
+        assert enable_secondary.status_code == 200
+        assert enable_secondary.json()["connector"]["name"] == "github-secondary"
+        assert connect_mock.call_count == 2
+
+        disable_primary = await client.post(
+            "/api/extensions/seraph.multi-connector-pack/connectors/enabled",
+            json={"reference": "mcp/github-primary.json", "enabled": False},
+        )
+        assert disable_primary.status_code == 409
+        disable_primary_approval_id = disable_primary.json()["detail"]["approval_id"]
+
+        approve_disable_primary = await client.post(f"/api/approvals/{disable_primary_approval_id}/approve")
+        assert approve_disable_primary.status_code == 200
+
+        disable_primary = await client.post(
+            "/api/extensions/seraph.multi-connector-pack/connectors/enabled",
+            json={"reference": "mcp/github-primary.json", "enabled": False},
+        )
+        assert disable_primary.status_code == 200
+        assert disable_primary.json()["connector"]["name"] == "github-primary"
+        assert disconnect_mock.call_count == 1
+
+        disable_secondary = await client.post(
+            "/api/extensions/seraph.multi-connector-pack/connectors/enabled",
+            json={"reference": "mcp/github-secondary.json", "enabled": False},
+        )
+        assert disable_secondary.status_code == 409
+        assert disable_secondary.json()["detail"]["approval_id"] != disable_primary_approval_id
 
 
 @pytest.mark.asyncio

--- a/docs/implementation/01-trust-boundaries.md
+++ b/docs/implementation/01-trust-boundaries.md
@@ -218,6 +218,26 @@
 - review pass:
   - direct review against regressions found the real risk was not broad uninstall approval in general, but the missing destructive boundary specifically for already-approved high-risk extensions; the fix keeps low-risk removals direct and only tightens the high-risk mutation seam
 
+### `extension-disable-and-connector-target-boundary-enforcement-v1`
+
+- status: complete on `feat/extension-config-boundary-hardening-batch-ad-v4`, intended for the next Batch AD PR for `#299`
+- root cause addressed:
+  - high-risk extension disable still bypassed lifecycle approval even after install, update, enable, and remove were hardened, which let privileged or safety-relevant packages be silently deactivated
+  - packaged connector approval was also extension-scoped rather than target-scoped, so approval for one high-risk connector could be reused for a sibling connector inside the same pack when their boundary profile matched
+  - degraded packages could lose derived contribution permission profiles entirely, which made the disable path fail open because the preview no longer advertised the lifecycle approval boundary that the manifest still declared
+- scope:
+  - high-risk extension disable now routes through the same lifecycle approval seam as the rest of the mutation surface instead of remaining an ungated teardown path
+  - packaged connector enable and disable approvals now fingerprint the specific connector target reference, name, and type, so sibling connectors cannot reuse each other's lifecycle approvals
+  - lifecycle approval now falls back to declared manifest permissions when a degraded package loses its derived approval profile, keeping disable fail-closed under workflow or contribution validation drift
+- validation:
+  - `python3 -m py_compile backend/src/api/extensions.py backend/tests/test_extensions_api.py`
+  - `cd backend && .venv/bin/python -m pytest tests/test_extensions_api.py -x -vv -k "install_and_enable_high_risk_extension_require_approval or disable_high_risk_extension_requires_new_approval_if_package_changes or extension_connector_enable_endpoint_controls_packaged_mcp_runtime or connector_lifecycle_approval_is_scoped_to_each_packaged_connector_target or install_toggle_and_remove_workspace_connector_extension or enable_rejects_degraded_extension_with_invalid_workflow_before_approval"`
+  - `cd docs && npm run build`
+  - `git diff --check`
+- review pass:
+  - the first implementation pass exposed a real fail-open regression: once a high-risk package became degraded, its projected `approval_profile` dropped out and disable reverted to `200` without approval
+  - fixed by deriving a fallback lifecycle approval profile from declared manifest permissions when the live preview no longer carries one, which keeps the disable seam hard without widening low-risk packages that still declare no lifecycle boundaries
+
 ### `planner-secret-surface-isolation-v1`
 
 - status: complete on `develop` via PR `#245`


### PR DESCRIPTION
Summary
- require lifecycle approval before disabling high-risk extensions instead of leaving disable as the last ungated lifecycle mutation
- scope packaged-connector lifecycle approvals to the exact connector target so approval for one connector cannot unlock its siblings
- fail closed for degraded packages by rebuilding lifecycle approval context from declared manifest permissions when derived contribution profiles disappear
- add focused regressions for high-risk disable reapproval, degraded-package disable, connector disable approval, and per-connector approval scoping

Validation
- python3 -m py_compile backend/src/api/extensions.py backend/tests/test_extensions_api.py
- cd backend && .venv/bin/python -m pytest tests/test_extensions_api.py -x -vv -k "install_and_enable_high_risk_extension_require_approval or disable_high_risk_extension_requires_new_approval_if_package_changes or extension_connector_enable_endpoint_controls_packaged_mcp_runtime or connector_lifecycle_approval_is_scoped_to_each_packaged_connector_target or install_toggle_and_remove_workspace_connector_extension or enable_rejects_degraded_extension_with_invalid_workflow_before_approval"
- cd docs && npm run build
- git diff --check

Notes
- review/fix pass found one real fail-open seam in the first implementation: degraded high-risk packages were losing their derived approval profile, which let disable fall back to 200 without approval until the manifest-permission fallback was added
- the focused backend slice is what I am claiming here; I am not claiming a clean full extensions suite run from this environment
