### PR TITLE
docs: add world-class strategy framework

### DIFF
--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -32,14 +32,15 @@ When these docs are updated on an open feature branch, they describe the intende
 - `docs/implementation/08-docs-contract.md` explains the boundary between research truth and implementation truth.
 - `docs/implementation/09-benchmark-status.md` mirrors the benchmark axes from research as shipped implementation status.
 - `docs/implementation/10-superiority-delivery.md` mirrors the superiority program from research as delivery ownership and implementation translation.
-- `docs/implementation/01` through `07` are the only workstream docs; `08` through `10` are cross-cutting implementation mirrors, not extra workstreams.
+- `docs/implementation/11-world-class-strategy-delivery.md` mirrors the cross-cutting world-class strategy translation as delivery rules.
+- `docs/implementation/01` through `07` are the only workstream docs; `08` through `11` are cross-cutting implementation mirrors, not extra workstreams.
 - if research adds a new benchmark/program layer without an implementation mirror, the docs are incomplete.
 - active execution state belongs in the GitHub Project, issues, and PRs rather than this document
 
 ## Current Status
 
 Read this roadmap together with [Development Status](./STATUS.md).
-For the implementation-side mirrors of the evidence, benchmark, and superiority layers, also read [08. Docs Contract](./08-docs-contract.md), [09. Benchmark Status](./09-benchmark-status.md), and [10. Superiority Delivery](./10-superiority-delivery.md).
+For the implementation-side mirrors of the evidence, benchmark, superiority, and world-class strategy layers, also read [08. Docs Contract](./08-docs-contract.md), [09. Benchmark Status](./09-benchmark-status.md), [10. Superiority Delivery](./10-superiority-delivery.md), and [11. World-Class Strategy Delivery](./11-world-class-strategy-delivery.md).
 
 Legend for the checklist column:
 
@@ -531,7 +532,7 @@ This was the major Guardian Intelligence execution program after the first-pass 
 6. Embodied Interface
 7. Ecosystem And Delegation
 
-Implementation docs `08` through `10` are supporting mirror layers for this roadmap, not additional workstreams.
+Implementation docs `08` through `11` are supporting mirror layers for this roadmap, not additional workstreams.
 
 ## Stable Interfaces Outside This Transition
 
@@ -612,7 +613,7 @@ Implementation docs `08` through `10` are supporting mirror layers for this road
 
 1. Read [Development Status](./STATUS.md) for the live shipped vs unfinished view.
 2. Read this file for workstream ordering and current scope.
-3. Read [08. Docs Contract](./08-docs-contract.md), [09. Benchmark Status](./09-benchmark-status.md), and [10. Superiority Delivery](./10-superiority-delivery.md) for the implementation-side mirrors of the research benchmark/program docs.
+3. Read [08. Docs Contract](./08-docs-contract.md), [09. Benchmark Status](./09-benchmark-status.md), [10. Superiority Delivery](./10-superiority-delivery.md), and [11. World-Class Strategy Delivery](./11-world-class-strategy-delivery.md) for the implementation-side mirrors of the research benchmark/program docs and cross-cutting strategy translation.
 4. Read `01` through `07` for detailed per-workstream checklists.
 5. Read the research docs for the benchmark and superiority target.
 6. Treat `/legacy` docs as supporting history, not the live source of truth.

--- a/docs/implementation/08-docs-contract.md
+++ b/docs/implementation/08-docs-contract.md
@@ -35,6 +35,7 @@ If a major concept appears in research but not implementation, or vice versa, th
 - [x] `docs/implementation/00-master-roadmap.md` owns the strategic implementation program, completed-program record, and workstream-to-gap translation
 - [x] `docs/implementation/09-benchmark-status.md` mirrors the benchmark on shipped implementation terms
 - [x] `docs/implementation/10-superiority-delivery.md` mirrors the superiority program on delivery terms
+- [x] `docs/implementation/11-world-class-strategy-delivery.md` mirrors the cross-cutting world-class strategy translation on delivery terms
 - [x] the GitHub Project owns execution state
 - [x] GitHub issues and PRs own active work tracking, review state, and merge state
 - [x] `docs/docs/` owns historical/archive material that is no longer current truth
@@ -44,7 +45,7 @@ If a major concept appears in research but not implementation, or vice versa, th
 - [x] If research adds a new benchmark or program layer, implementation needs a mirror doc in the same PR.
 - [x] If implementation changes shipped truth, update `STATUS.md`, the owning workstream file, and any affected mirror docs in the same PR.
 - [x] If active execution state changes, update the GitHub Project, issue, or PR instead of mirroring that state in docs.
-- [x] If the strategic implementation program changes materially, update the roadmap and any affected mirror docs in the same PR.
+- [x] If the strategic implementation program or cross-cutting strategy translation changes materially, update the roadmap and any affected mirror docs in the same PR.
 - [x] Open PRs, review state, and branch state belong in issues, PRs, and the GitHub Project, not in docs that claim to describe `develop`.
 
 ## Project Workflow
@@ -129,7 +130,7 @@ Use this as the default execution model when several internal slices will land t
 - [x] Every implementation workstream should link to its paired research doc or docs.
 - [x] Research should not carry a stale duplicate of GitHub execution state.
 - [x] Implementation should not make benchmark or superiority claims without a research-side source.
-- [ ] The trees are only “in parity” when a reader can move from synthesis -> benchmark/program -> shipped implementation without guessing which file owns what.
+- [ ] The trees are only “in parity” when a reader can move from synthesis -> benchmark/program -> shipped implementation -> cross-cutting strategy mirror without guessing which file owns what.
 
 ## Acceptance Checklist
 

