### PR TITLE
fix: preserve authenticated source audit context

### DIFF
--- a/backend/src/tools/audit.py
+++ b/backend/src/tools/audit.py
@@ -12,7 +12,7 @@ from src.approval.runtime import get_current_session_id
 from src.audit.formatting import format_tool_call_summary, redact_for_audit, summarize_tool_result
 from src.audit.repository import audit_repository
 from src.llm_runtime import get_current_llm_request_id
-from src.tools.policy import get_current_tool_policy_mode, get_tool_risk_level
+from src.tools.policy import get_current_tool_policy_mode, get_tool_risk_level, get_tool_source_context
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +80,22 @@ def _custom_audit_arguments(tool: Any, arguments: dict[str, Any]) -> dict[str, A
     return None
 
 
+def _enrich_audit_details(
+    tool: Any,
+    arguments: dict[str, Any],
+    details: dict[str, Any],
+    *,
+    approval_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    enriched = dict(details)
+    source_context = get_tool_source_context(tool)
+    if isinstance(source_context, dict) and "source_context" not in enriched:
+        enriched["source_context"] = dict(source_context)
+    if isinstance(approval_context, dict) and approval_context and "approval_context" not in enriched:
+        enriched["approval_context"] = dict(approval_context)
+    return enriched
+
+
 class AuditedTool(Tool):
     """Tool wrapper that records execution lifecycle events for real invocations."""
 
@@ -118,6 +134,7 @@ class AuditedTool(Tool):
         audit_arguments = _custom_audit_arguments(self.wrapped_tool, arguments)
         if audit_arguments is None:
             audit_arguments = redact_for_audit(arguments)
+        approval_context = self.get_approval_context(arguments)
 
         if session_id is None:
             return self.wrapped_tool(*args, sanitize_inputs_outputs=sanitize_inputs_outputs, **kwargs)
@@ -128,6 +145,12 @@ class AuditedTool(Tool):
         else:
             call_summary = format_tool_call_summary(self.name, arguments, set())
             call_details = {"arguments": audit_arguments}
+        call_details = _enrich_audit_details(
+            self.wrapped_tool,
+            arguments,
+            call_details,
+            approval_context=approval_context,
+        )
         call_event_id = self._log_event(
             session_id=session_id,
             event_type="tool_call",
@@ -147,6 +170,12 @@ class AuditedTool(Tool):
                     "arguments": audit_arguments,
                     "error": redact_for_audit(str(exc)),
                 }
+            failure_details = _enrich_audit_details(
+                self.wrapped_tool,
+                arguments,
+                failure_details,
+                approval_context=approval_context,
+            )
             if call_event_id and "call_event_id" not in failure_details:
                 failure_details = {
                     **failure_details,
@@ -165,6 +194,12 @@ class AuditedTool(Tool):
             result_summary, result_details = custom_payload
         else:
             result_summary, result_details = summarize_tool_result(self.name, str(result))
+        result_details = _enrich_audit_details(
+            self.wrapped_tool,
+            arguments,
+            result_details,
+            approval_context=approval_context,
+        )
         if call_event_id and "call_event_id" not in result_details:
             result_details = {
                 **result_details,

--- a/backend/tests/test_tool_audit.py
+++ b/backend/tests/test_tool_audit.py
@@ -88,6 +88,33 @@ class DummyAuthenticatedMCPFailTool(Tool):
         )
 
 
+class DummyAuthenticatedMCPDefaultAuditTool(Tool):
+    name = "mcp_fetch_repo"
+    description = "Dummy authenticated MCP tool with default audit payloads"
+    inputs = {"query": {"type": "string", "description": "Query"}}
+    output_type = "string"
+
+    def __init__(self):
+        super().__init__()
+        self.seraph_source_context = {
+            "server_name": "github",
+            "authenticated_source": True,
+            "credential_sources": ["header:authorization"],
+        }
+        self.is_initialized = True
+
+    def forward(self, query: str) -> str:
+        return f"ok:{query}"
+
+    def get_approval_context(self, _arguments):
+        return {
+            "execution_boundaries": ["external_mcp", "authenticated_external_source"],
+            "authenticated_source": True,
+            "server_name": "github",
+            "credential_sources": ["header:authorization"],
+        }
+
+
 def _tool_context() -> CurrentContext:
     return CurrentContext(tool_policy_mode="full", mcp_policy_mode="full")
 
@@ -222,6 +249,31 @@ def test_secret_ref_wrapper_preserves_authenticated_mcp_failure_audit_payload(as
     failure = next(e for e in events if e["event_type"] == "tool_failed" and e["tool_name"] == "mcp_fetch_repo")
     assert failure["summary"] == "mcp_fetch_repo failed for authenticated source"
     assert failure["details"]["source_context"]["authenticated_source"] is True
+
+
+def test_audited_tool_defaults_include_authenticated_source_context(async_db):
+    tool = wrap_tools_for_audit(
+        wrap_tools_for_secret_refs([DummyAuthenticatedMCPDefaultAuditTool()]),
+        treat_all_as_mcp=True,
+    )[0]
+    tokens = set_runtime_context("s1", "high_risk")
+
+    try:
+        with patch("src.tools.policy.context_manager.get_context", return_value=_tool_context()):
+            assert tool(query="repo") == "ok:repo"
+    finally:
+        reset_runtime_context(tokens)
+
+    events = asyncio.run(audit_repository.list_events(limit=10))
+    call = next(e for e in events if e["event_type"] == "tool_call" and e["tool_name"] == "mcp_fetch_repo")
+    result = next(e for e in events if e["event_type"] == "tool_result" and e["tool_name"] == "mcp_fetch_repo")
+    assert call["details"]["source_context"]["authenticated_source"] is True
+    assert call["details"]["approval_context"]["execution_boundaries"] == [
+        "external_mcp",
+        "authenticated_external_source",
+    ]
+    assert result["details"]["source_context"]["credential_sources"] == ["header:authorization"]
+    assert result["details"]["approval_context"]["authenticated_source"] is True
 
 
 def test_onboarding_agent_uses_audited_tools():

--- a/docs/implementation/01-trust-boundaries.md
+++ b/docs/implementation/01-trust-boundaries.md
@@ -276,6 +276,24 @@
   - the first proof shape targeted a low-risk managed-connector package and therefore would not have exercised the hardened lifecycle path at all
   - fixed by pinning the regression on the already high-risk `wave2` pack, where changing only the non-secret `node_url` now requires fresh approval while a redacted no-op reconfigure stays direct
 
+### `authenticated-source-audit-visibility-hardening-v1`
+
+- status: complete on `feat/authenticated-source-audit-hardening-batch-ad-v8`, intended for the next Batch AD PR for `#299`
+- root cause addressed:
+  - authenticated-source and approval context were only guaranteed in audit events when a tool supplied custom MCP audit payloads, so wrapper-composed tools could lose source provenance and privilege context from default `tool_call`, `tool_result`, or `tool_failed` events
+  - that weakened the operator trail exactly where Batch AD is trying to make privileged paths easier to inspect and explain
+- scope:
+  - the audit wrapper now enriches default and custom audit payloads with wrapper-visible source context and approval context whenever they are available
+  - authenticated MCP tools keep their credential/source provenance visible even when they rely on default audit summaries instead of custom payload hooks
+  - the enrichment remains additive and fail-open, so existing custom audit payloads still win for summaries and bespoke fields
+- validation:
+  - `python3 -m py_compile backend/src/tools/audit.py backend/tests/test_tool_audit.py`
+  - `cd backend && .venv/bin/python -m pytest tests/test_tool_audit.py -q -k "secret_ref_wrapper_preserves_authenticated_mcp_failure_audit_payload or audited_tool_defaults_include_authenticated_source_context"`
+  - `git diff --check`
+- review pass:
+  - the real risk here was not missing audit entirely, but silent loss of authenticated-source provenance whenever a wrapper chain fell back to the generic audit path
+  - fixed by enriching audit details centrally in the audit wrapper instead of requiring every privileged tool surface to remember its own source-context plumbing
+
 ### `planner-secret-surface-isolation-v1`
 
 - status: complete on `develop` via PR `#245`


### PR DESCRIPTION
Summary:
- enrich default and custom audit payloads with wrapper-visible source context and approval context
- keep authenticated MCP provenance visible even when tool audit falls back to the generic path
- pin the contract with deterministic authenticated-source audit regressions

Testing:
- python3 -m py_compile backend/src/tools/audit.py backend/tests/test_tool_audit.py
- cd backend && .venv/bin/python -m pytest tests/test_tool_audit.py -q -k 'secret_ref_wrapper_preserves_authenticated_mcp_failure_audit_payload or audited_tool_defaults_include_authenticated_source_context'
- cd docs && npm run build
- git diff --check

Part of #299