### PR TITLE
Complete M1 capability contract batch

### DIFF
--- a/backend/src/api/capabilities.py
+++ b/backend/src/api/capabilities.py
@@ -23,7 +23,8 @@ from src.api.catalog import (
 from src.audit.runtime import log_integration_event
 from src.db.engine import get_session as get_db
 from src.db.models import UserProfile
-from src.extensions.lifecycle import get_extension
+from src.extensions.capability_contract import build_native_tool_contract
+from src.extensions.lifecycle import get_extension, list_extensions
 from src.extensions.registry import ExtensionRegistry, bundled_manifest_root, default_manifest_roots_for_workspace
 from src.extensions.source_capabilities import list_source_capability_inventory
 from src.extensions.source_operations import (
@@ -1421,15 +1422,28 @@ def _tool_status_list(tool_mode: str) -> list[dict[str, Any]]:
     for tool_name in sorted(TOOL_METADATA.keys()):
         metadata = get_tool_metadata(tool_name) or {}
         allowed = is_tool_allowed(tool_name, tool_mode)
+        availability = "ready" if allowed else "blocked"
+        blocked_reason = None if allowed else f"tool_policy_{tool_mode}"
+        execution_boundaries = get_tool_execution_boundaries(tool_name)
+        risk_level = get_tool_risk_level(tool_name)
         result.append({
             "name": tool_name,
             "description": metadata.get("description", ""),
             "policy_modes": metadata.get("policy_modes", []),
-            "risk_level": get_tool_risk_level(tool_name),
-            "execution_boundaries": get_tool_execution_boundaries(tool_name),
+            "risk_level": risk_level,
+            "execution_boundaries": execution_boundaries,
             "accepts_secret_refs": bool(metadata.get("accepts_secret_refs", False)),
-            "availability": "ready" if allowed else "blocked",
-            "blocked_reason": None if allowed else f"tool_policy_{tool_mode}",
+            "availability": availability,
+            "blocked_reason": blocked_reason,
+            "capability_contract": build_native_tool_contract(
+                name=tool_name,
+                description=str(metadata.get("description") or ""),
+                policy_modes=list(metadata.get("policy_modes", [])),
+                risk_level=risk_level,
+                execution_boundaries=execution_boundaries,
+                availability=availability,
+                blocked_reason=blocked_reason,
+            ),
         })
     return result
 
@@ -1717,6 +1731,47 @@ def _marketplace_flows(
     return flows
 
 
+def _capability_contract_inventory(native_tools: list[dict[str, Any]]) -> dict[str, Any]:
+    contracts = [
+        tool["capability_contract"]
+        for tool in native_tools
+        if isinstance(tool.get("capability_contract"), dict)
+    ]
+    try:
+        extension_payload = list_extensions()
+    except Exception:
+        extension_payload = {"extensions": []}
+    for extension in extension_payload.get("extensions", []) or []:
+        if not isinstance(extension, dict):
+            continue
+        for contribution in extension.get("contributions", []) or []:
+            if not isinstance(contribution, dict):
+                continue
+            contract = contribution.get("capability_contract")
+            if isinstance(contract, dict):
+                contracts.append(contract)
+    enforcement_counts: dict[str, int] = {}
+    family_counts: dict[str, int] = {}
+    for contract in contracts:
+        family = str(contract.get("family") or contract.get("contribution_type") or "unknown")
+        family_counts[family] = family_counts.get(family, 0) + 1
+        enforcement = contract.get("enforcement")
+        status = (
+            str(enforcement.get("status") or "unknown")
+            if isinstance(enforcement, dict)
+            else str(contract.get("quarantine", {}).get("state") or "unknown")
+        )
+        enforcement_counts[status] = enforcement_counts.get(status, 0) + 1
+    return {
+        "contracts": contracts,
+        "summary": {
+            "total": len(contracts),
+            "families": family_counts,
+            "enforcement": enforcement_counts,
+        },
+    }
+
+
 def _build_capability_overview() -> dict[str, Any]:
     base_tools, active_skill_names, mcp_mode = get_base_tools_and_active_skills()
     tool_mode = get_current_tool_policy_mode()
@@ -1756,6 +1811,7 @@ def _build_capability_overview() -> dict[str, Any]:
         catalog_items=catalog_items,
         runbooks=runbooks,
     )
+    capability_contract_inventory = _capability_contract_inventory(native_tools)
     ready_tools = sum(1 for tool in native_tools if tool["availability"] == "ready")
     ready_skills = sum(1 for skill in skills if skill["availability"] == "ready")
     ready_workflows = sum(1 for workflow in workflows if workflow["availability"] == "ready")
@@ -1782,6 +1838,9 @@ def _build_capability_overview() -> dict[str, Any]:
                 if str(flow.get("availability") or "") in {"ready", "installed"}
             ),
             "marketplace_flows_total": len(marketplace_flows),
+            "capability_contracts_total": int(capability_contract_inventory["summary"]["total"]),
+            "capability_contract_families": capability_contract_inventory["summary"]["families"],
+            "capability_contract_enforcement": capability_contract_inventory["summary"]["enforcement"],
         },
         "native_tools": native_tools,
         "skills": skills,
@@ -1794,6 +1853,7 @@ def _build_capability_overview() -> dict[str, Any]:
         "recommendations": recommendations,
         "runbooks": runbooks,
         "marketplace_flows": marketplace_flows,
+        "capability_contracts": capability_contract_inventory["contracts"],
     }
 
 

--- a/backend/src/defaults/catalog-extensions/hermes-browserbase/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-browserbase/manifest.yaml
@@ -19,4 +19,18 @@ permissions:
     - browser_session
   execution_boundaries:
     - external_read
+    - secret_management
   network: true
+  data_access:
+    - browser_session_state
+    - external_web_pages
+    - provider_credentials
+  mutation_rights:
+    - browser_navigation
+    - remote_browser_session_config
+  audit_events:
+    - connector_configured
+    - connector_enabled
+    - browser_session_started
+  secrets:
+    - browserbase_api_key

--- a/backend/src/defaults/catalog-extensions/hermes-discord-relay/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-discord-relay/manifest.yaml
@@ -10,7 +10,24 @@ trust: bundled
 summary: Discord messaging connector definition for future Seraph operator notifications and continuations.
 description: Packages Discord relay metadata and configuration so Seraph can stage guarded delivery into Discord as the messaging runtime matures.
 permissions:
+  execution_boundaries:
+    - external_read
+    - connector_mutation
+    - secret_management
   network: true
+  data_access:
+    - operator_messages
+    - delivery_threads
+    - messaging_credentials
+  mutation_rights:
+    - send_operator_message
+    - update_delivery_thread
+  audit_events:
+    - connector_configured
+    - connector_enabled
+    - message_delivery_attempted
+  secrets:
+    - discord_bot_token
 contributes:
   messaging_connectors:
     - connectors/messaging/discord.yaml

--- a/backend/src/defaults/catalog-extensions/hermes-github-mcp/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-github-mcp/manifest.yaml
@@ -10,6 +10,8 @@ trust: bundled
 summary: GitHub MCP connector packaged with a matching operator toolset preset.
 description: Installs a packaged GitHub MCP connector and a toolset preset that makes the server easier to reason about in the operator surface.
 permissions:
+  execution_boundaries:
+    - external_mcp
   network: true
 contributes:
   mcp_servers:

--- a/backend/src/defaults/catalog-extensions/hermes-research-ops/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-research-ops/manifest.yaml
@@ -14,6 +14,9 @@ permissions:
     - browse_webpage
     - web_search
     - write_file
+  execution_boundaries:
+    - external_read
+    - workspace_write
   network: true
 contributes:
   skills:

--- a/backend/src/defaults/catalog-extensions/hermes-session-memory/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-session-memory/manifest.yaml
@@ -14,6 +14,10 @@ permissions:
     - clarify
     - session_search
     - todo
+  execution_boundaries:
+    - conversation
+    - conversation_history_read
+    - conversation_state
   network: false
 contributes:
   skills:

--- a/backend/src/defaults/catalog-extensions/hermes-slack-relay/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-slack-relay/manifest.yaml
@@ -10,7 +10,25 @@ trust: bundled
 summary: Slack messaging connector definition for future Seraph channel and direct operator updates.
 description: Packages Slack relay metadata and configuration so Seraph can stage guarded updates and thread continuations into Slack as the messaging runtime matures.
 permissions:
+  execution_boundaries:
+    - external_read
+    - connector_mutation
+    - secret_management
   network: true
+  data_access:
+    - operator_messages
+    - delivery_threads
+    - messaging_credentials
+  mutation_rights:
+    - send_operator_message
+    - update_delivery_thread
+  audit_events:
+    - connector_configured
+    - connector_enabled
+    - message_delivery_attempted
+  secrets:
+    - slack_bot_token
+    - slack_app_token
 contributes:
   messaging_connectors:
     - connectors/messaging/slack.yaml

--- a/backend/src/defaults/catalog-extensions/hermes-telegram-relay/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/hermes-telegram-relay/manifest.yaml
@@ -10,7 +10,24 @@ trust: bundled
 summary: Telegram messaging connector definition for future Seraph reach beyond the browser workspace.
 description: Packages Telegram relay metadata and configuration so Seraph can stage guarded delivery into Telegram as the messaging runtime matures.
 permissions:
