### PR TITLE
Fix guardian memory benchmark truth surface

### DIFF
--- a/backend/src/api/memory.py
+++ b/backend/src/api/memory.py
@@ -10,6 +10,10 @@ router = APIRouter()
 @router.get("/memory/providers")
 async def list_memory_providers():
     payload = list_memory_provider_inventory()
-    payload["canonical_memory_reconciliation"] = await summarize_memory_reconciliation_state()
-    payload["guardian_memory_benchmark"] = await build_guardian_memory_benchmark_report()
+    reconciliation = await summarize_memory_reconciliation_state()
+    payload["canonical_memory_reconciliation"] = reconciliation
+    payload["guardian_memory_benchmark"] = await build_guardian_memory_benchmark_report(
+        run_suite=False,
+        reconciliation=reconciliation,
+    )
     return payload

--- a/backend/src/evals/harness.py
+++ b/backend/src/evals/harness.py
@@ -4161,6 +4161,7 @@ async def _eval_memory_provider_stale_evidence_behavior() -> dict[str, Any]:
 
 async def _eval_memory_provider_writeback_behavior() -> dict[str, Any]:
     import json
+    import itertools
     import tempfile
     from dataclasses import dataclass, field
     from unittest.mock import AsyncMock
@@ -4323,13 +4324,17 @@ async def _eval_memory_provider_writeback_behavior() -> dict[str, Any]:
         adapter = EvalMemoryProviderAdapter()
         register_memory_provider_adapter(adapter)
         try:
+            vector_ids = itertools.count(1)
             with (
                 patch.object(settings, "workspace_dir", workspace_dir),
                 patch(
                     "src.memory.consolidator.completion_with_fallback",
                     AsyncMock(return_value=mock_resp),
                 ),
-                patch("src.memory.consolidator.add_memory", side_effect=["vec-project", "vec-commitment"]),
+                patch(
+                    "src.memory.consolidator.add_memory",
+                    side_effect=lambda *_args, **_kwargs: f"vec-memory-{next(vector_ids)}",
+                ),
                 patch(
                     "src.memory.consolidator.sync_soul_file_to_profile",
                     AsyncMock(return_value={"Identity": "Builder"}),
@@ -4883,7 +4888,7 @@ async def _eval_memory_engineering_retrieval_benchmark_behavior() -> dict[str, A
                 session_id="memory-engineering-current",
                 user_message="What unblocks issue 399 after PR 405 lands?",
             )
-            report = await build_guardian_memory_benchmark_report()
+            report = await build_guardian_memory_benchmark_report(run_suite=False)
 
     return {
         "engineering_memory_has_issue_reference": "Issue #399" in state.memory_context,
@@ -4978,7 +4983,7 @@ async def _eval_memory_selective_forgetting_surface_behavior() -> dict[str, Any]
             to_memory_id=superseded.memory_id,
             edge_type=MemoryEdgeType.contradicts,
         )
-        report = await build_guardian_memory_benchmark_report()
+        report = await build_guardian_memory_benchmark_report(run_suite=False)
 
     failure_types = {item["type"] for item in report["failure_report"]}
     return {
@@ -4993,7 +4998,34 @@ async def _eval_memory_selective_forgetting_surface_behavior() -> dict[str, Any]
 async def _eval_operator_memory_benchmark_surface_behavior() -> dict[str, Any]:
     from src.api.operator import get_operator_memory_benchmark
 
-    payload = await get_operator_memory_benchmark()
+    suite_summary = EvalSummary(
+        results=[
+            types.SimpleNamespace(
+                name="memory_engineering_retrieval_benchmark_behavior",
+                passed=True,
+                error=None,
+            )
+        ],
+        duration_ms=12,
+    )
+    reconciliation = {
+        "state": "steady",
+        "archived_count": 0,
+        "superseded_count": 0,
+        "recent_conflicts": [],
+        "recent_archivals": [],
+    }
+    with (
+        patch(
+            "src.memory.benchmark._run_guardian_memory_benchmark_suite",
+            AsyncMock(return_value=suite_summary),
+        ),
+        patch(
+            "src.memory.benchmark.summarize_memory_reconciliation_state",
+            AsyncMock(return_value=reconciliation),
+        ),
+    ):
+        payload = await get_operator_memory_benchmark()
     return {
         "suite_name_visible": payload["summary"]["suite_name"] == "guardian_memory_quality",
         "operator_status_visible": payload["summary"]["operator_status"] == "memory_proof_visible",

--- a/backend/src/memory/benchmark.py
+++ b/backend/src/memory/benchmark.py
@@ -143,23 +143,83 @@ def _memory_failure_report(summary: dict[str, Any]) -> list[dict[str, str]]:
     return failures[:6]
 
 
-async def build_guardian_memory_benchmark_report() -> dict[str, Any]:
-    reconciliation = await summarize_memory_reconciliation_state()
-    failure_report = _memory_failure_report(reconciliation)
-    contradiction_state = str(reconciliation.get("state") or "steady")
+def _guardian_memory_suite_failure_report(summary: Any) -> list[dict[str, str]]:
+    failures: list[dict[str, str]] = []
+    for result in getattr(summary, "results", []):
+        if getattr(result, "passed", True):
+            continue
+        failures.append(
+            {
+                "type": "benchmark_regression",
+                "scenario_name": str(getattr(result, "name", "") or "unknown_scenario"),
+                "summary": str(getattr(result, "error", "") or "Guardian memory benchmark scenario failed."),
+                "reason": "deterministic_eval_failure",
+            }
+        )
+    return failures[:6]
+
+
+def _placeholder_guardian_memory_benchmark_summary():
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        total=None,
+        passed=None,
+        failed=0,
+        duration_ms=None,
+        results=[],
+    )
+
+
+async def _run_guardian_memory_benchmark_suite():
+    from src.evals.harness import run_benchmark_suites
+
+    return await run_benchmark_suites([GUARDIAN_MEMORY_BENCHMARK_SUITE_NAME])
+
+
+async def build_guardian_memory_benchmark_report(
+    *,
+    run_suite: bool = True,
+    reconciliation: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    summary = (
+        await _run_guardian_memory_benchmark_suite()
+        if run_suite
+        else _placeholder_guardian_memory_benchmark_summary()
+    )
+    reconciliation_summary = (
+        reconciliation
+        if isinstance(reconciliation, dict)
+        else await summarize_memory_reconciliation_state()
+    )
+    benchmark_failures = _guardian_memory_suite_failure_report(summary) if run_suite else []
+    reconciliation_failures = _memory_failure_report(reconciliation_summary)
+    failure_report = (benchmark_failures + reconciliation_failures)[:6]
+    contradiction_state = str(reconciliation_summary.get("state") or "steady")
+    if run_suite:
+        benchmark_posture = (
+            "ci_gated_operator_visible"
+            if summary.failed == 0
+            else "ci_regressions_detected_operator_visible"
+        )
+        active_failure_count = summary.failed + len(reconciliation_failures)
+    else:
+        benchmark_posture = "suite_contract_visible_not_run"
+        active_failure_count = len(reconciliation_failures)
     return {
         "summary": {
             "suite_name": GUARDIAN_MEMORY_BENCHMARK_SUITE_NAME,
-            "benchmark_posture": "ci_gated_operator_visible",
+            "benchmark_posture": benchmark_posture,
             "operator_status": "memory_proof_visible",
             "scenario_count": len(GUARDIAN_MEMORY_BENCHMARK_SCENARIO_NAMES),
             "dimension_count": len(guardian_memory_benchmark_dimensions()),
             "failure_mode_count": len(guardian_memory_failure_taxonomy()),
-            "active_failure_count": len(failure_report),
+            "active_failure_count": active_failure_count,
             "contradiction_state": contradiction_state,
             "selective_forgetting_state": (
                 "active"
-                if int(reconciliation.get("archived_count") or 0) or int(reconciliation.get("superseded_count") or 0)
+                if int(reconciliation_summary.get("archived_count") or 0)
+                or int(reconciliation_summary.get("superseded_count") or 0)
                 else "steady"
             ),
         },
@@ -168,5 +228,12 @@ async def build_guardian_memory_benchmark_report() -> dict[str, Any]:
         "failure_taxonomy": guardian_memory_failure_taxonomy(),
         "failure_report": failure_report,
         "policy": guardian_memory_benchmark_policy_payload(),
-        "canonical_memory_reconciliation": reconciliation,
+        "latest_run": {
+            "total": summary.total,
+            "passed": summary.passed,
+            "failed": summary.failed,
+            "duration_ms": summary.duration_ms,
+            "executed": run_suite,
+        },
+        "canonical_memory_reconciliation": reconciliation_summary,
     }

--- a/backend/tests/test_memory_benchmark.py
+++ b/backend/tests/test_memory_benchmark.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.memory.benchmark import build_guardian_memory_benchmark_report
+
+
+@pytest.mark.asyncio
+async def test_guardian_memory_benchmark_report_reflects_suite_failures():
+    summary = SimpleNamespace(
+        total=8,
+        passed=7,
+        failed=1,
+        duration_ms=140,
+        results=[
+            SimpleNamespace(
+                name="memory_engineering_retrieval_benchmark_behavior",
+                passed=False,
+                error="engineering continuity retrieval missed approval evidence",
+            )
+        ],
+    )
+    reconciliation = {
+        "state": "steady",
+        "archived_count": 0,
+        "superseded_count": 0,
+        "recent_conflicts": [],
+        "recent_archivals": [],
+    }
+
+    with (
+        patch(
+            "src.memory.benchmark._run_guardian_memory_benchmark_suite",
+            AsyncMock(return_value=summary),
+        ),
+        patch(
+            "src.memory.benchmark.summarize_memory_reconciliation_state",
+            AsyncMock(return_value=reconciliation),
+        ),
+    ):
+        report = await build_guardian_memory_benchmark_report()
+
+    assert report["summary"]["benchmark_posture"] == "ci_regressions_detected_operator_visible"
+    assert report["summary"]["active_failure_count"] == 1
+    assert report["latest_run"]["failed"] == 1
+    assert report["failure_report"][0]["type"] == "benchmark_regression"
+    assert report["failure_report"][0]["scenario_name"] == "memory_engineering_retrieval_benchmark_behavior"
+
+
+@pytest.mark.asyncio
+async def test_guardian_memory_benchmark_report_stays_ci_gated_when_suite_passes():
+    summary = SimpleNamespace(
+        total=8,
+        passed=8,
+        failed=0,
+        duration_ms=92,
+        results=[
+            SimpleNamespace(
+                name="memory_engineering_retrieval_benchmark_behavior",
+                passed=True,
+                error=None,
+            )
+        ],
+    )
+    reconciliation = {
+        "state": "steady",
+        "archived_count": 0,
+        "superseded_count": 0,
+        "recent_conflicts": [],
+        "recent_archivals": [],
+    }
+
+    with (
+        patch(
+            "src.memory.benchmark._run_guardian_memory_benchmark_suite",
+            AsyncMock(return_value=summary),
+        ),
+        patch(
+            "src.memory.benchmark.summarize_memory_reconciliation_state",
+            AsyncMock(return_value=reconciliation),
+        ),
+    ):
+        report = await build_guardian_memory_benchmark_report()
+
+    assert report["summary"]["benchmark_posture"] == "ci_gated_operator_visible"
+    assert report["summary"]["active_failure_count"] == 0
+    assert report["failure_report"] == []
+    assert report["latest_run"]["failed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_guardian_memory_benchmark_report_marks_embedded_mode_as_not_run():
+    reconciliation = {
+        "state": "steady",
+        "archived_count": 0,
+        "superseded_count": 0,
+        "recent_conflicts": [],
+        "recent_archivals": [],
+    }
+
+    with patch(
+        "src.memory.benchmark.summarize_memory_reconciliation_state",
+        AsyncMock(return_value=reconciliation),
+    ):
+        report = await build_guardian_memory_benchmark_report(run_suite=False)
+
+    assert report["summary"]["benchmark_posture"] == "suite_contract_visible_not_run"
+    assert report["summary"]["active_failure_count"] == 0
+    assert report["latest_run"]["executed"] is False
+    assert report["latest_run"]["total"] is None

--- a/backend/tests/test_memory_providers.py
+++ b/backend/tests/test_memory_providers.py
@@ -245,7 +245,13 @@ async def test_memory_provider_inventory_endpoint_lists_configured_additive_prov
     assert payload["canonical_memory_reconciliation"]["policy"]["authoritative_memory"] == "guardian"
     assert payload["canonical_memory_reconciliation"]["recent_conflicts"][0]["summary"] == "Atlas launch delayed"
     assert payload["guardian_memory_benchmark"]["summary"]["suite_name"] == "guardian_memory_quality"
+    assert payload["guardian_memory_benchmark"]["summary"]["benchmark_posture"] == "suite_contract_visible_not_run"
     assert payload["guardian_memory_benchmark"]["policy"]["ci_gate_mode"] == "required_benchmark_suite"
+    assert payload["guardian_memory_benchmark"]["latest_run"]["executed"] is False
+    assert (
+        payload["guardian_memory_benchmark"]["canonical_memory_reconciliation"]
+        == payload["canonical_memory_reconciliation"]
+    )
     assert payload["provenance_taxonomy"][0]["name"] == "guardian_canonical"
     assert payload["adapter_model_rules"][0].startswith("Every provider capability is modeled")
     assert payload["quality_controls"]["project_scoped_buckets"] == [


### PR DESCRIPTION
## Summary
- execute the guardian memory benchmark suite in the live memory benchmark report instead of hard-coding a green CI-gated posture
- prevent self-referential benchmark recursion by using not-run embedded benchmark payloads inside suite-internal and provider inventory surfaces
- add regression coverage for suite pass/fail behavior, embedded not-run truthfulness, and reconciliation consistency in the provider inventory endpoint

Closes #412

## Validation
- `python3 -m py_compile backend/src/memory/benchmark.py backend/src/api/memory.py backend/src/evals/harness.py backend/tests/test_memory_benchmark.py backend/tests/test_memory_providers.py`
- `cd backend && .venv/bin/python -m pytest tests/test_memory_benchmark.py tests/test_eval_harness.py::test_run_benchmark_suites_executes_guardian_memory_quality_suite tests/test_operator_api.py::test_operator_memory_benchmark_surface_reports_failure_taxonomy_and_policy tests/test_memory_providers.py::test_memory_provider_inventory_endpoint_lists_configured_additive_provider -q -o addopts=''`
- `cd backend && .venv/bin/python -c "import asyncio; from src.memory.benchmark import build_guardian_memory_benchmark_report; report = asyncio.run(build_guardian_memory_benchmark_report()); print(report['summary']['benchmark_posture']); print(report['latest_run'])"`
- `git diff --check`

## Review
- `Godel` review attempt timed out
- `Herschel` found 2 real issues in the first draft: embedded `/memory/providers` benchmark payloads still overclaimed a successful run, and the endpoint computed reconciliation twice
- both issues are fixed and covered by regression tests
