### PR TITLE
M2 execution profiles and patch receipts

### DIFF
--- a/backend/src/agent/context_window.py
+++ b/backend/src/agent/context_window.py
@@ -15,6 +15,7 @@ from src.llm_runtime import completion_with_fallback_sync
 logger = logging.getLogger(__name__)
 
 _summary_cache: dict[str, str] = {}
+_encoding_unavailable = False
 
 
 @lru_cache(maxsize=1)
@@ -23,9 +24,13 @@ def _load_encoding():
 
 
 def _get_encoding():
+    global _encoding_unavailable
+    if _encoding_unavailable:
+        return None
     try:
         return _load_encoding()
     except Exception:
+        _encoding_unavailable = True
         logger.warning("Failed to load tiktoken encoding, using approximate token counts", exc_info=True)
         return None
 

--- a/backend/src/agent/specialists.py
+++ b/backend/src/agent/specialists.py
@@ -43,6 +43,8 @@ TOOL_DOMAINS: dict[str, str] = {
     "browser_session": "research",
     "read_file": "files",
     "write_file": "files",
+    "preview_workspace_patch": "files",
+    "apply_workspace_patch": "files",
     "fill_template": "files",
     "execute_code": "files",
 }

--- a/backend/src/api/capabilities.py
+++ b/backend/src/api/capabilities.py
@@ -1443,6 +1443,7 @@ def _tool_status_list(tool_mode: str) -> list[dict[str, Any]]:
                 execution_boundaries=execution_boundaries,
                 availability=availability,
                 blocked_reason=blocked_reason,
+                execution=metadata.get("execution") if isinstance(metadata.get("execution"), dict) else None,
             ),
         })
     return result

--- a/backend/src/api/operator.py
+++ b/backend/src/api/operator.py
@@ -214,6 +214,19 @@ def _within_operator_window(value: str | datetime | None, cutoff: datetime) -> b
     return _parse_iso(value) >= cutoff
 
 