+  execution_boundaries:
+    - external_read
+    - connector_mutation
+    - secret_management
   network: true
+  data_access:
+    - operator_messages
+    - delivery_threads
+    - messaging_credentials
+  mutation_rights:
+    - send_operator_message
+    - update_delivery_thread
+  audit_events:
+    - connector_configured
+    - connector_enabled
+    - message_delivery_attempted
+  secrets:
+    - telegram_bot_token
 contributes:
   messaging_connectors:
     - connectors/messaging/telegram.yaml

--- a/backend/src/defaults/catalog-extensions/openclaw-extension-relay/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-extension-relay/manifest.yaml
@@ -19,4 +19,18 @@ permissions:
     - browser_session
   execution_boundaries:
     - external_read
+    - secret_management
   network: true
+  data_access:
+    - browser_session_state
+    - external_web_pages
+    - relay_credentials
+  mutation_rights:
+    - browser_navigation
+    - extension_relay_session_config
+  audit_events:
+    - connector_configured
+    - connector_enabled
+    - browser_session_started
+  secrets:
+    - extension_relay_token

--- a/backend/src/defaults/catalog-extensions/openclaw-remote-cdp/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-remote-cdp/manifest.yaml
@@ -20,3 +20,14 @@ permissions:
   execution_boundaries:
     - external_read
   network: true
+  data_access:
+    - browser_session_state
+    - external_web_pages
+    - remote_cdp_endpoint
+  mutation_rights:
+    - browser_navigation
+    - remote_browser_session_config
+  audit_events:
+    - connector_configured
+    - connector_enabled
+    - browser_session_started

--- a/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/manifest.yaml
+++ b/backend/src/defaults/catalog-extensions/openclaw-workflow-runtimes/manifest.yaml
@@ -13,6 +13,9 @@ permissions:
   tools:
     - session_search
     - delegate_task
+  execution_boundaries:
+    - conversation_history_read
+    - delegation
   network: false
 contributes:
   workflow_runtimes:

--- a/backend/src/defaults/extensions/core-capabilities/manifest.yaml
+++ b/backend/src/defaults/extensions/core-capabilities/manifest.yaml
@@ -27,6 +27,16 @@ permissions:
     - view_soul
     - web_search
     - write_file
+  execution_boundaries:
+    - authenticated_external_source
+    - connector_mutation
+    - external_mcp
+    - external_read
+    - guardian_state_read
+    - guardian_state_write
+    - sandbox_execution
+    - workspace_read
+    - workspace_write
   network: true
 contributes:
   skills:

--- a/backend/src/extensions/__init__.py
+++ b/backend/src/extensions/__init__.py
@@ -21,6 +21,12 @@ from .doctor import (
     doctor_extension,
     doctor_snapshot,
 )