--- a/docs/implementation/11-world-class-strategy-delivery.md
+++ b/docs/implementation/11-world-class-strategy-delivery.md
@@ -1,0 +1,113 @@
+---
+title: 11. World-Class Strategy Delivery
+---
+
+# 11. World-Class Strategy Delivery
+
+## Status On `develop`
+
+- [ ] The world-class strategy is only partially translated into shipped implementation on `develop`.
+
+## Paired Research
+
+- design source of truth: [11. Superiority Program](/research/superiority-program)
+- benchmark input: [10. Competitive Benchmark](/research/competitive-benchmark)
+- canonical strategy source of truth: [17. Seraph World-Class Strategy](/research/seraph-world-class-strategy)
+- synthesis context: [00. Research Synthesis](/research)
+
+## Purpose
+
+This file is the implementation-side mirror for the world-class Seraph strategy.
+
+It translates strategy into delivery rules without time-boxed roadmaps.
+
+Active execution remains in the GitHub Project, issues, and PRs. This doc only explains how implementation should be prioritized, proven, and bounded on `develop`.
+
+## Priority Model
+
+Priority is a leverage model, not a calendar model.
+
+- `P0`: must ship to defend the core moat or the core trust boundary; if it is missing, broader leverage compounds the wrong thing.
+- `P1`: major strategic leverage that sharpens the moat, broadens power-user value, or removes a meaningful execution bottleneck.
+- `P2`: important product quality, control-surface, or reach expansion work that improves the system but should not outrank the moat or trust layers.
+- `Guardrail Product Boundary Discipline`: the named non-negotiable guardrail that keeps the strategy coherent; safety, audit, boundary, and proof constraints must hold across all priorities and any item that does not strengthen a named pillar should be rejected, deferred, or reframed.
+
+## P0 Guardian Intelligence Moat
+
+Implementation meaning: Seraph should keep becoming better at durable judgment, project continuity, selective attention, and long-horizon operator support than a generic assistant can be.
+
+- shipped foundations: persistent guardian state, memory, observer synthesis, project and continuity modeling, learning signals, contradiction-aware world-model arbitration, watchpoints, and the first governed additive memory-provider lane
+- missing strategic gaps: deeper long-horizon learning loops, stronger project arbitration under sparse or conflicting evidence, more faithful reuse of continuity across sessions and threads, and stronger additive memory-provider follow-through without replacing canonical guardian memory
+- proof requirements: benchmark coverage for long-horizon recall and judgment, repeatable demos that show continuity surviving session churn, and explicit receipts that live evidence can override stale procedural bias when it should
+
+## P0 Trusted Intelligence and Trusted Execution
+
+Implementation meaning: Seraph should infer locally first, move into an attested TEE lane when the task deserves it, fall back to redacted cloud execution only when needed, and keep every tool/action path isolated from unnecessary privilege.
+
+- shipped foundations: approvals, audit logging, secret redaction, secret-reference containment, sandboxed execution, background-process partitioning, disposable worker roots, credential-egress allowlists, managed connector boundary metadata, and replay drift blocking on privileged surfaces
+- missing strategic gaps: broader host-grade isolation, stricter enforcement across future delegated/background/browser/provider paths, deeper credential-egress discipline for connector and browser work, and clearer tool/action separation for the routes that can mutate state
+- proof requirements: boundary-specific evals for browser, connector, delegation, background, and provider fallback paths; operator-visible audit receipts; and fail-closed behavior when a path cannot prove it stayed within its trust envelope
+
+TEEs are helpful, but they do not solve prompt injection or unsafe tool execution by themselves.
+
+Existing trust-drift blocking should be deepened and generalized across future delegated/background/browser/provider paths, not treated as a missing foundation.
+
+## P1 Capabilities And Extension Discipline
+
+Implementation meaning: extension capability should stay typed, governable, and easy to reason about, with clear core-vs-extension boundaries and a stable capability taxonomy.
+
+- shipped foundations: skills, MCP, starter packs, extension lifecycle, package health, capability discovery, managed connectors, typed source adapters, and cockpit-visible operator control over packaged capability surfaces
+- missing strategic gaps: stronger typed extension contracts across all extension kinds, more explicit managed-connector governance, clearer version and compatibility semantics, and a stable taxonomy that keeps core features separate from extension contributions
+- proof requirements: manifest and lifecycle validation, compatibility and enable/disable receipts, connector and extension health proofs, and operator surfaces that show why a capability exists, where it came from, and what trust level it carries
+
+## P1 Supervised Workflow Operating Layer
+
+Implementation meaning: Seraph should operate long-running work as a supervised system, not as isolated run executions.
+
+- shipped foundations: workflow history, step records, branch-family supervision, typed artifact handoff, checkpoint-truthful resume/branch control, workspace-level orchestration, live operator timelines, activity ledgers, and background-session continuity
+- missing strategic gaps: deeper step-level control, richer multi-session supervision, more complete lineage and checkpoint control, and stronger recovery/repair surfaces for long-running work
+- proof requirements: deterministic workflow-endurance and supervision evals, inspectable branch and recovery receipts, and operator flows that can continue, compare, repair, or branch without reconstructing context manually
+
+## P1 Benchmark And Proof System
+
+Implementation meaning: no strategic claim should be considered real unless the implementation, the benchmark, and the operator demo all agree.
+
+- shipped foundations: deterministic runtime evals, named benchmark suites for memory, workflow endurance, trust boundaries, computer use, and governed improvement, plus operator-readable receipts for several key execution seams
+- missing strategic gaps: broader live-provider and real-world integration proof, stronger coverage for future delegated and browser paths, and more repeatable proof surfaces for claims that would otherwise stay aspirational
+- proof requirements: every major strategy item needs an explicit benchmark, a concrete operator-visible demo path, and a traceable implementation receipt on `develop`
+
+## P2 Cockpit Legibility And Control
+
+Implementation meaning: the operator surface should stay obvious, dense, and fast enough that the user can understand what Seraph is doing without hunting across panes.
+
+- shipped foundations: browser cockpit, command surfaces, activity ledger, operator terminal, workflow supervision views, live feed, and active triage
+- missing strategic gaps: denser control over complex flows, better cross-surface explanation of system state, and more direct actions for recovery, comparison, and follow-through
+- proof requirements: cockpit tasks should be inspectable without source diving, common operator moves should stay keyboard-first, and the surface should make trust and execution state legible at a glance
+
+## P2 Selective Reach
+
+Implementation meaning: Seraph should expand beyond the browser only where the additional channel improves leverage, trust, or continuity.
+
+- shipped foundations: browser-native continuity, desktop presence, messaging and connector surfaces, and typed reach/adaptor inventory
+- missing strategic gaps: broader but selective non-browser reach, clearer operator control over which channels are active, and stronger continuity across the channels that matter most
+- proof requirements: each added reach surface should justify its trust cost, demonstrate a clear use case, and preserve continuity rather than fragmenting it
+
+## Guardrail Product Boundary Discipline
+
+- do not turn active execution into a doc-tracked queue; GitHub Project items, issues, and PRs own that state
+- do not treat time as the organizing principle; priority, moat, proof, and trust boundary are the organizing principles
+- do not ship a roadmap item without a named pillar, a competitor or capability gap, a moat effect, a proof or eval plan, a trust boundary, and an operator surface
+- do not treat TEEs as a complete safety story; keep approvals, audit, sandboxing, and tool isolation as first-class constraints
+- do not reclassify already-shipped trust-drift blocking as missing work; deepen and generalize the existing receipts across future delegated/background/browser/provider paths instead
+- do not let extension growth blur the line between core platform behavior and extension-owned behavior
+
+## Acceptance Rules For Future Roadmap Items
+
+Future roadmap items should be accepted only when they clearly answer all of the following:
+
+- pillar: which strategic pillar does this belong to?
+- gap: which competitor gap or internal weakness does it close?
+- moat: how does it strengthen Guardian Intelligence, Trusted Execution, or another durable advantage?
+- proof: what benchmark, eval, or repeatable demo will prove it?
+- trust boundary: what new or existing boundary does it touch?
+- operator surface: where will an operator see, control, or verify it?

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -31,6 +31,7 @@ When this file is updated on an open feature branch, it reflects the intended po
 - [x] Seraph now also fails closed on field-scoped secret-reference injection and connector-backed authenticated mutation payloads: tool metadata surfaces explicit `secret_ref_fields`, runtime secret refs only resolve on declared injection-safe fields, and managed write actions reject undeclared payload keys instead of forwarding arbitrary connector arguments.
 - [x] Seraph now also binds managed background-process recovery to the originating session: process list, output-read, and stop surfaces fail closed outside that session instead of leaving long-running helper recovery broadly discoverable.
 - [x] Seraph now also runs direct command and managed background-process execution inside disposable worker roots outside the workspace, requires explicit credential-egress allowlists before secret-bearing MCP execution can cross a connector boundary, and keeps delegated/workflow/operator trust receipts truthful about connector-egress plus branch-handoff partitions instead of flattening them back to a generic session surface.
+- [x] `docs/implementation/11-world-class-strategy-delivery.md` now translates the world-class strategy into delivery rules, while active execution remains in the GitHub Project, issues, and PRs.
 - [x] Seraph now also has a governed self-evolution loop for declarative capability assets: `/api/evolution` plus `propose_capability_evolution` can generate eval-scored review candidates for skills, runbooks, starter packs, and prompt packs, persist review receipts inside the managed workspace package, and block semantic drift or privileged prompt-surface expansion before anything reaches human PR review.
 - [x] Governed self-evolution receipts now also carry explicit change summaries and review-risk notes, so saved candidates and PR drafts explain why a variant still needs human review instead of only returning raw blocked/pass constraints.
 - [x] Governed self-improvement now also blocks obvious preference-collapse drift, carries explicit canary-only and rollback-ready benchmark-gate receipts on saved candidates, and exposes recent saved proposal receipts through the operator benchmark surface instead of treating candidate generation alone as proof.
@@ -73,8 +74,8 @@ When this file is updated on an open feature branch, it reflects the intended po
 - [x] `docs/research/11-superiority-program.md` owns the design-level superiority program.
 - [x] this file owns the fastest shipped snapshot on `develop`.
 - [x] `docs/implementation/00-master-roadmap.md` owns the strategic implementation program and completed-program record.
