### PR TITLE
Batch AD: harden workflow replay delegation boundaries

### DIFF
--- a/backend/src/api/workflows.py
+++ b/backend/src/api/workflows.py
@@ -298,15 +298,19 @@ def _normalize_approval_context(value: Any, *, workflow_name: str | None = None)
     risk_level = str(value.get("risk_level") or "").strip()
     execution_boundaries = _normalize_string_list(value.get("execution_boundaries"))
     step_tools = _normalize_string_list(value.get("step_tools"))
+    delegated_specialists = _normalize_string_list(value.get("delegated_specialists"))
     authenticated_source = bool(value.get("authenticated_source", False))
+    delegation_target_unresolved = bool(value.get("delegation_target_unresolved", False))
     source_systems = _normalize_source_systems(value.get("source_systems"))
     if not any(
         [
             risk_level,
             execution_boundaries,
             step_tools,
+            delegated_specialists,
             "accepts_secret_refs" in value,
             authenticated_source,
+            delegation_target_unresolved,
             source_systems,
         ]
     ):
@@ -318,8 +322,12 @@ def _normalize_approval_context(value: Any, *, workflow_name: str | None = None)
         "accepts_secret_refs": bool(value.get("accepts_secret_refs", False)),
         "step_tools": step_tools,
     }
+    if delegated_specialists:
+        normalized["delegated_specialists"] = delegated_specialists
     if authenticated_source:
         normalized["authenticated_source"] = True
+    if delegation_target_unresolved:
+        normalized["delegation_target_unresolved"] = True
     if source_systems:
         normalized["source_systems"] = source_systems
     return normalized

