### PR TITLE
test: fix stale approval pending contract

### DIFF
--- a/backend/tests/test_approval_tools.py
+++ b/backend/tests/test_approval_tools.py
@@ -129,13 +129,13 @@ def test_secret_ref_wrapper_preserves_authenticated_mcp_approval_context(async_d
     try:
         with pytest.raises(ApprovalRequired) as excinfo:
             tool(query="repo")
-        pending = asyncio.run(approval_repository.get_pending("s1"))
+        pending = asyncio.run(approval_repository.list_pending(session_id="s1"))
     finally:
         reset_runtime_context(tokens)
 
-    request = next(item for item in pending if item.id == excinfo.value.approval_id)
-    assert request.details["approval_context"]["authenticated_source"] is True
-    assert request.details["approval_context"]["execution_boundaries"] == [
+    request = next(item for item in pending if item["id"] == excinfo.value.approval_id)
+    assert request["approval_context"]["authenticated_source"] is True
+    assert request["approval_context"]["execution_boundaries"] == [
         "external_mcp",
         "authenticated_external_source",
     ]


### PR DESCRIPTION
Summary:
- fix the stale approval-tools regression that still called the removed get_pending API
- align the authenticated MCP approval-context assertion with the current list_pending(session_id=...) payload contract
- remove the first deterministic backend CI failure on current head for Batch AD

Testing:
- python3 -m py_compile backend/tests/test_approval_tools.py
- cd backend && .venv/bin/python -m pytest tests/test_approval_tools.py -q -k 'secret_ref_wrapper_preserves_authenticated_mcp_approval_context or forced_approval_does_not_consume_approval_after_boundary_context_changes'
- cd backend && .venv/bin/python -m pytest tests/test_extensions_api.py -x -vv -k 'install_and_configure_workspace_managed_connector_extension or install_configure_and_toggle_wave2_contribution_surfaces'
- git diff --check

Part of #299