+def _engineering_memory_reference_time(*groups: list[dict[str, Any]]) -> datetime:
+    timestamps: list[datetime] = []
+    for group in groups:
+        for item in group if isinstance(group, list) else []:
+            if not isinstance(item, dict):
+                continue
+            for key in ("updated_at", "started_at", "created_at", "matched_at"):
+                value = item.get(key)
+                if value:
+                    timestamps.append(_parse_iso(value))
+    return max(timestamps) if timestamps else datetime.now(timezone.utc)
+
+
 def _build_engineering_memory_bundles(
     workflow_runs: list[dict[str, Any]],
     pending_approvals: list[dict[str, Any]],
@@ -3012,25 +3025,35 @@ async def get_operator_engineering_memory(
         if normalized_query
         else asyncio.sleep(0, result=[]),
     )
+    workflow_runs = workflow_runs if isinstance(workflow_runs, list) else []
+    pending_approvals = pending_approvals if isinstance(pending_approvals, list) else []
+    audit_events = audit_events if isinstance(audit_events, list) else []
+    session_search_matches = session_search_matches if isinstance(session_search_matches, list) else []
+    cutoff = _engineering_memory_reference_time(
+        workflow_runs,
+        pending_approvals,
+        audit_events,
+        session_search_matches,
+    ) - timedelta(hours=window_hours)
     filtered_workflow_runs = [
         run
-        for run in (workflow_runs if isinstance(workflow_runs, list) else [])
+        for run in workflow_runs
         if isinstance(run, dict) and _within_operator_window(run.get("updated_at") or run.get("started_at"), cutoff)
     ]
     filtered_pending_approvals = [
         approval
-        for approval in (pending_approvals if isinstance(pending_approvals, list) else [])
+        for approval in pending_approvals
         if isinstance(approval, dict) and _within_operator_window(approval.get("created_at"), cutoff)
     ]
     filtered_session_search_matches = [
         match
-        for match in (session_search_matches if isinstance(session_search_matches, list) else [])
+        for match in session_search_matches
         if isinstance(match, dict) and _within_operator_window(match.get("matched_at"), cutoff)
     ]
     all_bundles = _build_engineering_memory_bundles(
         filtered_workflow_runs,
         filtered_pending_approvals,
-        audit_events if isinstance(audit_events, list) else [],
+        audit_events,
         filtered_session_search_matches,
         normalized_query=_engineering_query(normalized_query),
         limit_bundles=None,

--- a/backend/src/extensions/capability_contract.py
+++ b/backend/src/extensions/capability_contract.py
@@ -263,6 +263,7 @@ def build_native_tool_contract(
     execution_boundaries: list[str],
     availability: str,
     blocked_reason: str | None,
+    execution: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     permission_profile = {
         "ok": availability == "ready",
@@ -324,6 +325,7 @@ def build_native_tool_contract(
             },
         },
         "mutation_rights": _mutation_rights(required_boundaries),
+        "execution": dict(execution or {}),
         "audit": _audit_contract(permission_profile, required_boundaries),
         "health": health,
         "preflight": {

--- a/backend/src/extensions/scaffold.py
+++ b/backend/src/extensions/scaffold.py
@@ -15,6 +15,7 @@ from .doctor import ExtensionDoctorReport, doctor_snapshot
 from .layout import CONTRIBUTION_LAYOUTS
 from .manifest import ExtensionKind, ExtensionTrust
 from .registry import ExtensionRegistry
+from src.tools.policy import get_tool_execution_boundaries
 
 _DEFAULT_CAPABILITY_CONTRIBUTIONS: tuple[str, ...] = ("skills",)
 _DEFAULT_CONNECTOR_CONTRIBUTIONS: tuple[str, ...] = ("managed_connectors",)
@@ -23,6 +24,19 @@ _DEFAULT_TOOL_PERMISSIONS: dict[str, tuple[str, ...]] = {
     "skills": (),
     "workflows": ("read_file",),
     "toolset_presets": ("read_file",),
+}
+
+_DEFAULT_DATA_ACCESS_BY_BOUNDARY: dict[str, str] = {
+    "workspace_read": "workspace_files",
+    "workspace_write": "workspace_files",
+}
+
+_DEFAULT_AUDIT_BY_BOUNDARY: dict[str, str] = {
+    "workspace_read": "filesystem_read",
+    "workspace_write": "filesystem_write",
+    "external_read": "external_fetch",
+    "external_mcp": "mcp_request",
+    "secret_management": "secret_management",
 }
 
 _NETWORKED_SCAFFOLD_CONTRIBUTIONS = {
@@ -309,6 +323,9 @@ def scaffold_extension_package(
     created_files: list[Path] = []
     manifest_contributions: dict[str, list[str]] = {}
     required_tools: list[str] = []
+    required_boundaries: list[str] = []
+    data_access: list[str] = []
+    audit_events: list[str] = []
 
     for contribution_type in selected_contributions:
         template_path, builder = _PLACEHOLDER_BUILDERS[contribution_type]
@@ -322,6 +339,19 @@ def scaffold_extension_package(
         for tool_name in _DEFAULT_TOOL_PERMISSIONS.get(contribution_type, ()):
             if tool_name not in required_tools:
                 required_tools.append(tool_name)
+            for boundary in get_tool_execution_boundaries(tool_name):
+                if boundary not in required_boundaries:
+                    required_boundaries.append(boundary)
+                access = _DEFAULT_DATA_ACCESS_BY_BOUNDARY.get(boundary)
+                if access and access not in data_access:
+                    data_access.append(access)
+                audit_event = _DEFAULT_AUDIT_BY_BOUNDARY.get(boundary)
+                if audit_event and audit_event not in audit_events:
+                    audit_events.append(audit_event)
+        if contribution_type in _NETWORKED_SCAFFOLD_CONTRIBUTIONS and "secret_management" not in required_boundaries:
+            required_boundaries.append("secret_management")
+            if "secret_management" not in audit_events:
+                audit_events.append("secret_management")
 
     manifest_payload = {
         "id": extension_id,
@@ -334,6 +364,9 @@ def scaffold_extension_package(
         "contributes": manifest_contributions,
         "permissions": {
             "tools": required_tools,
+            "execution_boundaries": required_boundaries,
+            "data_access": data_access,
+            "audit_events": audit_events,
             "network": any(
                 contribution_type in _NETWORKED_SCAFFOLD_CONTRIBUTIONS
                 for contribution_type in selected_contributions

--- a/backend/src/native_tools/registry.py
+++ b/backend/src/native_tools/registry.py
@@ -9,6 +9,76 @@ TOOL_NAME_ALIASES: dict[str, str] = {
 }
 
 
+_EXECUTION_PROFILES: dict[str, dict] = {
+    "workspace_read": {
+        "operation_modes": ["inspect"],
+        "session_model": "stateless_workspace_call",
+        "persistence": "audit_receipt_only",
+        "recovery_actions": ["retry_after_path_correction"],
+        "artifact_contract": {"outputs": ["file_text"], "receipt_required": True},
+        "provider_health": {"provider": "local_workspace", "state": "ready"},
+        "interactive_controls": ["inspect"],
+    },
+    "workspace_write": {
+        "operation_modes": ["mutate"],
+        "session_model": "stateless_workspace_call",
+        "persistence": "workspace_file_plus_audit_receipt",
+        "recovery_actions": ["restore_from_receipt_hash", "retry_after_path_correction"],
+        "artifact_contract": {"outputs": ["file_write_receipt"], "receipt_required": True},
+        "provider_health": {"provider": "local_workspace", "state": "ready"},
+        "interactive_controls": ["inspect", "approve"],
+    },
+    "workspace_patch": {
+        "operation_modes": ["preview", "mutate"],
+        "session_model": "stateless_workspace_call",
+        "persistence": "workspace_file_plus_diff_receipt",
+        "recovery_actions": ["preview", "apply", "guarded_reapply", "retry_after_occurrence_mismatch"],
+        "artifact_contract": {
+            "outputs": ["unified_diff", "before_after_hashes", "rollback_hint"],
+            "receipt_required": True,
+        },
+        "provider_health": {"provider": "local_workspace", "state": "ready"},
+        "interactive_controls": ["inspect", "approve", "repair", "compare"],
+    },
+    "sandbox": {
+        "operation_modes": ["execute", "inspect"],
+        "session_model": "ephemeral_sandbox_call",
+        "persistence": "stdout_stderr_exit_receipt",
+        "recovery_actions": ["retry_with_bounded_input", "inspect_error"],
+        "artifact_contract": {"outputs": ["stdout", "stderr", "exit_code"], "receipt_required": True},
+        "provider_health": {"provider": "snekbox", "state": "configured_by_runtime"},
+        "interactive_controls": ["inspect", "approve"],
+    },
+    "process": {
+        "operation_modes": ["execute", "stream", "background"],
+        "session_model": "session_scoped_process_group",
+        "persistence": "process_handle_plus_stream_receipts",
+        "recovery_actions": ["read_output", "stop", "retry", "repair_command"],
+        "artifact_contract": {"outputs": ["stdout", "stderr", "exit_code", "process_id"], "receipt_required": True},
+        "provider_health": {"provider": "managed_process_runtime", "state": "policy_gated"},
+        "interactive_controls": ["inspect", "approve", "pause", "stop", "retry", "repair"],
+    },
+    "browser": {
+        "operation_modes": ["navigate", "extract", "snapshot"],
+        "session_model": "session_scoped_browser_provider",
+        "persistence": "audit_receipt_and_optional_snapshot",
+        "recovery_actions": ["retry_navigation", "inspect_snapshot", "repair_selector"],
+        "artifact_contract": {"outputs": ["html_text", "screenshot_ref", "browser_receipt"], "receipt_required": True},
+        "provider_health": {"provider": "playwright_or_configured_browser_provider", "state": "policy_gated"},
+        "interactive_controls": ["inspect", "approve", "pause", "retry"],
+    },
+    "external_http": {
+        "operation_modes": ["fetch"],
+        "session_model": "stateless_external_request",
+        "persistence": "response_receipt",
+        "recovery_actions": ["retry", "inspect_redirect_block"],
+        "artifact_contract": {"outputs": ["status", "headers", "truncated_body"], "receipt_required": True},
+        "provider_health": {"provider": "httpx_connector", "state": "ssrf_guarded"},
+        "interactive_controls": ["inspect", "approve"],
+    },
+}
+
+
 def canonical_tool_name(tool_name: str) -> str:
     """Return the canonical runtime tool name for a tool or legacy alias."""
     return TOOL_NAME_ALIASES.get(tool_name, tool_name)
@@ -25,11 +95,25 @@ TOOL_METADATA: dict[str, dict] = {
         "description": "Read a file from the workspace",
         "policy_modes": ["safe", "balanced", "full"],
         "execution_boundaries": ["workspace_read"],
+        "execution": _EXECUTION_PROFILES["workspace_read"],
     },
     "write_file": {
         "description": "Write content to a file",
         "policy_modes": ["balanced", "full"],
         "execution_boundaries": ["workspace_write"],
+        "execution": _EXECUTION_PROFILES["workspace_write"],
+    },
+    "preview_workspace_patch": {
+        "description": "Preview a bounded workspace text replacement with diff and rollback hashes",
+        "policy_modes": ["safe", "balanced", "full"],
+        "execution_boundaries": ["workspace_read"],
+        "execution": _EXECUTION_PROFILES["workspace_patch"],
+    },
+    "apply_workspace_patch": {
+        "description": "Apply a bounded workspace text replacement with diff receipt and rollback hashes",
+        "policy_modes": ["balanced", "full"],
+        "execution_boundaries": ["workspace_read", "workspace_write"],
+        "execution": _EXECUTION_PROFILES["workspace_patch"],
     },
     "fill_template": {
         "description": "Fill a text template with values",
@@ -71,6 +155,7 @@ TOOL_METADATA: dict[str, dict] = {
         "description": "Execute bounded code in a sandboxed environment",
         "policy_modes": ["full"],
         "execution_boundaries": ["sandbox_execution"],
+        "execution": _EXECUTION_PROFILES["sandbox"],
     },
     "delegate_task": {
         "description": "Delegate a bounded subtask to a specialist runtime",
@@ -106,42 +191,50 @@ TOOL_METADATA: dict[str, dict] = {
         "description": "Run an approved workspace-scoped command inside the runtime container",
         "policy_modes": ["full"],
         "execution_boundaries": ["container_process_execution", "workspace_scoped_paths"],
+        "execution": _EXECUTION_PROFILES["process"],
     },
     "start_process": {
         "description": "Start an approved workspace-scoped background process inside the runtime container",
         "policy_modes": ["full"],
         "execution_boundaries": ["container_process_management", "background_execution", "session_process_partition"],
         "approval_behavior": "always",
+        "execution": _EXECUTION_PROFILES["process"],
     },
     "list_processes": {
         "description": "List background processes started through the runtime process manager",
         "policy_modes": ["full"],
         "execution_boundaries": ["container_process_read", "session_process_partition"],
+        "execution": _EXECUTION_PROFILES["process"],
     },
     "read_process_output": {
         "description": "Read recent stdout/stderr output for a managed background process",
         "policy_modes": ["full"],
         "execution_boundaries": ["container_process_read", "session_process_partition"],
+        "execution": _EXECUTION_PROFILES["process"],
     },
     "stop_process": {
         "description": "Stop a managed background process inside the runtime container",
         "policy_modes": ["full"],
         "execution_boundaries": ["container_process_management", "session_process_partition"],
+        "execution": _EXECUTION_PROFILES["process"],
     },
     "browse_webpage": {
         "description": "Browse and extract content from a webpage",
         "policy_modes": ["safe", "balanced", "full"],
         "execution_boundaries": ["external_read"],
+        "execution": _EXECUTION_PROFILES["browser"],
     },
     "browser_session": {
         "description": "Manage structured browser sessions, page refs, and snapshots for the current session",
         "policy_modes": ["safe", "balanced", "full"],
         "execution_boundaries": ["external_read"],
+        "execution": _EXECUTION_PROFILES["browser"],
     },
     "http_request": {
         "description": "Fetch an HTTP resource through the packaged request connector",
         "policy_modes": ["safe", "balanced", "full"],
         "execution_boundaries": ["external_read"],
+        "execution": _EXECUTION_PROFILES["external_http"],
     },
     "source_capabilities": {
         "description": "Inspect the provider-neutral source access surfaces available to the current runtime",

--- a/backend/src/security/site_policy.py
+++ b/backend/src/security/site_policy.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import ipaddress
 import socket
+from dataclasses import dataclass
 from urllib.parse import urlparse
 
 from config.settings import settings
@@ -19,6 +19,7 @@ class SiteAccessDecision:
     reason: str | None = None
     matched_rule: str | None = None
     allowlist_active: bool = False
+    resolved_addresses: tuple[str, ...] = ()
 
 
 def _normalize_rule(raw_rule: str) -> str:
@@ -62,23 +63,52 @@ def _hostname_matches_rule(hostname: str, rule: str) -> bool:
     return hostname == rule or hostname.endswith(f".{rule}")
 
 
-def _is_internal_hostname(hostname: str) -> bool:
-    if hostname in _BLOCKED_HOSTS:
-        return True
+def _is_internal_ip(value: str) -> bool:
     try:
-        ip = ipaddress.ip_address(hostname)
+        ip = ipaddress.ip_address(value)
         return ip.is_private or ip.is_loopback or ip.is_link_local
     except ValueError:
-        pass
+        return False
+
+
+def _resolved_addresses(hostname: str) -> tuple[str, ...]:
+    addresses: list[str] = []
+    seen: set[str] = set()
+    try:
+        results = socket.getaddrinfo(hostname, None)
+    except OSError:
+        return ()
+    for result in results:
+        sockaddr = result[4]
+        if not sockaddr:
+            continue
+        address = str(sockaddr[0])
+        if address and address not in seen:
+            addresses.append(address)
+            seen.add(address)
+    return tuple(addresses)
+
+
+def _is_internal_hostname(hostname: str, *, resolve_dns: bool = False) -> tuple[bool, tuple[str, ...]]:
+    if hostname in _BLOCKED_HOSTS:
+        return True, ()
+    if _is_internal_ip(hostname):
+        return True, ()
     try:
         ipv4 = ipaddress.ip_address(socket.inet_aton(hostname))
-        return ipv4.is_private or ipv4.is_loopback or ipv4.is_link_local
+        if ipv4.is_private or ipv4.is_loopback or ipv4.is_link_local:
+            return True, ()
     except (OSError, ValueError):
         pass
-    return hostname.endswith((".local", ".internal", ".localhost"))
+    if hostname.endswith((".local", ".internal", ".localhost")):
+        return True, ()
+    addresses = _resolved_addresses(hostname) if resolve_dns else ()
+    if any(_is_internal_ip(address) for address in addresses):
+        return True, addresses
+    return False, addresses
 
 
-def evaluate_site_access(url_or_hostname: str) -> SiteAccessDecision:
+def evaluate_site_access(url_or_hostname: str, *, resolve_dns: bool = False) -> SiteAccessDecision:
     hostname = _normalize_hostname(url_or_hostname)
     allowlist = _configured_allowlist()
     blocklist = _configured_blocklist()
@@ -91,12 +121,14 @@ def evaluate_site_access(url_or_hostname: str) -> SiteAccessDecision:
             allowlist_active=bool(allowlist),
         )
 
-    if _is_internal_hostname(hostname):
+    is_internal, resolved_addresses = _is_internal_hostname(hostname, resolve_dns=resolve_dns)
+    if is_internal:
         return SiteAccessDecision(
             allowed=False,
             hostname=hostname,
             reason="internal_private",
             allowlist_active=bool(allowlist),
+            resolved_addresses=resolved_addresses,
         )
 
     for rule in blocklist:
@@ -107,6 +139,7 @@ def evaluate_site_access(url_or_hostname: str) -> SiteAccessDecision:
                 reason="blocklisted_domain",
                 matched_rule=rule,
                 allowlist_active=bool(allowlist),
+                resolved_addresses=resolved_addresses,
             )
 
     if allowlist:
@@ -117,15 +150,22 @@ def evaluate_site_access(url_or_hostname: str) -> SiteAccessDecision:
                     hostname=hostname,
                     matched_rule=rule,
                     allowlist_active=True,
+                    resolved_addresses=resolved_addresses,
                 )
         return SiteAccessDecision(
             allowed=False,
             hostname=hostname,
             reason="not_allowlisted",
             allowlist_active=True,
+            resolved_addresses=resolved_addresses,
         )
 
-    return SiteAccessDecision(allowed=True, hostname=hostname, allowlist_active=False)
+    return SiteAccessDecision(
+        allowed=True,
+        hostname=hostname,
+        allowlist_active=False,
+        resolved_addresses=resolved_addresses,
+    )
 
 
 def site_policy_summary(url_or_hostname: str) -> dict[str, str | bool]:

--- a/backend/src/tools/browser_tool.py
+++ b/backend/src/tools/browser_tool.py
@@ -12,7 +12,7 @@ from src.security.site_policy import SiteAccessDecision, evaluate_site_access
 
 logger = logging.getLogger(__name__)
 
-def _browser_details(url: str, action: str, decision: SiteAccessDecision | None = None) -> dict[str, str | bool]:
+def _browser_details(url: str, action: str, decision: SiteAccessDecision | None = None) -> dict[str, object]:
     parsed = urlparse(url)
     details: dict[str, str | bool] = {
         "hostname": parsed.hostname or "",
@@ -23,6 +23,7 @@ def _browser_details(url: str, action: str, decision: SiteAccessDecision | None 
         details["site_policy_reason"] = decision.reason or ""
         details["site_policy_rule"] = decision.matched_rule or ""
         details["site_allowlist_active"] = decision.allowlist_active
+        details["resolved_addresses"] = list(decision.resolved_addresses)
     return details
 
 
@@ -34,6 +35,20 @@ def _blocked_site_message(decision: SiteAccessDecision) -> str:
     if decision.reason == "not_allowlisted":
         return f"Error: Access to '{decision.hostname}' is not permitted by the browser site allowlist."
     return "Error: URL could not be evaluated by site policy."
+
+
+async def _route_guarded_browser_request(route, request) -> None:
+    decision = evaluate_site_access(request.url, resolve_dns=True)
+    if not decision.allowed:
+        logger.warning(
+            "Blocked browser request by site policy: url=%s reason=%s resolved=%s",
+            request.url,
+            decision.reason,
+            decision.resolved_addresses,
+        )
+        await route.abort()
+        return
+    await route.continue_()
 
 
 async def _browse(url: str, action: str) -> str:
@@ -50,13 +65,18 @@ async def _browse(url: str, action: str) -> str:
             ),
         )
         page = await context.new_page()
+        await page.route("**/*", _route_guarded_browser_request)
 
         try:
-            await page.goto(
+            response = await page.goto(
                 url,
                 wait_until="domcontentloaded",
                 timeout=settings.browser_timeout * 1000,
             )
+            final_url = getattr(response, "url", None) or page.url
+            final_decision = evaluate_site_access(str(final_url), resolve_dns=True)
+            if not final_decision.allowed:
+                raise PermissionError(_blocked_site_message(final_decision))
             # Wait a bit for dynamic content
             await page.wait_for_timeout(1000)
 
@@ -113,7 +133,7 @@ def browse_webpage(url: str, action: str = "extract") -> str:
     if not url.startswith(("http://", "https://")):
         return "Error: URL must start with http:// or https://"
 
-    decision = evaluate_site_access(url)
+    decision = evaluate_site_access(url, resolve_dns=True)
     if not decision.allowed:
         log_integration_event_sync(
             integration_type="browser",

--- a/backend/src/tools/delegate_task_tool.py
+++ b/backend/src/tools/delegate_task_tool.py
@@ -64,7 +64,14 @@ _SPECIALIST_DEFAULT_TOOL_NAMES: dict[str, tuple[str, ...]] = {
         "collect_source_evidence",
         "plan_source_review",
     ),
-    "file_worker": ("read_file", "write_file", "fill_template", "execute_code"),
+    "file_worker": (
+        "read_file",
+        "write_file",
+        "preview_workspace_patch",
+        "apply_workspace_patch",
+        "fill_template",
+        "execute_code",
+    ),
 }
 
 

--- a/backend/src/tools/filesystem_tool.py
+++ b/backend/src/tools/filesystem_tool.py
@@ -1,4 +1,7 @@
 import logging
+import difflib
+import hashlib
+import json
 from pathlib import Path
 
 from smolagents import tool
@@ -21,9 +24,75 @@ def _safe_resolve(file_path: str) -> Path:
     """Resolve a file path ensuring it stays within the workspace directory."""
     workspace = Path(settings.workspace_dir).resolve()
     resolved = (workspace / file_path).resolve()
-    if not str(resolved).startswith(str(workspace)):
+    try:
+        resolved.relative_to(workspace)
+    except ValueError:
         raise ValueError(f"Path traversal blocked: {file_path}")
     return resolved
+
+
+def _sha256_text(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _patch_receipt(
+    *,
+    file_path: str,
+    operation: str,
+    before: str,
+    after: str,
+    diff: str,
+    occurrence_count: int,
+    applied: bool,
+    before_hash_guarded: bool,
+) -> str:
+    changed_lines = sum(1 for line in diff.splitlines() if line.startswith(("+", "-")) and not line.startswith(("+++", "---")))
+    return json.dumps(
+        {
+            "operation": operation,
+            "file_path": file_path,
+            "applied": applied,
+            "occurrence_count": occurrence_count,
+            "changed_lines": changed_lines,
+            "before_sha256": _sha256_text(before),
+            "after_sha256": _sha256_text(after),
+            "before_hash_guarded": before_hash_guarded,
+            "rollback": {
+                "tool": "apply_workspace_patch",
+                "file_path": file_path,
+                "requires_old_text": True,
+                "expected_before_sha256": _sha256_text(after),
+                "old_text_sha256": _sha256_text(after),
+                "restore_text_sha256": _sha256_text(before),
+            },
+            "diff": diff,
+        },
+        sort_keys=True,
+    )
+
+
+def _replacement_diff(file_path: str, before: str, after: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            before.splitlines(keepends=True),
+            after.splitlines(keepends=True),
+            fromfile=f"a/{file_path}",
+            tofile=f"b/{file_path}",
+        )
+    )
+
+
+def _replace_once(content: str, old_text: str, new_text: str, expected_occurrences: int) -> tuple[str, int]:
+    if expected_occurrences != 1:
+        raise ValueError("expected_occurrences must be 1 until indexed or replace-all patching is supported")
+    if not old_text:
+        raise ValueError("old_text must not be empty")
+    occurrence_count = content.count(old_text)
+    if occurrence_count != expected_occurrences:
+        raise ValueError(
+            f"Expected {expected_occurrences} occurrence(s) of old_text, found {occurrence_count}"
+        )
+    return content.replace(old_text, new_text, 1), occurrence_count
 
 
 @tool
@@ -125,3 +194,138 @@ def write_file(file_path: str, content: str) -> str:
         )
         logger.exception("Failed to write file into workspace")
         return f"Error: Failed to write file: {exc}"
+
+
+@tool
+def preview_workspace_patch(
+    file_path: str,
+    old_text: str,
+    new_text: str,
+    expected_occurrences: int = 1,
+) -> str:
+    """Preview a bounded workspace text replacement and return a receipt with a unified diff.
+
+    Args:
+        file_path: Relative path to the file within the workspace.
+        old_text: Exact text to replace.
+        new_text: Replacement text.
+        expected_occurrences: Required number of old_text occurrences before the preview is valid.
+
+    Returns:
+        A JSON receipt containing the diff, hashes, and application status.
+    """
+    try:
+        resolved = _safe_resolve(file_path)
+        before = resolved.read_text(encoding="utf-8")
+        after, occurrence_count = _replace_once(before, old_text, new_text, expected_occurrences)
+        diff = _replacement_diff(file_path, before, after)
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="succeeded",
+            details=_filesystem_details(
+                file_path,
+                "preview_patch",
+                occurrence_count=occurrence_count,
+                changed_lines=sum(1 for line in diff.splitlines() if line.startswith(("+", "-"))),
+            ),
+        )
+        return _patch_receipt(
+            file_path=file_path,
+            operation="preview_patch",
+            before=before,
+            after=after,
+            diff=diff,
+            occurrence_count=occurrence_count,
+            applied=False,
+            before_hash_guarded=False,
+        )
+    except ValueError as exc:
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="blocked",
+            details=_filesystem_details(file_path, "preview_patch", error=str(exc)),
+        )
+        raise
+    except Exception as exc:
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="failed",
+            details=_filesystem_details(file_path, "preview_patch", error=str(exc)),
+        )
+        logger.exception("Failed to preview workspace patch")
+        return f"Error: Failed to preview workspace patch: {exc}"
+
+
+@tool
+def apply_workspace_patch(
+    file_path: str,
+    old_text: str,
+    new_text: str,
+    expected_occurrences: int = 1,
+    expected_before_sha256: str = "",
+) -> str:
+    """Apply a bounded workspace text replacement and return a receipt with rollback hashes.
+
+    Args:
+        file_path: Relative path to the file within the workspace.
+        old_text: Exact text to replace.
+        new_text: Replacement text.
+        expected_occurrences: Required number of old_text occurrences before the write is valid.
+        expected_before_sha256: Optional SHA-256 hash guard for the current file content.
+
+    Returns:
+        A JSON receipt containing the diff, hashes, and application status.
+    """
+    try:
+        resolved = _safe_resolve(file_path)
+        before = resolved.read_text(encoding="utf-8")
+        before_sha256 = _sha256_text(before)
+        if expected_before_sha256 and expected_before_sha256 != before_sha256:
+            raise ValueError("Current file content does not match expected_before_sha256")
+        after, occurrence_count = _replace_once(before, old_text, new_text, expected_occurrences)
+        diff = _replacement_diff(file_path, before, after)
+        resolved.write_text(after, encoding="utf-8")
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="succeeded",
+            details=_filesystem_details(
+                file_path,
+                "apply_patch",
+                occurrence_count=occurrence_count,
+                changed_lines=sum(1 for line in diff.splitlines() if line.startswith(("+", "-"))),
+                before_sha256=before_sha256,
+                after_sha256=_sha256_text(after),
+                before_hash_guarded=bool(expected_before_sha256),
+            ),
+        )
+        return _patch_receipt(
+            file_path=file_path,
+            operation="apply_patch",
+            before=before,
+            after=after,
+            diff=diff,
+            occurrence_count=occurrence_count,
+            applied=True,
+            before_hash_guarded=bool(expected_before_sha256),
+        )
+    except ValueError as exc:
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="blocked",
+            details=_filesystem_details(file_path, "apply_patch", error=str(exc)),
+        )
+        raise
+    except Exception as exc:
+        log_integration_event_sync(
+            integration_type="filesystem",
+            name="workspace",
+            outcome="failed",
+            details=_filesystem_details(file_path, "apply_patch", error=str(exc)),
+        )
+        logger.exception("Failed to apply workspace patch")
+        return f"Error: Failed to apply workspace patch: {exc}"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 from contextlib import asynccontextmanager
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -142,3 +143,8 @@ def reset_memory_flush_cache():
     _reset_memory_flush_state()
     yield
     _reset_memory_flush_state()
+
+
+@pytest.fixture(autouse=True)
+def ensure_test_workspace_dir():
+    Path(os.environ["WORKSPACE_DIR"]).mkdir(parents=True, exist_ok=True)

--- a/backend/tests/test_browser_tool.py
+++ b/backend/tests/test_browser_tool.py
@@ -8,6 +8,7 @@ import pytest
 from config.settings import settings
 from src.audit.repository import audit_repository
 from src.tools.browser_tool import browse_webpage
+from src.tools.browser_tool import _route_guarded_browser_request
 
 
 class _ImmediateFuture:
@@ -92,6 +93,45 @@ def test_browse_webpage_blocks_site_policy_domain(async_db):
     assert events[0]["details"]["hostname"] == "docs.example.com"
     assert events[0]["details"]["site_policy_reason"] == "blocklisted_domain"
     assert events[0]["details"]["site_policy_rule"] == "example.com"
+
+
+def test_browse_webpage_blocks_private_dns_resolution_preflight(async_db):
+    with patch(
+        "src.security.site_policy.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("10.0.0.11", 0))],
+    ):
+        result = browse_webpage("https://public-looking.example/docs")
+
+    assert "internal/private" in result.lower()
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=5)
+        return [e for e in events if e["event_type"] == "integration_blocked"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["details"]["site_policy_reason"] == "internal_private"
+    assert events[0]["details"]["resolved_addresses"] == ["10.0.0.11"]
+
+
+def test_browser_route_guard_blocks_internal_subrequest():
+    route = AsyncMock()
+    request = type("Request", (), {"url": "http://127.0.0.1/secret.js"})()
+
+    asyncio.run(_route_guarded_browser_request(route, request))
+
+    route.abort.assert_awaited_once()
+    route.continue_.assert_not_called()
+
+
+def test_browser_route_guard_allows_external_subrequest():
+    route = AsyncMock()
+    request = type("Request", (), {"url": "https://cdn.example.com/app.js"})()
+
+    asyncio.run(_route_guarded_browser_request(route, request))
+
+    route.continue_.assert_awaited_once()
+    route.abort.assert_not_called()
 
 
 def test_browse_webpage_logs_timeout_runtime_audit(async_db):

--- a/backend/tests/test_capabilities_api.py
+++ b/backend/tests/test_capabilities_api.py
@@ -305,7 +305,14 @@ def test_tool_status_list_exposes_native_capability_contract():
     assert contract["family"] == "native_tool"
     assert contract["trust_class"] == "seraph_bundled"
     assert contract["permissions"]["required"]["execution_boundaries"] == ["workspace_read"]
+    assert contract["execution"]["operation_modes"] == ["inspect"]
+    assert contract["execution"]["artifact_contract"]["receipt_required"] is True
     assert contract["preflight"]["ready"] is True
+
+    patch_contract = tools["apply_workspace_patch"]["capability_contract"]
+    assert patch_contract["permissions"]["required"]["execution_boundaries"] == ["workspace_read", "workspace_write"]
+    assert patch_contract["execution"]["operation_modes"] == ["preview", "mutate"]
+    assert "guarded_reapply" in patch_contract["execution"]["recovery_actions"]
 
     blocked_contract = tools["write_file"]["capability_contract"]
     assert blocked_contract["preflight"]["ready"] is False

--- a/backend/tests/test_extensions_api.py
+++ b/backend/tests/test_extensions_api.py
@@ -50,6 +50,9 @@ def _write_installable_extension(
         "    - starter-packs/local-pack.json\n"
         "permissions:\n"
         "  tools: [read_file]\n"
+        "  execution_boundaries: [workspace_read]\n"
+        "  data_access: [workspace_files]\n"
+        "  audit_events: [filesystem_read]\n"
         "  network: false\n",
         encoding="utf-8",
     )
@@ -118,6 +121,9 @@ def _write_high_risk_extension(root: Path) -> Path:
         "    - workflows/write-note.md\n"
         "permissions:\n"
         "  tools: [write_file]\n"
+        "  execution_boundaries: [workspace_write]\n"
+        "  data_access: [workspace_files]\n"
+        "  audit_events: [filesystem_write]\n"
         "  network: false\n",
         encoding="utf-8",
     )
@@ -159,6 +165,9 @@ def _write_multi_high_risk_extension(root: Path) -> Path:
         "    - workflows/write-note-b.md\n"
         "permissions:\n"
         "  tools: [write_file]\n"
+        "  execution_boundaries: [workspace_write]\n"
+        "  data_access: [workspace_files]\n"
+        "  audit_events: [filesystem_write]\n"
         "  network: false\n",
         encoding="utf-8",
     )
@@ -223,6 +232,8 @@ def _write_mcp_connector_extension(
         "  mcp_servers:\n"
         "    - mcp/github.json\n"
         "permissions:\n"
+        "  execution_boundaries: [external_mcp]\n"
+        "  audit_events: [mcp_request]\n"
         "  network: true\n",
         encoding="utf-8",
     )
@@ -258,6 +269,8 @@ def _write_multi_mcp_connector_extension(root: Path) -> Path:
         "    - mcp/github-primary.json\n"
         "    - mcp/github-secondary.json\n"
         "permissions:\n"
+        "  execution_boundaries: [external_mcp]\n"
+        "  audit_events: [mcp_request]\n"
         "  network: true\n",
         encoding="utf-8",
     )
@@ -303,6 +316,7 @@ def _write_managed_connector_extension(root: Path) -> Path:
         "  managed_connectors:\n"
         "    - connectors/managed/github.yaml\n"
         "permissions:\n"
+        "  execution_boundaries: []\n"
         "  network: true\n",
         encoding="utf-8",
     )
@@ -350,6 +364,9 @@ def _write_mixed_managed_connector_extension(root: Path) -> Path:
         "    - connectors/managed/github.yaml\n"
         "permissions:\n"
         "  tools: [read_file]\n"
+        "  execution_boundaries: [workspace_read]\n"
+        "  data_access: [workspace_files]\n"
+        "  audit_events: [filesystem_read]\n"
         "  network: true\n",
         encoding="utf-8",
     )
@@ -434,6 +451,9 @@ def _write_wave2_extension(root: Path) -> Path:
         "trust: local\n"
         "permissions:\n"
         "  tools: [read_file]\n"
+        "  execution_boundaries: [workspace_read, secret_management]\n"
+        "  data_access: [workspace_files]\n"
+        "  audit_events: [filesystem_read, secret_management]\n"
         "  network: true\n"
         "contributes:\n"
         "  toolset_presets:\n"
@@ -498,6 +518,7 @@ def _write_toolset_boundary_extension(root: Path, *, boundary: str, network: boo
         "  name: Seraph\n"
         "trust: local\n"
         "permissions:\n"
+        f"  execution_boundaries: [{boundary}]\n"
         f"  network: {network_literal}\n"
         "contributes:\n"
         "  toolset_presets:\n"
@@ -3049,6 +3070,9 @@ async def test_workspace_extension_source_save_updates_package_members(client, e
                     "    - starter-packs/local-pack.json\n"
                     "permissions:\n"
                     "  tools: [read_file]\n"
+                    "  execution_boundaries: [workspace_read]\n"
+                    "  data_access: [workspace_files]\n"
+                    "  audit_events: [filesystem_read]\n"
                     "  network: false\n"
                 ),
             },
@@ -3351,6 +3375,9 @@ async def test_manifest_source_save_rejects_unloadable_package_updates(client, e
                     "    - skills/local-skill.md\n"
                     "permissions:\n"
                     "  tools: [read_file]\n"
+                    "  execution_boundaries: [workspace_read]\n"
+                    "  data_access: [workspace_files]\n"
+                    "  audit_events: [filesystem_read]\n"
                     "  network: false\n"
                 ),
             },
