### PR TITLE
Batch AD: hide blocked workflow resume surfaces

### DIFF
--- a/backend/src/api/workflows.py
+++ b/backend/src/api/workflows.py
@@ -832,6 +832,10 @@ def _workflow_replay_policy(
     return True, None
 
 
+def _workflow_resume_surface_allowed(*, replay_block_reason: str | None) -> bool:
+    return replay_block_reason not in {"approval_context_changed", "approval_context_missing"}
+
+
 def _workflow_runtime_statuses() -> dict[str, dict[str, Any]]:
     base_tools, active_skill_names, _ = get_base_tools_and_active_skills()
     available_tool_names = [tool.name for tool in base_tools]
@@ -1299,10 +1303,17 @@ async def _list_workflow_runs(
             approvals=approvals,
             continued_error_steps=list(run.get("continued_error_steps", [])),
         )
+        resume_surface_allowed = _workflow_resume_surface_allowed(
+            replay_block_reason=replay_block_reason,
+        )
         resume_from_step = (
-            "approval_gate"
-            if approvals
-            else (run["continued_error_steps"][0] if run.get("continued_error_steps") else None)
+            (
+                "approval_gate"
+                if approvals
+                else (run["continued_error_steps"][0] if run.get("continued_error_steps") else None)
+            )
+            if resume_surface_allowed
+            else None
         )
         retry_from_step_draft = (
             _workflow_retry_from_step_draft(
@@ -1314,7 +1325,8 @@ async def _list_workflow_runs(
                 branch_kind="retry_failed_step",
                 branch_depth=int(lineage.get("branch_depth") or 0) + 1,
             )
-            if replay_allowed
+            if resume_surface_allowed
+            and replay_allowed
             and run.get("continued_error_steps")
             and (
                 bool(run.get("checkpoint_context_available"))
@@ -1346,7 +1358,7 @@ async def _list_workflow_runs(
             "resume_checkpoint_label": _resume_checkpoint_label(
                 approvals=approvals,
                 continued_error_steps=list(run.get("continued_error_steps", [])),
-            ),
+            ) if resume_surface_allowed else None,
             "approval_recovery_message": (
                 f"Workflow '{run['workflow_name']}' changed its trust boundary after this run. Start a fresh run instead of replaying or resuming."
                 if bool(run.get("approval_context_mismatch"))
@@ -1384,8 +1396,12 @@ async def _list_workflow_runs(
             ),
             **lineage,
         })
-        run["checkpoint_candidates"] = _workflow_checkpoint_candidates(run, approvals=approvals)
-        run["resume_plan"] = _workflow_resume_plan(run, approvals=approvals)
+        if resume_surface_allowed:
+            run["checkpoint_candidates"] = _workflow_checkpoint_candidates(run, approvals=approvals)
+            run["resume_plan"] = _workflow_resume_plan(run, approvals=approvals)
+        else:
+            run["checkpoint_candidates"] = []
+            run["resume_plan"] = None
         completed.append(run)
 
     for run_queue in pending_by_key.values():
@@ -1494,10 +1510,17 @@ async def _list_workflow_runs(
                 approvals=approvals,
                 continued_error_steps=list(run.get("continued_error_steps", [])),
             )
+            resume_surface_allowed = _workflow_resume_surface_allowed(
+                replay_block_reason=replay_block_reason,
+            )
             resume_from_step = (
-                "approval_gate"
-                if approvals
-                else (run["continued_error_steps"][0] if run.get("continued_error_steps") else None)
+                (
+                    "approval_gate"
+                    if approvals
+                    else (run["continued_error_steps"][0] if run.get("continued_error_steps") else None)
+                )
+                if resume_surface_allowed
+                else None
             )
             run.update({
                 "thread_id": run.get("session_id"),
@@ -1525,7 +1548,8 @@ async def _list_workflow_runs(
                         branch_kind="retry_failed_step",
                         branch_depth=int(lineage.get("branch_depth") or 0) + 1,
                     )
-                    if replay_allowed
+                    if resume_surface_allowed
+                    and replay_allowed
                     and run.get("continued_error_steps")
                     and (
                         bool(run.get("checkpoint_context_available"))
@@ -1540,7 +1564,7 @@ async def _list_workflow_runs(
                 "resume_checkpoint_label": _resume_checkpoint_label(
                     approvals=approvals,
                     continued_error_steps=list(run.get("continued_error_steps", [])),
-                ),
+                ) if resume_surface_allowed else None,
                 "approval_recovery_message": (
                     f"Workflow '{run['workflow_name']}' changed its trust boundary after this run. Start a fresh run instead of replaying or resuming."
                     if bool(run.get("approval_context_mismatch"))
@@ -1578,8 +1602,12 @@ async def _list_workflow_runs(
                 ),
                 **lineage,
             })
-            run["checkpoint_candidates"] = _workflow_checkpoint_candidates(run, approvals=approvals)
-            run["resume_plan"] = _workflow_resume_plan(run, approvals=approvals)
+            if resume_surface_allowed:
+                run["checkpoint_candidates"] = _workflow_checkpoint_candidates(run, approvals=approvals)
+                run["resume_plan"] = _workflow_resume_plan(run, approvals=approvals)
+            else:
+                run["checkpoint_candidates"] = []
+                run["resume_plan"] = None
             completed.append(run)
 
     completed.sort(

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -1614,6 +1614,115 @@ async def test_workflow_runs_endpoint_uses_stored_fingerprint_for_redacted_argum
 
 
 @pytest.mark.asyncio
+async def test_workflow_runs_endpoint_hides_resume_metadata_when_pending_run_lacks_tracked_authenticated_context(client):
+    current_context = {
+        "workflow_name": "web-brief-to-file",
+        "risk_level": "medium",
+        "execution_boundaries": ["external_read", "workspace_write"],
+        "accepts_secret_refs": False,
+        "step_tools": ["web_search", "write_file"],
+        "authenticated_source": True,
+        "source_systems": [
+            {
+                "server_name": "github",
+                "hostname": "api.github.com",
+                "source": "extension",
+                "authenticated_source": True,
+            }
+        ],
+    }
+    runtime_workflow_tool = SimpleNamespace(
+        name="workflow_web_brief_to_file",
+        get_approval_context=lambda _arguments: current_context,
+    )
+
+    with (
+        patch(
+            "src.api.workflows.audit_repository.list_events",
+            return_value=[
+                {
+                    "id": "evt-call",
+                    "session_id": "session-1",
+                    "event_type": "tool_call",
+                    "tool_name": "workflow_web_brief_to_file",
+                    "summary": "Calling workflow",
+                    "created_at": "2026-03-18T12:01:00Z",
+                    "details": {
+                        "run_fingerprint": "web-brief-auth-pending",
+                        "arguments": {"query": "seraph", "file_path": "notes/brief.md"},
+                    },
+                },
+            ],
+        ),
+        patch(
+            "src.api.workflows.approval_repository.list_pending",
+            return_value=[
+                {
+                    "id": "approval-1",
+                    "tool_name": "workflow_web_brief_to_file",
+                    "session_id": "session-1",
+                    "fingerprint": "web-brief-auth-pending",
+                    "summary": "Approval pending for workflow_web_brief_to_file",
+                    "risk_level": "medium",
+                    "created_at": "2026-03-18T12:01:10Z",
+                    "resume_message": "Continue the authenticated brief once approved",
+                }
+            ],
+        ),
+        patch(
+            "src.api.workflows.workflow_manager.get_tool_metadata",
+            return_value={
+                "risk_level": "medium",
+                "execution_boundaries": ["external_read", "workspace_write"],
+                "accepts_secret_refs": False,
+                "approval_context": {
+                    "workflow_name": "web-brief-to-file",
+                    "risk_level": "medium",
+                    "execution_boundaries": ["external_read", "workspace_write"],
+                    "accepts_secret_refs": False,
+                    "step_tools": ["web_search", "write_file"],
+                },
+            },
+        ),
+        patch("src.api.workflows.get_base_tools_and_active_skills", return_value=([], [], "full")),
+        patch("src.api.workflows.workflow_manager.build_workflow_tools", return_value=[runtime_workflow_tool]),
+        patch(
+            "src.api.workflows.workflow_manager.list_workflows",
+            return_value=[
+                {
+                    "name": "web-brief-to-file",
+                    "inputs": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "file_path": {"type": "string", "description": "Output path"},
+                    },
+                    "enabled": True,
+                    "is_available": True,
+                    "missing_tools": [],
+                    "missing_skills": [],
+                }
+            ],
+        ),
+        patch(
+            "src.api.workflows.session_manager.list_sessions",
+            return_value=[{"id": "session-1", "title": "Research thread"}],
+        ),
+        patch("src.api.workflows.get_current_tool_policy_mode", return_value="balanced"),
+    ):
+        response = await client.get("/api/workflows/runs?session_id=session-1")
+
+    assert response.status_code == 200
+    run = response.json()["runs"][0]
+    assert run["replay_allowed"] is False
+    assert run["replay_block_reason"] == "approval_context_missing"
+    assert run["resume_from_step"] is None
+    assert run["resume_checkpoint_label"] is None
+    assert run["checkpoint_candidates"] == []
+    assert run["resume_plan"] is None
+    assert run["thread_continue_message"] == "Continue the authenticated brief once approved"
+    assert "predates trust-boundary tracking" in run["approval_recovery_message"]
+
+
+@pytest.mark.asyncio
 async def test_workflow_runs_endpoint_marks_waiting_runs_as_awaiting_approval(client):
     with (
         patch(
@@ -2503,6 +2612,10 @@ async def test_workflow_runs_endpoint_blocks_replay_when_approval_context_change
     assert run["replay_block_reason"] == "approval_context_changed"
     assert run["risk_level"] == "medium"
     assert run["execution_boundaries"] == ["external_read", "workspace_write"]
+    assert run["resume_from_step"] is None
+    assert run["resume_checkpoint_label"] is None
+    assert run["checkpoint_candidates"] == []
+    assert run["resume_plan"] is None
     assert "trust boundary" in run["approval_recovery_message"]
 
 
@@ -2717,6 +2830,8 @@ async def test_workflow_runs_endpoint_detects_authenticated_source_context_drift
     assert run["approval_context_mismatch"] is True
     assert run["replay_allowed"] is False
     assert run["replay_block_reason"] == "approval_context_changed"
+    assert run["checkpoint_candidates"] == []
+    assert run["resume_plan"] is None
     assert run["current_approval_context"]["authenticated_source"] is True
     assert run["current_approval_context"]["source_systems"] == [
         {
@@ -2979,6 +3094,8 @@ async def test_workflow_runs_endpoint_detects_delegated_specialist_context_drift
     assert run["approval_context_mismatch"] is True
     assert run["replay_allowed"] is False
     assert run["replay_block_reason"] == "approval_context_changed"
+    assert run["checkpoint_candidates"] == []
+    assert run["resume_plan"] is None
     assert run["current_approval_context"]["delegated_specialists"] == ["mcp_github"]
 
 
@@ -3288,6 +3405,10 @@ async def test_workflow_runs_endpoint_blocks_replay_when_approval_context_is_mis
     assert run["approval_context_mismatch"] is False
     assert run["replay_allowed"] is False
     assert run["replay_block_reason"] == "approval_context_missing"
+    assert run["resume_from_step"] is None
+    assert run["resume_checkpoint_label"] is None
+    assert run["checkpoint_candidates"] == []
+    assert run["resume_plan"] is None
     assert "predates trust-boundary tracking" in run["approval_recovery_message"]
 
 

--- a/docs/implementation/01-trust-boundaries.md
+++ b/docs/implementation/01-trust-boundaries.md
@@ -333,6 +333,25 @@
   - the first implementation pass had a real syntax regression in the replay recovery-message branch because I duplicated the nested conditional while adding the new `approval_context_missing` case
   - after fixing that, I reran the targeted seam set to make sure the older authenticated-source and delegated-stability cases still behaved the same while only the legacy protected runs started failing closed
 
+### `workflow-surface-boundary-truthfulness-v1`
+
+- status: complete on `feat/workflow-surface-boundary-hardening-batch-ad-v12`, intended for the next Batch AD PR for `#299`
+- root cause addressed:
+  - the workflows runs API already marked trust-boundary drift correctly with `approval_context_changed` and `approval_context_missing`, but it still serialized checkpoint candidates and a concrete `resume_plan` for those same blocked runs
+  - that left operator surfaces with stale branch/retry metadata even though `/api/workflows/runs/{run_identity}/resume-plan` would fail closed, which made the API contract less truthful than the runtime boundary
+- scope:
+  - workflow run projection now clears `resume_from_step`, `resume_checkpoint_label`, `checkpoint_candidates`, and `resume_plan` whenever replay is blocked because the trust boundary changed or because the run predates tracked lineage for the current privileged surface
+  - the same fail-closed rule now applies to both completed workflow runs reconstructed from audit events and still-pending runs reconstructed from call state, so the operator surface does not advertise stale continuation paths on either side
+  - pending approvals, repair guidance, and other non-boundary replay blocks still keep their existing branch metadata where that metadata is part of the intended operator contract
+- validation:
+  - `python3 -m py_compile backend/src/api/workflows.py backend/tests/test_workflows.py`
+  - `cd backend && .venv/bin/python -m pytest tests/test_workflows.py -q -k "approval_context_changes or authenticated_source_context_drift or delegated_specialist_context_drift or approval_context_is_missing_for_authenticated_surface or approval_context_list_reordering or authenticated_source_system_reordering or delegated_specialist_reordering"`
+  - `cd docs && npm run build`
+  - `git diff --check`
+- review pass:
+  - the real issue here was not backend resume enforcement, which was already fail-closed, but surface drift: blocked runs still looked resumable because branch metadata was generated before the trust-boundary stop was applied consistently across the serialized run shape
+  - fixed by moving the trust-boundary decision up into the run projection itself and pinning both mismatch and legacy-missing-context cases in the workflow suite
+
 ### `planner-secret-surface-isolation-v1`
 
 - status: complete on `develop` via PR `#245`


### PR DESCRIPTION
## Summary
- make workflow run projection fail closed when trust-boundary drift already blocks replay
- hide stale checkpoint candidates and resume plans for `approval_context_changed` and `approval_context_missing` runs
- add workflow regressions for completed and pending authenticated/delegated boundary drift cases

## Validation
- `python3 -m py_compile backend/src/api/workflows.py backend/tests/test_workflows.py`
- `cd backend && .venv/bin/python -m pytest tests/test_workflows.py -q -k "approval_context_changes or authenticated_source_context_drift or delegated_specialist_context_drift or approval_context_is_missing_for_authenticated_surface or approval_context_list_reordering or authenticated_source_system_reordering or delegated_specialist_reordering or pending_run_lacks_tracked_authenticated_context"`
- `cd docs && npm run build`
- `git diff --check`

## Review notes
- real issue fixed: the runs API still serialized concrete checkpoint candidates and `resume_plan` data even after the trust boundary had already been marked unsafe, so operator surfaces could still look resumable while `/resume-plan` would fail closed
- fix keeps pending-approval and normal repair surfaces intact while clearing only the blocked trust-boundary cases
