### PR TITLE
Batch AD: block legacy replay on privileged surfaces

### DIFF
--- a/backend/src/api/workflows.py
+++ b/backend/src/api/workflows.py
@@ -27,7 +27,7 @@ from src.extensions.workflow_runtimes import list_workflow_runtime_inventory
 from src.extensions.workspace_package import save_workspace_contribution
 from src.tools.policy import get_current_tool_policy_mode
 from src.workflows.loader import parse_workflow_content
-from src.workflows.manager import workflow_manager
+from src.workflows.manager import approval_context_requires_tracked_lineage, workflow_manager
 from src.workflows.run_identity import build_workflow_run_identity, parse_workflow_run_identity
 
 router = APIRouter()
@@ -808,6 +808,7 @@ def _workflow_replay_policy(
     accepts_secret_refs: bool,
     pending_approval_count: int,
     approval_context_mismatch: bool,
+    approval_context_missing_for_protected_surface: bool,
 ) -> tuple[bool, str | None]:
     if availability == "disabled":
         return False, "workflow_disabled"
@@ -815,6 +816,8 @@ def _workflow_replay_policy(
         return False, "workflow_unavailable"
     if approval_context_mismatch:
         return False, "approval_context_changed"
+    if approval_context_missing_for_protected_surface:
+        return False, "approval_context_missing"
     if pending_approval_count > 0:
         return False, "pending_approval"
     if accepts_secret_refs:
@@ -1179,6 +1182,10 @@ async def _list_workflow_runs(
             recorded_approval_context is not None
             and recorded_approval_context != current_approval_context
         )
+        approval_context_missing_for_protected_surface = bool(
+            recorded_approval_context is None
+            and approval_context_requires_tracked_lineage(current_approval_context)
+        )
 
         run.update({
             "status": "failed" if event.get("event_type") == "tool_failed" else "succeeded",
@@ -1278,6 +1285,7 @@ async def _list_workflow_runs(
             accepts_secret_refs=bool(run["accepts_secret_refs"]),
             pending_approval_count=len(approvals),
             approval_context_mismatch=bool(run.get("approval_context_mismatch")),
+            approval_context_missing_for_protected_surface=approval_context_missing_for_protected_surface,
         )
         run_identity = build_workflow_run_identity(
             run.get("session_id") if isinstance(run.get("session_id"), str) else None,
@@ -1343,12 +1351,16 @@ async def _list_workflow_runs(
                 f"Workflow '{run['workflow_name']}' changed its trust boundary after this run. Start a fresh run instead of replaying or resuming."
                 if bool(run.get("approval_context_mismatch"))
                 else (
-                    f"Review pending approval(s) for workflow '{run['workflow_name']}' before replaying."
-                    if len(approvals) > 0
+                    f"Workflow '{run['workflow_name']}' predates trust-boundary tracking for its current privileged surface. Start a fresh run instead of replaying or resuming."
+                    if approval_context_missing_for_protected_surface
                     else (
-                        f"Repair workflow '{run['workflow_name']}' before replaying."
-                        if str(run["availability"]) != "ready"
-                        else None
+                        f"Review pending approval(s) for workflow '{run['workflow_name']}' before replaying."
+                        if len(approvals) > 0
+                        else (
+                            f"Repair workflow '{run['workflow_name']}' before replaying."
+                            if str(run["availability"]) != "ready"
+                            else None
+                        )
                     )
                 )
             ),
@@ -1401,6 +1413,10 @@ async def _list_workflow_runs(
             approval_context_mismatch = bool(
                 recorded_approval_context is not None
                 and recorded_approval_context != current_approval_context
+            )
+            approval_context_missing_for_protected_surface = bool(
+                recorded_approval_context is None
+                and approval_context_requires_tracked_lineage(current_approval_context)
             )
             run.update({
                 "approval_context": effective_approval_context,
@@ -1460,6 +1476,7 @@ async def _list_workflow_runs(
                 accepts_secret_refs=bool(run["accepts_secret_refs"]),
                 pending_approval_count=len(approvals),
                 approval_context_mismatch=bool(run.get("approval_context_mismatch")),
+                approval_context_missing_for_protected_surface=approval_context_missing_for_protected_surface,
             )
             run_identity = build_workflow_run_identity(
                 run.get("session_id") if isinstance(run.get("session_id"), str) else None,
@@ -1528,12 +1545,16 @@ async def _list_workflow_runs(
                     f"Workflow '{run['workflow_name']}' changed its trust boundary after this run. Start a fresh run instead of replaying or resuming."
                     if bool(run.get("approval_context_mismatch"))
                     else (
-                        f"Review pending approval(s) for workflow '{run['workflow_name']}' before replaying."
-                        if len(approvals) > 0
+                        f"Workflow '{run['workflow_name']}' predates trust-boundary tracking for its current privileged surface. Start a fresh run instead of replaying or resuming."
+                        if approval_context_missing_for_protected_surface
                         else (
-                            f"Repair workflow '{run['workflow_name']}' before replaying."
-                            if str(run["availability"]) != "ready"
-                            else None
+                            f"Review pending approval(s) for workflow '{run['workflow_name']}' before replaying."
+                            if len(approvals) > 0
+                            else (
+                                f"Repair workflow '{run['workflow_name']}' before replaying."
+                                if str(run["availability"]) != "ready"
+                                else None
+                            )
                         )
                     )
                 ),
@@ -1738,12 +1759,17 @@ async def build_workflow_resume_plan(
             run = next((item for item in runs if item.get("run_identity") == run_identity), None)
     if run is None:
         raise HTTPException(status_code=404, detail=f"Workflow run '{run_identity}' not found")
-    if str(run.get("replay_block_reason") or "") == "approval_context_changed":
+    if str(run.get("replay_block_reason") or "") in {"approval_context_changed", "approval_context_missing"}:
         raise HTTPException(
             status_code=409,
             detail=(
                 f"Workflow run '{run_identity}' cannot resume because its trust boundary "
                 "changed after the original run. Start a fresh run instead."
+                if str(run.get("replay_block_reason") or "") == "approval_context_changed"
+                else (
+                    f"Workflow run '{run_identity}' cannot resume because it predates trust-boundary "
+                    "tracking for the current privileged workflow surface. Start a fresh run instead."
+                )
             ),
         )
     resume_plan = _workflow_resume_plan(

--- a/backend/src/workflows/manager.py
+++ b/backend/src/workflows/manager.py
@@ -351,6 +351,34 @@ def normalize_workflow_approval_context(
     return normalized
 
 
+def approval_context_requires_tracked_lineage(value: dict[str, Any] | None) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if bool(value.get("accepts_secret_refs", False)):
+        return True
+    if bool(value.get("authenticated_source", False)):
+        return True
+    if bool(value.get("delegation_target_unresolved", False)):
+        return True
+    if _normalize_string_list(value.get("delegated_specialists")):
+        return True
+    boundaries = {
+        str(boundary)
+        for boundary in value.get("execution_boundaries", [])
+        if isinstance(boundary, str)
+    }
+    if boundaries & {
+        "authenticated_external_source",
+        "delegation",
+        "external_mcp",
+        "secret_injection",
+        "secret_management",
+        "secret_read",
+    }:
+        return True
+    return str(value.get("risk_level") or "") == "high"
+
+
 def _delegate_step_approval_context(
     workflow: Workflow,
     step: Any,
@@ -923,6 +951,14 @@ class WorkflowTool(Tool):
             raise RuntimeError(
                 f"Workflow '{self.workflow.name}' cannot resume from step '{requested_step_id}' "
                 "because the parent run changed its trust boundary"
+            )
+        if (
+            recorded_approval_context is None
+            and approval_context_requires_tracked_lineage(current_approval_context)
+        ):
+            raise RuntimeError(
+                f"Workflow '{self.workflow.name}' cannot resume from step '{requested_step_id}' "
+                "because the parent run predates trust-boundary tracking for the current workflow surface"
             )
         raw_checkpoint_context = details.get("checkpoint_context")
         if not isinstance(raw_checkpoint_context, dict):

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -791,6 +791,61 @@ def test_workflow_tool_resume_rejects_when_delegation_boundary_changes():
             _seraph_root_run_identity=parent_run_identity,
         )
 
+
+def test_workflow_tool_resume_rejects_legacy_checkpoint_for_authenticated_surface():
+    workflow = Workflow(
+        name="authenticated-replay",
+        description="Resume authenticated source work",
+        inputs={"query": {"type": "string", "required": True}},
+        steps=[
+            WorkflowStep(id="search", tool="web_search", arguments={"query": "{{ query }}"}),
+            WorkflowStep(id="save", tool="write_file", arguments={"file_path": "notes/out.md", "content": "{{ steps.search.result }}"}),
+        ],
+        requires_tools=["web_search", "write_file"],
+    )
+    workflow_tool = WorkflowTool(
+        workflow,
+        {
+            "web_search": DummyTool("web_search", lambda query: f"fresh result for {query}"),
+            "write_file": DummyTool("write_file", lambda file_path, content: f"saved {file_path}: {content}"),
+        },
+    )
+    workflow_tool.get_approval_context = lambda _arguments: {
+        "workflow_name": "authenticated-replay",
+        "risk_level": "medium",
+        "execution_boundaries": ["external_read", "workspace_write"],
+        "accepts_secret_refs": False,
+        "step_tools": ["web_search", "write_file"],
+        "authenticated_source": True,
+        "source_systems": [{"server_name": "github", "hostname": "api.github.com", "source": "extension", "authenticated_source": True}],
+    }
+    parent_run_identity = "session-1:workflow_authenticated_replay:parent"
+    checkpoint_payload = {
+        "workflow_name": "authenticated-replay",
+        "checkpoint_context": {
+            "search": {
+                "tool": "web_search",
+                "arguments": {"query": "seraph"},
+                "result": "cached search result",
+            }
+        },
+        "step_records": [{"id": "search", "tool": "web_search", "status": "succeeded"}],
+    }
+
+    with (
+        patch(
+            "src.workflows.manager._load_workflow_checkpoint_payload",
+            AsyncMock(return_value=checkpoint_payload),
+        ),
+        pytest.raises(RuntimeError, match="predates trust-boundary tracking"),
+    ):
+        workflow_tool(
+            query="seraph",
+            _seraph_resume_from_step="save",
+            _seraph_parent_run_identity=parent_run_identity,
+            _seraph_root_run_identity=parent_run_identity,
+        )
+
     def test_workflow_tool_audit_call_payload_uses_normalized_control_inputs_for_fingerprint(self):
         workflow = Workflow(
             name="web-brief",
@@ -3126,6 +3181,211 @@ async def test_workflow_resume_plan_rejects_when_approval_context_changes(client
 
     assert response.status_code == 409
     assert "trust boundary" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_runs_endpoint_blocks_replay_when_approval_context_is_missing_for_authenticated_surface(client):
+    current_context = {
+        "workflow_name": "web-brief-to-file",
+        "risk_level": "medium",
+        "execution_boundaries": ["external_read", "workspace_write"],
+        "accepts_secret_refs": False,
+        "step_tools": ["web_search", "write_file"],
+        "authenticated_source": True,
+        "source_systems": [
+            {
+                "server_name": "github",
+                "hostname": "api.github.com",
+                "source": "extension",
+                "authenticated_source": True,
+                "credential_sources": ["vault:github_token"],
+            }
+        ],
+    }
+    runtime_workflow_tool = SimpleNamespace(
+        name="workflow_web_brief_to_file",
+        get_approval_context=lambda _arguments: current_context,
+    )
+
+    with (
+        patch(
+            "src.api.workflows.audit_repository.list_events",
+            return_value=[
+                {
+                    "id": "evt-result",
+                    "session_id": "session-1",
+                    "event_type": "tool_result",
+                    "tool_name": "workflow_web_brief_to_file",
+                    "summary": "workflow_web_brief_to_file succeeded (2 steps)",
+                    "created_at": "2026-03-18T12:01:45Z",
+                    "details": {
+                        "workflow_name": "web-brief-to-file",
+                        "run_fingerprint": "web-brief-legacy-auth",
+                        "step_tools": ["web_search", "write_file"],
+                        "step_records": [],
+                        "artifact_paths": ["notes/brief.md"],
+                        "continued_error_steps": [],
+                    },
+                },
+                {
+                    "id": "evt-call",
+                    "session_id": "session-1",
+                    "event_type": "tool_call",
+                    "tool_name": "workflow_web_brief_to_file",
+                    "summary": "Calling workflow",
+                    "created_at": "2026-03-18T12:01:00Z",
+                    "details": {
+                        "run_fingerprint": "web-brief-legacy-auth",
+                        "arguments": {"query": "seraph", "file_path": "notes/brief.md"},
+                    },
+                },
+            ],
+        ),
+        patch("src.api.workflows.approval_repository.list_pending", return_value=[]),
+        patch(
+            "src.api.workflows.workflow_manager.get_tool_metadata",
+            return_value={
+                "risk_level": "medium",
+                "execution_boundaries": ["external_read", "workspace_write"],
+                "accepts_secret_refs": False,
+                "approval_context": {
+                    "workflow_name": "web-brief-to-file",
+                    "risk_level": "medium",
+                    "execution_boundaries": ["external_read", "workspace_write"],
+                    "accepts_secret_refs": False,
+                    "step_tools": ["web_search", "write_file"],
+                },
+            },
+        ),
+        patch("src.api.workflows.get_base_tools_and_active_skills", return_value=([], [], "full")),
+        patch("src.api.workflows.workflow_manager.build_workflow_tools", return_value=[runtime_workflow_tool]),
+        patch(
+            "src.api.workflows.workflow_manager.list_workflows",
+            return_value=[
+                {
+                    "name": "web-brief-to-file",
+                    "inputs": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "file_path": {"type": "string", "description": "Output path"},
+                    },
+                    "enabled": True,
+                    "is_available": True,
+                    "missing_tools": [],
+                    "missing_skills": [],
+                }
+            ],
+        ),
+        patch(
+            "src.api.workflows.session_manager.list_sessions",
+            return_value=[{"id": "session-1", "title": "Research thread"}],
+        ),
+        patch("src.api.workflows.get_current_tool_policy_mode", return_value="balanced"),
+    ):
+        response = await client.get("/api/workflows/runs?session_id=session-1")
+
+    assert response.status_code == 200
+    run = response.json()["runs"][0]
+    assert run["approval_context_mismatch"] is False
+    assert run["replay_allowed"] is False
+    assert run["replay_block_reason"] == "approval_context_missing"
+    assert "predates trust-boundary tracking" in run["approval_recovery_message"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_resume_plan_rejects_when_approval_context_is_missing_for_authenticated_surface(client):
+    current_context = {
+        "workflow_name": "web-brief-to-file",
+        "risk_level": "medium",
+        "execution_boundaries": ["external_read", "workspace_write"],
+        "accepts_secret_refs": False,
+        "step_tools": ["web_search", "write_file"],
+        "authenticated_source": True,
+        "source_systems": [
+            {
+                "server_name": "github",
+                "hostname": "api.github.com",
+                "source": "extension",
+                "authenticated_source": True,
+            }
+        ],
+    }
+
+    with (
+        patch(
+            "src.api.workflows.audit_repository.list_events",
+            return_value=[
+                {
+                    "id": "evt-result",
+                    "session_id": "session-1",
+                    "event_type": "tool_result",
+                    "tool_name": "workflow_web_brief_to_file",
+                    "summary": "workflow_web_brief_to_file succeeded (2 steps)",
+                    "created_at": "2026-03-18T12:01:45Z",
+                    "details": {
+                        "workflow_name": "web-brief-to-file",
+                        "run_fingerprint": "web-brief-legacy-auth",
+                        "step_tools": ["web_search", "write_file"],
+                        "step_records": [
+                            {"id": "search", "tool": "web_search", "status": "succeeded"},
+                            {"id": "save", "tool": "write_file", "status": "succeeded"},
+                        ],
+                        "checkpoint_step_ids": ["search", "save"],
+                        "last_completed_step_id": "save",
+                        "continued_error_steps": [],
+                    },
+                },
+                {
+                    "id": "evt-call",
+                    "session_id": "session-1",
+                    "event_type": "tool_call",
+                    "tool_name": "workflow_web_brief_to_file",
+                    "summary": "Calling workflow",
+                    "created_at": "2026-03-18T12:01:00Z",
+                    "details": {
+                        "run_fingerprint": "web-brief-legacy-auth",
+                        "arguments": {"query": "seraph", "file_path": "notes/brief.md"},
+                    },
+                },
+            ],
+        ),
+        patch("src.api.workflows.approval_repository.list_pending", return_value=[]),
+        patch(
+            "src.api.workflows.workflow_manager.get_tool_metadata",
+            return_value={
+                "risk_level": "medium",
+                "execution_boundaries": ["external_read", "workspace_write"],
+                "accepts_secret_refs": False,
+                "approval_context": current_context,
+            },
+        ),
+        patch("src.api.workflows.get_base_tools_and_active_skills", return_value=([], [], "full")),
+        patch("src.api.workflows.workflow_manager.build_workflow_tools", return_value=[SimpleNamespace(name="workflow_web_brief_to_file", get_approval_context=lambda _arguments: current_context)]),
+        patch(
+            "src.api.workflows.workflow_manager.list_workflows",
+            return_value=[
+                {
+                    "name": "web-brief-to-file",
+                    "inputs": {},
+                    "enabled": True,
+                    "is_available": True,
+                    "missing_tools": [],
+                    "missing_skills": [],
+                }
+            ],
+        ),
+        patch(
+            "src.api.workflows.session_manager.list_sessions",
+            return_value=[{"id": "session-1", "title": "Research thread"}],
+        ),
+        patch("src.api.workflows.get_current_tool_policy_mode", return_value="balanced"),
+    ):
+        response = await client.post(
+            "/api/workflows/runs/session-1:workflow_web_brief_to_file:web-brief-legacy-auth/resume-plan",
+            json={"step_id": "save"},
+        )
+
+    assert response.status_code == 409
+    assert "predates trust-boundary tracking" in response.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/docs/implementation/01-trust-boundaries.md
+++ b/docs/implementation/01-trust-boundaries.md
@@ -314,6 +314,25 @@
   - while pinning the fix, I also caught two real test regressions of my own: one existing workflow failure-payload method was accidentally dedented during the edit, and one older approval-context reordering assertion was overwritten with the wrong replay expectation
   - both were corrected before publish, and the expanded targeted suite now covers the old stable cases alongside the new delegated-boundary drift cases
 
+### `workflow-legacy-replay-boundary-enforcement-v1`
+
+- status: complete on `feat/workflow-legacy-replay-boundary-hardening-batch-ad-v11`, intended for the next Batch AD PR for `#299`
+- root cause addressed:
+  - legacy workflow runs can still carry reusable checkpoint context without any recorded approval context at all, and direct resume trusted those payloads as long as the workflow name matched
+  - the API replay projection had the same blind spot for protected medium-risk surfaces like authenticated external sources, where replay could still look valid even though the run predates trust-boundary tracking
+- scope:
+  - privileged workflow surfaces now require tracked approval lineage before replay or resume is considered safe, including authenticated sources, delegated specialist routes, unresolved delegation, secret-bearing boundaries, external MCP, and other high-risk surfaces
+  - direct checkpoint restore now fails closed when a parent run predates trust-boundary tracking for the current protected workflow surface
+  - workflow run projection now reports `approval_context_missing` for those legacy protected runs so replay/resume UI and API paths surface the same fresh-run requirement
+- validation:
+  - `python3 -m py_compile backend/src/workflows/manager.py backend/src/api/workflows.py backend/tests/test_workflows.py`
+  - `cd backend && .venv/bin/python -m pytest tests/test_workflows.py -q -k "approval_context_is_missing_for_authenticated_surface or resume_rejects_legacy_checkpoint_for_authenticated_surface or approval_context_changes or authenticated_source_context_drift or authenticated_source_system_reordering or delegated_specialist_context_drift or delegated_specialist_reordering or approval_context_list_reordering"`
+  - `cd docs && npm run build`
+  - `git diff --check`
+- review pass:
+  - the first implementation pass had a real syntax regression in the replay recovery-message branch because I duplicated the nested conditional while adding the new `approval_context_missing` case
+  - after fixing that, I reran the targeted seam set to make sure the older authenticated-source and delegated-stability cases still behaved the same while only the legacy protected runs started failing closed
+
 ### `planner-secret-surface-isolation-v1`
 
 - status: complete on `develop` via PR `#245`


### PR DESCRIPTION
## Summary
- fail closed when replay or resume targets a protected workflow surface but the parent run predates trust-boundary tracking
- block direct checkpoint restore across legacy authenticated-source and delegated execution seams
- add regression coverage for legacy authenticated replay gating alongside the existing drift and stable-reordering cases

## Validation
- python3 -m py_compile backend/src/workflows/manager.py backend/src/api/workflows.py backend/tests/test_workflows.py
- cd backend && .venv/bin/python -m pytest tests/test_workflows.py -q -k "approval_context_is_missing_for_authenticated_surface or resume_rejects_legacy_checkpoint_for_authenticated_surface or approval_context_changes or authenticated_source_context_drift or authenticated_source_system_reordering or delegated_specialist_context_drift or delegated_specialist_reordering or approval_context_list_reordering"
- cd docs && npm run build
- git diff --check