@@ -3401,6 +3428,9 @@ async def test_manifest_source_save_validates_manifest_yml_aliases(client, exten
                     "    - skills/local-skill.md\n"
                     "permissions:\n"
                     "  tools: [read_file]\n"
+                    "  execution_boundaries: [workspace_read]\n"
+                    "  data_access: [workspace_files]\n"
+                    "  audit_events: [filesystem_read]\n"
                     "  network: false\n"
                 ),
             },
@@ -3463,6 +3493,9 @@ async def test_broken_workspace_manifest_can_be_loaded_and_repaired_via_source_a
                     "    - starter-packs/local-pack.json\n"
                     "permissions:\n"
                     "  tools: [read_file]\n"
+                    "  execution_boundaries: [workspace_read]\n"
+                    "  data_access: [workspace_files]\n"
+                    "  audit_events: [filesystem_read]\n"
                     "  network: false\n"
                 ),
             },

--- a/backend/tests/test_http_mcp_server.py
+++ b/backend/tests/test_http_mcp_server.py
@@ -62,6 +62,11 @@ class TestIsInternalUrl:
     def test_blocks_ipv6_loopback(self):
         assert _is_internal_url("http://[::1]:8080/") is True
 
+    @patch("server.socket.getaddrinfo", return_value=[(None, None, None, None, ("10.0.0.9", 0))])
+    def test_blocks_private_dns_resolution_preflight(self, _mock_getaddrinfo):
+        assert _is_internal_url("https://public-looking.example", resolve_dns=True) is True
+        assert _is_internal_url("https://public-looking.example") is False
+
 
 class TestHttpRequest:
     def test_rejects_invalid_method(self):