--- a/backend/src/workflows/manager.py
+++ b/backend/src/workflows/manager.py
@@ -251,6 +251,106 @@ def _append_unique_source_systems(
             target.append(source_system)
 
 
+def _normalize_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    normalized: dict[str, None] = {}
+    for item in value:
+        text = str(item).strip()
+        if text:
+            normalized[text] = None
+    return sorted(normalized)
+
+
+def _normalize_source_systems(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str, bool, tuple[str, ...]]] = set()
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        server_name = str(item.get("server_name") or "").strip()
+        hostname = str(item.get("hostname") or "").strip()
+        source = str(item.get("source") or "").strip()
+        authenticated_source = bool(item.get("authenticated_source", False))
+        credential_sources = tuple(_normalize_string_list(item.get("credential_sources")))
+        key = (
+            server_name,
+            hostname,
+            source,
+            authenticated_source,
+            credential_sources,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(
+            {
+                "server_name": server_name,
+                "hostname": hostname,
+                "source": source,
+                "authenticated_source": authenticated_source,
+                "credential_sources": list(credential_sources),
+            }
+        )
+    normalized.sort(
+        key=lambda item: (
+            str(item.get("server_name") or ""),
+            str(item.get("hostname") or ""),
+            str(item.get("source") or ""),
+            bool(item.get("authenticated_source", False)),
+            tuple(item.get("credential_sources") or []),
+        )
+    )
+    return normalized
+
+
+def normalize_workflow_approval_context(
+    value: Any,
+    *,
+    workflow_name: str | None = None,
+) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    risk_level = str(value.get("risk_level") or "").strip()
+    execution_boundaries = _normalize_string_list(value.get("execution_boundaries"))
+    step_tools = _normalize_string_list(value.get("step_tools"))
+    delegated_specialists = _normalize_string_list(value.get("delegated_specialists"))
+    authenticated_source = bool(value.get("authenticated_source", False))
+    delegation_target_unresolved = bool(value.get("delegation_target_unresolved", False))
+    source_systems = _normalize_source_systems(value.get("source_systems"))
+    if not any(
+        [
+            risk_level,
+            execution_boundaries,
+            step_tools,
+            delegated_specialists,
+            "accepts_secret_refs" in value,
+            authenticated_source,
+            delegation_target_unresolved,
+            source_systems,
+        ]
+    ):
+        return None
+    normalized = {
+        "workflow_name": str(value.get("workflow_name") or workflow_name or "").strip() or None,
+        "risk_level": risk_level or "unknown",
+        "execution_boundaries": execution_boundaries,
+        "accepts_secret_refs": bool(value.get("accepts_secret_refs", False)),
+        "step_tools": step_tools,
+    }
+    if delegated_specialists:
+        normalized["delegated_specialists"] = delegated_specialists
+    if authenticated_source:
+        normalized["authenticated_source"] = True
+    if delegation_target_unresolved:
+        normalized["delegation_target_unresolved"] = True
+    if source_systems:
+        normalized["source_systems"] = source_systems
+    return normalized
+
+
 def _delegate_step_approval_context(
     workflow: Workflow,
     step: Any,
@@ -517,6 +617,7 @@ class WorkflowTool(Tool):
             start_index, restored_step_records, restored_artifact_paths, restored_context = self._restore_checkpoint_context(
                 control_inputs=control_inputs,
                 canonical_step_tools=canonical_step_tools,
+                approval_context=approval_context,
             )
             for step_id, state in restored_context.items():
                 context["steps"][step_id] = state
@@ -780,6 +881,7 @@ class WorkflowTool(Tool):
         *,
         control_inputs: dict[str, Any],
         canonical_step_tools: list[str],
+        approval_context: dict[str, Any],
     ) -> tuple[int, list[dict[str, Any]], list[str], dict[str, dict[str, Any]]]:
         requested_step_id = str(control_inputs.get("_seraph_resume_from_step") or "").strip()
         if not requested_step_id:
@@ -805,6 +907,22 @@ class WorkflowTool(Tool):
         if str(details.get("workflow_name") or self.workflow.name) != self.workflow.name:
             raise RuntimeError(
                 f"Workflow '{self.workflow.name}' cannot reuse checkpoint state from a different workflow"
+            )
+        recorded_approval_context = normalize_workflow_approval_context(
+            details.get("approval_context"),
+            workflow_name=self.workflow.name,
+        )
+        current_approval_context = normalize_workflow_approval_context(
+            approval_context,
+            workflow_name=self.workflow.name,
+        )
+        if (
+            recorded_approval_context is not None
+            and recorded_approval_context != current_approval_context
+        ):
+            raise RuntimeError(
+                f"Workflow '{self.workflow.name}' cannot resume from step '{requested_step_id}' "
+                "because the parent run changed its trust boundary"
             )
         raw_checkpoint_context = details.get("checkpoint_context")
         if not isinstance(raw_checkpoint_context, dict):

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -726,6 +726,71 @@ class TestWorkflowManager:
         assert details["step_records"][1]["error_kind"] == "PermissionError"
         assert details["error"] == "denied"
 
+def test_workflow_tool_resume_rejects_when_delegation_boundary_changes():
+    workflow = Workflow(
+        name="delegation-replay",
+        description="Resume delegated work",
+        inputs={"topic": {"type": "string", "required": True}},
+        steps=[
+            WorkflowStep(id="search", tool="web_search", arguments={"query": "{{ topic }}"}),
+            WorkflowStep(
+                id="delegate",
+                tool="delegate_task",
+                arguments={"task": "Investigate {{ topic }}"},
+            ),
+        ],
+        requires_tools=["web_search", "delegate_task"],
+    )
+    workflow_tool = WorkflowTool(
+        workflow,
+        {
+            "web_search": DummyTool("web_search", lambda query: f"fresh result for {query}"),
+            "delegate_task": DummyTool("delegate_task", lambda task: f"delegated {task}"),
+        },
+    )
+    workflow_tool.get_approval_context = lambda _arguments: {
+        "workflow_name": "delegation-replay",
+        "risk_level": "high",
+        "execution_boundaries": ["delegation", "external_mcp"],
+        "accepts_secret_refs": True,
+        "step_tools": ["delegate_task", "web_search"],
+        "delegated_specialists": ["mcp_github"],
+    }
+    parent_run_identity = "session-1:workflow_delegation_replay:parent"
+    checkpoint_payload = {
+        "workflow_name": "delegation-replay",
+        "approval_context": {
+            "workflow_name": "delegation-replay",
+            "risk_level": "high",
+            "execution_boundaries": ["delegation", "external_mcp"],
+            "accepts_secret_refs": True,
+            "step_tools": ["web_search", "delegate_task"],
+            "delegated_specialists": ["mcp_jira"],
+        },
+        "checkpoint_context": {
+            "search": {
+                "tool": "web_search",
+                "arguments": {"query": "seraph"},
+                "result": "cached search result",
+            }
+        },
+        "step_records": [{"id": "search", "tool": "web_search", "status": "succeeded"}],
+    }
+
+    with (
+        patch(
+            "src.workflows.manager._load_workflow_checkpoint_payload",
+            AsyncMock(return_value=checkpoint_payload),
+        ),
+        pytest.raises(RuntimeError, match="trust boundary"),
+    ):
+        workflow_tool(
+            topic="seraph",
+            _seraph_resume_from_step="delegate",
+            _seraph_parent_run_identity=parent_run_identity,
+            _seraph_root_run_identity=parent_run_identity,
+        )
+
     def test_workflow_tool_audit_call_payload_uses_normalized_control_inputs_for_fingerprint(self):
         workflow = Workflow(
             name="web-brief",
@@ -2756,6 +2821,215 @@ async def test_workflow_runs_endpoint_ignores_authenticated_source_system_reorde
             "authenticated_source": True,
             "credential_sources": ["vault:jira_token"],
         },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_workflow_runs_endpoint_detects_delegated_specialist_context_drift(client):
+    recorded_context = {
+        "workflow_name": "delegated-brief",
+        "risk_level": "high",
+        "execution_boundaries": ["delegation", "external_mcp"],
+        "accepts_secret_refs": True,
+        "step_tools": ["delegate_task", "write_file"],
+        "delegated_specialists": ["mcp_jira"],
+    }
+    current_context = {
+        "workflow_name": "delegated-brief",
+        "risk_level": "high",
+        "execution_boundaries": ["delegation", "external_mcp"],
+        "accepts_secret_refs": True,
+        "step_tools": ["write_file", "delegate_task"],
+        "delegated_specialists": ["mcp_github"],
+    }
+    runtime_workflow_tool = SimpleNamespace(
+        name="workflow_delegated_brief",
+        get_approval_context=lambda _arguments: current_context,
+    )
+
+    with (
+        patch(
+            "src.api.workflows.audit_repository.list_events",
+            return_value=[
+                {
+                    "id": "evt-result",
+                    "session_id": "session-1",
+                    "event_type": "tool_result",
+                    "tool_name": "workflow_delegated_brief",
+                    "summary": "workflow_delegated_brief succeeded (2 steps)",
+                    "created_at": "2026-03-18T12:01:45Z",
+                    "details": {
+                        "workflow_name": "delegated-brief",
+                        "run_fingerprint": "delegated-brief-drift",
+                        "approval_context": recorded_context,
+                        "step_tools": ["delegate_task", "write_file"],
+                        "step_records": [],
+                        "artifact_paths": ["notes/brief.md"],
+                        "continued_error_steps": [],
+                    },
+                },
+                {
+                    "id": "evt-call",
+                    "session_id": "session-1",
+                    "event_type": "tool_call",
+                    "tool_name": "workflow_delegated_brief",
+                    "summary": "Calling workflow",
+                    "created_at": "2026-03-18T12:01:00Z",
+                    "details": {
+                        "run_fingerprint": "delegated-brief-drift",
+                        "approval_context": recorded_context,
+                        "arguments": {"query": "seraph", "file_path": "notes/brief.md"},
+                    },
+                },
+            ],
+        ),
+        patch("src.api.workflows.approval_repository.list_pending", return_value=[]),
+        patch(
+            "src.api.workflows.workflow_manager.get_tool_metadata",
+            return_value={
+                "risk_level": "high",
+                "execution_boundaries": ["delegation", "external_mcp"],
+                "accepts_secret_refs": True,
+                "approval_context": recorded_context,
+            },
+        ),
+        patch("src.api.workflows.get_base_tools_and_active_skills", return_value=([], [], "full")),
+        patch("src.api.workflows.workflow_manager.build_workflow_tools", return_value=[runtime_workflow_tool]),
+        patch(
+            "src.api.workflows.workflow_manager.list_workflows",
+            return_value=[
+                {
+                    "name": "delegated-brief",
+                    "inputs": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "file_path": {"type": "string", "description": "Output path"},
+                    },
+                    "enabled": True,
+                    "is_available": True,
+                    "missing_tools": [],
+                    "missing_skills": [],
+                }
+            ],
+        ),
+        patch(
+            "src.api.workflows.session_manager.list_sessions",
+            return_value=[{"id": "session-1", "title": "Research thread"}],
+        ),
+        patch("src.api.workflows.get_current_tool_policy_mode", return_value="balanced"),
+    ):
+        response = await client.get("/api/workflows/runs?session_id=session-1")
+
+    assert response.status_code == 200
+    run = response.json()["runs"][0]
+    assert run["approval_context_mismatch"] is True
+    assert run["replay_allowed"] is False
+    assert run["replay_block_reason"] == "approval_context_changed"
+    assert run["current_approval_context"]["delegated_specialists"] == ["mcp_github"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_runs_endpoint_ignores_delegated_specialist_reordering(client):
+    recorded_context = {
+        "workflow_name": "delegated-brief",
+        "risk_level": "high",
+        "execution_boundaries": ["delegation", "external_mcp"],
+        "accepts_secret_refs": True,
+        "step_tools": ["delegate_task", "write_file"],
+        "delegated_specialists": ["mcp_jira", "mcp_github"],
+    }
+    current_context = {
+        "workflow_name": "delegated-brief",
+        "risk_level": "high",
+        "execution_boundaries": ["external_mcp", "delegation"],
+        "accepts_secret_refs": True,
+        "step_tools": ["write_file", "delegate_task"],
+        "delegated_specialists": ["mcp_github", "mcp_jira"],
+    }
+    runtime_workflow_tool = SimpleNamespace(
+        name="workflow_delegated_brief",
+        get_approval_context=lambda _arguments: current_context,
+    )
+
+    with (
+        patch(
+            "src.api.workflows.audit_repository.list_events",
+            return_value=[
+                {
+                    "id": "evt-result",
+                    "session_id": "session-1",
+                    "event_type": "tool_result",
+                    "tool_name": "workflow_delegated_brief",
+                    "summary": "workflow_delegated_brief succeeded (2 steps)",
+                    "created_at": "2026-03-18T12:01:45Z",
+                    "details": {
+                        "workflow_name": "delegated-brief",
+                        "run_fingerprint": "delegated-brief-stable",
+                        "approval_context": recorded_context,
+                        "step_tools": ["delegate_task", "write_file"],
+                        "step_records": [],
+                        "artifact_paths": ["notes/brief.md"],
+                        "continued_error_steps": [],
+                    },
+                },
+                {
+                    "id": "evt-call",
+                    "session_id": "session-1",
+                    "event_type": "tool_call",
+                    "tool_name": "workflow_delegated_brief",
+                    "summary": "Calling workflow",
+                    "created_at": "2026-03-18T12:01:00Z",
+                    "details": {
+                        "run_fingerprint": "delegated-brief-stable",
+                        "approval_context": recorded_context,
+                        "arguments": {"query": "seraph", "file_path": "notes/brief.md"},
+                    },
+                },
+            ],
+        ),
+        patch("src.api.workflows.approval_repository.list_pending", return_value=[]),
+        patch(
+            "src.api.workflows.workflow_manager.get_tool_metadata",
+            return_value={
+                "risk_level": "high",
+                "execution_boundaries": ["delegation", "external_mcp"],
+                "accepts_secret_refs": True,
+                "approval_context": recorded_context,
+            },
+        ),
+        patch("src.api.workflows.get_base_tools_and_active_skills", return_value=([], [], "full")),
+        patch("src.api.workflows.workflow_manager.build_workflow_tools", return_value=[runtime_workflow_tool]),
+        patch(
+            "src.api.workflows.workflow_manager.list_workflows",
+            return_value=[
+                {
+                    "name": "delegated-brief",
+                    "inputs": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "file_path": {"type": "string", "description": "Output path"},
+                    },
+                    "enabled": True,
+                    "is_available": True,
+                    "missing_tools": [],
+                    "missing_skills": [],
+                }
+            ],
+        ),
+        patch(
+            "src.api.workflows.session_manager.list_sessions",
+            return_value=[{"id": "session-1", "title": "Research thread"}],
+        ),
+        patch("src.api.workflows.get_current_tool_policy_mode", return_value="balanced"),
+    ):
+        response = await client.get("/api/workflows/runs?session_id=session-1")
+
+    assert response.status_code == 200
+    run = response.json()["runs"][0]
+    assert run["approval_context_mismatch"] is False
+    assert run["replay_allowed"] is False
+    assert run["replay_block_reason"] == "secret_ref_surface"
+    assert run["current_approval_context"]["delegated_specialists"] == [
+        "mcp_github",
+        "mcp_jira",
     ]
 
 

