### PR TITLE
Batch AD: suppress stale blocked resume prompts

### DIFF
--- a/backend/src/api/workflows.py
+++ b/backend/src/api/workflows.py
@@ -1378,7 +1378,7 @@ async def _list_workflow_runs(
             ),
             "thread_continue_message": (
                 approvals[0].get("resume_message")
-                if approvals and isinstance(approvals[0], dict)
+                if resume_surface_allowed and approvals and isinstance(approvals[0], dict)
                 else None
             ),
             "run_identity": run_identity,
@@ -1584,7 +1584,7 @@ async def _list_workflow_runs(
                 ),
                 "thread_continue_message": (
                     approvals[0].get("resume_message")
-                    if approvals and isinstance(approvals[0], dict)
+                    if resume_surface_allowed and approvals and isinstance(approvals[0], dict)
                     else None
                 ),
                 "run_identity": run_identity,

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -1718,7 +1718,7 @@ async def test_workflow_runs_endpoint_hides_resume_metadata_when_pending_run_lac
     assert run["resume_checkpoint_label"] is None
     assert run["checkpoint_candidates"] == []
     assert run["resume_plan"] is None
-    assert run["thread_continue_message"] == "Continue the authenticated brief once approved"
+    assert run["thread_continue_message"] is None
     assert "predates trust-boundary tracking" in run["approval_recovery_message"]
 
 

--- a/docs/implementation/01-trust-boundaries.md
+++ b/docs/implementation/01-trust-boundaries.md
@@ -342,6 +342,7 @@
 - scope:
   - workflow run projection now clears `resume_from_step`, `resume_checkpoint_label`, `checkpoint_candidates`, and `resume_plan` whenever replay is blocked because the trust boundary changed or because the run predates tracked lineage for the current privileged surface
   - the same fail-closed rule now applies to both completed workflow runs reconstructed from audit events and still-pending runs reconstructed from call state, so the operator surface does not advertise stale continuation paths on either side
+  - blocked trust-boundary runs also stop surfacing approval-style thread continuation prompts, so activity and cockpit layers fall back to the recovery message instead of implying that approval alone can unblock the run
   - pending approvals, repair guidance, and other non-boundary replay blocks still keep their existing branch metadata where that metadata is part of the intended operator contract
 - validation:
   - `python3 -m py_compile backend/src/api/workflows.py backend/tests/test_workflows.py`


### PR DESCRIPTION
## Summary
- stop surfacing approval-style thread continuation prompts when workflow replay is blocked by trust-boundary drift
- keep recovery messaging aligned with the fail-closed replay/resume contract
- pin the blocked authenticated pending-run case in the workflow suite

## Validation
- `python3 -m py_compile backend/src/api/workflows.py backend/tests/test_workflows.py`
- `cd backend && .venv/bin/python -m pytest tests/test_workflows.py -q -k "pending_run_lacks_tracked_authenticated_context or approval_context_is_missing_for_authenticated_surface or approval_context_changes"`
- `git diff --check`

## Review notes
- real issue fixed: blocked runs could still emit `thread_continue_message` from a pending approval, so activity and cockpit layers could imply that approval alone would unblock a run that already required a fresh start
- fix leaves normal pending-approval surfaces intact and only suppresses the stale prompt when the replay boundary is already fail-closed