@@ -80,6 +85,7 @@ class TestHttpRequest:
         mock_response.status_code = 200
         mock_response.headers = {"content-type": "application/json"}
         mock_response.text = '{"ok": true}'
+        mock_response.url = "https://api.example.com/test"
 
         mock_client = MagicMock()
         mock_client.__enter__ = MagicMock(return_value=mock_client)
@@ -91,6 +97,25 @@ class TestHttpRequest:
         assert result["status"] == 200
         assert result["body"] == '{"ok": true}'
         assert "headers" in result
+
+    @patch("server.httpx.Client")
+    def test_blocks_redirect_to_internal_url(self, mock_client_cls):
+        mock_response = MagicMock()
+        mock_response.status_code = 302
+        mock_response.headers = {"location": "http://127.0.0.1/secret"}
+        mock_response.url = "https://api.example.com/start"
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        result = http_request("GET", "https://api.example.com/start")
+
+        assert "error" in result
+        assert "redirect" in result["error"].lower()
+        assert mock_client.request.call_count == 1
 
     @patch("server.httpx.Client")
     def test_timeout_handling(self, mock_client_cls):

--- a/backend/tests/test_site_policy.py
+++ b/backend/tests/test_site_policy.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from src.security.site_policy import evaluate_site_access
 
 
@@ -13,3 +15,15 @@ def test_site_policy_blocks_short_loopback_host():
 
     assert decision.allowed is False
     assert decision.reason == "internal_private"