--- a/docs/implementation/01-trust-boundaries.md
+++ b/docs/implementation/01-trust-boundaries.md
@@ -294,6 +294,26 @@
   - the real risk here was not missing audit entirely, but silent loss of authenticated-source provenance whenever a wrapper chain fell back to the generic audit path
   - fixed by enriching audit details centrally in the audit wrapper instead of requiring every privileged tool surface to remember its own source-context plumbing
 
+### `workflow-replay-delegation-boundary-enforcement-v1`
+
+- status: complete on `feat/workflow-replay-delegation-boundary-hardening-batch-ad-v10`, intended for the next Batch AD PR for `#299`
+- root cause addressed:
+  - workflow replay and resume projection normalized risk, secret, and authenticated-source fields, but it still ignored delegated-specialist routing fields when comparing the recorded trust boundary to the current one
+  - the underlying workflow runtime also restored checkpoint state without re-checking the parent run's approval context, so direct resume could bypass the API-side `approval_context_changed` guard and reuse state across delegated-boundary drift
+- scope:
+  - approval-context normalization for workflow replay now includes `delegated_specialists` and `delegation_target_unresolved`, so delegated routing drift is treated as a real trust-boundary change instead of noise
+  - checkpoint restore now compares the parent run's normalized approval context to the current workflow approval context before reusing any saved step state, and it fails closed when the boundary changed
+  - reordering of delegated specialists or authenticated source-system metadata remains non-material and does not trigger false drift
+- validation:
+  - `python3 -m py_compile backend/src/workflows/manager.py backend/src/api/workflows.py backend/tests/test_workflows.py`
+  - `cd backend && .venv/bin/python -m pytest tests/test_workflows.py -q -k "resume_rejects_when_delegation_boundary_changes or detects_delegated_specialist_context_drift or ignores_delegated_specialist_reordering or approval_context_list_reordering or approval_context_changes or authenticated_source_context_drift or authenticated_source_system_reordering or failure_payload_keeps_checkpoint"`
+  - `cd docs && npm run build`
+  - `git diff --check`
+- review pass:
+  - the first proof pass only blocked the direct resume seam, which would still have left replay projection blind to delegated-specialist drift
+  - while pinning the fix, I also caught two real test regressions of my own: one existing workflow failure-payload method was accidentally dedented during the edit, and one older approval-context reordering assertion was overwritten with the wrong replay expectation
+  - both were corrected before publish, and the expanded targeted suite now covers the old stable cases alongside the new delegated-boundary drift cases
+
 ### `planner-secret-surface-isolation-v1`
 
 - status: complete on `develop` via PR `#245`


### PR DESCRIPTION
## Summary
- include delegated-specialist routing fields in workflow approval-context normalization for replay and resume projection
- fail closed when direct checkpoint resume tries to reuse parent state across trust-boundary drift
- add workflow regressions for delegated boundary drift, stable reordering, and direct resume rejection

## Validation
- python3 -m py_compile backend/src/workflows/manager.py backend/src/api/workflows.py backend/tests/test_workflows.py
- cd backend && .venv/bin/python -m pytest tests/test_workflows.py -q -k "resume_rejects_when_delegation_boundary_changes or detects_delegated_specialist_context_drift or ignores_delegated_specialist_reordering or approval_context_list_reordering or approval_context_changes or authenticated_source_context_drift or authenticated_source_system_reordering or failure_payload_keeps_checkpoint"
- cd docs && npm run build
- git diff --check