-- [x] `docs/implementation/08-docs-contract.md`, `docs/implementation/09-benchmark-status.md`, and `docs/implementation/10-superiority-delivery.md` are the implementation-side mirrors of the research evidence/benchmark/program docs.
-- [x] `docs/implementation/01` through `07` remain the workstream docs; `08` through `10` are meta mirrors, not extra workstreams.
+- [x] `docs/implementation/08-docs-contract.md`, `docs/implementation/09-benchmark-status.md`, `docs/implementation/10-superiority-delivery.md`, and `docs/implementation/11-world-class-strategy-delivery.md` are the implementation-side mirrors of the research evidence, benchmark, program, and cross-cutting strategy layers.
+- [x] `docs/implementation/01` through `07` remain the workstream docs; `08` through `11` are meta mirrors, not extra workstreams.
 - [x] the GitHub Project, issues, and PRs own active execution and review state.
 
 ## Current Focus On `develop`
@@ -97,6 +98,7 @@ When this file is updated on an open feature branch, it reflects the intended po
 - [x] The cockpit desktop shell, presence pane, and active triage now also surface explicit presence-surface ready/attention summaries plus direct repair/follow-up drafts for messaging, adapter, and observer surfaces, so broader non-browser reach no longer hides behind route-only health or catalog inventory views.
 - [x] Runtime Reliability now has deterministic proof for activity-ledger attribution, imported capability surfaces, and simulation-grade route-planning visibility in addition to the earlier guardian/runtime contracts.
 - [x] The repo-wide strategic program is tracked in `docs/implementation/00-master-roadmap.md`, while active execution is tracked in the GitHub Project, issues, and PRs.
+- [x] The cross-cutting world-class strategy translation is tracked in `docs/implementation/11-world-class-strategy-delivery.md`.
 - [x] The next strategic focus is now post-import hardening: deeper execution isolation beyond the new field-scoped secret-ref, mutation-allowlist, and session-bound process-recovery layer, denser operator/debug ergonomics, production-grade reach hardening, and stronger guardian learning on top of the expanded capability surface.
 
 ## Current Target Shape

--- a/docs/research/00-synthesis.md
+++ b/docs/research/00-synthesis.md
@@ -97,6 +97,7 @@ Seraph should be judged against OpenClaw, Hermes, and IronClaw on explicit axes:
 
 ## Implementation Mapping
 
+- The canonical strategy and priority stack live in [17. Seraph World-Class Strategy](./17-seraph-world-class-strategy.md).
 - Research 01 and 02 map to Workstream 05 in `docs/implementation/05-guardian-intelligence.md`
 - Research 03 maps to Workstream 03 in `docs/implementation/03-runtime-reliability.md`
 - Research 04 maps to Workstream 01 in `docs/implementation/01-trust-boundaries.md`

--- a/docs/research/17-seraph-world-class-strategy.md
+++ b/docs/research/17-seraph-world-class-strategy.md
@@ -1,0 +1,204 @@
+---
+title: 17. Seraph World-Class Strategy
+---
+
+# 17. Seraph World-Class Strategy
+
+## Purpose
+
+This is the canonical strategy document for Seraph becoming the strongest guardian agent for a power-user operator.
+
+It does not define a calendar roadmap. It defines the priority stack, moat logic, proof requirements, and product boundary rules that should govern every future decision.
+
+Use this document with:
+
+- [00. Research Synthesis](./00-synthesis.md)
+- [10. Competitive Benchmark](./10-competitive-benchmark.md)
+- [11. Superiority Program](./11-superiority-program.md)
+- [12. Plugin System And MCP Strategy](./12-plugin-system-and-mcp-strategy.md)
+- [13. Hermes And OpenClaw Capability Import Plan](./13-hermes-and-openclaw-capability-import-plan.md)
+- [14. Seraph Memory SOTA Roadmap](./14-seraph-memory-sota-roadmap.md)
+- [16. Seraph State And Roadmap Corrections 2026-04](./16-seraph-state-and-roadmap-corrections-2026-04.md)
+
+## Locked Product Shape
+
+Seraph is a **power-user guardian workspace**.
+
+That means:
+
+- single-operator-first by default
+- dense operator legibility over generic consumer polish
+- long-horizon memory, intervention quality, and safe execution over one-shot chat competence
+- team/operator governance as an extension path, not the category center
+- supervision, approvals, audit, and recovery as first-class product behavior
+
+Seraph is not trying to become:
+
+- a generic AI OS
+- a gateway-first bot platform
+- a village, game, or editor revival
+- a plugin soup product where capability breadth outruns trust and legibility
+
+## Strategy Thesis
+
+The world-class path for Seraph is to become the best supervised guardian workspace for one serious operator, then extend that model outward through governed collaboration and selective reach.
+
+The moat is not just model quality. The moat is the combination of:
+
+- durable guardian intelligence
+- trusted intelligence and execution
+- disciplined capability import
+- supervised workflow operation
+- benchmark-grade proof
+- cockpit legibility and control
+- selective reach
+
+## Priority Pillars
+
+### P0. Guardian Intelligence Moat
+
+This is the core product moat.
+
+Seraph should build the strongest possible living model of the human, their work, their commitments, their constraints, their collaborators, their routines, and their intervention preferences.
+
+The moat lives in:
+
+- longitudinal memory that improves over time
+- contradiction-aware world modeling
+- interruption, cadence, channel, and restraint judgment
+- intervention timing and intervention quality
+- state that is useful even when the model is uncertain
+
+The competitor gap to close is not "more memory objects." It is better guardian judgment.
+
+### P0. Trusted Intelligence and Trusted Execution
+
+This is the trust moat.
+
+Seraph should prefer local-first LLM execution where feasible, use attested TEE inference for sensitive high-capability remote workloads, and fall back to redacted cloud execution only when that tradeoff is acceptable.
+
+The trust contract must also include:
+
+- strict tool and action isolation
+- approval gates for risky or privileged work
+- audit and replay integrity
+- credential-egress controls
+- resume and retry behavior that preserves trust boundaries
+- explicit provenance for what ran, where it ran, and what it was allowed to touch
+
+NEAR AI Cloud and TEEs are a strategic lane worth tracking, but they should be treated as a privacy and verifiability lane, not as a complete safety solution.
+
+TEEs can strengthen confidentiality and attestability. They do not replace policy, least privilege, approval, or audit.
+
+### P1. Capabilities and Extension Discipline
+
+Seraph should compound capability without turning into plugin soup.
+
+The extension model must stay disciplined:
+
+- core vs extension boundaries must stay explicit
+- typed extensions should be the default shape
+- MCP should be governed, not treated as a free-for-all
+- managed connectors should exist for high-value, high-trust integrations
+- capability taxonomy should remain clear enough that operators understand what class of thing they are enabling
+
+The rule is simple:
+
+- core owns trust, policy, approvals, audit, memory authority, and execution boundaries
+- extensions contribute reusable capabilities inside those boundaries
+- connectors adapt external systems without collapsing the product into provider-specific pipelines
+
+### P1. Supervised Workflow Operating Layer
+
+Seraph should become a supervised operating layer for long-running work, not just a chat surface that happens to call tools.
+
+That means the product must excel at:
+
+- branch, repair, checkpoint, resume, and continue flows
+- delegated work with trust partitions
+- background work with visible ownership
+- artifact handoff and workflow recovery
+- operator supervision across multiple sessions and threads
+
+The goal is a workspace where one operator can safely run complex work over time without losing control, context, or trust.
+
+### P1. Benchmark And Proof System
+
+Seraph should only make superiority claims when proof exists.
+
+Every serious product claim should have:
+
+- a competitor gap
+- a moat explanation
+- a repeatable eval or benchmark
+- a trust boundary description
+- a cockpit/operator surface that exposes the claim
+
+Proof must include more than static documentation. It should include deterministic suites, replayable scenarios, longitudinal checks, and operator-visible receipts that show the claim is real on `develop`.
+
+### P2. Cockpit Legibility And Control
+
+The cockpit should be the best supervised-agent control surface in the category.
+
+That means:
+
+- clear evidence before action
+- visible trust boundaries
+- direct approval and recovery control
+- branch and comparison tools that reduce operator burden
+- fast inspection of what happened, why it happened, and how to fix it
+
+Density is only useful if it improves operator speed, confidence, and recovery.
+
+### P2. Selective Reach
+
+Seraph should extend beyond the browser only where reach increases guardian value.
+
+Selective reach means:
+
+- choose channels that improve intervention timing, continuity, or execution
+- prefer managed connectors over uncontrolled sprawl
+- keep channel growth subordinate to the guardian workspace
+- avoid broad platform expansion unless it clearly strengthens the moat
+
+### Guardrail. Product Boundary Discipline
+
+This is the guardrail that keeps the strategy coherent.
+
+If a proposed item does not strengthen one of the priority pillars, it should be rejected, deferred, or reframed.
+
+If it does not improve one of these surfaces, it is probably not strategic:
+
+- guardian intelligence
+- trusted execution
+- extension discipline
+- supervised workflow operation
+- benchmark proof
+- cockpit control
+- selective reach
+
+## Roadmap Item Contract
+
+Every roadmap item should answer all of these questions before it is accepted:
+
+1. Which pillar does this support?
+2. Which competitor gap does it close?
+3. What moat does it strengthen?
+4. What proof or eval will show it worked?
+5. What trust boundary does it touch?
+6. What cockpit or operator surface exposes it?
+
+If any answer is vague, the item is not ready.
+
+## Strategic Implications
+
+The report memo and the surrounding research point to the same conclusion:
+
+- Seraph should stay disciplined about category shape
+- trusted execution is a first-class moat, not a side feature
+- workflows and delegation should become a supervised operating layer
+- selective reach beats broad reach
+- capability import must stay typed and governed
+- superiority claims must be benchmarked, not assumed
+
+That is the strategy for becoming the greatest guardian agent in the world: win the guardian loop, win the trust loop, win the workflow loop, and prove it.