+
+
+def test_site_policy_blocks_private_dns_resolution_preflight():
+    with patch(
+        "src.security.site_policy.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("10.0.0.7", 0))],
+    ):
+        decision = evaluate_site_access("https://public-looking.example/", resolve_dns=True)
+
+    assert decision.allowed is False
+    assert decision.reason == "internal_private"
+    assert decision.resolved_addresses == ("10.0.0.7",)

--- a/backend/tests/test_specialists.py
+++ b/backend/tests/test_specialists.py
@@ -29,7 +29,7 @@ class TestToolDomainMapping:
             "store_secret", "get_secret", "get_secret_ref", "list_secrets", "delete_secret",
             "create_goal", "update_goal", "get_goals", "get_goal_progress",
             "web_search", "browse_webpage", "browser_session",
-            "read_file", "write_file", "fill_template", "execute_code",
+            "read_file", "write_file", "preview_workspace_patch", "apply_workspace_patch", "fill_template", "execute_code",
         }
         assert set(TOOL_DOMAINS.keys()) == expected_tools
 
@@ -200,7 +200,14 @@ class TestNamedFactories:
         create_file_worker(tools_by_name)
         agent_kwargs = mock_agent_cls.call_args[1]
         tool_names = {t.name for t in agent_kwargs["tools"]}
