### PR TITLE
Add agent parity execution roadmap

### DIFF
--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -33,7 +33,8 @@ When these docs are updated on an open feature branch, they describe the intende
 - `docs/implementation/09-benchmark-status.md` mirrors the benchmark axes from research as shipped implementation status.
 - `docs/implementation/10-superiority-delivery.md` mirrors the superiority program from research as delivery ownership and implementation translation.
 - `docs/implementation/11-world-class-strategy-delivery.md` mirrors the cross-cutting world-class strategy translation as delivery rules.
-- `docs/implementation/01` through `07` are the only workstream docs; `08` through `11` are cross-cutting implementation mirrors, not extra workstreams.
+- `docs/implementation/16-agent-parity-execution-roadmap.md` mirrors the agent parity and targeted exceedance goals from research as implementation sequencing, proof gates, and board linkage rules.
+- `docs/implementation/01` through `07` are the only workstream docs; `08` through `11` and `16` are cross-cutting implementation mirrors, not extra workstreams.
 - if research adds a new benchmark/program layer without an implementation mirror, the docs are incomplete.
 - active execution state belongs in the GitHub Project, issues, and PRs rather than this document
 - M1 capability-kernel contract changes must update this roadmap plus [08. Docs Contract](./08-docs-contract.md) and [11. World-Class Strategy Delivery](./11-world-class-strategy-delivery.md) together, because M2 execution breadth, M3 trust-boundary enforcement, and M9 ecosystem governance all consume that contract.
@@ -41,7 +42,7 @@ When these docs are updated on an open feature branch, they describe the intende
 ## Current Status
 
 Read this roadmap together with [Development Status](./STATUS.md).
-For the implementation-side mirrors of the evidence, benchmark, superiority, and world-class strategy layers, also read [08. Docs Contract](./08-docs-contract.md), [09. Benchmark Status](./09-benchmark-status.md), [10. Superiority Delivery](./10-superiority-delivery.md), and [11. World-Class Strategy Delivery](./11-world-class-strategy-delivery.md).
+For the implementation-side mirrors of the evidence, benchmark, superiority, world-class strategy, and agent parity goal layers, also read [08. Docs Contract](./08-docs-contract.md), [09. Benchmark Status](./09-benchmark-status.md), [10. Superiority Delivery](./10-superiority-delivery.md), [11. World-Class Strategy Delivery](./11-world-class-strategy-delivery.md), and [16. Agent Parity Execution Roadmap](./16-agent-parity-execution-roadmap.md).
 
 ## M1 Capability Contract
 
@@ -649,7 +650,7 @@ Implementation docs `08` through `11` are supporting mirror layers for this road
 
 1. Read [Development Status](./STATUS.md) for the live shipped vs unfinished view.
 2. Read this file for workstream ordering and current scope.
-3. Read [08. Docs Contract](./08-docs-contract.md), [09. Benchmark Status](./09-benchmark-status.md), [10. Superiority Delivery](./10-superiority-delivery.md), and [11. World-Class Strategy Delivery](./11-world-class-strategy-delivery.md) for the implementation-side mirrors of the research benchmark/program docs and cross-cutting strategy translation.
+3. Read [08. Docs Contract](./08-docs-contract.md), [09. Benchmark Status](./09-benchmark-status.md), [10. Superiority Delivery](./10-superiority-delivery.md), [11. World-Class Strategy Delivery](./11-world-class-strategy-delivery.md), and [16. Agent Parity Execution Roadmap](./16-agent-parity-execution-roadmap.md) for the implementation-side mirrors of the research benchmark/program docs, cross-cutting strategy translation, and agent parity execution roadmap.
 4. Read `01` through `07` for detailed per-workstream checklists.
 5. Read the research docs for the benchmark and superiority target.
 6. Treat `/legacy` docs as supporting history, not the live source of truth.

