### PR TITLE
fix(extensions): gate high-risk source mutations

### DIFF
--- a/backend/src/api/extensions.py
+++ b/backend/src/api/extensions.py
@@ -823,12 +823,26 @@ async def get_extension_package_source(extension_id: str, reference: str):
 
 @router.post("/extensions/{extension_id}/source")
 async def save_extension_package_source(extension_id: str, req: ExtensionSourceSaveRequest):
+    preview: dict[str, Any] | None = None
     try:
+        source_preview = get_extension_source(extension_id, req.reference)
+        preview = source_preview.get("extension") if isinstance(source_preview, dict) else None
+        if isinstance(preview, dict):
+            await _require_extension_lifecycle_approval(
+                "save_source",
+                {
+                    **preview,
+                    "target_reference": req.reference,
+                    "target_name": req.reference,
+                    "target_type": "source_file",
+                },
+            )
         payload = save_extension_source(extension_id, req.reference, req.content)
     except KeyError as exc:
         await _log_extension_lifecycle_event(
             action="save_source",
             outcome="failed",
+            preview=preview,
             path=extension_id,
             error=f"Extension '{extension_id}' not found",
             extra_details={"reference": req.reference},
@@ -838,6 +852,7 @@ async def save_extension_package_source(extension_id: str, req: ExtensionSourceS
         await _log_extension_lifecycle_event(
             action="save_source",
             outcome="failed",
+            preview=preview,
             path=extension_id,
             error=str(exc),
             extra_details={"reference": req.reference},

--- a/backend/tests/test_extensions_api.py
+++ b/backend/tests/test_extensions_api.py
@@ -140,6 +140,63 @@ def _write_high_risk_extension(root: Path) -> Path:
     return package_dir
 
 
+def _write_multi_high_risk_extension(root: Path) -> Path:
+    package_dir = root / "multi-high-risk-pack"
+    (package_dir / "workflows").mkdir(parents=True)
+    (package_dir / "manifest.yaml").write_text(
+        "id: seraph.multi-high-risk-pack\n"
+        "version: 2026.3.21\n"
+        "display_name: Multi High Risk Pack\n"
+        "kind: capability-pack\n"
+        "compatibility:\n"
+        "  seraph: \">=2026.3.19\"\n"
+        "publisher:\n"
+        "  name: Seraph\n"
+        "trust: local\n"
+        "contributes:\n"
+        "  workflows:\n"
+        "    - workflows/write-note-a.md\n"
+        "    - workflows/write-note-b.md\n"
+        "permissions:\n"
+        "  tools: [write_file]\n"
+        "  network: false\n",
+        encoding="utf-8",
+    )
+    (package_dir / "workflows" / "write-note-a.md").write_text(
+        "---\n"
+        "name: write-note-a\n"
+        "description: Write note A into the workspace\n"
+        "requires:\n"
+        "  tools: [write_file]\n"
+        "steps:\n"
+        "  - id: save\n"
+        "    tool: write_file\n"
+        "    arguments:\n"
+        "      file_path: notes/high-risk-a.md\n"
+        "      content: approved-a\n"
+        "---\n\n"
+        "Write note A.\n",
+        encoding="utf-8",
+    )
+    (package_dir / "workflows" / "write-note-b.md").write_text(
+        "---\n"
+        "name: write-note-b\n"
+        "description: Write note B into the workspace\n"
+        "requires:\n"
+        "  tools: [write_file]\n"
+        "steps:\n"
+        "  - id: save\n"
+        "    tool: write_file\n"
+        "    arguments:\n"
+        "      file_path: notes/high-risk-b.md\n"
+        "      content: approved-b\n"
+        "---\n\n"
+        "Write note B.\n",
+        encoding="utf-8",
+    )
+    return package_dir
+
+
 def _write_mcp_connector_extension(
     root: Path,
     *,
@@ -2929,6 +2986,172 @@ async def test_workspace_extension_source_save_updates_package_members(client, e
 
 
 @pytest.mark.asyncio
+async def test_high_risk_extension_source_save_requires_lifecycle_approval(client, extension_runtime, tmp_path):
+    package_dir = _write_high_risk_extension(tmp_path)
+
+    with (
+        patch(
+            "src.extensions.lifecycle.get_base_tools_and_active_skills",
+            return_value=([SimpleNamespace(name="write_file")], [], "approval"),
+        ),
+        patch("src.api.extensions.log_integration_event", AsyncMock()),
+    ):
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 409
+        install_approval_id = install_response.json()["detail"]["approval_id"]
+
+        approve_install = await client.post(f"/api/approvals/{install_approval_id}/approve")
+        assert approve_install.status_code == 200
+
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 201
+
+        save_response = await client.post(
+            "/api/extensions/seraph.high-risk-pack/source",
+            json={
+                "reference": "workflows/write-note.md",
+                "content": (
+                    "---\n"
+                    "name: write-note\n"
+                    "description: Updated high-risk workflow\n"
+                    "requires:\n"
+                    "  tools: [write_file]\n"
+                    "steps:\n"
+                    "  - id: save\n"
+                    "    tool: write_file\n"
+                    "    arguments:\n"
+                    "      file_path: notes/high-risk-updated.md\n"
+                    "      content: updated\n"
+                    "---\n\n"
+                    "Write an updated note.\n"
+                ),
+            },
+        )
+        assert save_response.status_code == 409
+        approval_detail = save_response.json()["detail"]
+        assert approval_detail["type"] == "approval_required"
+
+        approve_save = await client.post(f"/api/approvals/{approval_detail['approval_id']}/approve")
+        assert approve_save.status_code == 200
+
+        save_response = await client.post(
+            "/api/extensions/seraph.high-risk-pack/source",
+            json={
+                "reference": "workflows/write-note.md",
+                "content": (
+                    "---\n"
+                    "name: write-note\n"
+                    "description: Updated high-risk workflow\n"
+                    "requires:\n"
+                    "  tools: [write_file]\n"
+                    "steps:\n"
+                    "  - id: save\n"
+                    "    tool: write_file\n"
+                    "    arguments:\n"
+                    "      file_path: notes/high-risk-updated.md\n"
+                    "      content: updated\n"
+                    "---\n\n"
+                    "Write an updated note.\n"
+                ),
+            },
+        )
+        assert save_response.status_code == 200
+        assert save_response.json()["validation"]["workflow"]["name"] == "write-note"
+
+
+@pytest.mark.asyncio
+async def test_high_risk_extension_source_save_requires_new_approval_if_package_changes(client, extension_runtime, tmp_path):
+    package_dir = _write_high_risk_extension(tmp_path)
+
+    with (
+        patch(
+            "src.extensions.lifecycle.get_base_tools_and_active_skills",
+            return_value=([SimpleNamespace(name="write_file")], [], "approval"),
+        ),
+        patch("src.api.extensions.log_integration_event", AsyncMock()),
+    ):
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 409
+        install_approval_id = install_response.json()["detail"]["approval_id"]
+
+        approve_install = await client.post(f"/api/approvals/{install_approval_id}/approve")
+        assert approve_install.status_code == 200
+
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 201
+
+        first_save = await client.post(
+            "/api/extensions/seraph.high-risk-pack/source",
+            json={
+                "reference": "workflows/write-note.md",
+                "content": (
+                    "---\n"
+                    "name: write-note\n"
+                    "description: Updated high-risk workflow\n"
+                    "requires:\n"
+                    "  tools: [write_file]\n"
+                    "steps:\n"
+                    "  - id: save\n"
+                    "    tool: write_file\n"
+                    "    arguments:\n"
+                    "      file_path: notes/high-risk-updated.md\n"
+                    "      content: updated\n"
+                    "---\n\n"
+                    "Write an updated note.\n"
+                ),
+            },
+        )
+        assert first_save.status_code == 409
+        first_approval_id = first_save.json()["detail"]["approval_id"]
+
+        approve_save = await client.post(f"/api/approvals/{first_approval_id}/approve")
+        assert approve_save.status_code == 200
+
+        installed_root = extension_runtime / "extensions" / "seraph-high-risk-pack"
+        (installed_root / "workflows" / "write-note.md").write_text(
+            "---\n"
+            "name: write-note\n"
+            "description: Drifted high-risk workflow\n"
+            "requires:\n"
+            "  tools: [write_file]\n"
+            "steps:\n"
+            "  - id: save\n"
+            "    tool: write_file\n"
+            "    arguments:\n"
+            "      file_path: notes/high-risk-drifted.md\n"
+            "      content: drifted\n"
+            "---\n\n"
+            "Write a drifted note.\n",
+            encoding="utf-8",
+        )
+
+        second_save = await client.post(
+            "/api/extensions/seraph.high-risk-pack/source",
+            json={
+                "reference": "workflows/write-note.md",
+                "content": (
+                    "---\n"
+                    "name: write-note\n"
+                    "description: Updated high-risk workflow again\n"
+                    "requires:\n"
+                    "  tools: [write_file]\n"
+                    "steps:\n"
+                    "  - id: save\n"
+                    "    tool: write_file\n"
+                    "    arguments:\n"
+                    "      file_path: notes/high-risk-updated-again.md\n"
+                    "      content: updated-again\n"
+                    "---\n\n"
+                    "Write another updated note.\n"
+                ),
+            },
+        )
+        assert second_save.status_code == 409
+        second_approval_id = second_save.json()["detail"]["approval_id"]
+        assert second_approval_id != first_approval_id
+
+
+@pytest.mark.asyncio
 async def test_manifest_source_save_rejects_unloadable_package_updates(client, extension_runtime, tmp_path):
     package_dir = _write_installable_extension(tmp_path)
 
@@ -3348,6 +3571,103 @@ async def test_workflow_source_save_allows_cross_package_references(client, exte
 
         assert response.status_code == 200
         assert response.json()["validation"]["workflow"]["name"] == "local-workflow"
+
+
+@pytest.mark.asyncio
+async def test_high_risk_source_save_approval_is_scoped_to_each_target(client, extension_runtime, tmp_path):
+    package_dir = _write_multi_high_risk_extension(tmp_path)
+
+    with (
+        patch(
+            "src.extensions.lifecycle.get_base_tools_and_active_skills",
+            return_value=([SimpleNamespace(name="write_file")], [], "approval"),
+        ),
+        patch("src.api.extensions.log_integration_event", AsyncMock()),
+    ):
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 409
+        install_approval_id = install_response.json()["detail"]["approval_id"]
+
+        approve_install = await client.post(f"/api/approvals/{install_approval_id}/approve")
+        assert approve_install.status_code == 200
+
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 201
+
+        primary_save = await client.post(
+            "/api/extensions/seraph.multi-high-risk-pack/source",
+            json={
+                "reference": "workflows/write-note-a.md",
+                "content": (
+                    "---\n"
+                    "name: write-note-a\n"
+                    "description: Updated high-risk workflow A\n"
+                    "requires:\n"
+                    "  tools: [write_file]\n"
+                    "steps:\n"
+                    "  - id: save\n"
+                    "    tool: write_file\n"
+                    "    arguments:\n"
+                    "      file_path: notes/high-risk-a-updated.md\n"
+                    "      content: updated-a\n"
+                    "---\n\n"
+                    "Write updated note A.\n"
+                ),
+            },
+        )
+        assert primary_save.status_code == 409
+        primary_approval_id = primary_save.json()["detail"]["approval_id"]
+
+        approve_primary = await client.post(f"/api/approvals/{primary_approval_id}/approve")
+        assert approve_primary.status_code == 200
+
+        primary_save = await client.post(
+            "/api/extensions/seraph.multi-high-risk-pack/source",
+            json={
+                "reference": "workflows/write-note-a.md",
+                "content": (
+                    "---\n"
+                    "name: write-note-a\n"
+                    "description: Updated high-risk workflow A\n"
+                    "requires:\n"
+                    "  tools: [write_file]\n"
+                    "steps:\n"
+                    "  - id: save\n"
+                    "    tool: write_file\n"
+                    "    arguments:\n"
+                    "      file_path: notes/high-risk-a-updated.md\n"
+                    "      content: updated-a\n"
+                    "---\n\n"
+                    "Write updated note A.\n"
+                ),
+            },
+        )
+        assert primary_save.status_code == 200
+
+        secondary_save = await client.post(
+            "/api/extensions/seraph.multi-high-risk-pack/source",
+            json={
+                "reference": "workflows/write-note-b.md",
+                "content": (
+                    "---\n"
+                    "name: write-note-b\n"
+                    "description: Updated high-risk workflow B\n"
+                    "requires:\n"
+                    "  tools: [write_file]\n"
+                    "steps:\n"
+                    "  - id: save\n"
+                    "    tool: write_file\n"
+                    "    arguments:\n"
+                    "      file_path: notes/high-risk-b-updated.md\n"
+                    "      content: updated-b\n"
+                    "---\n\n"
+                    "Write updated note B.\n"
+                ),
+            },
+        )
+        assert secondary_save.status_code == 409
+        secondary_approval_id = secondary_save.json()["detail"]["approval_id"]
+        assert secondary_approval_id != primary_approval_id
 
 
 @pytest.mark.asyncio

--- a/docs/implementation/01-trust-boundaries.md
+++ b/docs/implementation/01-trust-boundaries.md
@@ -238,6 +238,25 @@
   - the first implementation pass exposed a real fail-open regression: once a high-risk package became degraded, its projected `approval_profile` dropped out and disable reverted to `200` without approval
   - fixed by deriving a fallback lifecycle approval profile from declared manifest permissions when the live preview no longer carries one, which keeps the disable seam hard without widening low-risk packages that still declare no lifecycle boundaries
 
+### `extension-source-mutation-boundary-enforcement-v1`
+
+- status: complete on `feat/extension-source-boundary-hardening-batch-ad-v5`, intended for the next Batch AD PR for `#299`
+- root cause addressed:
+  - workspace extension source edits were writing directly into installed package files after validation, but they never re-entered the lifecycle approval seam
+  - that meant a high-risk installed package could be materially rewritten after installation approval without any new destructive or privileged mutation approval, and the edited reference itself was not part of the approval identity
+- scope:
+  - source-save mutations now route through lifecycle approval before writing into installed workspace extension files
+  - source-save approvals are target-scoped by edited reference, so approval for one high-risk file does not unlock a sibling workflow or other editable file in the same package
+  - low-risk package editing remains direct, and broken-manifest repair still works because source-save approval falls back to the current extension payload rather than assuming the package is already fully healthy
+- validation:
+  - `python3 -m py_compile backend/src/api/extensions.py backend/tests/test_extensions_api.py`
+  - `cd backend && .venv/bin/python -m pytest tests/test_extensions_api.py -x -vv -k "high_risk_extension_source_save_requires_lifecycle_approval or high_risk_extension_source_save_requires_new_approval_if_package_changes or workspace_extension_source_save_updates_package_members or broken_workspace_manifest_can_be_loaded_and_repaired_via_source_api or high_risk_source_save_approval_is_scoped_to_each_target"`
+  - `cd docs && npm run build`
+  - `git diff --check`
+- review pass:
+  - the first target-scoping regression used packaged MCP source files and ran into unrelated packaged-MCP draft validation noise, which obscured the approval contract the slice was supposed to prove
+  - fixed by pinning target-scoped source-save approval on a multi-workflow high-risk package instead, so the regression exercises the same save path without coupling to MCP-specific source semantics
+
 ### `planner-secret-surface-isolation-v1`
 
 - status: complete on `develop` via PR `#245`


### PR DESCRIPTION
Summary
- require lifecycle approval before mutating installed high-risk extension source files
- scope source-save approvals to the exact edited reference so approval for one high-risk file cannot unlock sibling workflow edits
- keep low-risk source edits and broken-manifest repair working while closing the post-install authoring seam for high-risk packages
- add focused regressions for high-risk source-save approval, package-drift reapproval, broken-manifest repair, and per-target approval scoping

Validation
- python3 -m py_compile backend/src/api/extensions.py backend/tests/test_extensions_api.py
- cd backend && .venv/bin/python -m pytest tests/test_extensions_api.py -x -vv -k "high_risk_extension_source_save_requires_lifecycle_approval or high_risk_extension_source_save_requires_new_approval_if_package_changes or workspace_extension_source_save_updates_package_members or broken_workspace_manifest_can_be_loaded_and_repaired_via_source_api or high_risk_source_save_approval_is_scoped_to_each_target"
- cd docs && npm run build
- git diff --check

Notes
- review/fix pass found one real test design problem: the first target-scoping regression used packaged MCP source files and picked up unrelated MCP draft-validation noise, so the regression was moved to a multi-workflow high-risk package to pin the actual approval contract
- there is still no new deterministic GitHub Actions failure on current head to patch; the visible red historical runs remain cancellations or runner-side disconnects, not reproducible repo failures