-        assert tool_names == {"read_file", "write_file", "fill_template", "execute_code"}
+        assert tool_names == {
+            "read_file",
+            "write_file",
+            "preview_workspace_patch",
+            "apply_workspace_patch",
+            "fill_template",
+            "execute_code",
+        }
 
     def test_factory_returns_none_with_no_tools(self):
         agent = create_memory_keeper({})

--- a/backend/tests/test_tools.py
+++ b/backend/tests/test_tools.py
@@ -1,11 +1,12 @@
 import asyncio
+import json
 from unittest.mock import patch
 
 import pytest
 
 from config.settings import settings
 from src.audit.repository import audit_repository
-from src.tools.filesystem_tool import _safe_resolve, read_file, write_file
+from src.tools.filesystem_tool import _safe_resolve, apply_workspace_patch, preview_workspace_patch, read_file, write_file
 from src.tools.template_tool import fill_template
 from src.tools.web_search_tool import web_search
 
@@ -78,6 +79,70 @@ class TestFilesystemTool:
         monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
         write_file.forward("sub/dir/file.txt", "nested content")
         assert (tmp_path / "sub" / "dir" / "file.txt").read_text() == "nested content"
+
+    def test_preview_workspace_patch_returns_diff_without_writing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
+        (tmp_path / "notes.md").write_text("alpha\nbeta\n", encoding="utf-8")
+
+        receipt = json.loads(preview_workspace_patch.forward("notes.md", "beta", "gamma"))
+
+        assert receipt["applied"] is False
+        assert receipt["occurrence_count"] == 1
+        assert "+gamma" in receipt["diff"]
+        assert (tmp_path / "notes.md").read_text(encoding="utf-8") == "alpha\nbeta\n"
+
+    def test_apply_workspace_patch_writes_and_logs_receipt(self, tmp_path, monkeypatch, async_db):
+        monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
+        (tmp_path / "notes.md").write_text("alpha\nbeta\n", encoding="utf-8")
+
+        receipt = json.loads(apply_workspace_patch.forward("notes.md", "beta", "gamma"))
+
+        assert receipt["applied"] is True
+        assert receipt["rollback"]["tool"] == "apply_workspace_patch"
+        assert receipt["before_hash_guarded"] is False
+        assert (tmp_path / "notes.md").read_text(encoding="utf-8") == "alpha\ngamma\n"
+
+        async def _fetch():
+            events = await audit_repository.list_events(limit=5)
+            return [e for e in events if e["event_type"] == "integration_succeeded"]
+
+        events = asyncio.run(_fetch())
+        patch_event = next(e for e in events if e["details"]["operation"] == "apply_patch")
+        assert patch_event["tool_name"] == "filesystem:workspace"
+        assert patch_event["details"]["occurrence_count"] == 1
+        assert patch_event["details"]["before_sha256"] == receipt["before_sha256"]
+
+    def test_apply_workspace_patch_blocks_stale_before_hash(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
+        (tmp_path / "notes.md").write_text("alpha\nbeta\n", encoding="utf-8")
+        receipt = json.loads(preview_workspace_patch.forward("notes.md", "beta", "gamma"))
+        (tmp_path / "notes.md").write_text("alpha\nchanged elsewhere\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="expected_before_sha256"):
+            apply_workspace_patch.forward(
+                "notes.md",
+                "beta",
+                "gamma",
+                expected_before_sha256=receipt["before_sha256"],
+            )
+
+        assert (tmp_path / "notes.md").read_text(encoding="utf-8") == "alpha\nchanged elsewhere\n"
+
+    def test_workspace_patch_blocks_ambiguous_occurrences(self, tmp_path, monkeypatch, async_db):
+        monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
+        (tmp_path / "notes.md").write_text("repeat\nrepeat\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Expected 1 occurrence"):
+            apply_workspace_patch.forward("notes.md", "repeat", "changed")
+
+        assert (tmp_path / "notes.md").read_text(encoding="utf-8") == "repeat\nrepeat\n"
+
+    def test_workspace_patch_rejects_replace_all_semantics_until_supported(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))
+        (tmp_path / "notes.md").write_text("repeat\nrepeat\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="expected_occurrences must be 1"):
+            preview_workspace_patch.forward("notes.md", "repeat", "changed", expected_occurrences=2)
 
     def test_read_file_not_a_file(self, tmp_path, monkeypatch):
         monkeypatch.setattr("src.tools.filesystem_tool.settings.workspace_dir", str(tmp_path))

--- a/docs/implementation/02-execution-plane.md
+++ b/docs/implementation/02-execution-plane.md
@@ -75,6 +75,14 @@
 - [ ] deeper long-running workflow supervision and durable orchestration beyond the current cockpit workflow-run surface, long-run state capsules, queue-state recovery supervision, anticipatory repair drafts, backup-branch candidates, condensation-fidelity state, branch/output debugger density, typed artifact-input handoff, branch-family supervision, checkpoint branch controls, approval-aware timeline, and boundary-aware replay model
 - [ ] broader external system leverage without weakening trust boundaries or the new credential-egress contract
 
+## M2 Batch Acceptance Notes
+
+- execution capability metadata should make native tool contracts show operation modes, session model, persistence, artifact contracts, provider health, interactive controls, and recovery actions instead of leaving execution semantics implicit in tool names
+- file mutation should include patch preview/apply receipts with unified diffs, before/after hashes, occurrence checks, and rollback hints, so agents can inspect, compare, repair, and recover edits without relying only on raw overwrite behavior
+- browser and HTTP execution must keep internal/private network protections on initial requests, browser subrequests, and redirected/final targets, with private-address DNS-resolution preflight coverage
+- the batch should repair prior PR test failures that are milestone-relevant, especially deterministic benchmark proof, engineering-memory search evidence, extension example validation, and session-owned process cleanup
+- the batch should not claim M2 is complete from one PR; it should claim only the concrete shipped surfaces and tests that land on `develop`
+
 ## Current Slice Record
 
 ### `workflow-autonomy-supervision-and-artifact-control-v1`

--- a/docs/implementation/11-world-class-strategy-delivery.md
+++ b/docs/implementation/11-world-class-strategy-delivery.md
@@ -155,6 +155,14 @@ Implementation meaning: Seraph should be excellent at real work across terminal,
 - missing strategic gaps: broader repair coverage across connectors, browser/computer-use providers, delegated workers, automation triggers, external credentials, local/remote sandboxes, and artifact handoffs; clearer failure grouping by capability family
 - proof requirements: repeatable execution and blocked-capability scenarios with inspectable diagnosis, safe repair action, audit receipt, and operator-visible recovery state
 
+M2 batch execution rules:
+
+- execution depth must land as capability contract surface area, runnable tool behavior, operator-visible receipts, and deterministic tests together
+- file work needs first-class patch preview/apply behavior, not only raw file overwrite
+- terminal, process, browser, HTTP, sandbox, filesystem, patch, and background-session surfaces should expose operation modes, session model, persistence, artifact contract, health, controls, and recovery actions
+- M2 cannot claim parity or excellence if #435 trust-boundary checks are left as follow-up work; SSRF, DNS-resolution preflight for private addresses, redirect-to-internal, path traversal, secret egress, replay drift, delegation, and prompt/extension permission creep must stay in the acceptance frame
+- previous failed PR tests are part of the batch acceptance burden when they affect the same milestone surfaces, especially deterministic benchmark and engineering-memory proof
+
 ## M3 Trusted Execution Boundaries
 
 Implementation meaning: every capability path needs least privilege, approval behavior, auditability, and fail-closed semantics appropriate to its risk.

--- a/examples/extensions/research-pack/manifest.yaml
+++ b/examples/extensions/research-pack/manifest.yaml
@@ -17,4 +17,10 @@ contributes:
 permissions:
   tools:
   - read_file
+  execution_boundaries:
+  - workspace_read
+  data_access:
+  - workspace_files
+  audit_events:
+  - filesystem_read
   network: false

--- a/mcp-servers/http-request/server.py
+++ b/mcp-servers/http-request/server.py
@@ -1,7 +1,8 @@
 """HTTP Request MCP Server — exposes a single http_request tool via FastMCP."""
 
 import ipaddress
-from urllib.parse import urlparse
+import socket
+from urllib.parse import urljoin, urlparse
 
 import httpx
 from fastmcp import FastMCP
@@ -9,9 +10,37 @@ from fastmcp import FastMCP
 mcp = FastMCP("http-request", host="0.0.0.0", port=9200)
 
 _BLOCKED_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "[::1]"}
+_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+_MAX_REDIRECTS = 5
 
 
-def _is_internal_url(url: str) -> bool:
+def _is_internal_ip(value: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(value)
+        return ip.is_private or ip.is_loopback or ip.is_link_local
+    except ValueError:
+        return False
+
+
+def _resolved_addresses(hostname: str) -> tuple[str, ...]:
+    addresses: list[str] = []
+    seen: set[str] = set()
+    try:
+        results = socket.getaddrinfo(hostname, None)
+    except OSError:
+        return ()
+    for result in results:
+        sockaddr = result[4]
+        if not sockaddr:
+            continue
+        address = str(sockaddr[0])
+        if address and address not in seen:
+            addresses.append(address)
+            seen.add(address)
+    return tuple(addresses)
+
+
+def _is_internal_url(url: str, *, resolve_dns: bool = False) -> bool:
     """Check if a URL points to an internal/private network address."""
     parsed = urlparse(url)
     hostname = parsed.hostname or ""
@@ -19,16 +48,47 @@ def _is_internal_url(url: str) -> bool:
     if hostname in _BLOCKED_HOSTS:
         return True
 
-    try:
-        ip = ipaddress.ip_address(hostname)
-        return ip.is_private or ip.is_loopback or ip.is_link_local
-    except ValueError:
-        pass
+    if _is_internal_ip(hostname):
+        return True
 
     if hostname.endswith((".local", ".internal", ".localhost")):
         return True
 
+    if resolve_dns and any(_is_internal_ip(address) for address in _resolved_addresses(hostname)):
+        return True
+
     return False
+
+
+def _request_checked_redirects(
+    client: httpx.Client,
+    *,
+    method: str,
+    url: str,
+    headers: dict[str, str] | None,
+    body: str | None,
+) -> httpx.Response | dict:
+    current_url = url
+    for _ in range(_MAX_REDIRECTS + 1):
+        if _is_internal_url(current_url, resolve_dns=True):
+            return {"error": "Requests to internal/private network addresses are blocked"}
+        response = client.request(
+            method=method,
+            url=current_url,
+            headers=headers,
+            content=body,
+            follow_redirects=False,
+        )
+        location = response.headers.get("location") if response.headers else None
+        if response.status_code not in _REDIRECT_STATUSES or not location:
+            return response
+        next_url = urljoin(str(response.url or current_url), str(location))
+        if _is_internal_url(next_url, resolve_dns=True):
+            return {"error": "Redirects to internal/private network addresses are blocked"}
+        current_url = next_url
+        method = "GET" if response.status_code == 303 else method
+        body = None if response.status_code == 303 else body
+    return {"error": f"Too many redirects; maximum is {_MAX_REDIRECTS}"}
 
 
 _ALLOWED_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"}
@@ -55,19 +115,22 @@ def http_request(
     if method not in _ALLOWED_METHODS:
         return {"error": f"Invalid method '{method}'. Allowed: {', '.join(sorted(_ALLOWED_METHODS))}"}
 
-    if _is_internal_url(url):
+    if _is_internal_url(url, resolve_dns=True):
         return {"error": "Requests to internal/private network addresses are blocked"}
 
     timeout = max(1, min(60, timeout))
 
     try:
-        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
-            response = client.request(
+        with httpx.Client(timeout=timeout) as client:
+            response = _request_checked_redirects(
+                client,
                 method=method,
                 url=url,
                 headers=headers,
-                content=body,
+                body=body,
             )
+        if isinstance(response, dict):
+            return response
         return {
             "status": response.status_code,
             "headers": dict(response.headers),


### PR DESCRIPTION
## Summary
- add native execution profiles for file, patch, sandbox, process, browser, and HTTP surfaces in the capability contract
- add preview/apply workspace patch tools with unified diff receipts, before/after hashes, stale-content guards, and audit records
- harden browser and HTTP private-network handling with DNS-resolution preflight, browser request routing, final URL checks, and redirect-to-internal blocking
- repair prior PR failure classes around deterministic token counting, engineering-memory windowing, session-owned process test setup, and extension manifest boundary declarations
- update M2 implementation docs with batch acceptance rules without claiming M2 is complete

## Team
- Lead/integrator: Codex
- Architecture mapper: Kierkegaard
- Critic/Contrarian: Pasteur and Chandrasekhar
- CI/test historian: Dalton did not return usable output and was closed; GitHub/local test evidence was used directly

## Critic / Contrarian Disposition
- Accepted: browser preflight alone was insufficient, so this adds request routing and final URL checks.
- Accepted: DNS language was softened to private-address DNS-resolution preflight instead of overclaiming full DNS-rebinding closure.
- Accepted: patch receipts now support guarded apply via `expected_before_sha256`; metadata no longer advertises unavailable rollback execution.
- Accepted: multi-occurrence replacement is rejected until indexed or replace-all semantics are implemented.

## Validation
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_tools.py::TestFilesystemTool tests/test_capabilities_api.py::test_tool_status_list_exposes_native_capability_contract tests/test_site_policy.py tests/test_browser_tool.py tests/test_http_mcp_server.py tests/test_tool_registry.py tests/test_native_tools_loader.py tests/test_specialists.py tests/test_extension_examples.py tests/test_sessions_api.py::TestDeleteSession::test_success_stops_session_owned_processes tests/test_operator_api.py::test_operator_benchmark_proof_surfaces_suite_coverage_and_evolution_gates tests/test_operator_api.py::test_operator_engineering_memory_groups_repo_and_pr_bundles tests/test_operator_api.py::test_operator_engineering_memory_applies_window_and_reports_total_bundle_counts tests/test_eval_harness.py::test_run_benchmark_suites_executes_guardian_memory_quality_suite tests/test_eval_harness.py::test_runtime_eval_scenarios_expose_expected_details tests/test_eval_harness.py::test_engineering_memory_runtime_eval_exposes_expected_details -q -o addopts=''` -> 94 passed, 4 warnings
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_extensions_api.py tests/test_extension_examples.py -q -o addopts=''` -> 65 passed
- `git diff --check`

Refs #427
Refs #435