--- a/docs/implementation/08-docs-contract.md
+++ b/docs/implementation/08-docs-contract.md
@@ -35,11 +35,13 @@ If a major concept appears in research but not implementation, or vice versa, th
 - [x] `docs/research/11-superiority-program.md` owns the design-level superiority program
 - [x] `docs/research/18-agent-competition-truth-table.md` owns M0 competitor truth and capability benchmark pressure
 - [x] `docs/research/19-strategy-claim-ledger.md` owns claim status, allowed wording, and proof-gate review rules
+- [x] `docs/research/20-seraph-agent-parity-and-exceedance-goals.md` owns the Hermes/OpenClaw/IronClaw parity pressure overlay and guardian-preserving target feature set
 - [x] `docs/implementation/STATUS.md` owns the fastest shipped snapshot
 - [x] `docs/implementation/00-master-roadmap.md` owns the strategic implementation program, completed-program record, and workstream-to-gap translation
 - [x] `docs/implementation/09-benchmark-status.md` mirrors the benchmark on shipped implementation terms
 - [x] `docs/implementation/10-superiority-delivery.md` mirrors the superiority program on delivery terms
 - [x] `docs/implementation/11-world-class-strategy-delivery.md` mirrors the cross-cutting world-class strategy translation on delivery terms
+- [x] `docs/implementation/16-agent-parity-execution-roadmap.md` mirrors the agent parity and targeted exceedance goal on implementation sequencing, proof gates, board linkage, and duplicate-issue avoidance
 - [x] the GitHub Project owns execution state
 - [x] GitHub issues and PRs own active work tracking, review state, and merge state
 - [x] `docs/docs/` owns historical/archive material that is no longer current truth

--- a/docs/implementation/11-world-class-strategy-delivery.md
+++ b/docs/implementation/11-world-class-strategy-delivery.md
@@ -15,6 +15,7 @@ title: 11. World-Class Strategy Delivery
 - canonical strategy source of truth: [17. Seraph World-Class Strategy](/research/seraph-world-class-strategy)
 - M0 competitor truth: [18. Agent Competition Truth Table](/research/agent-competition-truth-table)
 - M0 claim and wording gate: [19. Strategy Claim Ledger](/research/strategy-claim-ledger)
+- agent parity goal overlay: [20. Seraph Agent Parity And Exceedance Goals](/research/seraph-agent-parity-and-exceedance-goals)
 - synthesis context: [00. Research Synthesis](/research)
 
 ## Purpose

