### PR TITLE
feat: finish Batch AD workflow boundary hardening

### DIFF
--- a/backend/src/api/activity.py
+++ b/backend/src/api/activity.py
@@ -10,7 +10,13 @@ from fastapi import APIRouter, Query
 
 from src.agent.session import session_manager
 from src.api.observer import _continuity_surface
-from src.api.workflows import _list_workflow_runs
+from src.api.workflows import (
+    _list_workflow_runs,
+    workflow_surface_continue_message,
+    workflow_surface_recommended_actions,
+    workflow_surface_replay_draft,
+    workflow_surface_resume_metadata,
+)
 from src.approval.repository import approval_repository
 from src.audit.repository import audit_repository
 from src.guardian.feedback import guardian_feedback_repository
@@ -416,6 +422,7 @@ async def get_activity_ledger(
         updated_at = str(run.get("updated_at") or run.get("started_at") or "")
         if _parse_iso(updated_at) < cutoff:
             continue
+        workflow_surface = workflow_surface_resume_metadata(run)
         items.append({
             "id": f"workflow:{run['id']}",
             "kind": "workflow_run",
@@ -427,16 +434,11 @@ async def get_activity_ledger(
             "updated_at": updated_at,
             "thread_id": run.get("thread_id"),
             "thread_label": run.get("thread_label"),
-            "continue_message": (
-                run.get("thread_continue_message")
-                or run.get("approval_recovery_message")
-                or run.get("retry_from_step_draft")
-                or run.get("replay_draft")
-            ),
-            "replay_draft": run.get("replay_draft"),
-            "replay_allowed": run.get("replay_allowed"),
+            "continue_message": workflow_surface_continue_message(run),
+            "replay_draft": workflow_surface_replay_draft(run),
+            "replay_allowed": workflow_surface["replay_allowed"],
             "replay_block_reason": run.get("replay_block_reason"),
-            "recommended_actions": run.get("replay_recommended_actions", []),
+            "recommended_actions": workflow_surface_recommended_actions(run),
             "source": "workflow",
             "model": None,
             "provider": None,
@@ -456,10 +458,10 @@ async def get_activity_ledger(
                 "branch_kind": run.get("branch_kind"),
                 "run_identity": run.get("run_identity"),
                 "run_fingerprint": run.get("run_fingerprint"),
-                "resume_from_step": run.get("resume_from_step"),
-                "resume_checkpoint_label": run.get("resume_checkpoint_label"),
-                "checkpoint_candidates": run.get("checkpoint_candidates", []),
-                "resume_plan": run.get("resume_plan"),
+                "resume_from_step": workflow_surface["resume_from_step"],
+                "resume_checkpoint_label": workflow_surface["resume_checkpoint_label"],
+                "checkpoint_candidates": workflow_surface["checkpoint_candidates"],
+                "resume_plan": workflow_surface["resume_plan"],
             },
         })
 

--- a/backend/src/api/operator.py
+++ b/backend/src/api/operator.py
@@ -9,7 +9,13 @@ from fastapi import APIRouter, Query
 
 from src.agent.session import session_manager
 from src.api.observer import _continuity_surface
-from src.api.workflows import _list_workflow_runs
+from src.api.workflows import (
+    _list_workflow_runs,
+    workflow_surface_continue_message,
+    workflow_surface_recommended_actions,
+    workflow_surface_replay_draft,
+    workflow_surface_resume_metadata,
+)
 from src.approval.repository import approval_repository
 from src.audit.repository import audit_repository
 from src.guardian.feedback import guardian_feedback_repository
@@ -56,6 +62,7 @@ async def get_operator_timeline(
     items: list[dict[str, Any]] = []
 
     for run in workflow_runs:
+        workflow_surface = workflow_surface_resume_metadata(run)
         items.append({
             "id": f"workflow:{run['id']}",
             "kind": "workflow_run",
@@ -66,16 +73,11 @@ async def get_operator_timeline(
             "updated_at": str(run["updated_at"]),
             "thread_id": run.get("thread_id"),
             "thread_label": run.get("thread_label"),
-            "continue_message": (
-                run.get("thread_continue_message")
-                or run.get("approval_recovery_message")
-                or run.get("retry_from_step_draft")
-                or run.get("replay_draft")
-            ),
-            "replay_draft": run.get("replay_draft"),
-            "replay_allowed": run.get("replay_allowed"),
+            "continue_message": workflow_surface_continue_message(run),
+            "replay_draft": workflow_surface_replay_draft(run),
+            "replay_allowed": workflow_surface["replay_allowed"],
             "replay_block_reason": run.get("replay_block_reason"),
-            "recommended_actions": run.get("replay_recommended_actions", []),
+            "recommended_actions": workflow_surface_recommended_actions(run),
             "source": "workflow",
             "metadata": {
                 "run_identity": run.get("run_identity"),
@@ -86,16 +88,16 @@ async def get_operator_timeline(
                 "failed_step_ids": list(run.get("continued_error_steps", []) or []),
                 "failed_step_tool": run.get("failed_step_tool"),
                 "pending_approval_count": run.get("pending_approval_count", 0),
-                "resume_from_step": run.get("resume_from_step"),
-                "resume_checkpoint_label": run.get("resume_checkpoint_label"),
+                "resume_from_step": workflow_surface["resume_from_step"],
+                "resume_checkpoint_label": workflow_surface["resume_checkpoint_label"],
                 "last_completed_step_id": run.get("last_completed_step_id"),
                 "checkpoint_step_ids": list(run.get("checkpoint_step_ids", []) or []),
-                "checkpoint_candidates": run.get("checkpoint_candidates", []),
+                "checkpoint_candidates": workflow_surface["checkpoint_candidates"],
                 "branch_kind": run.get("branch_kind"),
                 "branch_depth": run.get("branch_depth"),
                 "parent_run_identity": run.get("parent_run_identity"),
                 "root_run_identity": run.get("root_run_identity"),
-                "resume_plan": run.get("resume_plan"),
+                "resume_plan": workflow_surface["resume_plan"],
                 "availability": run.get("availability"),
             },
         })

--- a/backend/src/api/workflows.py
+++ b/backend/src/api/workflows.py
@@ -299,6 +299,7 @@ def _normalize_approval_context(value: Any, *, workflow_name: str | None = None)
     execution_boundaries = _normalize_string_list(value.get("execution_boundaries"))
     step_tools = _normalize_string_list(value.get("step_tools"))
     delegated_specialists = _normalize_string_list(value.get("delegated_specialists"))
+    delegated_tool_names = _normalize_string_list(value.get("delegated_tool_names"))
     authenticated_source = bool(value.get("authenticated_source", False))
     delegation_target_unresolved = bool(value.get("delegation_target_unresolved", False))
     source_systems = _normalize_source_systems(value.get("source_systems"))
@@ -308,6 +309,7 @@ def _normalize_approval_context(value: Any, *, workflow_name: str | None = None)
             execution_boundaries,
             step_tools,
             delegated_specialists,
+            delegated_tool_names,
             "accepts_secret_refs" in value,
             authenticated_source,
             delegation_target_unresolved,
@@ -324,6 +326,8 @@ def _normalize_approval_context(value: Any, *, workflow_name: str | None = None)
     }
     if delegated_specialists:
         normalized["delegated_specialists"] = delegated_specialists
+    if delegated_tool_names:
+        normalized["delegated_tool_names"] = delegated_tool_names
     if authenticated_source:
         normalized["authenticated_source"] = True
     if delegation_target_unresolved:
@@ -810,14 +814,14 @@ def _workflow_replay_policy(
     approval_context_mismatch: bool,
     approval_context_missing_for_protected_surface: bool,
 ) -> tuple[bool, str | None]:
-    if availability == "disabled":
-        return False, "workflow_disabled"
-    if availability != "ready":
-        return False, "workflow_unavailable"
     if approval_context_mismatch:
         return False, "approval_context_changed"
     if approval_context_missing_for_protected_surface:
         return False, "approval_context_missing"
+    if availability == "disabled":
+        return False, "workflow_disabled"
+    if availability != "ready":
+        return False, "workflow_unavailable"
     if pending_approval_count > 0:
         return False, "pending_approval"
     if accepts_secret_refs:
@@ -834,6 +838,63 @@ def _workflow_replay_policy(
 
 def _workflow_resume_surface_allowed(*, replay_block_reason: str | None) -> bool:
     return replay_block_reason not in {"approval_context_changed", "approval_context_missing"}
+
+
+def _workflow_repair_surface_allowed(*, replay_block_reason: str | None) -> bool:
+    return replay_block_reason not in {"approval_context_changed", "approval_context_missing"}
+
+
+def _workflow_boundary_blocked(*, replay_block_reason: str | None) -> bool:
+    return replay_block_reason in {"approval_context_changed", "approval_context_missing"}
+
+
+def workflow_surface_continue_message(run: dict[str, Any]) -> str | None:
+    replay_block_reason = str(run.get("replay_block_reason") or "") or None
+    if _workflow_boundary_blocked(replay_block_reason=replay_block_reason):
+        message = run.get("approval_recovery_message")
+        return str(message) if isinstance(message, str) and message.strip() else None
+    for value in (
+        run.get("thread_continue_message"),
+        run.get("approval_recovery_message"),
+        run.get("retry_from_step_draft"),
+        run.get("replay_draft"),
+    ):
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def workflow_surface_replay_draft(run: dict[str, Any]) -> str | None:
+    replay_block_reason = str(run.get("replay_block_reason") or "") or None
+    if _workflow_boundary_blocked(replay_block_reason=replay_block_reason):
+        return None
+    value = run.get("replay_draft")
+    return str(value) if isinstance(value, str) and value.strip() else None
+
+
+def workflow_surface_recommended_actions(run: dict[str, Any]) -> list[dict[str, Any]]:
+    replay_block_reason = str(run.get("replay_block_reason") or "") or None
+    if _workflow_boundary_blocked(replay_block_reason=replay_block_reason):
+        return []
+    value = run.get("replay_recommended_actions")
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def workflow_surface_resume_metadata(run: dict[str, Any]) -> dict[str, Any]:
+    replay_block_reason = str(run.get("replay_block_reason") or "") or None
+    blocked = _workflow_boundary_blocked(replay_block_reason=replay_block_reason)
+    checkpoint_candidates = run.get("checkpoint_candidates")
+    if not isinstance(checkpoint_candidates, list):
+        checkpoint_candidates = []
+    return {
+        "replay_allowed": False if blocked else bool(run.get("replay_allowed")),
+        "resume_from_step": None if blocked else run.get("resume_from_step"),
+        "resume_checkpoint_label": None if blocked else run.get("resume_checkpoint_label"),
+        "checkpoint_candidates": [] if blocked else checkpoint_candidates,
+        "resume_plan": None if blocked else run.get("resume_plan"),
+    }
 
 
 def _workflow_runtime_statuses() -> dict[str, dict[str, Any]]:
@@ -1291,6 +1352,18 @@ async def _list_workflow_runs(
             approval_context_mismatch=bool(run.get("approval_context_mismatch")),
             approval_context_missing_for_protected_surface=approval_context_missing_for_protected_surface,
         )
+        repair_surface_allowed = _workflow_repair_surface_allowed(
+            replay_block_reason=replay_block_reason,
+        )
+        if not repair_surface_allowed:
+            run["replay_recommended_actions"] = []
+            if isinstance(step_records, list):
+                for step in step_records:
+                    if not isinstance(step, dict):
+                        continue
+                    step["recovery_actions"] = []
+                    step["recovery_hint"] = None
+                    step["is_recoverable"] = False
         run_identity = build_workflow_run_identity(
             run.get("session_id") if isinstance(run.get("session_id"), str) else None,
             tool_name,
@@ -1494,6 +1567,18 @@ async def _list_workflow_runs(
                 approval_context_mismatch=bool(run.get("approval_context_mismatch")),
                 approval_context_missing_for_protected_surface=approval_context_missing_for_protected_surface,
             )
+            repair_surface_allowed = _workflow_repair_surface_allowed(
+                replay_block_reason=replay_block_reason,
+            )
+            if not repair_surface_allowed:
+                run["replay_recommended_actions"] = []
+                if isinstance(step_records, list):
+                    for step in step_records:
+                        if not isinstance(step, dict):
+                            continue
+                        step["recovery_actions"] = []
+                        step["recovery_hint"] = None
+                        step["is_recoverable"] = False
             run_identity = build_workflow_run_identity(
                 run.get("session_id") if isinstance(run.get("session_id"), str) else None,
                 str(run["tool_name"]),

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -5534,6 +5534,113 @@ async def _eval_threaded_operator_timeline_behavior() -> dict[str, Any]:
     }
 
 
+async def _eval_workflow_boundary_blocked_surface_behavior() -> dict[str, Any]:
+    from src.api.activity import get_activity_ledger
+    from src.api.operator import get_operator_timeline
+
+    started_at = datetime.now(timezone.utc) - timedelta(minutes=6)
+    updated_at = started_at + timedelta(minutes=3)
+    blocked_run = {
+        "id": "run-1",
+        "workflow_name": "authenticated-brief",
+        "summary": "Authenticated workflow boundary drifted.",
+        "status": "failed",
+        "started_at": started_at.isoformat().replace("+00:00", "Z"),
+        "updated_at": updated_at.isoformat().replace("+00:00", "Z"),
+        "thread_id": "thread-1",
+        "thread_label": "Research thread",
+        "thread_continue_message": "Continue from stale approval.",
+        "approval_recovery_message": (
+            "Workflow 'authenticated-brief' changed its trust boundary after this run. "
+            "Start a fresh run instead of replaying or resuming."
+        ),
+        "retry_from_step_draft": 'Run workflow "authenticated-brief" with query="seraph". Resume from step "save".',
+        "replay_draft": 'Run workflow "authenticated-brief" with query="seraph".',
+        "replay_allowed": True,
+        "replay_block_reason": "approval_context_changed",
+        "replay_recommended_actions": [{"type": "open_settings", "label": "Open settings"}],
+        "risk_level": "medium",
+        "execution_boundaries": ["authenticated_external_source", "workspace_write"],
+        "pending_approval_count": 0,
+        "resume_from_step": "save",
+        "resume_checkpoint_label": "save (write_file)",
+        "run_identity": "thread-1:workflow_authenticated_brief:auth-brief",
+        "run_fingerprint": "auth-brief",
+        "continued_error_steps": ["save"],
+        "failed_step_tool": "write_file",
+        "checkpoint_step_ids": ["search", "save"],
+        "last_completed_step_id": "search",
+        "checkpoint_candidates": [
+            {
+                "step_id": "save",
+                "label": "save (write_file)",
+                "kind": "retry_failed_step",
+                "status": "continued_error",
+            }
+        ],
+        "branch_kind": "retry_failed_step",
+        "branch_depth": 0,
+        "parent_run_identity": None,
+        "root_run_identity": "thread-1:workflow_authenticated_brief:auth-brief",
+        "resume_plan": {
+            "source_run_identity": "thread-1:workflow_authenticated_brief:auth-brief",
+            "parent_run_identity": "thread-1:workflow_authenticated_brief:auth-brief",
+            "root_run_identity": "thread-1:workflow_authenticated_brief:auth-brief",
+            "branch_kind": "retry_failed_step",
+            "resume_from_step": "save",
+            "resume_checkpoint_label": "save (write_file)",
+            "requires_manual_execution": True,
+        },
+        "availability": "ready",
+        "step_records": [
+            {"id": "search", "tool": "web_search", "status": "succeeded"},
+            {"id": "save", "tool": "write_file", "status": "continued_error"},
+        ],
+    }
+
+    with (
+        patch(
+            "src.api.operator.session_manager.list_sessions",
+            return_value=[{"id": "thread-1", "title": "Research thread"}],
+        ),
+        patch("src.api.operator._list_workflow_runs", return_value=[blocked_run]),
+        patch("src.api.operator.approval_repository.list_pending", return_value=[]),
+        patch("src.api.operator.native_notification_queue.list", return_value=[]),
+        patch("src.api.operator.insight_queue.peek_all", return_value=[]),
+        patch("src.api.operator.guardian_feedback_repository.list_recent", return_value=[]),
+        patch("src.api.operator.audit_repository.list_events", return_value=[]),
+        patch(
+            "src.api.activity.session_manager.list_sessions",
+            return_value=[{"id": "thread-1", "title": "Research thread"}],
+        ),
+        patch("src.api.activity._list_workflow_runs", return_value=[blocked_run]),
+        patch("src.api.activity.approval_repository.list_pending", return_value=[]),
+        patch("src.api.activity.native_notification_queue.list", return_value=[]),
+        patch("src.api.activity.insight_queue.peek_all", return_value=[]),
+        patch("src.api.activity.guardian_feedback_repository.list_recent", return_value=[]),
+        patch("src.api.activity.audit_repository.list_events", return_value=[]),
+        patch("src.api.activity.list_recent_llm_calls", return_value=[]),
+    ):
+        operator_payload = await get_operator_timeline(limit=10, session_id="thread-1")
+        activity_payload = await get_activity_ledger(limit=10, session_id="thread-1", window_hours=24)
+
+    operator_item = next(item for item in operator_payload["items"] if item["kind"] == "workflow_run")
+    activity_item = next(item for item in activity_payload["items"] if item["kind"] == "workflow_run")
+
+    return {
+        "operator_continue_message_mentions_boundary": "trust boundary" in operator_item["continue_message"].lower(),
+        "operator_replay_draft_is_none": operator_item["replay_draft"] is None,
+        "operator_recommended_actions_empty": operator_item["recommended_actions"] == [],
+        "operator_resume_plan_is_none": operator_item["metadata"]["resume_plan"] is None,
+        "operator_checkpoint_candidates_empty": operator_item["metadata"]["checkpoint_candidates"] == [],
+        "activity_continue_message_mentions_boundary": "trust boundary" in activity_item["continue_message"].lower(),
+        "activity_replay_draft_is_none": activity_item["replay_draft"] is None,
+        "activity_recommended_actions_empty": activity_item["recommended_actions"] == [],
+        "activity_resume_plan_is_none": activity_item["metadata"]["resume_plan"] is None,
+        "activity_checkpoint_candidates_empty": activity_item["metadata"]["checkpoint_candidates"] == [],
+    }
+
+
 def _eval_capability_preflight_behavior() -> dict[str, Any]:
     from src.api.capabilities import _build_capability_overview, _capability_preflight_payload
 
@@ -6717,6 +6824,12 @@ _SCENARIOS: tuple[EvalScenario, ...] = (
         category="behavior",
         description="The operator timeline keeps workflows, approvals, notifications, queued bundles, interventions, and failures bound to one thread with the right continue and replay metadata.",
         runner=_eval_threaded_operator_timeline_behavior,
+    ),
+    EvalScenario(
+        name="workflow_boundary_blocked_surface_behavior",
+        category="behavior",
+        description="Operator and activity workflow surfaces fail closed when trust-boundary drift blocks replay or resume, instead of advertising stale continuation controls.",
+        runner=_eval_workflow_boundary_blocked_surface_behavior,
     ),
     EvalScenario(
         name="capability_repair_behavior",

--- a/backend/src/tools/delegate_task_tool.py
+++ b/backend/src/tools/delegate_task_tool.py
@@ -97,6 +97,17 @@ def _max_risk_level(current: str, candidate: str) -> str:
     return current if current_rank >= candidate_rank else candidate
 
 
+def _normalize_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    normalized: dict[str, None] = {}
+    for item in value:
+        text = str(item).strip()
+        if text:
+            normalized[text] = None
+    return sorted(normalized)
+
+
 def _build_specialists_by_name(specialists: Iterable[object]) -> dict[str, object]:
     specialists_by_name: dict[str, object] = {}
     for specialist in specialists:
@@ -153,6 +164,7 @@ def infer_delegation_approval_context(
     accepts_secret_refs = False
     authenticated_source = False
     source_systems: list[dict[str, Any]] = []
+    delegated_tool_names: list[str] = []
     risk_level = "low"
 
     raw_specialist_tools = getattr(selected_runtime, "tools", []) or []
@@ -163,6 +175,7 @@ def infer_delegation_approval_context(
     if not specialist_tools and isinstance(selected_name, str):
         for tool_name in _SPECIALIST_DEFAULT_TOOL_NAMES.get(selected_name, ()):
             canonical_name = canonical_tool_name(tool_name)
+            delegated_tool_names.append(canonical_name)
             for boundary in get_tool_execution_boundaries(canonical_name):
                 if boundary not in execution_boundaries:
                     execution_boundaries.append(boundary)
@@ -181,6 +194,7 @@ def infer_delegation_approval_context(
         if not isinstance(tool_name, str) or not tool_name:
             continue
         canonical_name = canonical_tool_name(tool_name)
+        delegated_tool_names.append(canonical_name)
         is_mcp = canonical_name.startswith("mcp_")
         for boundary in get_tool_execution_boundaries(canonical_name, is_mcp=is_mcp, tool=tool):
             if boundary not in execution_boundaries:
@@ -195,6 +209,7 @@ def infer_delegation_approval_context(
                 "hostname": str(source_context.get("hostname") or ""),
                 "source": str(source_context.get("source") or "manual"),
                 "authenticated_source": True,
+                "credential_sources": _normalize_string_list(source_context.get("credential_sources")),
             }
             if source_system not in source_systems:
                 source_systems.append(source_system)
@@ -206,6 +221,7 @@ def infer_delegation_approval_context(
 
     return {
         "delegated_specialist": selected_name,
+        "delegated_tool_names": sorted(dict.fromkeys(delegated_tool_names)),
         "delegation_target_unresolved": unresolved,
         "risk_level": risk_level,
         "execution_boundaries": execution_boundaries,

--- a/backend/src/workflows/manager.py
+++ b/backend/src/workflows/manager.py
@@ -317,6 +317,7 @@ def normalize_workflow_approval_context(
     execution_boundaries = _normalize_string_list(value.get("execution_boundaries"))
     step_tools = _normalize_string_list(value.get("step_tools"))
     delegated_specialists = _normalize_string_list(value.get("delegated_specialists"))
+    delegated_tool_names = _normalize_string_list(value.get("delegated_tool_names"))
     authenticated_source = bool(value.get("authenticated_source", False))
     delegation_target_unresolved = bool(value.get("delegation_target_unresolved", False))
     source_systems = _normalize_source_systems(value.get("source_systems"))
@@ -326,6 +327,7 @@ def normalize_workflow_approval_context(
             execution_boundaries,
             step_tools,
             delegated_specialists,
+            delegated_tool_names,
             "accepts_secret_refs" in value,
             authenticated_source,
             delegation_target_unresolved,
@@ -342,6 +344,8 @@ def normalize_workflow_approval_context(
     }
     if delegated_specialists:
         normalized["delegated_specialists"] = delegated_specialists
+    if delegated_tool_names:
+        normalized["delegated_tool_names"] = delegated_tool_names
     if authenticated_source:
         normalized["authenticated_source"] = True
     if delegation_target_unresolved:
@@ -514,6 +518,7 @@ def _approval_context_for_workflow(
     authenticated_source = False
     source_systems: list[dict[str, Any]] = []
     delegated_specialists: list[str] = []
+    delegated_tool_names: list[str] = []
     delegation_target_unresolved = False
     risk_level = "low"
     for tool_name in workflow.step_tools:
@@ -536,6 +541,7 @@ def _approval_context_for_workflow(
                         "hostname": str(source_context.get("hostname") or ""),
                         "source": str(source_context.get("source") or "manual"),
                         "authenticated_source": True,
+                        "credential_sources": _normalize_string_list(source_context.get("credential_sources")),
                     }
                 )
             continue
@@ -563,6 +569,9 @@ def _approval_context_for_workflow(
             delegated_specialist = delegate_context.get("delegated_specialist")
             if isinstance(delegated_specialist, str) and delegated_specialist:
                 delegated_specialists.append(delegated_specialist)
+            for delegated_tool_name in delegate_context.get("delegated_tool_names", []):
+                if isinstance(delegated_tool_name, str) and delegated_tool_name:
+                    delegated_tool_names.append(delegated_tool_name)
             if bool(delegate_context.get("delegation_target_unresolved", False)):
                 delegation_target_unresolved = True
             risk_level = _max_risk_level(risk_level, str(delegate_context.get("risk_level") or "high"))
@@ -583,6 +592,7 @@ def _approval_context_for_workflow(
         "authenticated_source": authenticated_source,
         "source_systems": source_systems,
         "delegated_specialists": sorted(dict.fromkeys(delegated_specialists)),
+        "delegated_tool_names": sorted(dict.fromkeys(delegated_tool_names)),
         "delegation_target_unresolved": delegation_target_unresolved,
         "step_tools": sorted(dict.fromkeys(canonical_step_tools)),
     }

--- a/backend/tests/test_activity_api.py
+++ b/backend/tests/test_activity_api.py
@@ -168,6 +168,88 @@ async def test_activity_ledger_aggregates_llm_calls_budget_and_threaded_actions(
 
 
 @pytest.mark.asyncio
+async def test_activity_ledger_hides_stale_resume_surface_when_workflow_boundary_is_blocked(client):
+    with (
+        patch(
+            "src.api.activity._list_workflow_runs",
+            AsyncMock(
+                return_value=[
+                    {
+                        "id": "run-2",
+                        "workflow_name": "authenticated-brief",
+                        "summary": "Authenticated workflow boundary drifted.",
+                        "status": "failed",
+                        "started_at": _iso_offset(minutes=-8),
+                        "updated_at": _iso_offset(minutes=-6),
+                        "thread_id": "session-1",
+                        "thread_label": "Research thread",
+                        "thread_continue_message": "Continue from stale approval.",
+                        "approval_recovery_message": (
+                            "Workflow 'authenticated-brief' changed its trust boundary after this run. "
+                            "Start a fresh run instead of replaying or resuming."
+                        ),
+                        "retry_from_step_draft": "Retry workflow \"authenticated-brief\" from step \"save\".",
+                        "replay_draft": "Replay authenticated workflow",
+                        "replay_allowed": True,
+                        "replay_block_reason": "approval_context_changed",
+                        "replay_recommended_actions": [
+                            {"type": "set_tool_policy", "label": "Allow write_file", "mode": "full"}
+                        ],
+                        "risk_level": "medium",
+                        "execution_boundaries": ["authenticated_external_source", "workspace_write"],
+                        "pending_approval_count": 0,
+                        "resume_from_step": "save",
+                        "resume_checkpoint_label": "Save step",
+                        "run_identity": "session-1:workflow_authenticated_brief:run-2",
+                        "run_fingerprint": "authenticated-brief",
+                        "continued_error_steps": ["save"],
+                        "failed_step_tool": "write_file",
+                        "checkpoint_candidates": [
+                            {
+                                "step_id": "save",
+                                "label": "save (write_file)",
+                                "kind": "retry_failed_step",
+                                "status": "continued_error",
+                            },
+                        ],
+                        "branch_kind": "retry_failed_step",
+                        "resume_plan": {
+                            "resume_from_step": "save",
+                            "draft": "Retry workflow \"authenticated-brief\" from step \"save\".",
+                        },
+                        "availability": "ready",
+                        "step_records": [{"id": "save", "tool": "write_file", "status": "continued_error"}],
+                    }
+                ]
+            ),
+        ),
+        patch("src.api.activity.approval_repository.list_pending", AsyncMock(return_value=[])),
+        patch("src.api.activity.native_notification_queue.list", AsyncMock(return_value=[])),
+        patch("src.api.activity.insight_queue.peek_all", AsyncMock(return_value=[])),
+        patch("src.api.activity.guardian_feedback_repository.list_recent", AsyncMock(return_value=[])),
+        patch("src.api.activity.audit_repository.list_events", AsyncMock(return_value=[])),
+        patch("src.api.activity.list_recent_llm_calls", return_value=[]),
+        patch(
+            "src.api.activity.session_manager.list_sessions",
+            AsyncMock(return_value=[{"id": "session-1", "title": "Research thread"}]),
+        ),
+    ):
+        response = await client.get("/api/activity/ledger", params={"session_id": "session-1", "limit": 20})
+
+    assert response.status_code == 200
+    payload = response.json()
+    workflow_item = next(item for item in payload["items"] if item["kind"] == "workflow_run")
+    assert workflow_item["continue_message"].startswith("Workflow 'authenticated-brief' changed its trust boundary")
+    assert workflow_item["replay_draft"] is None
+    assert workflow_item["replay_allowed"] is False
+    assert workflow_item["recommended_actions"] == []
+    assert workflow_item["metadata"]["resume_from_step"] is None
+    assert workflow_item["metadata"]["resume_checkpoint_label"] is None
+    assert workflow_item["metadata"]["checkpoint_candidates"] == []
+    assert workflow_item["metadata"]["resume_plan"] is None
+
+
+@pytest.mark.asyncio
 async def test_activity_ledger_respects_window_and_classifies_background_llm_calls(client):
     with (
         patch("src.api.activity._list_workflow_runs", AsyncMock(return_value=[])),

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -78,6 +78,7 @@ def test_main_lists_available_scenarios(capsys):
     assert "workflow_composition_behavior" in captured.out
     assert "workflow_approval_threading_behavior" in captured.out
     assert "threaded_operator_timeline_behavior" in captured.out
+    assert "workflow_boundary_blocked_surface_behavior" in captured.out
     assert "capability_repair_behavior" in captured.out
     assert "capability_preflight_behavior" in captured.out
     assert "activity_ledger_attribution_behavior" in captured.out
@@ -190,6 +191,7 @@ def test_runtime_eval_scenarios_expose_expected_details():
                 "workflow_composition_behavior",
                 "workflow_approval_threading_behavior",
                 "threaded_operator_timeline_behavior",
+                "workflow_boundary_blocked_surface_behavior",
                 "capability_repair_behavior",
                 "capability_preflight_behavior",
                 "activity_ledger_attribution_behavior",
@@ -724,6 +726,16 @@ def test_runtime_eval_scenarios_expose_expected_details():
     )
     assert details_by_name["threaded_operator_timeline_behavior"]["intervention_source"] == "native_notification"
     assert details_by_name["threaded_operator_timeline_behavior"]["audit_thread_label"] == "Research thread"
+    assert details_by_name["workflow_boundary_blocked_surface_behavior"]["operator_continue_message_mentions_boundary"] is True
+    assert details_by_name["workflow_boundary_blocked_surface_behavior"]["operator_replay_draft_is_none"] is True
+    assert details_by_name["workflow_boundary_blocked_surface_behavior"]["operator_recommended_actions_empty"] is True
+    assert details_by_name["workflow_boundary_blocked_surface_behavior"]["operator_resume_plan_is_none"] is True
+    assert details_by_name["workflow_boundary_blocked_surface_behavior"]["operator_checkpoint_candidates_empty"] is True
+    assert details_by_name["workflow_boundary_blocked_surface_behavior"]["activity_continue_message_mentions_boundary"] is True
+    assert details_by_name["workflow_boundary_blocked_surface_behavior"]["activity_replay_draft_is_none"] is True
+    assert details_by_name["workflow_boundary_blocked_surface_behavior"]["activity_recommended_actions_empty"] is True
+    assert details_by_name["workflow_boundary_blocked_surface_behavior"]["activity_resume_plan_is_none"] is True
+    assert details_by_name["workflow_boundary_blocked_surface_behavior"]["activity_checkpoint_candidates_empty"] is True
     assert details_by_name["capability_repair_behavior"]["starter_pack_availability"] == "blocked"
     assert "set_tool_policy" in details_by_name["capability_repair_behavior"]["starter_pack_repair_actions"]
     assert "set_tool_policy" in details_by_name["capability_repair_behavior"]["workflow_repair_actions"]

--- a/backend/tests/test_operator_api.py
+++ b/backend/tests/test_operator_api.py
@@ -425,3 +425,92 @@ async def test_operator_timeline_uses_retry_draft_when_no_thread_continue_messag
     payload = resp.json()
     workflow_item = next(item for item in payload["items"] if item["kind"] == "workflow_run")
     assert workflow_item["continue_message"] == "Retry workflow \"retryable-save\" from step \"save\"."
+
+
+@pytest.mark.asyncio
+async def test_operator_timeline_hides_stale_resume_surface_when_workflow_boundary_is_blocked(client):
+    with (
+        patch(
+            "src.api.operator._list_workflow_runs",
+            AsyncMock(
+                return_value=[
+                    {
+                        "id": "run-3",
+                        "workflow_name": "authenticated-brief",
+                        "summary": "Run is blocked by trust-boundary drift.",
+                        "status": "failed",
+                        "started_at": "2026-03-19T10:00:00Z",
+                        "updated_at": "2026-03-19T10:02:00Z",
+                        "thread_id": "session-1",
+                        "thread_label": "Session 1",
+                        "thread_continue_message": "Continue from stale approval.",
+                        "approval_recovery_message": (
+                            "Workflow 'authenticated-brief' changed its trust boundary after this run. "
+                            "Start a fresh run instead of replaying or resuming."
+                        ),
+                        "retry_from_step_draft": "Retry workflow \"authenticated-brief\" from step \"save\".",
+                        "replay_draft": "Replay authenticated workflow",
+                        "replay_allowed": True,
+                        "replay_block_reason": "approval_context_changed",
+                        "replay_recommended_actions": [
+                            {"type": "set_tool_policy", "label": "Allow write_file", "mode": "full"}
+                        ],
+                        "risk_level": "medium",
+                        "execution_boundaries": ["authenticated_external_source", "workspace_write"],
+                        "pending_approval_count": 0,
+                        "resume_from_step": "save",
+                        "resume_checkpoint_label": "Save step",
+                        "run_identity": "session-1:workflow_authenticated_brief:auth-brief",
+                        "run_fingerprint": "auth-brief",
+                        "continued_error_steps": ["save"],
+                        "failed_step_tool": "write_file",
+                        "checkpoint_step_ids": ["search", "save"],
+                        "last_completed_step_id": "search",
+                        "checkpoint_candidates": [
+                            {
+                                "step_id": "save",
+                                "label": "save (write_file)",
+                                "kind": "retry_failed_step",
+                                "status": "continued_error",
+                            },
+                        ],
+                        "branch_kind": "retry_failed_step",
+                        "branch_depth": 0,
+                        "parent_run_identity": None,
+                        "root_run_identity": "session-1:workflow_authenticated_brief:auth-brief",
+                        "resume_plan": {
+                            "resume_from_step": "save",
+                            "draft": "Retry workflow \"authenticated-brief\" from step \"save\".",
+                        },
+                        "availability": "ready",
+                        "step_records": [
+                            {"id": "search", "tool": "web_search", "status": "succeeded"},
+                            {"id": "save", "tool": "write_file", "status": "continued_error"},
+                        ],
+                    }
+                ]
+            ),
+        ),
+        patch("src.api.operator.approval_repository.list_pending", AsyncMock(return_value=[])),
+        patch("src.api.operator.native_notification_queue.list", AsyncMock(return_value=[])),
+        patch("src.api.operator.insight_queue.peek_all", AsyncMock(return_value=[])),
+        patch("src.api.operator.guardian_feedback_repository.list_recent", AsyncMock(return_value=[])),
+        patch("src.api.operator.audit_repository.list_events", AsyncMock(return_value=[])),
+        patch(
+            "src.api.operator.session_manager.list_sessions",
+            AsyncMock(return_value=[{"id": "session-1", "title": "Session 1"}]),
+        ),
+    ):
+        resp = await client.get("/api/operator/timeline", params={"session_id": "session-1", "limit": 8})
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    workflow_item = next(item for item in payload["items"] if item["kind"] == "workflow_run")
+    assert workflow_item["continue_message"].startswith("Workflow 'authenticated-brief' changed its trust boundary")
+    assert workflow_item["replay_draft"] is None
+    assert workflow_item["replay_allowed"] is False
+    assert workflow_item["recommended_actions"] == []
+    assert workflow_item["metadata"]["resume_from_step"] is None
+    assert workflow_item["metadata"]["resume_checkpoint_label"] is None
+    assert workflow_item["metadata"]["checkpoint_candidates"] == []
+    assert workflow_item["metadata"]["resume_plan"] is None

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -2620,6 +2620,109 @@ async def test_workflow_runs_endpoint_blocks_replay_when_approval_context_change
 
 
 @pytest.mark.asyncio
+async def test_workflow_runs_endpoint_hides_repair_actions_when_boundary_drift_blocks_replay(client):
+    recorded_context = {
+        "workflow_name": "web-brief-to-file",
+        "risk_level": "medium",
+        "execution_boundaries": ["external_read", "workspace_write"],
+        "accepts_secret_refs": False,
+        "step_tools": ["web_search", "write_file"],
+    }
+    current_context = {
+        "workflow_name": "web-brief-to-file",
+        "risk_level": "high",
+        "execution_boundaries": ["secret_injection", "workspace_write"],
+        "accepts_secret_refs": True,
+        "step_tools": ["get_secret_ref", "write_file"],
+    }
+
+    with (
+        patch(
+            "src.api.workflows.audit_repository.list_events",
+            return_value=[
+                {
+                    "id": "evt-failed",
+                    "session_id": "session-1",
+                    "event_type": "tool_failed",
+                    "tool_name": "workflow_web_brief_to_file",
+                    "summary": "workflow_web_brief_to_file failed on save",
+                    "created_at": "2026-03-18T12:01:45Z",
+                    "details": {
+                        "workflow_name": "web-brief-to-file",
+                        "run_fingerprint": "web-brief-repair-blocked",
+                        "approval_context": recorded_context,
+                        "step_tools": ["web_search", "write_file"],
+                        "step_records": [
+                            {"id": "search", "tool": "web_search", "status": "succeeded"},
+                            {
+                                "id": "save",
+                                "tool": "write_file",
+                                "status": "failed",
+                                "error_summary": "write_file blocked by policy",
+                            },
+                        ],
+                        "continued_error_steps": ["save"],
+                    },
+                },
+                {
+                    "id": "evt-call",
+                    "session_id": "session-1",
+                    "event_type": "tool_call",
+                    "tool_name": "workflow_web_brief_to_file",
+                    "summary": "Calling workflow",
+                    "created_at": "2026-03-18T12:01:00Z",
+                    "details": {
+                        "run_fingerprint": "web-brief-repair-blocked",
+                        "approval_context": recorded_context,
+                        "arguments": {"query": "seraph", "file_path": "notes/brief.md"},
+                    },
+                },
+            ],
+        ),
+        patch("src.api.workflows.approval_repository.list_pending", return_value=[]),
+        patch(
+            "src.api.workflows.workflow_manager.get_tool_metadata",
+            return_value={
+                "risk_level": "high",
+                "execution_boundaries": ["secret_injection", "workspace_write"],
+                "accepts_secret_refs": True,
+                "approval_context": current_context,
+            },
+        ),
+        patch(
+            "src.api.workflows.workflow_manager.list_workflows",
+            return_value=[
+                {
+                    "name": "web-brief-to-file",
+                    "inputs": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "file_path": {"type": "string", "description": "Output path"},
+                    },
+                    "enabled": True,
+                    "is_available": False,
+                    "missing_tools": ["write_file"],
+                    "missing_skills": [],
+                }
+            ],
+        ),
+        patch(
+            "src.api.workflows.session_manager.list_sessions",
+            return_value=[{"id": "session-1", "title": "Research thread"}],
+        ),
+        patch("src.api.workflows.get_current_tool_policy_mode", return_value="balanced"),
+    ):
+        response = await client.get("/api/workflows/runs?session_id=session-1")
+
+    assert response.status_code == 200
+    run = response.json()["runs"][0]
+    assert run["replay_block_reason"] == "approval_context_changed"
+    assert run["replay_recommended_actions"] == []
+    assert run["step_records"][1]["recovery_actions"] == []
+    assert run["step_records"][1]["recovery_hint"] is None
+    assert run["step_records"][1]["is_recoverable"] is False
+
+
+@pytest.mark.asyncio
 async def test_workflow_runs_endpoint_ignores_approval_context_list_reordering(client):
     recorded_context = {
         "workflow_name": "web-brief-to-file",
@@ -3097,6 +3200,249 @@ async def test_workflow_runs_endpoint_detects_delegated_specialist_context_drift
     assert run["checkpoint_candidates"] == []
     assert run["resume_plan"] is None
     assert run["current_approval_context"]["delegated_specialists"] == ["mcp_github"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_runs_endpoint_detects_delegated_authenticated_credential_source_drift(client):
+    recorded_context = {
+        "workflow_name": "delegated-brief",
+        "risk_level": "high",
+        "execution_boundaries": ["delegation", "external_mcp", "authenticated_external_source"],
+        "accepts_secret_refs": True,
+        "step_tools": ["delegate_task", "write_file"],
+        "delegated_specialists": ["mcp_github"],
+        "authenticated_source": True,
+        "source_systems": [
+            {
+                "server_name": "github",
+                "hostname": "api.github.com",
+                "source": "extension",
+                "authenticated_source": True,
+                "credential_sources": ["vault:github_token"],
+            }
+        ],
+    }
+    current_context = {
+        "workflow_name": "delegated-brief",
+        "risk_level": "high",
+        "execution_boundaries": ["authenticated_external_source", "external_mcp", "delegation"],
+        "accepts_secret_refs": True,
+        "step_tools": ["write_file", "delegate_task"],
+        "delegated_specialists": ["mcp_github"],
+        "authenticated_source": True,
+        "source_systems": [
+            {
+                "server_name": "github",
+                "hostname": "api.github.com",
+                "source": "extension",
+                "authenticated_source": True,
+                "credential_sources": ["env:GITHUB_TOKEN"],
+            }
+        ],
+    }
+    runtime_workflow_tool = SimpleNamespace(
+        name="workflow_delegated_brief",
+        get_approval_context=lambda _arguments: current_context,
+    )
+
+    with (
+        patch(
+            "src.api.workflows.audit_repository.list_events",
+            return_value=[
+                {
+                    "id": "evt-result",
+                    "session_id": "session-1",
+                    "event_type": "tool_result",
+                    "tool_name": "workflow_delegated_brief",
+                    "summary": "workflow_delegated_brief succeeded (2 steps)",
+                    "created_at": "2026-03-18T12:01:45Z",
+                    "details": {
+                        "workflow_name": "delegated-brief",
+                        "run_fingerprint": "delegated-brief-auth-cred",
+                        "approval_context": recorded_context,
+                        "step_tools": ["delegate_task", "write_file"],
+                        "step_records": [],
+                        "artifact_paths": ["notes/brief.md"],
+                        "continued_error_steps": [],
+                    },
+                },
+                {
+                    "id": "evt-call",
+                    "session_id": "session-1",
+                    "event_type": "tool_call",
+                    "tool_name": "workflow_delegated_brief",
+                    "summary": "Calling workflow",
+                    "created_at": "2026-03-18T12:01:00Z",
+                    "details": {
+                        "run_fingerprint": "delegated-brief-auth-cred",
+                        "approval_context": recorded_context,
+                        "arguments": {"query": "seraph", "file_path": "notes/brief.md"},
+                    },
+                },
+            ],
+        ),
+        patch("src.api.workflows.approval_repository.list_pending", return_value=[]),
+        patch(
+            "src.api.workflows.workflow_manager.get_tool_metadata",
+            return_value={
+                "risk_level": "high",
+                "execution_boundaries": ["delegation", "external_mcp", "authenticated_external_source"],
+                "accepts_secret_refs": True,
+                "approval_context": recorded_context,
+            },
+        ),
+        patch("src.api.workflows.get_base_tools_and_active_skills", return_value=([], [], "full")),
+        patch("src.api.workflows.workflow_manager.build_workflow_tools", return_value=[runtime_workflow_tool]),
+        patch(
+            "src.api.workflows.workflow_manager.list_workflows",
+            return_value=[
+                {
+                    "name": "delegated-brief",
+                    "inputs": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "file_path": {"type": "string", "description": "Output path"},
+                    },
+                    "enabled": True,
+                    "is_available": True,
+                    "missing_tools": [],
+                    "missing_skills": [],
+                }
+            ],
+        ),
+        patch(
+            "src.api.workflows.session_manager.list_sessions",
+            return_value=[{"id": "session-1", "title": "Research thread"}],
+        ),
+        patch("src.api.workflows.get_current_tool_policy_mode", return_value="balanced"),
+    ):
+        response = await client.get("/api/workflows/runs?session_id=session-1")
+
+    assert response.status_code == 200
+    run = response.json()["runs"][0]
+    assert run["approval_context_mismatch"] is True
+    assert run["replay_allowed"] is False
+    assert run["replay_block_reason"] == "approval_context_changed"
+    assert run["checkpoint_candidates"] == []
+    assert run["resume_plan"] is None
+    assert run["current_approval_context"]["source_systems"] == [
+        {
+            "server_name": "github",
+            "hostname": "api.github.com",
+            "source": "extension",
+            "authenticated_source": True,
+            "credential_sources": ["env:GITHUB_TOKEN"],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_workflow_runs_endpoint_detects_delegated_tool_inventory_drift(client):
+    recorded_context = {
+        "workflow_name": "delegated-brief",
+        "risk_level": "high",
+        "execution_boundaries": ["delegation", "external_mcp"],
+        "accepts_secret_refs": True,
+        "step_tools": ["delegate_task", "write_file"],
+        "delegated_specialists": ["mcp_github"],
+        "delegated_tool_names": ["mcp_github_issues"],
+    }
+    current_context = {
+        "workflow_name": "delegated-brief",
+        "risk_level": "high",
+        "execution_boundaries": ["external_mcp", "delegation"],
+        "accepts_secret_refs": True,
+        "step_tools": ["write_file", "delegate_task"],
+        "delegated_specialists": ["mcp_github"],
+        "delegated_tool_names": ["mcp_github_issues", "mcp_github_repo"],
+    }
+    runtime_workflow_tool = SimpleNamespace(
+        name="workflow_delegated_brief",
+        get_approval_context=lambda _arguments: current_context,
+    )
+
+    with (
+        patch(
+            "src.api.workflows.audit_repository.list_events",
+            return_value=[
+                {
+                    "id": "evt-result",
+                    "session_id": "session-1",
+                    "event_type": "tool_result",
+                    "tool_name": "workflow_delegated_brief",
+                    "summary": "workflow_delegated_brief succeeded (2 steps)",
+                    "created_at": "2026-03-18T12:01:45Z",
+                    "details": {
+                        "workflow_name": "delegated-brief",
+                        "run_fingerprint": "delegated-brief-tool-inventory",
+                        "approval_context": recorded_context,
+                        "step_tools": ["delegate_task", "write_file"],
+                        "step_records": [],
+                        "artifact_paths": ["notes/brief.md"],
+                        "continued_error_steps": [],
+                    },
+                },
+                {
+                    "id": "evt-call",
+                    "session_id": "session-1",
+                    "event_type": "tool_call",
+                    "tool_name": "workflow_delegated_brief",
+                    "summary": "Calling workflow",
+                    "created_at": "2026-03-18T12:01:00Z",
+                    "details": {
+                        "run_fingerprint": "delegated-brief-tool-inventory",
+                        "approval_context": recorded_context,
+                        "arguments": {"query": "seraph", "file_path": "notes/brief.md"},
+                    },
+                },
+            ],
+        ),
+        patch("src.api.workflows.approval_repository.list_pending", return_value=[]),
+        patch(
+            "src.api.workflows.workflow_manager.get_tool_metadata",
+            return_value={
+                "risk_level": "high",
+                "execution_boundaries": ["delegation", "external_mcp"],
+                "accepts_secret_refs": True,
+                "approval_context": recorded_context,
+            },
+        ),
+        patch("src.api.workflows.get_base_tools_and_active_skills", return_value=([], [], "full")),
+        patch("src.api.workflows.workflow_manager.build_workflow_tools", return_value=[runtime_workflow_tool]),
+        patch(
+            "src.api.workflows.workflow_manager.list_workflows",
+            return_value=[
+                {
+                    "name": "delegated-brief",
+                    "inputs": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "file_path": {"type": "string", "description": "Output path"},
+                    },
+                    "enabled": True,
+                    "is_available": True,
+                    "missing_tools": [],
+                    "missing_skills": [],
+                }
+            ],
+        ),
+        patch(
+            "src.api.workflows.session_manager.list_sessions",
+            return_value=[{"id": "session-1", "title": "Research thread"}],
+        ),
+        patch("src.api.workflows.get_current_tool_policy_mode", return_value="balanced"),
+    ):
+        response = await client.get("/api/workflows/runs?session_id=session-1")
+
+    assert response.status_code == 200
+    run = response.json()["runs"][0]
+    assert run["approval_context_mismatch"] is True
+    assert run["replay_allowed"] is False
+    assert run["replay_block_reason"] == "approval_context_changed"
+    assert run["checkpoint_candidates"] == []
+    assert run["resume_plan"] is None
+    assert run["current_approval_context"]["delegated_tool_names"] == [
+        "mcp_github_issues",
+        "mcp_github_repo",
+    ]
 
 
 @pytest.mark.asyncio
@@ -4062,6 +4408,7 @@ class TestWorkflowSurfaces:
             "hostname": "api.github.com",
             "source": "extension",
             "authenticated_source": True,
+            "credential_sources": ["vault:github_token"],
         }
 
         approval_context = _approval_context_for_workflow(
@@ -4077,6 +4424,7 @@ class TestWorkflowSurfaces:
                 "hostname": "api.github.com",
                 "source": "extension",
                 "authenticated_source": True,
+                "credential_sources": ["vault:github_token"],
             }
         ]
         assert _checkpoint_context_allowed(approval_context) is False
@@ -4139,6 +4487,7 @@ class TestWorkflowSurfaces:
             "hostname": "api.github.com",
             "source": "extension",
             "authenticated_source": True,
+            "credential_sources": ["env:GITHUB_TOKEN", "vault:github_token"],
         }
         github_specialist = SimpleNamespace(name="mcp_github", tools=[mcp_tool])
 
@@ -4153,6 +4502,7 @@ class TestWorkflowSurfaces:
         assert approval_context["risk_level"] == "high"
         assert approval_context["authenticated_source"] is True
         assert approval_context["delegated_specialists"] == ["mcp_github"]
+        assert approval_context["delegated_tool_names"] == ["mcp_github_issues"]
         assert "external_mcp" in approval_context["execution_boundaries"]
         assert "authenticated_external_source" in approval_context["execution_boundaries"]
         assert approval_context["source_systems"] == [
@@ -4161,9 +4511,51 @@ class TestWorkflowSurfaces:
                 "hostname": "api.github.com",
                 "source": "extension",
                 "authenticated_source": True,
+                "credential_sources": ["env:GITHUB_TOKEN", "vault:github_token"],
             }
         ]
         assert _checkpoint_context_allowed(approval_context) is False
+
+    def test_workflow_tool_approval_context_records_delegated_tool_inventory(self):
+        workflow = Workflow(
+            name="delegated-mcp-sync",
+            description="Delegate authenticated source work",
+            inputs={
+                "task": {"type": "string", "required": True},
+                "specialist": {"type": "string", "required": True},
+            },
+            steps=[
+                WorkflowStep(
+                    id="delegate",
+                    tool="delegate_task",
+                    arguments={
+                        "task": "{{ task }}",
+                        "specialist": "{{ specialist }}",
+                    },
+                )
+            ],
+            requires_tools=["delegate_task"],
+        )
+        workflow_tool = WorkflowTool(
+            workflow,
+            {"delegate_task": DummyTool("delegate_task", lambda **_kwargs: "delegated")},
+        )
+        issues_tool = MagicMock()
+        issues_tool.name = "mcp_github_issues"
+        repo_tool = MagicMock()
+        repo_tool.name = "mcp_github_repo"
+        github_specialist = SimpleNamespace(name="mcp_github", tools=[issues_tool, repo_tool])
+
+        with patch("src.agent.specialists.build_all_specialists", return_value=[github_specialist]):
+            approval_context = workflow_tool.get_approval_context(
+                {
+                    "task": "Review the assigned issues.",
+                    "specialist": "mcp_github",
+                }
+            )
+
+        assert approval_context["delegated_specialists"] == ["mcp_github"]
+        assert approval_context["delegated_tool_names"] == ["mcp_github_issues", "mcp_github_repo"]
 
     def test_workflow_metadata_fails_closed_when_delegate_target_is_dynamic(self):
         workflow = Workflow(

--- a/docs/implementation/01-trust-boundaries.md
+++ b/docs/implementation/01-trust-boundaries.md
@@ -340,9 +340,13 @@
   - the workflows runs API already marked trust-boundary drift correctly with `approval_context_changed` and `approval_context_missing`, but it still serialized checkpoint candidates and a concrete `resume_plan` for those same blocked runs
   - that left operator surfaces with stale branch/retry metadata even though `/api/workflows/runs/{run_identity}/resume-plan` would fail closed, which made the API contract less truthful than the runtime boundary
 - scope:
-  - workflow run projection now clears `resume_from_step`, `resume_checkpoint_label`, `checkpoint_candidates`, and `resume_plan` whenever replay is blocked because the trust boundary changed or because the run predates tracked lineage for the current privileged surface
+- workflow run projection now clears `resume_from_step`, `resume_checkpoint_label`, `checkpoint_candidates`, and `resume_plan` whenever replay is blocked because the trust boundary changed or because the run predates tracked lineage for the current privileged surface
+- operator timeline and activity ledger now re-sanitize blocked workflow runs too, so stale replay drafts, checkpoint metadata, and retry actions do not leak back in through downstream surfaces if upstream run payloads ever regress
   - the same fail-closed rule now applies to both completed workflow runs reconstructed from audit events and still-pending runs reconstructed from call state, so the operator surface does not advertise stale continuation paths on either side
   - blocked trust-boundary runs also stop surfacing approval-style thread continuation prompts, so activity and cockpit layers fall back to the recovery message instead of implying that approval alone can unblock the run
+  - blocked trust-boundary runs now also drop stale replay repair and step-recovery actions, so policy-lift or repair suggestions only appear when the run is actually blocked by availability or repair state rather than by privilege drift
+  - delegated and direct authenticated-source workflow approval context now carries credential-source provenance too, so replay and resume checks can detect credential-route drift rather than only server-name drift
+  - delegated workflow approval context now also records delegated tool inventory, so replay and resume checks can detect a widened specialist tool surface even when the specialist name stayed the same
   - pending approvals, repair guidance, and other non-boundary replay blocks still keep their existing branch metadata where that metadata is part of the intended operator contract
 - validation:
   - `python3 -m py_compile backend/src/api/workflows.py backend/tests/test_workflows.py`


### PR DESCRIPTION
Closes #299

## Done on develop
- [x] authenticated-source drift detection and replay/resume fail-closed checks landed for workflow runs
- [x] delegated specialist boundary propagation and extension lifecycle hardening landed across earlier Batch AD slices
- [x] authenticated-source audit provenance and legacy protected-run replay guards are already on `develop`

## Working in this PR
- [ ] preserve delegated credential-source provenance and delegated tool inventory in workflow approval context so delegated boundary drift is detectable
- [ ] clear stale repair, replay, checkpoint, and resume metadata when workflow trust boundaries block replay or resume
- [ ] fail closed in operator and activity workflow surfaces instead of trusting stale upstream continuation metadata
- [ ] add deterministic API coverage plus a runtime eval for blocked trust-boundary workflow surfaces
- [ ] record the shipped boundary truth in implementation docs

## Still to do after this PR
- [ ] move Batch AD to merged/done on the board once this lands
- [ ] start Batch AE from the refreshed roadmap

## Review notes
- [x] fixed a real boundary bug where workflow availability could mask `approval_context_changed`, which would have downgraded trust-boundary drift into a generic availability problem
- [x] fixed a real eval-fixture bug where the blocked-surface scenario used stale timestamps and was filtered out of the activity window
- [x] no unresolved review findings remain after the final validation pass

## Validation
- `python3 -m py_compile backend/src/api/workflows.py backend/src/api/operator.py backend/src/api/activity.py backend/src/evals/harness.py backend/src/workflows/manager.py backend/src/tools/delegate_task_tool.py backend/tests/test_workflows.py backend/tests/test_operator_api.py backend/tests/test_activity_api.py backend/tests/test_eval_harness.py`
- `cd backend && .venv/bin/python -m pytest tests/test_operator_api.py tests/test_activity_api.py -q -k "workflow_boundary_is_blocked"`
- `cd backend && .venv/bin/python -m pytest tests/test_operator_api.py -q -k "workflow_boundary_is_blocked or uses_retry_draft_when_no_thread_continue_message_exists or aggregates_threaded_workflows_notifications_and_repairs"`
- `cd backend && .venv/bin/python -m pytest tests/test_activity_api.py -q -k "workflow_boundary_is_blocked or aggregates_llm_calls_budget_and_threaded_actions"`
- `cd backend && OPENROUTER_API_KEY=test-key WORKSPACE_DIR=/tmp/seraph-test uv run python -m src.evals.harness --scenario workflow_boundary_blocked_surface_behavior --indent 0`
- `cd docs && npm run build`
- `git diff --check`