--- a/docs/seraph_raport.md
+++ b/docs/seraph_raport.md
@@ -1,0 +1,342 @@
+This memo is research input, not canonical roadmap; canonical strategy lives in `docs/research/17-seraph-world-class-strategy.md` and implementation delivery mirror in `docs/implementation/11-world-class-strategy-delivery.md` once those exist.
+
+I inspected Seraph through its official repo docs plus raw source files, then compared that against official Hermes and OpenClaw docs and IronClaw’s README / feature-parity docs. The short version is:
+
+**Seraph should become the best supervised guardian workspace for a single operator first, with team/operator governance as the expansion path.** The product should be judged on memory, intervention quality, real execution, legibility, workflow composition, dense interface efficiency, and selective reach, not generic model benchmarks. That framing is already explicit in Seraph’s own research and README. ([GitHub][1])
+
+## Executive summary
+
+Seraph’s strongest real asset is **not** broad tool count. It is the fact that the repo already wires together an explicit guardian loop: structured guardian state, a world model and user-model profile, contradiction-aware memory retrieval, scoped feedback learning, explicit intervention policy, workflow continuity/branching, approvals/audit, and an unusually dense operator cockpit. That combination is much closer to a real guardian workspace than the more common chat shell, gateway, or plugin hub patterns. ([GitHub][2])
+
+Seraph is behind Hermes, OpenClaw, and IronClaw mainly on **execution breadth and reach**. Hermes docs-claim a much broader runtime surface with many tools, multiple terminal backends, browser providers, cron, isolated subagents, voice, messaging, and broader platform reach. OpenClaw docs-claim the strongest gateway/control-plane and channel-routing story, plus browser modes, sandboxing, nodes, and voice/talk surfaces. IronClaw looks narrower than OpenClaw, but its repo-backed parity docs and README make it the clearest security-first competitor, with WASM sandboxing, credential protection, prompt-injection defenses, allowlisting, and defense-in-depth. The numeric breadth claims in those docs should be treated as docs-claimed until this memo cites exact source lines. ([hermes-agent.nousresearch.com][3])
+
+So the winning strategy is not “copy everything.” It is: **double down on the guardian moat, close the trust-boundary gap, turn the cockpit into the best supervised-agent control surface in the category, add only selective high-value connectors/reach, and publish benchmark proof that matches the product promise.** Seraph’s own implementation docs already say it cannot yet credibly claim broad superiority from shipped implementation alone, which is exactly right. The job now is to make its specific category superiority undeniable. ([GitHub][4])
+
+The biggest trap to avoid is becoming a generic “AI OS,” a gateway-first multi-channel platform, or an unrestricted plugin marketplace. Seraph’s own docs explicitly reject reviving the village/editor line and reject OpenClaw-style unrestricted in-process plugin runtime, provider/plugin sprawl, gateway-first framing, and open executable extension distribution without much stronger trust controls. That restraint is strategically correct. ([GitHub][5])
+
+## 1) Seraph’s target category and user promise
+
+**Target category:** **single-operator-first power-user guardian workspace, with team/operator governance as the expansion path.**
+
+That is the cleanest fit with the repo. Seraph’s own synthesis locks the product direction to a **power-user guardian workspace**, and the README describes a workspace-first agent with persistent identity, long-term memory, proactive reviews/intervention policy, reusable workflows, a browser cockpit, and optional desktop awareness. ([GitHub][1])
+
+Why this category, and not the others:
+
+* **Not “team operator console” first.** Seraph does have docs-backed team-control-plane language, but the distinctive architecture is still personalized modeling, intervention timing, and individual continuity. Team features should be an expansion path, not the category label. ([GitHub][5])
+* **Not “autonomous workflow runtime” first.** Seraph already has workflow machinery, but the core product logic is supervised operation: approvals, audit, intervention policy, operator receipts, and cockpit legibility. That is a guardian workspace, not a hidden automation engine. ([GitHub][6])
+* **Not “personal AI OS.”** That label invites breadth/platform traps. Seraph’s docs explicitly narrow the ambition to a guardian workspace and reject gateway-first/plugin-sprawl patterns. ([GitHub][1])
+
+**User promise:**
+*“Seraph keeps an evidence-backed living model of you and your work, notices what matters, intervenes with good timing, safely executes approved actions, and always shows you what it believed, why it acted, and how to recover.”* This is the promise implied by Seraph’s own benchmark axes and guardian loop. ([GitHub][1])
+
+## 2) Current-state map of Seraph, with GitHub evidence
+
+### A. Code-backed strengths
+
+* **Guardian intelligence is real, not just a README claim.** [guardian/state.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/guardian/state.py) builds an explicit guardian-state object, and [guardian/world_model.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/guardian/world_model.py) carries fields for focus, commitments, blockers, collaborators, routines, obligations, timeline, user-model profile, corroboration sources, stale-signal arbitration, and judgment risks. This is unusually aligned with the guardian category. ([GitHub][2])
+
+* **Memory is already more advanced than simple “chat history + vector DB.”** [memory/hybrid_retrieval.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/memory/hybrid_retrieval.py) combines semantic, episodic, linked-project, and vector hits, applies recency and active-project boosts, and suppresses lower-ranked contradictions. [memory/providers.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/memory/providers.py) makes external providers additive only, with canonical guardian memory authoritative, read-augment-only retrieval, advisory user-model overlays, post-canonical guarded writeback, and stale/irrelevant provider suppression. ([GitHub][7])
+
+* **Intervention timing is an explicit policy surface.** [observer/intervention_policy.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/observer/intervention_policy.py) makes deliver / bundle / defer / request-approval / stay-silent decisions based on urgency, confidence, user state, interruption cost, attention budget, scheduled instability, and learned timing/channel/suppression biases. [guardian/feedback.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/guardian/feedback.py) stores scoped learning signals across phrasing, cadence, channel, escalation, timing, blocked-state, and thread-preference axes, then refreshes learning memories on outcome/feedback updates. ([GitHub][8])
+
+* **Delivery is not a thin “send notification” wrapper.** [observer/delivery.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/observer/delivery.py) is a single proactive-message coordinator that reads current context, calls the intervention policy, supports websocket and native-notification transports, discovers active channel adapters, bundles items, and records intervention outcomes for learning. ([GitHub][9])
+
+* **Workflow continuity is a genuine differentiator.** [workflows/manager.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/workflows/manager.py) records resume-from-step, branch kind/depth, checkpoint context allowance, artifact paths, continued-error steps, risk level, and execution boundaries. That is exactly the substrate you need for a guardian that can continue, repair, or safely hand off real work instead of resetting every time. ([GitHub][10])
+
+* **Trust controls are present, but not yet enough to declare category leadership.** [agent/factory.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/agent/factory.py) wraps tools and MCP tools with secret-ref, audit, and approval layers, can disable delegation, and forces approval for workflow paths that cross an external MCP boundary. [security/site_policy.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/security/site_policy.py) blocks internal/private hostnames and supports browser allow/block lists. [security/context_scan.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/security/context_scan.py) scans extension content for prompt-exfiltration, override, bypass, and impersonation patterns. ([GitHub][11])
+
+* **There is real deterministic eval infrastructure.** [docs/implementation/09-benchmark-status.md](https://github.com/seraph-quest/seraph/blob/develop/docs/implementation/09-benchmark-status.md) says Seraph ships operator-visible deterministic suites for guardian memory, workflow endurance, trust boundaries, computer use, and governed improvement. The code backs that with suite-specific benchmark modules like [guardian/benchmark.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/guardian/benchmark.py), [workflows/benchmark.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/workflows/benchmark.py), and [security/benchmark.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/security/benchmark.py). ([GitHub][4])
+
+* **The cockpit is genuinely dense and operator-oriented.** [frontend/src/components/cockpit/inspector.ts](https://github.com/seraph-quest/seraph/blob/develop/frontend/src/components/cockpit/inspector.ts) tracks workflow step records, artifacts, risk level, execution boundaries, pending approvals, replay info, checkpoint candidates, approval recovery messages, anticipatory plans, and condensation fidelity. The STATUS doc also claims workflow supervision, activity ledger, evidence shortcuts, failure-lineage debugger rows, family-history comparison, and checkpoint drill-in. ([GitHub][12])
+
+### B. Docs-claimed shipped surfaces that look real, but are still staged or degraded in places
+
+* Seraph’s README and STATUS say the product already ships browser workspace UI, observer daemon, memory, proactive scheduler foundations, 17 built-in tools, workflow/starter-pack/skill/MCP surfaces, and a dense operator cockpit. The same sources also imply that broader native reach, imported capability surfaces, and deeper execution hardening are still staged, degraded, or local-fallback in parts rather than uniformly production-grade. That framing matches the code inspection: there is a serious core, but not yet a category-closing execution plane. ([GitHub][6])
+
+* The roadmap and STATUS also claim imported Hermes/OpenClaw capability waves, typed extension contributions, channel adapters, messaging connectors, browser providers, node adapters, and a team control plane. Those claims may be directionally true, but the strongest directly inspected runtime code still reads like a guardian/workflow/control-plane core rather than a fully mature cross-surface platform. Treat the broader reach story as real but uneven until production evidence proves otherwise. ([GitHub][5])
+
+### C. Where Seraph is weaker than its own ambition
+
+* **Memory quality is promising, but Seraph’s own research admits the current architecture still has thin schemas, one-shot extraction, an under-structured “soul,” narrow session search, and underfed world-model slots.** That self-critique matters, because it means the moat is real but unfinished. ([GitHub][13])
+
+* **Browser/runtime safety is the clearest gap between docs and dominance.** The inspected [browser/sessions.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/browser/sessions.py) centers owner-scoped browser sessions and snapshots, which is useful for receipts but lighter than the isolated browser and execution stories documented by Hermes/OpenClaw and the defense-in-depth story documented by IronClaw. Seraph’s own benchmark-status doc also says stronger host/container-grade privileged-path isolation is still missing. ([GitHub][14])
+
+* **Seraph itself says it cannot yet credibly claim broad benchmark superiority from implementation alone.** That is the right call; it has strong benchmark architecture, but not yet enough public proof or live-task evidence to close the case. ([GitHub][4])
+
+## 3) Competitor capability matrix
+
+### Hermes Agent by Nous Research
+
+Source set: [overview](https://hermes-agent.nousresearch.com/docs/user-guide/features/overview), [tools](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools), [memory](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory), [memory providers](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory-providers), [browser](https://hermes-agent.nousresearch.com/docs/user-guide/features/browser), [security](https://hermes-agent.nousresearch.com/docs/user-guide/security), [CLI](https://hermes-agent.nousresearch.com/docs/user-guide/cli/)
+**Confidence:** medium; official docs-backed, not independently code-verified. ([hermes-agent.nousresearch.com][15])
+
+* **Breadth:** Hermes docs-claim 47 built-in tools, 6 terminal backends, browser automation with multiple backends, code execution, cron/scheduled tasks, isolated subagents, MCP, messaging, voice, event hooks, provider routing/fallback, and wide platform reach. It appears to be the breadth leader in this comparison, but the numeric counts should be treated as docs-claimed unless exact official source lines are cited. ([hermes-agent.nousresearch.com][3])
+* **Memory:** Hermes uses bounded persistent memory (`MEMORY.md`, `USER.md`, context files/checkpoints) plus `session_search`, and documents multiple external memory providers. This is coherent and practical, but less guardian-specific than Seraph’s world-model/user-model direction. ([hermes-agent.nousresearch.com][15])
+* **Security/runtime:** Hermes documents manual/smart/off approval modes, dangerous-command protections, pairing, env allowlists, Docker hardening, and browser/session isolation. That is a stronger documented execution surface than what Seraph currently proves. ([hermes-agent.nousresearch.com][16])
+* **UI/operator ergonomics:** Hermes’s CLI documents a persistent status bar, slash commands, skill browsing, background control, and voice toggles. It looks efficient for terminal-first operators. ([hermes-agent.nousresearch.com][17])
+* **What Seraph should learn:** core runtime primitives, isolated delegation, scheduling, terminal/process breadth, browser providers, and operator-fast control patterns. **What Seraph should not imitate:** terminal-first identity as the primary product frame. Hermes is a broad runtime; Seraph should remain a guardian workspace. ([GitHub][18])
+
+### OpenClaw
+
+Source set: [docs home](https://docs.openclaw.ai/), [control UI](https://docs.openclaw.ai/web/control-ui), [tools](https://docs.openclaw.ai/tools), [browser](https://docs.openclaw.ai/tools/browser), [sandboxing](https://docs.openclaw.ai/gateway/sandboxing)
+**Confidence:** medium; official docs-backed, not independently code-verified. ([OpenClaw][19])
+
+* **Breadth/reach:** OpenClaw documents a gateway-first architecture with many chat/messaging channels, multi-agent routing, plugin layers, nodes/mobile surfaces, talk mode, wake words, control UI, and broad tooling. It is the reach leader. The exact counts and coverage claims should be treated as docs-claimed unless grounded in exact source lines. ([OpenClaw][19])
+* **Control plane:** The Control UI docs show health/debug state, event logs, manual RPC calls, log tailing, updates, restart, cron management, pairing, and browser controls. This is the strongest operator-control story among the reviewed docs. ([OpenClaw][20])
+* **Browser/sandbox:** OpenClaw documents a managed browser, Chrome extension relay, remote CDP, and sandbox/workspace-access modes. That is a richer browser/runtime surface than Seraph’s directly inspected browser module. ([OpenClaw][21])
+* **Memory:** OpenClaw’s documented memory is simpler: `MEMORY.md`, daily notes, optional dream file, and plugin-provided memory tools. Useful, but not obviously stronger than Seraph’s guardian-memory approach. ([OpenClaw][22])
+* **What Seraph should learn:** channel routing, browser mode taxonomy, control-plane health/debug surfaces, and selected device/companion patterns. **What Seraph should reject:** unrestricted native in-process plugin runtime, provider/plugin sprawl, gateway-first product framing, and open executable extension marketplaces. Seraph’s own import plan already says this. ([GitHub][18])
+
+### IronClaw by NEAR AI
+
+Source set: [README](https://github.com/nearai/ironclaw/blob/staging/README.md), [FEATURE_PARITY](https://github.com/nearai/ironclaw/blob/staging/FEATURE_PARITY.md), [site](https://www.ironclaw.com/)
+**Confidence:** medium-high on repo-backed capabilities/misses; low-medium on site marketing beyond the repo docs. ([GitHub][23])
+
+* **Security:** IronClaw’s README documents a security-first runtime with WASM sandboxing, capability permissions, credential injection/protection, prompt-injection defense, endpoint allowlisting, audit logs, local/encrypted data, and Docker sandboxing. Among the reviewed sources, it has the clearest repo-backed security posture. ([GitHub][23])
+* **Breadth:** IronClaw documents routines, parallel jobs, hybrid memory search, channels, hooks, MCP, dynamic tool building, and a dashboard. But its feature-parity file also says browser is not implemented, many channels are missing, plugin management is incomplete, and subagent spawn is missing. So it is strong on trust posture, weaker on breadth than OpenClaw/Hermes. ([GitHub][23])
+* **What Seraph should learn:** capability-scoped isolation, leak detection, endpoint/host allowlisting, and defense-in-depth expectations for real execution. **What Seraph should not copy:** security marketing as a product substitute, or a detour into security identity at the expense of guardian quality. ([GitHub][23])
+
+## 4) Gap matrix across the required axes
+
+### Operator visibility and legibility
+
+**Verdict:** Seraph is a contender, not yet the leader.
+Seraph’s cockpit types and STATUS surface show unusually rich workflow, artifact, checkpoint, approval, fidelity, and recovery data. But OpenClaw’s documented control UI and Hermes’s fast CLI ergonomics are more obviously battle-ready in the reviewed sources. Seraph needs simplification and measured operator-speed proof, not just density. ([GitHub][12])
+
+### Longitudinal memory and human modeling
+
+**Verdict:** This is Seraph’s best shot at category leadership.
+Seraph’s explicit guardian state, world model, user-model profile, additive provider contract, contradiction-aware retrieval, and guardian-user-model benchmark are more aligned with “guardian” superiority than Hermes’s bounded memory files or OpenClaw’s simpler memory notes. The catch is that Seraph’s own memory roadmap says the current writer/retrieval stack is still first-generation and under-structured. ([GitHub][2])
+
+### Intervention quality and timing
+
+**Verdict:** Seraph has the strongest architecture I found for this axis, but not enough public proof yet.
+Seraph has explicit delivery policy, scoped feedback learning, user-state/interruption-cost handling, and intervention outcome refresh loops. In the reviewed competitor materials, Hermes and OpenClaw clearly document scheduling, messaging, and reach, but I did not find equally explicit public intervention-policy and intervention-learning surfaces. That makes Seraph’s design promisingly ahead, but still under-proven. ([GitHub][8])
+
+### Safe real-world execution
+
+**Verdict:** Seraph is behind.
+Seraph has policy wrappers, secret-ref controls, suspicious-context scanning, site allow/block rules, and a trust-boundary benchmark suite. But Hermes documents stronger browser/terminal safety controls, OpenClaw documents richer sandbox/browser boundary options, and IronClaw documents the strongest repo-backed isolation story. Seraph’s own docs say stronger host/container-grade isolation is still a missing piece. ([GitHub][11])
+
+### Runtime reliability and eval rigor
+
+**Verdict:** Seraph is probably ahead internally, but not yet credibly ahead externally.
+Seraph is the only system in the reviewed source set that clearly exposes named deterministic benchmark suites tied to product behavior and operator-readable receipts. But Seraph’s own benchmark status says that still does not amount to a credible broad-superiority claim yet. That is the correct standard. ([GitHub][4])
+
+### Workflow composition and delegation
+
+**Verdict:** Seraph is strong on continuity/repair, behind on breadth.
+Seraph’s workflow manager, orchestration, and cockpit surfaces are excellent for branch/recovery/checkpoint legibility. Hermes still leads on breadth through isolated subagents, cron, tools, code execution, and messaging-driven tasking; OpenClaw leads on multi-agent/channel composition; IronClaw offers routines/hooks but still lacks some breadth like browser and subagent spawn. ([GitHub][10])
+
+### Dense interface efficiency
+
+**Verdict:** Seraph has the right ambition, but it must prove speed instead of only density.
+Seraph explicitly prioritizes dense, linked, evidence-backed operator surfaces, and the cockpit schema backs that up. But density alone can become clutter. OpenClaw’s control UI and Hermes’s CLI both show clearer immediate workflows in their docs. Seraph should aim to beat them on corrective-speed and recovery-speed, not on raw pane count. ([GitHub][1])
+
+### Presence and reach
+
+**Verdict:** Seraph is clearly behind, but the gap is not just “more apps.”
+Seraph currently presents as browser workspace plus optional macOS daemon and native/browser notification paths, with broader reach still marked in progress or partial. Hermes docs-claim 15+ platforms plus voice and messaging; OpenClaw documents many channels, nodes, mobile/voice; IronClaw implements several channels and dashboards even if it trails OpenClaw. The important nuance is that Seraph already has imported reach surfaces, but many are staged, degraded, or local-fallback rather than fully production-grade. ([GitHub][6])
+
+## 5) Which competitor capabilities Seraph should copy, reinterpret, or reject
+
+* **Isolated subagents / delegation:** **Harden and generalize existing foundations.** Hermes’s isolated delegation is high-value, and Seraph already has delegation foundations in [agent/factory.py](https://github.com/seraph-quest/seraph/blob/develop/backend/src/agent/factory.py). The right move is to add explicit trust partitions, handoff receipts, and branch-aware workflow continuity, not to treat delegation as missing from scratch. ([hermes-agent.nousresearch.com][15])
+
+* **Cron / routines / automation triggers:** **Core runtime plus typed extension triggers.** Hermes cron and OpenClaw automation breadth are valuable, but the right Seraph landing is core scheduling primitives plus typed trigger contributions, not a gateway-centric automation platform. ([hermes-agent.nousresearch.com][15])
+
+* **Browser modes and providers:** **Managed browser/native surfaces, not generic plugins.** OpenClaw’s managed browser / extension relay / remote CDP matrix is worth importing in spirit; Hermes’s browser backends are too. But Seraph should keep browser providers managed and policy-aware, because browser execution is a trust boundary, not just another plugin. ([hermes-agent.nousresearch.com][16])
+
+* **Memory providers:** **Keep Seraph’s current model.** Hermes shows market demand for pluggable memory backends, but Seraph’s additive-only, canonical-first model is better for a guardian product. Do not let external memory become parallel truth. ([hermes-agent.nousresearch.com][24])
+
+* **Control-plane health/log/debug surfaces:** **Reinterpret into the cockpit.** OpenClaw’s operator controls are excellent. Seraph should absorb the best parts - runtime posture, route health, failure triage, manual repair/debug entry points - but keep them anchored to guardian/workflow continuity rather than generic gateway ops. ([OpenClaw][20])
+
+* **Security primitives like capability isolation, allowlisting, leak detection:** **Copy selectively into core execution/security layers.** IronClaw’s strongest contribution is the expectation that dangerous execution surfaces deserve real isolation and secret containment. Seraph should import that standard for high-risk tool classes and managed connectors. ([GitHub][23])
+
+* **Messaging / push / voice / mobile reach:** **Managed connectors and companion surfaces only.** Hermes and OpenClaw prove the value of reach, but Seraph should add only the channels that strengthen guardian timing and continuity. Do not turn “presence” into a generic channel land-grab. ([hermes-agent.nousresearch.com][3])
+
+* **Unrestricted in-process plugins / open executable marketplaces:** **Reject.** Seraph’s own import plan is right: this conflicts directly with the guardian-workspace trust model. Keep runtime primitives core-owned, reusable capability surfaces typed and reviewable, and high-risk integrations managed. ([GitHub][18])
+
+## 6) Research-backed priority stack
+
+This section is intentionally not a calendar roadmap. It is a ranked set of research-backed bets that should be converted into actual delivery planning elsewhere.
+
+### 1. Harden the guardian-state moat all the way out
+
+**Why:** This is Seraph’s only credible path to being best in category. The explicit guardian state, world model, contradiction-aware retrieval, and scoped intervention learning are already differentiated; they now need higher-quality structured memory, better evidence fusion, and visible restraint/calibration receipts. ([GitHub][2])
+
+**What to harden:** typed memory/entity schema; stronger session/entity/project extraction; collaborator/timeline/routine feeds; better session search; guardian-state evidence cards in the cockpit. ([GitHub][13])
+
+**Risk if we get it wrong:** silent personalization drift, overconfident user modeling, too much complexity in the world model. ([GitHub][25])
+
+**Proof required:** lower user correction rate, higher helpful-intervention rate, fewer ambiguity failures, and stronger longitudinal replay performance on commitments/preferences/collaborator memory. ([GitHub][25])
+
+### 2. Productionize trusted execution
+
+**Why:** A guardian that cannot be trusted to act safely will never own the category. Seraph has solid trust scaffolding, but competitors still set a higher bar for isolation and execution containment. ([GitHub][26])
+
+**What to harden:** credential-egress broker, stronger host/container or WASM isolation for high-risk runtimes, browser provider isolation, trust-boundary drift enforcement on replay/resume, connector trust tiers. ([GitHub][26])
+
+**Risk if we get it wrong:** slower integration velocity, more engineering overhead, slightly higher latency.
+
+**Proof required:** zero secret-egress regressions in CI, explicit blocked-resume receipts on trust drift, red-team suites, and production telemetry showing no unsafe connector/browser leaks. ([GitHub][26])
+
+### 3. Generalize workflows + delegation into a supervised operating layer
+
+**Why:** Seraph is already good at continuity, branching, and repair. Add isolated subagents, scheduled triggers, and long-running queue continuity, and it becomes much closer to a real operating layer for one serious human rather than a fancy chat tool. ([GitHub][10])
+
+**What to harden:** delegated specialist partitions; queue state across sessions; repair/backup-branch selection UI; schedule/trigger ownership; trustworthy handoff summaries. ([GitHub][27])
+
+**Risk if we get it wrong:** invisible complexity, runaway background work, approval fatigue.
+
+**Proof required:** multi-session endurance pass rates, recovery rate after first failure, and time-to-resume metrics better than current baseline. ([GitHub][27])
+
+### 4. Make the cockpit the best supervised-agent interface in the category
+
+**Why:** Seraph’s cockpit already contains the raw materials for something genuinely special. But it only becomes a moat if operators can understand, approve, redirect, recover, and compare branches faster than they can in Hermes/OpenClaw. ([GitHub][12])
+
+**What to productionize:** guardian-state evidence cards, benchmark trendlines, continuity graph, one-click recovery/branch tools, keyboard-first corrective flows, simplified panes. ([GitHub][12])
+
+**Risk if we get it wrong:** UI complexity trap; too many surfaces without enough hierarchy.
+
+**Proof required:** operator time-to-understand, time-to-recover, and correction-per-task metrics that beat current Seraph and beat competitor-inspired baselines. ([GitHub][1])
+
+### 5. Add selective reach and publish hard proof
+
+**Why:** Seraph is behind on presence/reach and behind on external credibility. It does not need 15 channels. It needs a few high-value official surfaces - email, calendar, one messaging/push lane - and a benchmark program that makes the guardian claim measurable. ([GitHub][6])
+
+**What to productionize:** managed connectors, cross-surface continuity IDs, notification ownership, longitudinal replay harness, live task bench, versioned benchmark dashboards. ([GitHub][9])
+
+**Risk if we get it wrong:** channel sprawl, support burden, distraction from core guardian quality.
+
+**Proof required:** intervention open/acknowledge/helpfulness rates on real surfaces, plus public trendlines on deterministic and live-task suites. ([GitHub][8])
+
+## 7) What Seraph should avoid
+
+* **Do not revive the village/game/editor direction.** Seraph’s README, STATUS, and synthesis all say that line is retired. Bringing it back would dilute the category. ([GitHub][6])
+* **Do not become a gateway-first multi-channel platform.** That would push Seraph toward OpenClaw’s center of gravity and away from its own guardian-workspace moat. ([GitHub][18])
+* **Do not allow unrestricted in-process community plugins or a default-open executable extension marketplace.** Seraph’s own architecture docs reject this, and they should. ([GitHub][18])
+* **Do not chase generic model-benchmark bragging rights.** Seraph’s research explicitly defines superiority differently, and its implementation docs say broad superiority claims are not yet credible anyway. ([GitHub][1])
+* **Do not equate density with usability.** The cockpit should become faster and clearer, not merely more packed. ([GitHub][1])
+* **Do not let external memory/provider ecosystems override canonical guardian state.** Seraph’s additive-only memory model is a strength; keep it. ([GitHub][28])
+
+## 8) Eval program that would make superiority credible
+
+Start from the current deterministic suites and expand them into a four-layer proof system.
+
+### Layer 1: Deterministic CI suites
+
+Keep and harden the suites Seraph already names: guardian memory, guardian user-model restraint, workflow endurance/repair, trust boundaries/safety receipts, computer use, planning/retrieval reporting, governed improvement, and memory/workflow continuity. These are already the strongest eval foundation in the reviewed material. ([GitHub][4])
+
+Suggested CI metrics:
+
+* **Memory contradiction leakage rate**
+* **User-model ambiguity failure rate**
+* **Workflow recovery success rate**
+* **Unsafe-resume block accuracy**
+* **Browser replay fidelity**
+* **Benchmark pass rate by suite and by commit**
+
+### Layer 2: Live task benchmark
+
+Build a live or semi-live benchmark set that changes under real conditions:
+
+* browser tasks on changing websites
+* calendar/email/reporting tasks with approvals
+* source-review/report workflows
+* interruption and reminder tasks with timing windows
+* multi-session continuation tasks
+
+Benchmark Seraph against **competitor-inspired baselines**, not just its past self: a Hermes-style breadth baseline, an OpenClaw-style routing/control baseline, and an IronClaw-style security baseline. That aligns the proof with the actual competitive threats. ([hermes-agent.nousresearch.com][15])
+
+### Layer 3: Longitudinal replay
+
+This is the most important new layer for Seraph’s category. Create 7-day, 30-day, and 90-day replay corpora with:
+
+* changing commitments
+* contradictory evidence
+* shifting preferences
+* collaborator threads
+* blocked work states
+* stale project anchors
+* “good” and “bad” past intervention outcomes
+
+That is how Seraph proves it is a guardian, not a turn-by-turn assistant. Seraph’s own memory research already says behavior matters more than storage volume and that current world-model slots are underfed. ([GitHub][13])
+
+### Layer 4: Product metrics in the wild
+
+Instrument and publish trendlines for:
+
+* **user correction rate** = explicit user corrections / completed tasks
+* **recovery rate** = failed tasks later brought to success / failed tasks
+* **intervention helpfulness rate** = positive acknowledgements / delivered interventions
+* **timing regret rate** = quick dismissals or negative feedback / delivered interventions
+* **operator time-to-understand**
+* **operator time-to-recover**
+* **approval burden per successful task**
+* **latency and cost per completed workflow**
+* **safety failures per 1,000 actions**
+
+Seraph should claim superiority only when those lines improve release over release and beat its competitor-inspired baselines on the axes that matter to guardianship. ([GitHub][1])
+
+## 9) Candidate next slices
+
+These are not claims that the items are missing. They are the most valuable hardening/generalization slices if the team chooses to turn this memo into delivery work.
+
+1. **Guardian-state evidence cards v1** - expose world-model facets, evidence sources, confidence, freshness, and restraint reasons in the cockpit. ([GitHub][29])
+2. **Clarification watchpoint receipts** - make high-ambiguity clarify/wait/abstain decisions visible in intervention and workflow surfaces. ([GitHub][25])
+3. **Scoped learning inspector** - show global/thread/project learning signals for cadence/channel/timing/suppression. ([GitHub][30])
+4. **Replay/resume trust-drift hardening** - attach trust-boundary receipts to every resumable workflow and fail closed on drift. ([GitHub][26])
+5. **Browser session persistence v1** - replace purely in-memory snapshot continuity with persisted, TTL-managed, audited browser session state. ([GitHub][14])
+6. **Credential-egress broker v1** - enforce field-scoped secret refs plus host/connector allowlists across MCP and managed connectors. ([GitHub][11])
+7. **Delegated specialist partition descriptors** - define explicit tool, secret, memory, and approval scopes for child specialists. ([GitHub][11])
+8. **Benchmark trend dashboard** - store and display suite regressions, trendlines, and latest failure taxonomy in the cockpit. ([GitHub][4])
+9. **Calendar/email connector starter pack hardening** - source review, daily brief, follow-up, and write-action plans with scoped approvals. ([GitHub][1])
+10. **Longitudinal replay harness v1** - 7/30/90-day guardian scenarios with correction, recovery, timing, and safety metrics. ([GitHub][13])
+
+## 10) Assumptions, unknowns, and confidence levels
+
+* **High confidence:** Seraph’s category direction, current benchmark philosophy, and many core architectural claims, because they are supported by official repo docs plus source inspection. ([GitHub][1])
+* **Medium confidence:** Seraph’s broader shipped reach/import claims in roadmap/status docs, because some are more strongly documented in planning/status language than in the specific runtime modules I directly inspected. ([GitHub][5])
+* **Medium confidence:** Hermes and OpenClaw capability comparisons, because they are based on official docs rather than direct code inspection. ([hermes-agent.nousresearch.com][15])
+* **Medium-high confidence:** IronClaw’s implemented/missing capability profile, because its repo includes an explicit parity matrix. ([GitHub][31])
+* **Lower confidence / uncertain:** IronClaw site claims around enclaves/TEEs and other marketing-heavy assertions not independently corroborated by the repo materials I reviewed. ([IronClaw][32])
+
+The biggest remaining unknowns are real-world latency/cost, actual operator speed in the cockpit, true browser robustness under messy sites, real user helpfulness/regret rates for interventions, and how much of the broader reach/imported capability story is production-hardened versus staged, degraded, or local-fallback. Seraph should treat those as measurement problems, not storytelling problems. ([GitHub][4])
+
+**Bottom line:**
+Seraph can absolutely become the best agent in the world for its chosen category, but only if it stays disciplined. The winning move is to become the best **single-operator-first guardian workspace**, then expand into team/operator governance from that base: deeper human/world modeling, better intervention timing, stronger trust boundaries, tighter supervised delegation, a faster cockpit, and benchmark proof that makes those claims auditable. ([GitHub][1])
+
+If you want this turned into a board-style strategy memo or PRD, I can restructure it into that format.
+
+[1]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/docs/research/00-synthesis.md "https://raw.githubusercontent.com/seraph-quest/seraph/develop/docs/research/00-synthesis.md"
+[2]: https://github.com/seraph-quest/seraph/blob/develop/backend/src/guardian/state.py "https://github.com/seraph-quest/seraph/blob/develop/backend/src/guardian/state.py"
+[3]: https://hermes-agent.nousresearch.com/docs/ "https://hermes-agent.nousresearch.com/docs/"
+[4]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/docs/implementation/09-benchmark-status.md "https://raw.githubusercontent.com/seraph-quest/seraph/develop/docs/implementation/09-benchmark-status.md"
+[5]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/docs/implementation/STATUS.md "https://raw.githubusercontent.com/seraph-quest/seraph/develop/docs/implementation/STATUS.md"
+[6]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/README.md "https://raw.githubusercontent.com/seraph-quest/seraph/develop/README.md"
+[7]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/memory/hybrid_retrieval.py "https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/memory/hybrid_retrieval.py"
+[8]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/observer/intervention_policy.py "https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/observer/intervention_policy.py"
+[9]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/observer/delivery.py "https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/observer/delivery.py"
+[10]: https://github.com/seraph-quest/seraph/blob/develop/backend/src/workflows/manager.py "https://github.com/seraph-quest/seraph/blob/develop/backend/src/workflows/manager.py"
+[11]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/agent/factory.py "https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/agent/factory.py"
+[12]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/frontend/src/components/cockpit/inspector.ts "https://raw.githubusercontent.com/seraph-quest/seraph/develop/frontend/src/components/cockpit/inspector.ts"
+[13]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/docs/research/14-seraph-memory-sota-roadmap.md "https://raw.githubusercontent.com/seraph-quest/seraph/develop/docs/research/14-seraph-memory-sota-roadmap.md"
+[14]: https://github.com/seraph-quest/seraph/blob/develop/backend/src/browser/sessions.py "https://github.com/seraph-quest/seraph/blob/develop/backend/src/browser/sessions.py"
+[15]: https://hermes-agent.nousresearch.com/docs/user-guide/features/overview "https://hermes-agent.nousresearch.com/docs/user-guide/features/overview"
+[16]: https://hermes-agent.nousresearch.com/docs/user-guide/features/browser/ "https://hermes-agent.nousresearch.com/docs/user-guide/features/browser/"
+[17]: https://hermes-agent.nousresearch.com/docs/user-guide/cli/ "https://hermes-agent.nousresearch.com/docs/user-guide/cli/"
+[18]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/docs/research/13-hermes-and-openclaw-capability-import-plan.md "https://raw.githubusercontent.com/seraph-quest/seraph/develop/docs/research/13-hermes-and-openclaw-capability-import-plan.md"
+[19]: https://docs.openclaw.ai/ "https://docs.openclaw.ai/"
+[20]: https://docs.openclaw.ai/web/control-ui "https://docs.openclaw.ai/web/control-ui"
+[21]: https://docs.openclaw.ai/tools/browser "https://docs.openclaw.ai/tools/browser"
+[22]: https://docs.openclaw.ai/concepts/memory "https://docs.openclaw.ai/concepts/memory"
+[23]: https://raw.githubusercontent.com/nearai/ironclaw/staging/README.md "https://raw.githubusercontent.com/nearai/ironclaw/staging/README.md"
+[24]: https://hermes-agent.nousresearch.com/docs/user-guide/features/memory-providers/ "https://hermes-agent.nousresearch.com/docs/user-guide/features/memory-providers/"
+[25]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/guardian/benchmark.py "https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/guardian/benchmark.py"
+[26]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/security/benchmark.py "https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/security/benchmark.py"
+[27]: https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/workflows/benchmark.py "https://raw.githubusercontent.com/seraph-quest/seraph/develop/backend/src/workflows/benchmark.py"
+[28]: https://github.com/seraph-quest/seraph/blob/develop/backend/src/memory/providers.py "https://github.com/seraph-quest/seraph/blob/develop/backend/src/memory/providers.py"
+[29]: https://github.com/seraph-quest/seraph/blob/develop/backend/src/guardian/world_model.py "https://github.com/seraph-quest/seraph/blob/develop/backend/src/guardian/world_model.py"
+[30]: https://github.com/seraph-quest/seraph/blob/develop/backend/src/guardian/feedback.py "https://github.com/seraph-quest/seraph/blob/develop/backend/src/guardian/feedback.py"
+[31]: https://raw.githubusercontent.com/nearai/ironclaw/staging/FEATURE_PARITY.md "https://raw.githubusercontent.com/nearai/ironclaw/staging/FEATURE_PARITY.md"
+[32]: https://www.ironclaw.com/ "https://www.ironclaw.com/"


### PR DESCRIPTION
## Done on develop
- [x] Docs contract already separates research target shape from implementation shipped truth.
- [x] Existing superiority and benchmark docs establish strategic context.

## Working in this PR
- [x] Add the canonical world-class strategy research document.
- [x] Add the implementation-side delivery mirror for strategy-to-shipped-truth translation.
- [x] Update roadmap, status, synthesis, docs contract, and report surfaces to reference the strategy framework.
- [x] Use the Docusaurus route for the paired strategy link.

## Still to do after this PR
- [ ] Convert selected strategic gaps into tracked GitHub Project issues or parent batch issues when they become active work.

## Validation
- `cd docs && npm run build` - passes.
- Note: Docusaurus printed its update-check warning about access to `/home/pawel/.config`, but the production build completed successfully.