--- a/docs/implementation/16-agent-parity-execution-roadmap.md
+++ b/docs/implementation/16-agent-parity-execution-roadmap.md
@@ -1,0 +1,142 @@
+---
+title: 16. Agent Parity Execution Roadmap
+---
+
+# 16. Agent Parity Execution Roadmap
+
+## Status On `develop`
+
+- [ ] The full agent parity and targeted exceedance goal from [20. Seraph Agent Parity And Exceedance Goals](/research/seraph-agent-parity-and-exceedance-goals) is not complete on `develop`.
+
+## Paired Research
+
+- full goal document: [20. Seraph Agent Parity And Exceedance Goals](/research/seraph-agent-parity-and-exceedance-goals)
+- competitor truth and source discipline: [18. Agent Competition Truth Table](/research/agent-competition-truth-table)
+- claim gate: [19. Strategy Claim Ledger](/research/strategy-claim-ledger)
+- world-class strategy: [17. Seraph World-Class Strategy](/research/seraph-world-class-strategy)
+- superiority program: [11. Superiority Program](/research/superiority-program)
+
+## Purpose
+
+This file is the implementation-side roadmap for research document 20.
+
+It answers how Seraph should implement the full parity and targeted exceedance goal without duplicating the closed M0-M9 milestone foundation, creating a second live queue, or drifting away from the guardian-workspace vision.
+
+Active execution state remains in the GitHub Project, issues, and PRs. This roadmap owns durable sequencing, dependency logic, proof gates, and claim boundaries.
+
+## Execution Boundary
+
+Research document 20 is the competitor-pressure overlay. This roadmap is the implementation sequencing layer. The GitHub Project is the execution layer.
+
+- Do not recreate M0-M9 milestone issues; those are foundation anchors.
+- Do not create duplicate issues for the current live proof anchors: [#438](https://github.com/seraph-quest/seraph/issues/438), [#439](https://github.com/seraph-quest/seraph/issues/439), [#440](https://github.com/seraph-quest/seraph/issues/440), [#441](https://github.com/seraph-quest/seraph/issues/441), and [#467](https://github.com/seraph-quest/seraph/issues/467).
+- Do not parent new work under closed historical batch [#422](https://github.com/seraph-quest/seraph/issues/422).
+- Do not create an `ironclaw-*` import family. IronClaw pressure is implemented as secure-capability-host proof.
+- Do not treat raw channel count, plugin count, provider count, or voice/media presence as parity.
+- Do not claim `secure`, `private`, `production-ready`, `superior`, `best`, `fully at parity`, or `IronClaw-class` unless [19. Strategy Claim Ledger](/research/strategy-claim-ledger) allows that exact wording.
+
+## Board Receipts
+
+Verified on June 9, 2026 through GitHub Project GraphQL reads.
+
+| Issue | Role | Project item | Queue | Lane | Priority | Size | Status | PR | Code Review |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| [#468 Batch BQ: agent parity proof execution train](https://github.com/seraph-quest/seraph/issues/468) | current parent hub for the proof train | `PVTI_lADOD4qAvs4BS6n3zgvLeHs` | Now | Docs / Meta | P0 | L | In Progress | Open | Pending |
+| [#467 P1: Guardian-safe multimodal and voice proof](https://github.com/seraph-quest/seraph/issues/467) | next multimodal/voice proof-governance anchor | `PVTI_lADOD4qAvs4BS6n3zgvLV0A` | Next | Presence and Reach | P1 | M | Todo | Not Ready | Not Ready |
+| [#470 Batch BR: durable workflow state after endurance canary](https://github.com/seraph-quest/seraph/issues/470) | blocked durable workflow state follow-on | `PVTI_lADOD4qAvs4BS6n3zgvMBK8` | Blocked | Runtime Reliability | P1 | L | Todo | Not Ready | Not Ready |
+| [#471 Batch BS: guardian arbitration and live-learning receipts](https://github.com/seraph-quest/seraph/issues/471) | blocked guardian arbitration follow-on | `PVTI_lADOD4qAvs4BS6n3zgvMBLE` | Blocked | Guardian Intelligence | P1 | L | Todo | Not Ready | Not Ready |
+| [#472 Batch BT: governed capability-pack hardening receipts](https://github.com/seraph-quest/seraph/issues/472) | blocked ecosystem hardening follow-on | `PVTI_lADOD4qAvs4BS6n3zgvMBLI` | Blocked | Ecosystem and Leverage | P1 | L | Todo | Not Ready | Not Ready |
+
+The current parent hub is [#468](https://github.com/seraph-quest/seraph/issues/468). It coordinates the live proof train without splitting it into micro-issues:
+
+- [#457](https://github.com/seraph-quest/seraph/issues/457) / [PR #458](https://github.com/seraph-quest/seraph/pull/458): live long-horizon replay and proof substrate
+- [#439](https://github.com/seraph-quest/seraph/issues/439) / [PR #459](https://github.com/seraph-quest/seraph/pull/459): cockpit operator efficiency benchmark
+- [#441](https://github.com/seraph-quest/seraph/issues/441) / [PR #460](https://github.com/seraph-quest/seraph/pull/460): memory provider quality gate
+- [#440](https://github.com/seraph-quest/seraph/issues/440) / [PR #461](https://github.com/seraph-quest/seraph/pull/461): workflow endurance canary
+- [#438](https://github.com/seraph-quest/seraph/issues/438) / [PR #462](https://github.com/seraph-quest/seraph/pull/462): one excellent reach channel canary
+- [#467](https://github.com/seraph-quest/seraph/issues/467): guardian-safe multimodal and voice proof gate
+
+Blocked roadmap follow-ons are tracked separately so the board can represent the full goal without marking future work active:
+
+- [#470](https://github.com/seraph-quest/seraph/issues/470): durable workflow state after endurance canary
+- [#471](https://github.com/seraph-quest/seraph/issues/471): guardian arbitration and live-learning receipts
+- [#472](https://github.com/seraph-quest/seraph/issues/472): governed capability-pack hardening receipts
+
+## Roadmap Phases
+
+| Phase | Batch | Implementation goal | Proof gate | Dependency rule | Issue anchors |
+| ---: | --- | --- | --- | --- | --- |
+| 0 | Board, proof, and claim normalization | Keep execution state, parent linkage, review state, proof gates, and claim wording current before new readiness claims. | Project receipt plus claim-ledger review. | Must precede any new public parity or targeted exceedance wording. | [#468](https://github.com/seraph-quest/seraph/issues/468), [#436](https://github.com/seraph-quest/seraph/issues/436) |
+| 1 | Secure execution host v1 | Privileged paths fail closed across browser credentials, cookies, workspace escape, providers, connectors, delegation, shell, workflow replay, filesystem, background process, and secret egress. | `secure_capability_host` plus `trust_boundary_and_safety_receipts`, with cockpit-readable adversarial receipts. | Must precede high-risk reach, marketplace expansion, and stronger browser/computer-use claims. | historical [#428](https://github.com/seraph-quest/seraph/issues/428), [#435](https://github.com/seraph-quest/seraph/issues/435), [#455](https://github.com/seraph-quest/seraph/issues/455) |
+| 2 | Live long-horizon eval replay v1 | Add live-ish fake providers, replay fixtures, failure taxonomy, CI receipts, and operator evidence across memory, workflow, reach, security, cockpit, and intervention paths. | Cross-surface replay harness with deterministic and live-ish receipts. | Feeds every later quality claim; no broad parity claim should skip it. | [#457](https://github.com/seraph-quest/seraph/issues/457), [PR #458](https://github.com/seraph-quest/seraph/pull/458) |
+| 3 | Cockpit operator efficiency benchmark | Measure inspect, approve, deny, pause, resume, retry, repair, branch, compare, revoke, audit, confidence, and error detectability on real operator tasks. | M7 benchmark over workflow, memory, trust, and reach scenarios, not synthetic UI density alone. | Needs replay receipts so the same operator tasks can be re-run and compared. | [#439](https://github.com/seraph-quest/seraph/issues/439), [PR #459](https://github.com/seraph-quest/seraph/pull/459) |
+| 4 | Memory provider quality gate | External memory evidence declares provenance, confidence, privacy boundary, freshness, conflict behavior, usefulness, suppression, and canonical writeback rules. | `guardian_memory_quality` plus provider-quality receipts showing behavior change, suppression, or refusal. | Must land before memory-provider breadth is treated as a guardian advantage. | [#441](https://github.com/seraph-quest/seraph/issues/441), [PR #460](https://github.com/seraph-quest/seraph/pull/460) |
+| 5 | Workflow endurance canary | Multi-session work proves checkpoint, branch, interruption, delegated ownership, failure injection, recovery, artifact comparison, approval preservation, and audit trail. | `workflow_endurance_and_repair` with cockpit-visible final audit trail. | Can prove endurance canary behavior, but must not claim a durable workflow engine yet. | [#440](https://github.com/seraph-quest/seraph/issues/440), [PR #461](https://github.com/seraph-quest/seraph/pull/461) |
+| 6 | Durable workflow engine v1 | Move workflow state beyond audit-projected receipts into minimal durable state: crash-safe resume, heartbeat or reactive triggers, retry, repair, and delegated artifact review lifecycle. | Durable-state tests plus operator recovery receipts across crash, resume, and failed-step paths. | Depends on findings from the workflow endurance canary. | [#470](https://github.com/seraph-quest/seraph/issues/470) |
+| 7 | One excellent reach channel canary | One selected external channel proves pairing, revocation, health, retry, thread continuity, memory/context continuity, approval handoff, degraded UI, and external-message-to-audited-action flow. | M4 reach proof plus Activity Ledger and cockpit receipts. | Should follow security, replay, memory-quality, and workflow-endurance proof unless the Project explicitly promotes it. | [#438](https://github.com/seraph-quest/seraph/issues/438), [PR #462](https://github.com/seraph-quest/seraph/pull/462) |
+| 8 | Guardian world-model learning quality v2 | Deepen stale and conflicting evidence arbitration, salience/confidence calibration, false-positive and false-negative accounting, restraint, and follow-through. | Live-ish intervention replay with act, defer, bundle, clarify, approval, and stay-silent outcomes. | Depends on replay substrate and memory-quality proof; reach scenarios should only join after continuity is proven. | [#471](https://github.com/seraph-quest/seraph/issues/471) |
+| 9 | Governed extension marketplace hardening | Mature pack review, verification, compatibility semantics, supply-chain policy, provider trust downgrade handling, rollback posture, and authoring ergonomics. | `m9_governed_ecosystem` extension-review, downgrade, compatibility, and rollback receipts. | Depends on secure execution and M1/M9 manifest contracts; do not claim production marketplace security. | [#472](https://github.com/seraph-quest/seraph/issues/472) |
+| 10 | Guardian-safe multimodal and voice proof | Voice, TTS/STT, browser vision, image/media analysis, and media delivery exist only as governed capability families with audit, privacy, correction, and revocation. | Dedicated multimodal/voice proof showing channel safety plus actual guardian value. | Should follow one excellent reach channel and guardian-learning quality; do not ship as raw feature presence. | [#467](https://github.com/seraph-quest/seraph/issues/467) |
+
+## Feature Traceability
+
+| Research feature area | Canonical implementation phase | Guardian value gate | Blocked claim if failing |
+| --- | --- | --- | --- |
+| Capability kernel | Phases 0, 1, 9 | Every capability must expose source, owner, trust level, permission, health, dependency, recovery, and operator receipt before memory or guardian policy can rely on it. | capability parity, governed ecosystem depth |
+| Secure capability host | Phase 1 | The cockpit must explain both the mechanical boundary and the guardian reason for restraint, approval, refusal, or clarification. | secure execution, IronClaw-class security, production security |
+| Guardian memory | Phase 4 | Memory must change action choice, timing, channel, restraint, clarification, recovery, or follow-through, not merely increase stored context. | memory superiority, behavior-changing recall |
+| Intervention intelligence | Phase 8 | Better intervention means fewer bad interventions, clearer deferrals, stronger clarification, safer approvals, and grounded stay-silent decisions. | intervention superiority, guardian brain advantage |
+| Workflow endurance | Phases 5 and 6 | Long work must stay legible across interruptions, branches, failures, approvals, artifacts, and delegated ownership. | workflow superiority, durable workflow readiness |
+| Operator cockpit | Phase 3 | The operator must move from "what happened?" to "what should I do next?" through receipts and controls, not source diving. | cockpit efficiency, operator superiority |
+| Selective reach | Phase 7 | Reach must preserve memory, thread identity, approvals, audit, and recovery across surfaces while rejecting channel sprawl. | OpenClaw-style reach parity, always-available operation |
+| Browser/computer use | Phases 1, 2, 7 | Browser work must carry session partitioning, credential boundaries, replay receipts, and workflow/artifact continuity. | browser/computer-use parity, safe browser automation |
+| Ecosystem and marketplace | Phase 9 | Extensions must remain subordinate to Seraph's trust, review, compatibility, rollback, and guardian-governance model. | marketplace maturity, governed ecosystem superiority |
+| Multimodal and voice | Phase 10 | Voice/media must improve timing, accessibility, situational awareness, or intervention quality, and must show transcript/audit/privacy receipts. | multimodal parity, voice parity, guardian-safe voice |
+
+## Proof Template
+
+Every batch that claims progress against research document 20 should include:
+
+- proof suite: deterministic test, benchmark, replay, or canary name
+- receipt surface: cockpit, Activity Ledger, operator API, audit payload, PR artifact, or issue comment
+- negative cases: prompt injection, stale evidence, credential drift, replay drift, provider downgrade, channel loss, revocation, ambiguity, or unsafe memory
+- operator-visible pass criteria: what a user can inspect without reading code
+- blocked claims: the words or claims that remain disallowed if the proof fails
+- linked issue or PR: the GitHub object that owns acceptance and review
+
+## Strategic Order
+
+The durable order is:
+
+1. Normalize board, proof, and claim gates.
+2. Harden secure execution host boundaries.
+3. Land live long-horizon replay proof.
+4. Measure cockpit operator efficiency.
+5. Gate external memory-provider quality.
+6. Prove workflow endurance, then promote durable workflow state.
+7. Prove one excellent reach channel.
+8. Deepen guardian world-model learning quality.
+9. Harden governed ecosystem and marketplace foundations.
+10. Add guardian-safe multimodal and voice only after reach, trust, and guardian-value proof are ready.
+
+This order intentionally differs from raw competitor feature order. Seraph should expand capability breadth only when the guardian, trust, memory, workflow, and receipt layers can carry it.
+
+## Critic / Contrarian Disposition
+
+Accepted:
+
+- Research document 20 should remain a competitor-pressure overlay; implementation order belongs here and live execution belongs in the Project.
+- The roadmap must not duplicate closed M0-M9 anchors or the active #438/#439/#440/#441/#467 proof issues.
+- Closed [#422](https://github.com/seraph-quest/seraph/issues/422) must not be used as the parent for new work.
+- Selective reach must not outrun secure execution, replay proof, cockpit legibility, memory quality, and workflow endurance unless the Project deliberately promotes it.
+- Board receipt language must be backed by live Project reads; this doc includes only verified Project fields for #468 and #467.
+- Feature rows need guardian value gates, not only parity surfaces.
+
+Rejected:
+
+- The roadmap should not remove implementation sequencing entirely. The user explicitly asked for a roadmap to implement the full research document, so this file records durable sequencing while keeping active task state in GitHub.
+
+Accepted after follow-up:
+
+- The remaining roadmap-level follow-ons were created as blocked Project items instead of active work: [#470](https://github.com/seraph-quest/seraph/issues/470), [#471](https://github.com/seraph-quest/seraph/issues/471), and [#472](https://github.com/seraph-quest/seraph/issues/472).
+- A duplicate secure execution host v1 ticket was not created because closed [#455](https://github.com/seraph-quest/seraph/issues/455) already owns that batch; future secure-host work needs a narrowed follow-up with named uncovered negative cases.

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -78,8 +78,8 @@ When this file is updated on an open feature branch, it reflects the intended po
 - [x] `docs/research/11-superiority-program.md` owns the design-level superiority program.
 - [x] this file owns the fastest shipped snapshot on `develop`.
 - [x] `docs/implementation/00-master-roadmap.md` owns the strategic implementation program and completed-program record.
-- [x] `docs/implementation/08-docs-contract.md`, `docs/implementation/09-benchmark-status.md`, `docs/implementation/10-superiority-delivery.md`, and `docs/implementation/11-world-class-strategy-delivery.md` are the implementation-side mirrors of the research evidence, benchmark, program, and cross-cutting strategy layers.
-- [x] `docs/implementation/01` through `07` remain the workstream docs; `08` through `11` are meta mirrors, not extra workstreams.
+- [x] `docs/implementation/08-docs-contract.md`, `docs/implementation/09-benchmark-status.md`, `docs/implementation/10-superiority-delivery.md`, `docs/implementation/11-world-class-strategy-delivery.md`, and `docs/implementation/16-agent-parity-execution-roadmap.md` are the implementation-side mirrors of the research evidence, benchmark, program, cross-cutting strategy, and agent parity goal layers.
+- [x] `docs/implementation/01` through `07` remain the workstream docs; `08` through `11` and `16` are meta mirrors, not extra workstreams.
 - [x] the GitHub Project, issues, and PRs own active execution and review state.
 
 ## Current Focus On `develop`

--- a/docs/sidebars.implementation.ts
+++ b/docs/sidebars.implementation.ts
@@ -32,6 +32,7 @@ const sidebars: SidebarsConfig = {
         'benchmark-status',
         'superiority-delivery',
         'world-class-strategy-delivery',
+        'agent-parity-execution-roadmap',
       ],
     },
   ],

--- a/frontend/src/components/cockpit/CockpitView.test.tsx
+++ b/frontend/src/components/cockpit/CockpitView.test.tsx
@@ -3248,7 +3248,7 @@ describe("CockpitView", () => {
     );
     expect(within(evidence).queryByText("artifact: notes/older.md")).not.toBeInTheDocument();
 
-    fireEvent.keyDown(window, { key: "E", shiftKey: true });
+    fireEvent.click(await within(evidence).findByRole("button", { name: "Inspect artifact: notes/newer.md" }));
     const useButton = await screen.findByRole("button", { name: "Use In Command Bar" });
     fireEvent.click(useButton);
     await waitFor(() =>


### PR DESCRIPTION
## Summary
- add an implementation-side roadmap for research doc 20, translating Hermes/OpenClaw/IronClaw parity pressure into durable sequencing and proof gates
- wire the roadmap into the implementation sidebar, master roadmap, docs contract, status page, and world-class strategy mirror
- record verified Project receipts for #468, #467, #470, #471, and #472
- keep #468 as the current execution hub and create blocked follow-on tickets for the remaining non-duplicate roadmap work
- fix a stale cockpit artifact-shortcut test expectation surfaced by CI by selecting the evidence artifact before using its inspector action

## Roadmap tickets
- Current proof hub: #468
- Existing live/current anchors: #457/#458, #439/#459, #441/#460, #440/#461, #438/#462, #467
- Existing secure execution host batch: #455, not duplicated
- New blocked follow-ons: #470 durable workflow state after endurance canary, #471 guardian arbitration/live-learning receipts, #472 governed capability-pack hardening receipts

## Agent team
- Lead: Codex coordinated scope, branch discipline, board verification, docs integration, final synthesis, and CI fix
- Mapper: Harvey inspected the goal doc, implementation docs, issue anchors, and duplicate-risk boundaries
- Critic/Contrarian: Nietzsche challenged duplicate strategy surfaces, ordering drift, board-proof claims, claim wording, and missing guardian value gates
- Follow-up Critic/Contrarian: Ramanujan challenged issue-creation scope and required blocked, narrowed follow-ons instead of active duplicate tickets
- Goal-prompt Critic/Contrarian: Franklin reviewed the goal-command prompt requirements for duplicate prevention, board hygiene, claim boundaries, and batch discipline

## Critic disposition
- Accepted: keep doc 20 as competitor-pressure overlay; put implementation sequencing in this mirror and live state in the Project
- Accepted: do not duplicate closed M0-M9 anchors, active #438/#439/#440/#441/#467 proof issues, or closed #422
- Accepted: do not create a duplicate secure execution host v1 issue because #455 already exists
- Accepted: create #470/#471/#472 only as blocked roadmap-level follow-ons with explicit dependencies and Project fields
- Accepted: move selective reach behind trust, replay, cockpit, memory, and workflow proof unless the Project explicitly promotes it
- Accepted: include only verified Project receipt fields in the roadmap
- Rejected: removing implementation sequencing entirely, because the requested outcome is a roadmap for the full research goal document

## Validation
- npm run build (in docs)
- npm test -- CockpitView.test.tsx (in frontend)
- git diff --check

Refs #468, #467, #470, #471, #472