+from .capability_contract import (
+    CAPABILITY_CONTRACT_SCHEMA_VERSION,
+    CONTRACT_VERSION,
+    build_capability_contract,
+    build_native_tool_contract,
+)
 from .layout import (
     CONTRIBUTION_LAYOUTS,
     MANIFEST_FILENAMES,
@@ -56,8 +62,12 @@ __all__ = [
     "ExtensionRegistry",
     "ExtensionRegistrySnapshot",
     "CONTRIBUTION_LAYOUTS",
+    "CAPABILITY_CONTRACT_SCHEMA_VERSION",
+    "CONTRACT_VERSION",
     "MANIFEST_FILENAMES",
     "ScaffoldedExtensionPackage",
+    "build_capability_contract",
+    "build_native_tool_contract",
     "doctor_extension",
     "doctor_snapshot",
     "extension_registry",

--- a/backend/src/extensions/capability_contract.py
+++ b/backend/src/extensions/capability_contract.py
@@ -1,0 +1,453 @@
+"""Canonical capability contract helpers for runtime-visible Seraph surfaces."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from src.extensions.registry import ExtensionRecord
+
+CONTRACT_VERSION = "m1.2026-05"
+CAPABILITY_CONTRACT_SCHEMA_VERSION = "2026-05-04.m1"
+
+_REJECTED_CONTRIBUTION_TYPES = {
+    "skills",
+    "workflows",
+    "toolset_presets",
+    "mcp_servers",
+}
+
+CAPABILITY_FAMILY_BY_CONTRIBUTION_TYPE = {
+    "skills": "skill",
+    "workflows": "workflow",
+    "runbooks": "runbook",
+    "starter_packs": "starter_pack",
+    "provider_presets": "provider_preset",
+    "toolset_presets": "toolset_preset",
+    "prompt_packs": "prompt_pack",
+    "context_packs": "context_pack",
+    "scheduled_routines": "automation",
+    "mcp_servers": "mcp_server",
+    "managed_connectors": "connector",
+    "memory_providers": "memory_provider",
+    "automation_triggers": "automation_trigger",
+    "browser_providers": "browser_provider",
+    "messaging_connectors": "messaging_connector",
+    "observer_definitions": "observer_source",
+    "observer_connectors": "observer_connector",
+    "channel_adapters": "channel_adapter",
+    "canvas_outputs": "canvas_output",
+    "workflow_runtimes": "workflow_runtime",
+    "speech_profiles": "speech_profile",
+    "node_adapters": "node_adapter",
+    "workspace_adapters": "workspace_adapter",
+}
+
+NATIVE_TOOL_FAMILY = "native_tool"
+
+TRUST_CLASS_BY_EXTENSION_TRUST = {
+    "bundled": "seraph_bundled",
+    "verified": "verified_pack",
+    "local": "local_pack",
+}
+
+READ_BOUNDARIES = {
+    "workspace_read",
+    "external_read",
+    "guardian_state_read",
+    "conversation_history_read",
+    "container_process_read",
+}
+
+WRITE_BOUNDARIES = {
+    "workspace_write",
+    "guardian_state_write",
+    "automation_state",
+    "secret_management",
+    "connector_mutation",
+}
+
+EXECUTE_BOUNDARIES = {
+    "sandbox_execution",
+    "container_process_execution",
+    "container_process_management",
+    "background_execution",
+    "external_mcp",
+    "delegation",
+}
+
+SECRET_BOUNDARIES = {"secret_read", "secret_injection", "secret_management"}
+
+QUARANTINE_STATES = {"invalid", "conflict", "overridden", "requires_config", "invalid_config"}
+
+
+def _dedupe_strings(values: Any) -> list[str]:
+    if not isinstance(values, (list, tuple, set)):
+        return []
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        item = value.strip()
+        if not item or item in seen:
+            continue
+        normalized.append(item)
+        seen.add(item)
+    return normalized
+
+
+def _operator_description(
+    *,
+    family: str,
+    name: str,
+    description: str,
+    extension: ExtensionRecord | None = None,
+) -> str:
+    if description:
+        return description
+    if extension is not None and extension.manifest is not None:
+        manifest_description = extension.manifest.summary or extension.manifest.description
+        if manifest_description:
+            return manifest_description
+    return f"{family.replace('_', ' ')} capability {name}".strip()
+
+
+def _declared_permissions_payload(extension: ExtensionRecord | None) -> dict[str, Any]:
+    if extension is None or extension.manifest is None:
+        return {
+            "tools": [],
+            "execution_boundaries": [],
+            "network": None,
+            "data_access": [],
+            "mutation_rights": [],
+            "audit_events": [],
+            "secrets": [],
+            "env": [],
+        }
+    permissions = extension.manifest.permissions
+    return {
+        "tools": _dedupe_strings(permissions.tools),
+        "execution_boundaries": _dedupe_strings(permissions.execution_boundaries),
+        "network": bool(permissions.network),
+        "data_access": _dedupe_strings(getattr(permissions, "data_access", [])),
+        "mutation_rights": _dedupe_strings(getattr(permissions, "mutation_rights", [])),
+        "audit_events": _dedupe_strings(getattr(permissions, "audit_events", [])),
+        "secrets": _dedupe_strings(permissions.secrets),
+        "env": _dedupe_strings(permissions.env),
+    }
+
+
+def _capability_enforcement(
+    *,
+    contribution_type: str,
+    permission_profile: Mapping[str, Any],
+) -> dict[str, Any]:
+    missing_tools = _dedupe_strings(permission_profile.get("missing_tools"))
+    missing_boundaries = _dedupe_strings(permission_profile.get("missing_execution_boundaries"))
+    missing_network = bool(permission_profile.get("missing_network"))
+    missing: dict[str, Any] = {
+        "tools": missing_tools,
+        "execution_boundaries": missing_boundaries,
+        "network": missing_network,
+    }
+    if not missing_tools and not missing_boundaries and not missing_network:
+        return {
+            "status": "accepted",
+            "action": "allow",
+            "reason": "",
+            "missing": missing,
+            "runtime_ready": True,
+        }
+
+    action = "reject" if contribution_type in _REJECTED_CONTRIBUTION_TYPES else "quarantine"
+    status = "rejected" if action == "reject" else "quarantined"
+    reasons: list[str] = []
+    if missing_tools:
+        reasons.append(f"undeclared tools: {', '.join(missing_tools)}")
+    if missing_boundaries:
+        reasons.append(f"undeclared execution boundaries: {', '.join(missing_boundaries)}")
+    if missing_network:
+        reasons.append("undeclared network access")
+    return {
+        "status": status,
+        "action": action,
+        "reason": "; ".join(reasons),
+        "missing": missing,
+        "runtime_ready": False,
+    }
+
+
+def _mutation_rights(boundaries: list[str]) -> dict[str, bool]:
+    boundary_set = set(boundaries)
+    return {
+        "reads_workspace": "workspace_read" in boundary_set,
+        "writes_workspace": "workspace_write" in boundary_set,
+        "reads_external": "external_read" in boundary_set or "external_mcp" in boundary_set,
+        "mutates_external": "connector_mutation" in boundary_set or "external_mcp" in boundary_set,
+        "executes_code": bool(boundary_set.intersection(EXECUTE_BOUNDARIES)),
+        "reads_guardian_state": "guardian_state_read" in boundary_set,
+        "mutates_guardian_state": "guardian_state_write" in boundary_set,
+        "uses_secrets": bool(boundary_set.intersection(SECRET_BOUNDARIES)),
+    }
+
+
+def _audit_contract(permission_profile: Mapping[str, Any], boundaries: list[str]) -> dict[str, Any]:
+    risk_level = str(permission_profile.get("risk_level") or "low")
+    approval_behavior = str(permission_profile.get("approval_behavior") or "never")
+    requires_approval = bool(permission_profile.get("requires_approval"))
+    return {
+        "event_scope": "capability",
+        "required": risk_level != "low" or requires_approval or bool(boundaries),
+        "risk_level": risk_level,
+        "approval_behavior": approval_behavior,
+        "requires_approval": requires_approval,
+        "execution_boundaries": boundaries,
+    }
+
+
+def _permission_contract(permission_profile: Mapping[str, Any]) -> dict[str, Any]:
+    required_boundaries = _dedupe_strings(permission_profile.get("required_execution_boundaries"))
+    return {
+        "status": str(permission_profile.get("status") or "unknown"),
+        "declared_tools": _dedupe_strings(permission_profile.get("declared_tools")),
+        "required_tools": _dedupe_strings(permission_profile.get("required_tools")),
+        "missing_tools": _dedupe_strings(permission_profile.get("missing_tools")),
+        "declared_execution_boundaries": _dedupe_strings(
+            permission_profile.get("declared_execution_boundaries")
+        ),
+        "required_execution_boundaries": required_boundaries,
+        "missing_execution_boundaries": _dedupe_strings(
+            permission_profile.get("missing_execution_boundaries")
+        ),
+        "network": permission_profile.get("network"),
+        "requires_network": bool(permission_profile.get("requires_network")),
+        "missing_network": bool(permission_profile.get("missing_network")),
+        "secrets": _dedupe_strings(permission_profile.get("secrets")),
+        "env": _dedupe_strings(permission_profile.get("env")),
+    }
+
+
+def _quarantine_contract(
+    *,
+    permission_profile: Mapping[str, Any],
+    health: Mapping[str, Any] | None,
+    status: str,
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    if not bool(permission_profile.get("ok", True)):
+        if _dedupe_strings(permission_profile.get("missing_tools")):
+            reasons.append("undeclared_tools")
+        if _dedupe_strings(permission_profile.get("missing_execution_boundaries")):
+            reasons.append("undeclared_execution_boundaries")
+        if bool(permission_profile.get("missing_network")):
+            reasons.append("undeclared_network")
+    if status in QUARANTINE_STATES:
+        reasons.append(status)
+    if isinstance(health, Mapping) and health.get("ready") is False:
+        state = str(health.get("state") or "").strip()
+        if state and state not in reasons and state in QUARANTINE_STATES:
+            reasons.append(state)
+    return {
+        "state": "quarantined" if reasons else "active",
+        "reasons": reasons,
+    }
+
+
+def build_native_tool_contract(
+    *,
+    name: str,
+    description: str,
+    policy_modes: list[str],
+    risk_level: str,
+    execution_boundaries: list[str],
+    availability: str,
+    blocked_reason: str | None,
+) -> dict[str, Any]:
+    permission_profile = {
+        "ok": availability == "ready",
+        "status": "granted" if availability == "ready" else "policy_blocked",
+        "declared_tools": [name],
+        "required_tools": [name],
+        "missing_tools": [],
+        "declared_execution_boundaries": execution_boundaries,
+        "required_execution_boundaries": execution_boundaries,
+        "missing_execution_boundaries": [],
+        "network": "external_read" in execution_boundaries or "external_mcp" in execution_boundaries,
+        "requires_network": "external_read" in execution_boundaries or "external_mcp" in execution_boundaries,
+        "missing_network": False,
+        "risk_level": risk_level,
+        "approval_behavior": "high_risk" if risk_level == "high" else "never",
+        "requires_approval": risk_level == "high",
+    }
+    health = {
+        "state": availability,
+        "ready": availability == "ready",
+        "summary": blocked_reason or "Native tool is available under the current policy mode.",
+    }
+    permission_contract = _permission_contract(permission_profile)
+    required_boundaries = permission_contract["required_execution_boundaries"]
+    return {
+        "schema_version": CAPABILITY_CONTRACT_SCHEMA_VERSION,
+        "version": CONTRACT_VERSION,
+        "capability_id": f"native_tool:{name}",
+        "family": NATIVE_TOOL_FAMILY,
+        "name": name,
+        "operator_description": _operator_description(
+            family=NATIVE_TOOL_FAMILY,
+            name=name,
+            description=description,
+        ),
+        "trust_class": "seraph_bundled",
+        "provenance": {
+            "source": "native",
+            "registry": "src.native_tools.registry.TOOL_METADATA",
+        },
+        "permissions": {
+            "declared": {
+                "tools": permission_contract["declared_tools"],
+                "execution_boundaries": permission_contract["declared_execution_boundaries"],
+                "network": permission_contract["network"],
+                "secrets": permission_contract["secrets"],
+                "env": permission_contract["env"],
+            },
+            "required": {
+                "tools": permission_contract["required_tools"],
+                "execution_boundaries": required_boundaries,
+                "network": permission_contract["requires_network"],
+                "accepts_secret_refs": False,
+            },
+            "missing": {
+                "tools": permission_contract["missing_tools"],
+                "execution_boundaries": permission_contract["missing_execution_boundaries"],
+                "network": permission_contract["missing_network"],
+            },
+        },
+        "mutation_rights": _mutation_rights(required_boundaries),
+        "audit": _audit_contract(permission_profile, required_boundaries),
+        "health": health,
+        "preflight": {
+            "status": availability,
+            "ready": availability == "ready",
+            "blocking_reasons": [blocked_reason] if blocked_reason else [],
+            "policy_modes": policy_modes,
+        },
+        "compatibility": {"seraph": "runtime-native", "compatible": True},
+        "quarantine": _quarantine_contract(
+            permission_profile=permission_profile,
+            health=health,
+            status=availability,
+        ),
+    }
+
+
+def build_capability_contract(
+    extension: ExtensionRecord | None,
+    *,
+    contribution_type: str,
+    reference: str,
+    metadata: dict[str, Any],
+    permission_profile: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build the canonical operator-visible contract for an extension contribution."""
+    declared = _declared_permissions_payload(extension)
+    manifest = extension.manifest if extension is not None else None
+    family = CAPABILITY_FAMILY_BY_CONTRIBUTION_TYPE.get(contribution_type, contribution_type)
+    name = str(metadata.get("name") or metadata.get("tool_name") or reference)
+    required_boundaries = _dedupe_strings(permission_profile.get("required_execution_boundaries"))
+    provenance = {
+        "source": extension.source if extension is not None else "unmanaged",
+        "extension_id": extension.id if extension is not None else None,
+        "extension_display_name": extension.display_name if extension is not None else None,
+        "manifest_path": extension.manifest_path if extension is not None else None,
+        "root_path": extension.root_path if extension is not None else None,
+        "publisher": manifest.publisher.name if manifest is not None else None,
+        "version": manifest.version if manifest is not None else None,
+        "compatibility": manifest.compatibility.seraph if manifest is not None else None,
+        "trust_class": (
+            TRUST_CLASS_BY_EXTENSION_TRUST.get(extension.trust, extension.trust)
+            if extension is not None
+            else "unmanaged"
+        ),
+        "reference": reference,
+        "resolved_path": metadata.get("resolved_path"),
+    }
+    enforcement = _capability_enforcement(
+        contribution_type=contribution_type,
+        permission_profile=permission_profile,
+    )
+    return {
+        "schema_version": CAPABILITY_CONTRACT_SCHEMA_VERSION,
+        "version": CONTRACT_VERSION,
+        "capability_id": (
+            f"{extension.id}:{contribution_type}:{reference}"
+            if extension is not None
+            else f"unmanaged:{contribution_type}:{reference}"
+        ),
+        "extension_id": extension.id if extension is not None else None,
+        "contribution_type": contribution_type,
+        "family": family,
+        "reference": reference,
+        "name": name,
+        "trust_class": provenance["trust_class"],
+        "operator": {
+            "display_name": extension.display_name if extension is not None else name,
+            "description": _operator_description(
+                family=family,
+                name=name,
+                description=str(metadata.get("description") or ""),
+                extension=extension,
+            ),
+        },
+        "operator_description": _operator_description(
+            family=family,
+            name=name,
+            description=str(metadata.get("description") or ""),
+            extension=extension,
+        ),
+        "provenance": provenance,
+        "permissions": {
+            "declared": declared,
+            "required": {
+                "tools": _dedupe_strings(permission_profile.get("required_tools")),
+                "execution_boundaries": required_boundaries,
+                "network": bool(permission_profile.get("requires_network")),
+                "accepts_secret_refs": bool(permission_profile.get("accepts_secret_refs")),
+            },
+            "missing": {
+                "tools": _dedupe_strings(permission_profile.get("missing_tools")),
+                "execution_boundaries": _dedupe_strings(
+                    permission_profile.get("missing_execution_boundaries")
+                ),
+                "network": bool(permission_profile.get("missing_network")),
+            },
+        },
+        "mutation_rights": _mutation_rights(required_boundaries),
+        "audit": _audit_contract(permission_profile, required_boundaries),
+        "runtime": {
+            "risk_level": str(permission_profile.get("risk_level") or "low"),
+            "approval_behavior": str(permission_profile.get("approval_behavior") or "never"),
+            "requires_approval": bool(permission_profile.get("requires_approval")),
+            "lifecycle_approval_boundaries": _dedupe_strings(
+                permission_profile.get("lifecycle_approval_boundaries")
+            ),
+        },
+        "health": {
+            "state": "ready" if bool(permission_profile.get("ok", True)) else enforcement["status"],
+            "ready": bool(permission_profile.get("ok", True)),
+        },
+        "preflight": {
+            "status": "ready" if bool(permission_profile.get("ok", True)) else enforcement["status"],
+            "ready": bool(permission_profile.get("ok", True)),
+            "blocking_reasons": [enforcement["reason"]] if enforcement["reason"] else [],
+        },
+        "compatibility": {
+            "seraph": manifest.compatibility.seraph if manifest is not None else None,
+            "compatible": True,
+        },
+        "enforcement": enforcement,
+        "quarantine": {
+            "state": "active" if enforcement["status"] == "accepted" else enforcement["status"],
+            "reasons": [enforcement["reason"]] if enforcement["reason"] else [],
+        },
+    }

--- a/backend/src/extensions/lifecycle.py
+++ b/backend/src/extensions/lifecycle.py
@@ -34,6 +34,7 @@ from src.extensions.manifest import (
     load_extension_manifest,
     parse_extension_manifest,
 )
+from src.extensions.capability_contract import build_capability_contract
 from src.extensions.permissions import (
     evaluate_contribution_permissions,
     evaluate_tool_permissions,
@@ -1369,6 +1370,32 @@ def _planned_connector_definition_errors(contribution: ExtensionContributionReco
     return errors
 
 
+def _finalize_contribution_payload(
+    extension: ExtensionRecord,
+    contribution: ExtensionContributionRecord,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    permission_profile = payload.get("permission_profile")
+    if not isinstance(permission_profile, dict):
+        return payload
+    contract = build_capability_contract(
+        extension,
+        contribution_type=contribution.contribution_type,
+        reference=contribution.reference,
+        metadata=contribution.metadata,
+        permission_profile=permission_profile,
+    )
+    payload["capability_contract"] = contract
+    payload["capability_enforcement"] = contract["enforcement"]
+    enforcement_status = str(contract["enforcement"].get("status") or "")
+    if enforcement_status == "rejected":
+        payload["status"] = enforcement_status
+        payload["runtime_ready"] = False
+    elif enforcement_status == "quarantined":
+        payload["runtime_ready"] = False
+    return payload
+
+
 def _contribution_payload(
     extension: ExtensionRecord,
     contribution: ExtensionContributionRecord,
@@ -1414,7 +1441,7 @@ def _contribution_payload(
         health = mcp_server_health(contribution.metadata, runtime_entry)
         payload["health"] = health.as_payload()
         payload.setdefault("status", health.state)
-        return payload
+        return _finalize_contribution_payload(extension, contribution, payload)
     if contribution.contribution_type == "managed_connectors":
         default_enabled = _connector_default_enabled(contribution)
         enabled = _connector_enabled(contribution, state_entry)
@@ -1465,7 +1492,7 @@ def _contribution_payload(
             enabled=enabled,
         ).as_payload()
         payload["status"] = str(payload["health"].get("state") or payload["status"])
-        return payload
+        return _finalize_contribution_payload(extension, contribution, payload)
     if contribution.contribution_type in _PLANNED_CONNECTOR_CONTRIBUTION_TYPES:
         default_enabled = _connector_default_enabled(contribution)
         enabled = _connector_enabled(contribution, state_entry)
@@ -1540,7 +1567,7 @@ def _contribution_payload(
             payload["configured"] = configured and not config_errors
             payload["health"] = health.as_payload()
             payload["status"] = str(payload["health"].get("state") or "planned")
-        return payload
+        return _finalize_contribution_payload(extension, contribution, payload)
     if contribution.contribution_type == "observer_definitions":
         active_definition = (
             indexes.get("observer_definitions", {}).get(normalized_path or "")
@@ -1593,7 +1620,7 @@ def _contribution_payload(
             supports_disable=True,
             supports_test=True,
         ).as_payload()
-        return payload
+        return _finalize_contribution_payload(extension, contribution, payload)
     if contribution.contribution_type == "channel_adapters":
         active_adapter = (
             indexes.get("channel_adapters", {}).get(normalized_path or "")
@@ -1669,7 +1696,7 @@ def _contribution_payload(
             payload["health"] = health.as_payload()
             if daemon_connected is not None:
                 payload["health"]["connected"] = daemon_connected
-        return payload
+        return _finalize_contribution_payload(extension, contribution, payload)
     if contribution.contribution_type in {"observer_connectors", "workspace_adapters"}:
         payload = {
             "type": contribution.contribution_type,
@@ -1686,7 +1713,7 @@ def _contribution_payload(
                 "Runtime support for this connector surface is not wired yet.",
             ).as_payload(),
         }
-        return payload
+        return _finalize_contribution_payload(extension, contribution, payload)
     item = (
         indexes.get(contribution.contribution_type, {}).get(normalized_path or "")
         if normalized_path is not None
@@ -1766,7 +1793,7 @@ def _contribution_payload(
     payload.setdefault("missing_manifest_network", bool(payload["permission_profile"]["missing_network"]))
     payload.setdefault("approval_behavior", payload["permission_profile"]["approval_behavior"])
     payload.setdefault("requires_approval", bool(payload["permission_profile"]["requires_approval"]))
-    return payload
+    return _finalize_contribution_payload(extension, contribution, payload)
 
 
 def _toggle_targets(extension: ExtensionRecord) -> list[dict[str, str]]:
@@ -2212,6 +2239,32 @@ def _set_runtime_selector_contribution_enabled(
     }
 
 
+def _raise_if_capability_enforcement_blocks_enable(
+    extension: ExtensionRecord,
+    contribution: ExtensionContributionRecord,
+) -> None:
+    permission_profile = evaluate_contribution_permissions(
+        extension,
+        contribution_type=contribution.contribution_type,
+        metadata=contribution.metadata,
+    )
+    contract = build_capability_contract(
+        extension,
+        contribution_type=contribution.contribution_type,
+        reference=contribution.reference,
+        metadata=contribution.metadata,
+        permission_profile=permission_profile,
+    )
+    enforcement = contract["enforcement"]
+    if enforcement.get("status") not in {"rejected", "quarantined"}:
+        return
+    status = str(enforcement.get("status") or "blocked")
+    reason = str(enforcement.get("reason") or "manifest permissions do not cover the contribution")
+    raise ValueError(
+        f"connector '{contribution.reference}' in extension '{extension.id}' is {status}: {reason}"
+    )
+
+
 def set_extension_connector_enabled(
     extension_id: str,
     reference: str,
@@ -2226,6 +2279,8 @@ def set_extension_connector_enabled(
     contribution = next((item for item in extension.contributions if item.reference == reference), None)
     if contribution is None:
         raise KeyError(reference)
+    if enabled:
+        _raise_if_capability_enforcement_blocks_enable(extension, contribution)
     if contribution.contribution_type == "managed_connectors":
         return _set_managed_connector_enabled(extension, contribution, enabled=enabled)
     if contribution.contribution_type == "memory_providers":

--- a/backend/src/extensions/manifest.py
+++ b/backend/src/extensions/manifest.py
@@ -139,10 +139,21 @@ class ExtensionPermissions(BaseModel):
     tools: list[str] = Field(default_factory=list)
     execution_boundaries: list[str] = Field(default_factory=list)
     network: bool = False
+    data_access: list[str] = Field(default_factory=list)
+    mutation_rights: list[str] = Field(default_factory=list)
+    audit_events: list[str] = Field(default_factory=list)
     secrets: list[str] = Field(default_factory=list)
     env: list[str] = Field(default_factory=list)
 
-    @field_validator("tools", "execution_boundaries", "secrets", "env")
+    @field_validator(
+        "tools",
+        "execution_boundaries",
+        "data_access",
+        "mutation_rights",
+        "audit_events",
+        "secrets",
+        "env",
+    )
     @classmethod
     def _validate_string_list(cls, values: list[str]) -> list[str]:
         normalized: list[str] = []

--- a/backend/src/extensions/permissions.py
+++ b/backend/src/extensions/permissions.py
@@ -154,7 +154,7 @@ def _merge_explicit_boundaries_into_profile(
     missing_boundaries = [
         boundary
         for boundary in required_boundaries
-        if declared_boundaries and boundary not in declared_boundaries
+        if boundary not in declared_boundaries
     ]
     requires_network = bool(profile.get("requires_network")) or any(
         boundary in NETWORK_BOUNDARIES for boundary in required_boundaries
@@ -243,7 +243,7 @@ def evaluate_tool_permissions(
     missing_boundaries = [
         boundary
         for boundary in required_boundaries
-        if declared_boundaries and boundary not in declared_boundaries
+        if boundary not in declared_boundaries
     ]
     missing_network = requires_network and not manifest_permissions.network
     ok = not missing_tools and not missing_boundaries and not missing_network
@@ -315,7 +315,6 @@ def evaluate_contribution_permissions(
                     for _ in [0]
                     if extension is not None
                     and extension.manifest is not None
-                    and extension.manifest.permissions.execution_boundaries
                     and "external_mcp" not in extension.manifest.permissions.execution_boundaries
                 ],
                 "requires_network": True,
@@ -468,6 +467,21 @@ def summarize_extension_permissions(
         if extension.manifest is not None
         else []
     )
+    declared_data_access = (
+        _dedupe_strings(extension.manifest.permissions.data_access)
+        if extension.manifest is not None
+        else []
+    )
+    declared_mutation_rights = (
+        _dedupe_strings(extension.manifest.permissions.mutation_rights)
+        if extension.manifest is not None
+        else []
+    )
+    declared_audit_events = (
+        _dedupe_strings(extension.manifest.permissions.audit_events)
+        if extension.manifest is not None
+        else []
+    )
     required_tools = _dedupe_strings(
         [tool_name for profile in contribution_profiles for tool_name in profile.get("required_tools", [])]
     )
@@ -511,6 +525,9 @@ def summarize_extension_permissions(
             ),
             "secrets": declared_secrets,
             "env": declared_env,
+            "data_access": declared_data_access,
+            "mutation_rights": declared_mutation_rights,
+            "audit_events": declared_audit_events,
         },
         "required": {
             "tools": required_tools,

--- a/backend/src/native_tools/registry.py
+++ b/backend/src/native_tools/registry.py
@@ -138,6 +138,11 @@ TOOL_METADATA: dict[str, dict] = {
         "policy_modes": ["safe", "balanced", "full"],
         "execution_boundaries": ["external_read"],
     },
+    "http_request": {
+        "description": "Fetch an HTTP resource through the packaged request connector",
+        "policy_modes": ["safe", "balanced", "full"],
+        "execution_boundaries": ["external_read"],
+    },
     "source_capabilities": {
         "description": "Inspect the provider-neutral source access surfaces available to the current runtime",
         "policy_modes": ["safe", "balanced", "full"],

--- a/backend/tests/test_capabilities_api.py
+++ b/backend/tests/test_capabilities_api.py
@@ -295,6 +295,23 @@ def test_mcp_status_list_exposes_packaged_toolset_presets(tmp_path):
     ]
 
 
+def test_tool_status_list_exposes_native_capability_contract():
+    from src.api.capabilities import _tool_status_list
+
+    tools = {item["name"]: item for item in _tool_status_list("safe")}
+
+    contract = tools["read_file"]["capability_contract"]
+    assert contract["schema_version"] == "2026-05-04.m1"
+    assert contract["family"] == "native_tool"
+    assert contract["trust_class"] == "seraph_bundled"
+    assert contract["permissions"]["required"]["execution_boundaries"] == ["workspace_read"]
+    assert contract["preflight"]["ready"] is True
+
+    blocked_contract = tools["write_file"]["capability_contract"]
+    assert blocked_contract["preflight"]["ready"] is False
+    assert blocked_contract["preflight"]["blocking_reasons"] == ["tool_policy_safe"]
+
+
 def test_doctor_reports_missing_mcp_server_reference_for_toolset_preset(tmp_path):
     package_dir = tmp_path / "extensions" / "github-pack"
     (package_dir / "presets" / "toolset").mkdir(parents=True)

--- a/backend/tests/test_catalog_api.py
+++ b/backend/tests/test_catalog_api.py
@@ -622,6 +622,26 @@ class TestCatalogAPI:
         )
         assert messaging_connector["enabled"] is True
         assert messaging_connector["status"] == "planned"
+        contract = messaging_connector["capability_contract"]
+        assert contract["permissions"]["declared"]["data_access"] == [
+            "operator_messages",
+            "delivery_threads",
+            "messaging_credentials",
+        ]
+        assert contract["permissions"]["declared"]["mutation_rights"] == [
+            "send_operator_message",
+            "update_delivery_thread",
+        ]
+        assert contract["permissions"]["declared"]["execution_boundaries"] == [
+            "external_read",
+            "connector_mutation",
+            "secret_management",
+        ]
+        assert contract["permissions"]["declared"]["audit_events"] == [
+            "connector_configured",
+            "connector_enabled",
+            "message_delivery_attempted",
+        ]
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -707,6 +727,28 @@ class TestCatalogAPI:
         assert provider["name"] == "browserbase"
         assert provider["provider_kind"] == "browserbase"
         assert provider["status"] == "requires_config"
+        contract = provider["capability_contract"]
+        assert contract["schema_version"] == "2026-05-04.m1"
+        assert contract["trust_class"] == "seraph_bundled"
+        assert contract["provenance"]["version"] == "2026.3.23"
+        assert contract["permissions"]["declared"]["data_access"] == [
+            "browser_session_state",
+            "external_web_pages",
+            "provider_credentials",
+        ]
+        assert contract["permissions"]["declared"]["mutation_rights"] == [
+            "browser_navigation",
+            "remote_browser_session_config",
+        ]
+        assert contract["permissions"]["declared"]["audit_events"] == [
+            "connector_configured",
+            "connector_enabled",
+            "browser_session_started",
+        ]
+        assert contract["permissions"]["declared"]["execution_boundaries"] == [
+            "external_read",
+            "secret_management",
+        ]
         assert preset["name"] == "browserbase-ops"
         assert "browser_session" in preset["include_tools"]
 

--- a/backend/tests/test_extension_manifest.py
+++ b/backend/tests/test_extension_manifest.py
@@ -30,6 +30,12 @@ permissions:
   tools:
     - web_search
     - write_file
+  data_access:
+    - public_web
+  mutation_rights:
+    - workspace.files.write
+  audit_events:
+    - tool_call
   network: true
 """
     )
@@ -39,6 +45,9 @@ permissions:
     assert manifest.trust.value == "bundled"
     assert manifest.contributed_types() == {"skills", "workflows", "runbooks", "mcp_servers"}
     assert manifest.permissions.tools == ["web_search", "write_file"]
+    assert manifest.permissions.data_access == ["public_web"]
+    assert manifest.permissions.mutation_rights == ["workspace.files.write"]
+    assert manifest.permissions.audit_events == ["tool_call"]
     assert manifest.is_compatible_with("2026.4.10") is True
     assert manifest.is_compatible_with("2027.1.0") is False
 

--- a/backend/tests/test_extension_permissions.py
+++ b/backend/tests/test_extension_permissions.py
@@ -1,6 +1,9 @@
 from unittest.mock import MagicMock, patch
 
-from src.extensions.permissions import evaluate_tool_permissions
+from src.extensions.capability_contract import build_capability_contract
+from src.extensions.manifest import parse_extension_manifest
+from src.extensions.permissions import evaluate_contribution_permissions, evaluate_tool_permissions
+from src.extensions.registry import ExtensionRecord
 
 
 def test_evaluate_tool_permissions_preserves_runtime_mcp_secret_ref_fields():
@@ -16,3 +19,147 @@ def test_evaluate_tool_permissions_preserves_runtime_mcp_secret_ref_fields():
 
     assert permissions["accepts_secret_refs"] is True
 
+
+def _extension_record_for_manifest(manifest_content: str) -> ExtensionRecord:
+    manifest = parse_extension_manifest(manifest_content)
+    return ExtensionRecord(
+        id=manifest.id,
+        display_name=manifest.display_name,
+        kind=manifest.kind.value,
+        trust=manifest.trust.value,
+        source="manifest",
+        root_path="/tmp/contract-pack",
+        manifest_path="/tmp/contract-pack/manifest.yaml",
+        manifest=manifest,
+    )
+
+
+def test_capability_contract_rejects_undeclared_privileged_workflow_behavior():
+    extension = _extension_record_for_manifest(
+        """
+id: seraph.contract-test
+version: 2026.5.4
+display_name: Contract Test
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.4.10"
+publisher:
+  name: Seraph
+trust: local
+description: Operator-visible pack description.
+contributes:
+  workflows:
+    - workflows/write-note.md
+permissions:
+  tools: []
+  network: false
+  data_access:
+    - workspace.files
+  mutation_rights:
+    - none
+  audit_events:
+    - tool_call
+"""
+    )
+
+    profile = evaluate_contribution_permissions(
+        extension,
+        contribution_type="workflows",
+        metadata={"step_tools": ["write_file"], "description": "Writes into the workspace."},
+    )
+    contract = build_capability_contract(
+        extension,
+        contribution_type="workflows",
+        reference="workflows/write-note.md",
+        metadata={"step_tools": ["write_file"], "description": "Writes into the workspace."},
+        permission_profile=profile,
+    )
+
+    assert contract["schema_version"] == "2026-05-04.m1"
+    assert contract["provenance"]["extension_id"] == "seraph.contract-test"
+    assert contract["operator"]["description"] == "Writes into the workspace."
+    assert contract["permissions"]["declared"]["data_access"] == ["workspace.files"]
+    assert contract["permissions"]["declared"]["mutation_rights"] == ["none"]
+    assert contract["permissions"]["declared"]["audit_events"] == ["tool_call"]
+    assert contract["permissions"]["missing"]["tools"] == ["write_file"]
+    assert contract["permissions"]["missing"]["execution_boundaries"] == ["workspace_write"]
+    assert contract["enforcement"]["status"] == "rejected"
+    assert contract["enforcement"]["action"] == "reject"
+    assert contract["enforcement"]["runtime_ready"] is False
+
+
+def test_capability_contract_quarantines_undeclared_network_connector_behavior():
+    extension = _extension_record_for_manifest(
+        """
+id: seraph.connector-contract-test
+version: 2026.5.4
+display_name: Connector Contract Test
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.4.10"
+publisher:
+  name: Seraph
+trust: local
+contributes:
+  managed_connectors:
+    - connectors/managed/github.yaml
+permissions:
+  network: false
+"""
+    )
+
+    profile = evaluate_contribution_permissions(
+        extension,
+        contribution_type="managed_connectors",
+        metadata={"name": "github", "requires_network": True},
+    )
+    contract = build_capability_contract(
+        extension,
+        contribution_type="managed_connectors",
+        reference="connectors/managed/github.yaml",
+        metadata={"name": "github", "requires_network": True},
+        permission_profile=profile,
+    )
+
+    assert contract["permissions"]["missing"]["network"] is True
+    assert contract["enforcement"]["status"] == "quarantined"
+    assert contract["enforcement"]["action"] == "quarantine"
+
+
+def test_capability_contract_rejects_mcp_server_without_declared_boundary():
+    extension = _extension_record_for_manifest(
+        """
+id: seraph.mcp-contract-test
+version: 2026.5.4
+display_name: MCP Contract Test
+kind: connector-pack
+compatibility:
+  seraph: ">=2026.4.10"
+publisher:
+  name: Seraph
+trust: local
+contributes:
+  mcp_servers:
+    - mcp/github.json
+permissions:
+  network: true
+"""
+    )
+
+    profile = evaluate_contribution_permissions(
+        extension,
+        contribution_type="mcp_servers",
+        metadata={"name": "github", "transport": "stdio"},
+    )
+    contract = build_capability_contract(
+        extension,
+        contribution_type="mcp_servers",
+        reference="mcp/github.json",
+        metadata={"name": "github", "transport": "stdio"},
+        permission_profile=profile,
+    )
+
+    assert contract["permissions"]["missing"]["execution_boundaries"] == ["external_mcp"]
+    assert contract["permissions"]["missing"]["network"] is False
+    assert contract["enforcement"]["status"] == "rejected"
+    assert contract["enforcement"]["action"] == "reject"

--- a/backend/tests/test_extension_registry.py
+++ b/backend/tests/test_extension_registry.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from src.extensions.channels import select_active_channel_adapters
+from src.extensions.lifecycle import _contribution_payload
 from src.extensions.observers import select_active_observer_definitions
 from src.extensions.registry import ExtensionRegistry
 
@@ -43,6 +44,64 @@ contributes:
     assert extension.source == "manifest"
     assert {item.contribution_type for item in extension.contributions} == {"skills", "workflows"}
     assert extension.metadata["compatibility"] == ">=2026.4.10"
+
+
+def test_contribution_payload_surfaces_rejected_capability_contract(tmp_path: Path):
+    pack_dir = tmp_path / "extensions" / "contract-pack"
+    (pack_dir / "workflows").mkdir(parents=True)
+    (pack_dir / "manifest.yaml").write_text(
+        """
+id: seraph.contract-pack
+version: 2026.5.4
+display_name: Contract Pack
+kind: capability-pack
+compatibility:
+  seraph: ">=2026.4.10"
+publisher:
+  name: Seraph
+trust: local
+contributes:
+  workflows:
+    - workflows/write-note.md
+permissions:
+  tools: []
+  network: false
+""".strip(),
+        encoding="utf-8",
+    )
+    (pack_dir / "workflows" / "write-note.md").write_text(
+        "---\n"
+        "name: write-note\n"
+        "description: Write note\n"
+        "requires:\n"
+        "  tools: [write_file]\n"
+        "steps:\n"
+        "  - id: save\n"
+        "    tool: write_file\n"
+        "    arguments: {}\n"
+        "---\n",
+        encoding="utf-8",
+    )
+    snapshot = ExtensionRegistry(
+        manifest_roots=[str(tmp_path / "extensions")],
+        skill_dirs=[],
+        workflow_dirs=[],
+        mcp_runtime=None,
+    ).snapshot()
+    extension = snapshot.get_extension("seraph.contract-pack")
+    assert extension is not None
+
+    payload = _contribution_payload(
+        extension,
+        extension.contributions[0],
+        indexes={},
+        state_entry={},
+    )
+
+    assert payload["status"] == "rejected"
+    assert payload["runtime_ready"] is False
+    assert payload["capability_contract"]["permissions"]["missing"]["tools"] == ["write_file"]
+    assert payload["capability_enforcement"]["reason"]
 
 
 def test_registry_enriches_wave2_contribution_metadata(tmp_path: Path):

--- a/backend/tests/test_extensions_api.py
+++ b/backend/tests/test_extensions_api.py
@@ -791,6 +791,18 @@ async def test_list_extensions_includes_bundled_core_capabilities(client, extens
     assert bundled["version_line"] == ".".join(str(bundled["version"]).split(".")[:2])
     assert bundled["compatibility"]["compatible"] is True
     assert bundled["diagnostics_summary"]["issue_count"] == 0
+    skill_contribution = next(
+        item
+        for item in bundled["contributions"]
+        if item["type"] == "skills" and item.get("name") == "web-briefing"
+    )
+    contract = skill_contribution["capability_contract"]
+    assert contract["schema_version"] == "2026-05-04.m1"
+    assert contract["family"] == "skill"
+    assert contract["trust_class"] == "seraph_bundled"
+    assert contract["provenance"]["extension_id"] == "seraph.core-capabilities"
+    assert "web_search" in contract["permissions"]["required"]["tools"]
+    assert contract["enforcement"]["status"] == "accepted"
     managed = next(item for item in payload["extensions"] if item["id"] == "seraph.core-managed-connectors")
     assert managed["location"] == "bundled"
     assert managed["enable_supported"] is True

--- a/backend/tests/test_strategy_claims.py
+++ b/backend/tests/test_strategy_claims.py
@@ -8,6 +8,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 
+def _read_doc(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
 def test_strategy_claim_gate_passes_for_current_docs() -> None:
     result = subprocess.run(
         [sys.executable, str(ROOT / "scripts/check_strategy_claims.py")],
@@ -34,3 +38,51 @@ def test_strategy_claim_gate_rejects_unlinked_high_risk_claim(tmp_path: Path) ->
 
     assert result.returncode == 1
     assert "M0 claim ledger" in result.stderr
+
+
+def test_m1_capability_contract_docs_pin_downstream_acceptance_and_proof() -> None:
+    roadmap = _read_doc("docs/implementation/00-master-roadmap.md")
+    docs_contract = _read_doc("docs/implementation/08-docs-contract.md")
+    strategy_delivery = _read_doc("docs/implementation/11-world-class-strategy-delivery.md")
+
+    assert "## M1 Capability Contract" in roadmap
+    for downstream in ("M2", "M3", "M9"):
+        assert downstream in roadmap
+        assert downstream in strategy_delivery
+
+    required_contract_terms = (
+        "identity",
+        "manifest",
+        "permissions",
+        "provenance",
+        "mutation rights",
+        "health",
+        "compatibility",
+        "lifecycle state",
+        "trust level",
+    )
+    for term in required_contract_terms:
+        assert term in strategy_delivery
+
+    required_acceptance_terms = (
+        "capability classes covered",
+        "source and owner",
+        "declared permissions",
+        "the proof surface",
+        "Do not mark M1 complete from docs alone",
+    )
+    for term in required_acceptance_terms:
+        assert term in docs_contract
+
+    required_proof_receipts = (
+        "capability inventory payloads",
+        "lifecycle/validation output",
+        "audit or Activity Ledger receipts",
+        "deterministic tests",
+        "benchmark suites",
+        "issue links",
+        "PR validation",
+        "implementation-doc paths",
+    )
+    for receipt in required_proof_receipts:
+        assert receipt in strategy_delivery

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -36,11 +36,22 @@ When these docs are updated on an open feature branch, they describe the intende
 - `docs/implementation/01` through `07` are the only workstream docs; `08` through `11` are cross-cutting implementation mirrors, not extra workstreams.
 - if research adds a new benchmark/program layer without an implementation mirror, the docs are incomplete.
 - active execution state belongs in the GitHub Project, issues, and PRs rather than this document
+- M1 capability-kernel contract changes must update this roadmap plus [08. Docs Contract](./08-docs-contract.md) and [11. World-Class Strategy Delivery](./11-world-class-strategy-delivery.md) together, because M2 execution breadth, M3 trust-boundary enforcement, and M9 ecosystem governance all consume that contract.
 
 ## Current Status
 
 Read this roadmap together with [Development Status](./STATUS.md).
 For the implementation-side mirrors of the evidence, benchmark, superiority, and world-class strategy layers, also read [08. Docs Contract](./08-docs-contract.md), [09. Benchmark Status](./09-benchmark-status.md), [10. Superiority Delivery](./10-superiority-delivery.md), and [11. World-Class Strategy Delivery](./11-world-class-strategy-delivery.md).
+
+## M1 Capability Contract
+
+M1 is the stable source of truth for capability identity and manifest semantics that later milestones consume. It is not a separate feature queue.
+
+- M2 consumes M1 to know which execution surfaces exist, which owner controls them, what dependencies or health states block them, and which operator actions are allowed.
+- M3 consumes M1 to enforce declared permissions, mutation rights, trust levels, provenance, approval behavior, audit expectations, and fail-closed boundary rules.
+- M9 consumes M1 to govern extension-owned contributions through manifest kind, version, compatibility, publisher, lifecycle state, package health, and review or verification posture.
+- Capability inventory proof must stay operator-visible and evidence-grounded: each capability class should expose source, owner, trust level, boundary, health, dependencies, declared permissions, and available actions before later milestones treat that class as ready.
+- PRs that alter capability taxonomy, manifest semantics, permission vocabulary, provenance, health, compatibility, or lifecycle behavior must include acceptance and proof language that identifies the affected M2, M3, or M9 consumer.
 
 Legend for the checklist column:
 

--- a/docs/implementation/08-docs-contract.md
+++ b/docs/implementation/08-docs-contract.md
@@ -100,6 +100,26 @@ Use this as the default execution model when several internal slices will land t
 - do not mirror one aggregate PR across all child slice issues; the parent batch issue remains the main project item for aggregate `PR` and `Code Review` state
 - use issue comments or the PR body for receipts and progress notes, not as a second authoritative slice-state surface
 
+## M1 Capability Contract Updates
+
+M1 capability-kernel docs are contract docs. They define the reusable capability taxonomy and manifest semantics that M2, M3, and M9 depend on; they must not become a live issue mirror.
+
+When a PR changes capability identity, manifest contribution semantics, permission vocabulary, provenance, health, compatibility, lifecycle state, or package ownership, update all affected durable truth surfaces in the same PR:
+
+- [00. Master Roadmap](./00-master-roadmap.md): strategic contract and completed-program context
+- [11. World-Class Strategy Delivery](./11-world-class-strategy-delivery.md): milestone consumer rules and proof language
+- owning workstream docs: shipped behavior, missing gap, validation, and review receipts when shipped truth changes
+- [STATUS](./STATUS.md): only when the branch changes the fastest shipped snapshot after merge
+
+M1 acceptance language should identify:
+
+- capability classes covered, including core tools, workflow tools, MCP tools, skills, workflows, runbooks, starter packs, automations, browser or computer-use surfaces, managed connectors, memory providers, and extension-owned contributions
+- the source and owner for each class, including whether the behavior is core-owned, package-owned, connector-owned, or transitional compatibility behavior
+- declared permissions, mutation rights, provenance, trust level, health, dependencies, compatibility, and available operator actions
+- the proof surface, such as API payloads, manifest validation, lifecycle receipts, audit or activity receipts, cockpit inventory, deterministic tests, or benchmark suites
+
+Do not mark M1 complete from docs alone. Completion requires implementation receipts on `develop`, linked issue or PR proof, and operator-visible inventory that downstream M2/M3/M9 work can rely on.
+
 ## Latest Workflow Contract Update
 
 - [x] GitHub Project now owns the active execution layer for Seraph.

--- a/docs/implementation/11-world-class-strategy-delivery.md
+++ b/docs/implementation/11-world-class-strategy-delivery.md
@@ -123,6 +123,30 @@ Implementation meaning: Seraph needs one stable capability map and permission co
 - missing strategic gaps: sharper taxonomy for core tools vs workflow tools vs MCP tools vs skills vs runbooks vs starter packs vs connectors vs extension-owned surfaces; clearer capability family ownership; one contract for permissions, provenance, mutation rights, health, compatibility, and trust level
 - proof requirements: operator-visible inventory that shows source, trust level, owner, boundary, health, dependencies, declared permissions, and available actions for each capability class
 
+M1 source-of-truth contract:
+
+- scope: core tools, workflow tools, MCP tools, skills, workflows, runbooks, starter packs, automations, browser/computer-use surfaces, managed connectors, memory providers, source adapters, channel adapters, observer sources, and extension-owned contributions
+- identity: every capability class needs a stable family, source, owner, package or core boundary, lifecycle state, and operator-facing label
+- manifest contract: extension-owned capability must declare kind, contribution type, version, compatibility, publisher or origin, dependencies, declared permissions, trust level, health checks, and lifecycle controls before downstream milestones treat it as dependable
+- permission contract: mutation rights, secret use, filesystem/process/browser/provider reach, connector egress, approval profile, and audit expectations must be explicit enough for M3 trust-boundary work to enforce or fail closed
+- provenance contract: inventory and receipts should distinguish core-owned behavior, package-owned behavior, managed connector behavior, raw MCP exposure, external provider evidence, and transitional compatibility paths
+- operator proof: cockpit/API surfaces should let an operator inspect why a capability exists, where it came from, what it can do, what blocks it, what repair or install action is available, and which receipt proves the state
+
+Acceptance for #425/#434:
+
+- the durable docs name M1 as the capability-kernel source of truth for M2, M3, and M9
+- the accepted contract covers identity, manifest shape, permissions, provenance, mutation rights, health, compatibility, lifecycle state, and trust level
+- acceptance/proof wording is evidence-grounded and does not imply M1 is complete from documentation alone
+- future M2/M3/M9 work has a clear rule for when it must update M1 docs or reject a capability class as underdeclared
+
+Proof language for the batch should cite concrete receipts, not broad strategy claims: affected manifests or APIs, capability inventory payloads, lifecycle/validation output, audit or Activity Ledger receipts, deterministic tests, benchmark suites, issue links, PR validation, and implementation-doc paths.
+
+M2/M3/M9 dependency rules:
+
+- M2 may build execution depth only on capability classes with declared owner, dependencies, health, available actions, and recovery/repair semantics.
+- M3 may enforce trusted execution only on capability classes with declared permissions, mutation rights, approval behavior, audit expectations, provenance, and fail-closed behavior.
+- M9 may grow ecosystem breadth only on extension-owned capability classes with manifest kind, contribution type, version, compatibility, publisher or origin, lifecycle state, package health, and review or verification posture.
+
 ## M2 Execution Supremacy
 
 Implementation meaning: Seraph should be excellent at real work across terminal, process management, browser/computer use, file operations, patching, artifacts, sandboxes, background sessions, and repair.

--- a/frontend/src/components/cockpit/CockpitView.test.tsx
+++ b/frontend/src/components/cockpit/CockpitView.test.tsx
@@ -9426,7 +9426,45 @@ describe("CockpitView", () => {
               lifecycle_boundaries: ["workspace_write"],
             },
             connector_summary: { total: 1, ready: 0, states: { degraded: 1 } },
-            contributions: [],
+            contributions: [{
+              type: "messaging_connectors",
+              reference: "connectors/messaging/slack.yaml",
+              resolved_path: "/tmp/workspace/extensions/research-pack/connectors/messaging/slack.yaml",
+              loaded: true,
+              enabled: true,
+              configured: true,
+              name: "slack",
+              status: "ready",
+              health: { state: "ready", ready: true },
+              permission_profile: {
+                status: "granted",
+                requires_network: true,
+                missing_network: false,
+                requires_approval: true,
+                approval_behavior: "lifecycle",
+                missing_tools: [],
+                missing_execution_boundaries: [],
+              },
+              capability_contract: {
+                schema_version: "2026-05-04.m1",
+                trust_class: "workspace",
+                provenance: { extension_id: "seraph.research-pack", version: "2026.4.03" },
+                permissions: {
+                  declared: {
+                    data_access: ["operator_messages"],
+                    mutation_rights: ["send_operator_message"],
+                    audit_events: ["message_delivery_attempted"],
+                    execution_boundaries: ["external_read", "connector_mutation"],
+                  },
+                },
+              },
+              config_fields: [],
+              config_keys: [],
+              capabilities: [],
+              delivery_modes: ["channel"],
+              requires_network: true,
+              requires_daemon: false,
+            }],
             studio_files: [{
               key: "seraph.research-pack:manifest",
               role: "manifest",
@@ -9474,6 +9512,15 @@ describe("CockpitView", () => {
     expect(within(healthRow as HTMLElement).getByRole("button", { name: "draft" })).toBeInTheDocument();
     expect(within(healthRow as HTMLElement).getByText(/publisher Workspace/)).toBeInTheDocument();
     expect(within(healthRow as HTMLElement).getByText(/lifecycle approval/)).toBeInTheDocument();
+    expect(within(healthRow as HTMLElement).getByText(/1\/1 contracts/)).toBeInTheDocument();
+    expect(within(healthRow as HTMLElement).getByText(/operator messages data/)).toBeInTheDocument();
+    expect(within(healthRow as HTMLElement).getByText(/send operator message mutation/)).toBeInTheDocument();
+
+    const reachSection = screen.getByText("imported capability reach").closest(".cockpit-operator-section");
+    expect(reachSection).not.toBeNull();
+    const messagingRow = within(reachSection as HTMLElement).getByText("messaging").closest(".cockpit-operator-row");
+    expect(messagingRow).not.toBeNull();
+    expect(within(messagingRow as HTMLElement).getByText(/1 contracts/)).toBeInTheDocument();
 
     const flowSection = screen.getByText("marketplace flows").closest(".cockpit-operator-section");
     expect(flowSection).not.toBeNull();

--- a/frontend/src/components/cockpit/CockpitView.tsx
+++ b/frontend/src/components/cockpit/CockpitView.tsx
@@ -1287,6 +1287,39 @@ interface ExtensionContributionPermissionProfile {
   missing_execution_boundaries: string[];
 }
 
+interface ExtensionCapabilityContract {
+  schema_version?: string;
+  version?: string;
+  capability_id?: string;
+  family?: string;
+  trust_class?: string;
+  operator?: {
+    display_name?: string | null;
+    description?: string | null;
+  };
+  operator_description?: string | null;
+  provenance?: Record<string, unknown>;
+  permissions?: {
+    declared?: {
+      tools?: string[];
+      execution_boundaries?: string[];
+      network?: boolean | null;
+      data_access?: string[];
+      mutation_rights?: string[] | Record<string, boolean>;
+      audit_events?: string[];
+      secrets?: string[];
+      env?: string[];
+    };
+    required?: Record<string, unknown>;
+    missing?: Record<string, unknown>;
+  };
+  runtime?: Record<string, unknown>;
+  enforcement?: Record<string, unknown>;
+  mutation_rights?: Record<string, boolean>;
+  audit?: Record<string, unknown>;
+  quarantine?: Record<string, unknown>;
+}
+
 interface ExtensionContributionHealth {
   state: string;
   summary?: string | null;
@@ -1326,6 +1359,8 @@ interface ExtensionContributionInfo {
   effective_output_surface?: string | null;
   health?: ExtensionContributionHealth | null;
   permission_profile?: ExtensionContributionPermissionProfile | null;
+  capability_contract?: ExtensionCapabilityContract | null;
+  capability_enforcement?: Record<string, unknown> | null;
   config_fields: Array<Record<string, unknown>>;
   config_keys: string[];
   capabilities: string[];
@@ -1641,6 +1676,7 @@ interface ImportedCapabilityFamilySummary {
   ready: number;
   attention: number;
   approval: number;
+  contractCount: number;
   packages: string[];
   entries: Array<{
     packageId: string;
@@ -1978,6 +2014,52 @@ function formatExtensionGovernanceSummary(extensionPackage: ExtensionPackageInfo
     parts.push(`${degradedConnectors} degraded ${degradedConnectors === 1 ? "connector" : "connectors"}`);
   }
   return parts.length ? parts.join(" · ") : null;
+}
+
+function readContractDeclaredList(
+  contract: ExtensionCapabilityContract | null | undefined,
+  field: "data_access" | "audit_events" | "execution_boundaries",
+): string[] {
+  const value = contract?.permissions?.declared?.[field];
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0) : [];
+}
+
+function readContractMutationRights(contract: ExtensionCapabilityContract | null | undefined): string[] {
+  const declared = contract?.permissions?.declared?.mutation_rights;
+  if (Array.isArray(declared)) {
+    return declared.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+  }
+  if (declared && typeof declared === "object") {
+    return Object.entries(declared)
+      .filter(([, enabled]) => enabled === true)
+      .map(([name]) => name);
+  }
+  const derived = contract?.mutation_rights;
+  if (derived && typeof derived === "object") {
+    return Object.entries(derived)
+      .filter(([, enabled]) => enabled === true)
+      .map(([name]) => name);
+  }
+  return [];
+}
+
+function formatExtensionContractSummary(extensionPackage: ExtensionPackageInfo): string | null {
+  const contributionsWithContracts = extensionPackage.contributions.filter((item) => item.capability_contract);
+  if (!contributionsWithContracts.length) return null;
+  const dataAccess = Array.from(new Set(
+    contributionsWithContracts.flatMap((item) => readContractDeclaredList(item.capability_contract, "data_access")),
+  ));
+  const mutationRights = Array.from(new Set(
+    contributionsWithContracts.flatMap((item) => readContractMutationRights(item.capability_contract)),
+  ));
+  const parts = [`${contributionsWithContracts.length}/${extensionPackage.contributions.length} contracts`];
+  if (dataAccess.length) {
+    parts.push(`${dataAccess.slice(0, 2).map(activitySpendBucketLabel).join(", ")} data`);
+  }
+  if (mutationRights.length) {
+    parts.push(`${mutationRights.slice(0, 2).map(activitySpendBucketLabel).join(", ")} mutation`);
+  }
+  return parts.join(" · ");
 }
 
 function isContributionActive(contribution: ExtensionContributionInfo): boolean {
@@ -3426,6 +3508,14 @@ function normalizeExtensionContribution(value: Record<string, unknown>): Extensi
     effective_output_surface: readString("effective_output_surface"),
     health: normalizeContributionHealth(value.health),
     permission_profile: normalizeContributionPermissionProfile(value.permission_profile),
+    capability_contract:
+      value.capability_contract && typeof value.capability_contract === "object" && !Array.isArray(value.capability_contract)
+        ? value.capability_contract as ExtensionCapabilityContract
+        : null,
+    capability_enforcement:
+      value.capability_enforcement && typeof value.capability_enforcement === "object" && !Array.isArray(value.capability_enforcement)
+        ? value.capability_enforcement as Record<string, unknown>
+        : null,
     config_fields: Array.isArray(value.config_fields)
       ? value.config_fields.flatMap((entry) => (
         entry && typeof entry === "object" && !Array.isArray(entry) ? [entry as Record<string, unknown>] : []
@@ -3700,6 +3790,7 @@ function buildExtensionManifestEntity(extension: ExtensionPackageInfo): Operator
       permission_summary: extension.permission_summary ?? null,
       approval_profile: extension.approval_profile ?? null,
       connector_summary: extension.connector_summary ?? null,
+      capability_contract_summary: formatExtensionContractSummary(extension),
       contributions: extension.contributions,
     },
   };
@@ -6063,6 +6154,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
         entry.contribution.permission_profile?.requires_approval
         || entry.contribution.approval_behavior === "always"
       )).length;
+      const contractCount = entries.filter((entry) => entry.contribution.capability_contract).length;
       return {
         type: definition.type,
         label: definition.label,
@@ -6071,6 +6163,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
         ready,
         attention,
         approval,
+        contractCount,
         packages,
         entries,
       };
@@ -13600,6 +13693,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                                     status: entry.contribution.status,
                                     health: entry.contribution.health,
                                     permission_profile: entry.contribution.permission_profile,
+                                    capability_contract: entry.contribution.capability_contract,
                                   })),
                                 },
                               },
@@ -13613,6 +13707,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                             {family.installed > family.total ? ` · ${family.installed - family.total} inactive` : ""}
                             {family.attention ? ` · ${family.attention} attention` : ""}
                             {family.approval ? ` · ${family.approval} approval` : ""}
+                            {family.contractCount ? ` · ${family.contractCount} contracts` : ""}
                             {family.packages.length ? ` · ${family.packages.join(", ")}` : ""}
                           </div>
                         </button>
@@ -14160,6 +14255,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                                 formatExtensionCompatibilityLabel(extensionPackage.compatibility),
                                 formatExtensionDiagnosticsSummary(extensionPackage.diagnostics_summary),
                                 formatExtensionGovernanceSummary(extensionPackage),
+                                formatExtensionContractSummary(extensionPackage),
                                 formatExtensionPublisherLabel(extensionPackage.publisher),
                               ].filter(Boolean).join(" · ")}
                             </div>


### PR DESCRIPTION
## Summary
- add the M1 capability contract primitive and wire it into extension lifecycle payloads plus the capabilities overview
- fail closed on undeclared privileged capability behavior, including omitted execution-boundary declarations for MCP/tool-backed contributions
- migrate browser-provider and messaging-connector catalog packs to declared data access, mutation rights, audit events, secrets, and boundaries
- surface capability contract counts and data/mutation summaries in the cockpit operator view
- update M1 docs so M2/M3/M9 consume the contract without claiming those milestones are complete

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_extension_permissions.py tests/test_extension_manifest.py tests/test_extension_registry.py tests/test_extensions_api.py::test_list_extensions_includes_bundled_core_capabilities tests/test_extensions_api.py::test_duplicate_automation_trigger_name_invalidates_all_colliding_definitions tests/test_capabilities_api.py tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_messaging_connector_pack_can_be_configured_and_enabled tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_browserbase_pack_surfaces_browser_provider_metadata tests/test_catalog_api.py::TestCatalogAPI::test_install_catalog_extension_pack_updates_existing_workspace_install tests/test_strategy_claims.py -q -o addopts='' (78 passed)
- npm run test --prefix frontend -- CockpitView.test.tsx (64 passed)
- npm run build --prefix frontend
- npm run build --prefix docs (passed; Docusaurus local update-check warning only)
- python3 scripts/check_strategy_claims.py
- git diff --check && git diff --cached --check

## Critic / Contrarian
- Faraday found a P1 blocker: omitted execution_boundaries were accepted as permissive. Fixed by treating missing declared boundaries as missing, adding MCP regression coverage, and updating bundled/catalog manifests with explicit boundaries.
- Remaining concern: /capabilities/overview keeps extension inventory resilient if list_extensions raises; /extensions remains the diagnostic source for extension inventory failures.

Closes #425
Closes #434