### PR TITLE
Regress workflow benchmark summary states

### DIFF
--- a/backend/src/workflows/benchmark.py
+++ b/backend/src/workflows/benchmark.py
@@ -105,12 +105,27 @@ async def _run_workflow_endurance_benchmark_suite():
     return await run_benchmark_suites([WORKFLOW_ENDURANCE_BENCHMARK_SUITE_NAME])
 
 
+def _workflow_endurance_summary_states(healthy: bool) -> dict[str, str]:
+    if healthy:
+        return {
+            "anticipatory_repair_state": "checkpoint_and_pre_repair_visible",
+            "condensation_fidelity_state": "recovery_paths_and_output_history_retained",
+            "branch_continuity_state": "backup_branch_operator_selectable",
+        }
+    return {
+        "anticipatory_repair_state": "regressions_detected",
+        "condensation_fidelity_state": "regressions_detected",
+        "branch_continuity_state": "regressions_detected",
+    }
+
+
 async def build_workflow_endurance_benchmark_report() -> dict[str, Any]:
     summary = await _run_workflow_endurance_benchmark_suite()
     failure_report = _workflow_endurance_failure_report(summary)
+    healthy = summary.failed == 0
     benchmark_posture = (
         "ci_gated_operator_visible"
-        if summary.failed == 0
+        if healthy
         else "ci_regressions_detected_operator_visible"
     )
     return {
@@ -122,9 +137,7 @@ async def build_workflow_endurance_benchmark_report() -> dict[str, Any]:
             "dimension_count": len(workflow_endurance_benchmark_dimensions()),
             "failure_mode_count": len(workflow_endurance_failure_taxonomy()),
             "active_failure_count": summary.failed,
-            "anticipatory_repair_state": "checkpoint_and_pre_repair_visible",
-            "condensation_fidelity_state": "recovery_paths_and_output_history_retained",
-            "branch_continuity_state": "backup_branch_operator_selectable",
+            **_workflow_endurance_summary_states(healthy),
         },
         "scenario_names": list(WORKFLOW_ENDURANCE_BENCHMARK_SCENARIO_NAMES),
         "dimensions": workflow_endurance_benchmark_dimensions(),

--- a/backend/tests/test_operator_api.py
+++ b/backend/tests/test_operator_api.py
@@ -949,6 +949,34 @@ async def test_operator_workflow_endurance_benchmark_surface_reports_policy_and_
 
 
 @pytest.mark.asyncio
+async def test_operator_workflow_endurance_benchmark_surface_degrades_summary_on_failures(client):
+    failing_summary = SimpleNamespace(
+        total=4,
+        passed=2,
+        failed=2,
+        duration_ms=13,
+        results=[
+            SimpleNamespace(
+                passed=False,
+                name="workflow_backup_branch_surface_behavior",
+                error="backup branch regression",
+            )
+        ],
+    )
+
+    with patch("src.workflows.benchmark._run_workflow_endurance_benchmark_suite", AsyncMock(return_value=failing_summary)):
+        resp = await client.get("/api/operator/workflow-endurance-benchmark")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["summary"]["benchmark_posture"] == "ci_regressions_detected_operator_visible"
+    assert payload["summary"]["anticipatory_repair_state"] == "regressions_detected"
+    assert payload["summary"]["condensation_fidelity_state"] == "regressions_detected"
+    assert payload["summary"]["branch_continuity_state"] == "regressions_detected"
+    assert payload["failure_report"][0]["scenario_name"] == "workflow_backup_branch_surface_behavior"
+
+
+@pytest.mark.asyncio
 async def test_operator_trust_boundary_benchmark_surface_reports_policy_and_receipts(client):
     resp = await client.get("/api/operator/trust-boundary-benchmark")
 

--- a/backend/tests/test_workflow_benchmark.py
+++ b/backend/tests/test_workflow_benchmark.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.workflows.benchmark import build_workflow_endurance_benchmark_report
+
+
+@pytest.mark.asyncio
+async def test_workflow_endurance_benchmark_report_degrades_summary_states_on_failures():
+    summary = SimpleNamespace(
+        total=4,
+        passed=3,
+        failed=1,
+        duration_ms=110,
+        results=[
+            SimpleNamespace(
+                name="workflow_condensation_fidelity_behavior",
+                passed=False,
+                error="condensation fidelity regressed",
+            )
+        ],
+    )
+
+    with patch(
+        "src.workflows.benchmark._run_workflow_endurance_benchmark_suite",
+        AsyncMock(return_value=summary),
+    ):
+        report = await build_workflow_endurance_benchmark_report()
+
+    assert report["summary"]["benchmark_posture"] == "ci_regressions_detected_operator_visible"
+    assert report["summary"]["active_failure_count"] == 1
+    assert report["summary"]["anticipatory_repair_state"] == "regressions_detected"
+    assert report["summary"]["condensation_fidelity_state"] == "regressions_detected"
+    assert report["summary"]["branch_continuity_state"] == "regressions_detected"
+    assert report["failure_report"][0]["scenario_name"] == "workflow_condensation_fidelity_behavior"
+
+
+@pytest.mark.asyncio
+async def test_workflow_endurance_benchmark_report_keeps_healthy_summary_states_on_pass():
+    summary = SimpleNamespace(
+        total=4,
+        passed=4,
+        failed=0,
+        duration_ms=88,
+        results=[
+            SimpleNamespace(
+                name="workflow_anticipatory_repair_behavior",
+                passed=True,
+                error=None,
+            )
+        ],
+    )
+
+    with patch(
+        "src.workflows.benchmark._run_workflow_endurance_benchmark_suite",
+        AsyncMock(return_value=summary),
+    ):
+        report = await build_workflow_endurance_benchmark_report()
+
+    assert report["summary"]["benchmark_posture"] == "ci_gated_operator_visible"
+    assert report["summary"]["anticipatory_repair_state"] == "checkpoint_and_pre_repair_visible"
+    assert report["summary"]["condensation_fidelity_state"] == "recovery_paths_and_output_history_retained"
+    assert report["summary"]["branch_continuity_state"] == "backup_branch_operator_selectable"
+    assert report["failure_report"] == []


### PR DESCRIPTION
## Summary
- make workflow-endurance benchmark summary states degrade when the named suite fails instead of only flipping the top-level benchmark posture
- add direct report-builder coverage for healthy vs failing workflow benchmark summaries
- pin the operator endpoint contract so anticipatory repair, condensation fidelity, and branch continuity all report regressions truthfully on red benchmark runs

Closes #414

## Validation
- `python3 -m py_compile backend/src/workflows/benchmark.py backend/tests/test_workflow_benchmark.py backend/tests/test_operator_api.py`
- `cd backend && .venv/bin/python -m pytest tests/test_workflow_benchmark.py tests/test_operator_api.py::test_operator_workflow_endurance_benchmark_surface_reports_policy_and_state tests/test_operator_api.py::test_operator_workflow_endurance_benchmark_surface_degrades_summary_on_failures tests/test_eval_harness.py::test_workflow_endurance_benchmark_surface_behavior_runtime_eval_details tests/test_eval_harness.py::test_run_benchmark_suites_executes_workflow_endurance_and_repair_suite -q -o addopts=''`
- `git diff --check`

## Review
- `Godel` review attempt timed out
- PR claims local verification only
