### PR TITLE
feat(cockpit): add live workflow run controls

### DIFF
--- a/backend/src/api/workflows.py
+++ b/backend/src/api/workflows.py
@@ -45,6 +45,14 @@ class WorkflowResumePlanRequest(BaseModel):
     step_id: str | None = None
 
 
+class WorkflowRunControlRequest(BaseModel):
+    action: str
+    target: str | None = None
+    step_id: str | None = None
+    owner: str | None = None
+    operator_context: dict[str, Any] | None = None
+
+
 class WorkflowDraftRequest(BaseModel):
     content: str
     file_name: str | None = None
@@ -936,6 +944,22 @@ def _workflow_resume_plan(
         "requires_manual_execution": True,
         "checkpoint_candidates": checkpoint_candidates,
     }
+
+
+async def _find_workflow_run_for_control(run_identity: str) -> dict[str, Any] | None:
+    runs = await _list_workflow_runs(limit=100, session_id=None)
+    run = next((item for item in runs if item.get("run_identity") == run_identity), None)
+    if run is not None:
+        return run
+    scoped_events, scoped_session_id = await _load_workflow_events_for_identity(run_identity)
+    if scoped_events:
+        runs = await _list_workflow_runs(
+            limit=max(len(scoped_events), 1),
+            session_id=scoped_session_id,
+            events=scoped_events,
+        )
+        run = next((item for item in runs if item.get("run_identity") == run_identity), None)
+    return run
 
 
 def _parse_run_identity(run_identity: str) -> tuple[str | None, str, str, str | None]:
@@ -2121,13 +2145,7 @@ async def build_workflow_resume_plan(
     run_identity: str,
     req: WorkflowResumePlanRequest | None = None,
 ):
-    runs = await _list_workflow_runs(limit=100, session_id=None)
-    run = next((item for item in runs if item.get("run_identity") == run_identity), None)
-    if run is None:
-        scoped_events, scoped_session_id = await _load_workflow_events_for_identity(run_identity)
-        if scoped_events:
-            runs = await _list_workflow_runs(limit=max(len(scoped_events), 1), session_id=scoped_session_id, events=scoped_events)
-            run = next((item for item in runs if item.get("run_identity") == run_identity), None)
+    run = await _find_workflow_run_for_control(run_identity)
     if run is None:
         raise HTTPException(status_code=404, detail=f"Workflow run '{run_identity}' not found")
     if str(run.get("replay_block_reason") or "") in {"approval_context_changed", "approval_context_missing"}:
@@ -2152,4 +2170,193 @@ async def build_workflow_resume_plan(
         "run_identity": run_identity,
         "workflow_name": run["workflow_name"],
         "resume_plan": resume_plan,
+    }
+
+
+@router.post("/workflows/runs/{run_identity:path}/control")
+async def control_workflow_run(
+    run_identity: str,
+    req: WorkflowRunControlRequest,
+):
+    run = await _find_workflow_run_for_control(run_identity)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Workflow run '{run_identity}' not found")
+    if str(run.get("replay_block_reason") or "") in {"approval_context_changed", "approval_context_missing"}:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Workflow trust boundary changed; start a fresh run instead of applying a live control."
+                if str(run.get("replay_block_reason") or "") == "approval_context_changed"
+                else "Workflow predates trust-boundary tracking; start a fresh run instead of applying a live control."
+            ),
+        )
+
+    action = req.action.strip().lower().replace("-", "_")
+    allowed_actions = {
+        "pause",
+        "resume",
+        "retry",
+        "repair",
+        "branch",
+        "compare",
+        "revoke",
+        "quarantine",
+        "handoff",
+        "rollback",
+        "audit",
+        "replay",
+        "runbook",
+    }
+    if action not in allowed_actions:
+        raise HTTPException(status_code=422, detail=f"Unsupported workflow control action '{req.action}'")
+
+    owner = "cockpit"
+    target = str(req.target or req.step_id or run.get("workflow_name") or run_identity).strip()
+    operator_context = {
+        **(req.operator_context or {}),
+        "workflow_name": run.get("workflow_name"),
+        "thread_id": run.get("thread_id"),
+        "session_id": run.get("session_id"),
+        "requested_owner": req.owner,
+        "requested_step_id": req.step_id,
+    }
+
+    lease_result = None
+    recovery_result = None
+    transition_result = None
+    resume_plan = None
+
+    async def log_refusal(
+        *,
+        status_code: int,
+        detail: str,
+        lease: dict[str, Any] | None = None,
+        recovery: dict[str, Any] | None = None,
+        transition: dict[str, Any] | None = None,
+    ) -> None:
+        await audit_repository.log_event(
+            session_id=run.get("session_id") if isinstance(run.get("session_id"), str) else None,
+            actor="operator",
+            event_type="workflow_control_refused",
+            tool_name=run.get("tool_name") if isinstance(run.get("tool_name"), str) else "workflow",
+            risk_level=str(run.get("risk_level") or "medium"),
+            policy_mode=get_current_tool_policy_mode(),
+            summary=f"Operator {action} refused for workflow {run.get('workflow_name') or run_identity}",
+            details={
+                "run_identity": run_identity,
+                "workflow_name": run.get("workflow_name"),
+                "action": action,
+                "target": target,
+                "step_id": req.step_id,
+                "status_code": status_code,
+                "detail": detail,
+                "external_action_allowed": False,
+                "lease_receipt": lease.get("receipt") if isinstance(lease, dict) else None,
+                "recovery_receipt": recovery.get("receipt") if isinstance(recovery, dict) else None,
+                "transition_receipt": transition.get("receipt") if isinstance(transition, dict) else None,
+            },
+        )
+
+    if action in {"resume", "retry", "repair", "branch", "replay"}:
+        try:
+            resume_plan = _workflow_resume_plan(
+                run,
+                approvals=list(run.get("pending_approvals", [])),
+                requested_step_id=req.step_id,
+            )
+        except HTTPException as exc:
+            detail = str(exc.detail)
+            await log_refusal(status_code=exc.status_code, detail=detail)
+            raise
+
+        lease_result = await workflow_state_repository.acquire_or_renew_v2_lease(
+            run_identity=run_identity,
+            owner=owner,
+        )
+        if lease_result is None:
+            raise HTTPException(status_code=404, detail=f"Workflow run '{run_identity}' is not persisted yet")
+        lease_receipt = lease_result.get("receipt") if isinstance(lease_result, dict) else None
+        if isinstance(lease_receipt, dict) and lease_receipt.get("status") == "blocked":
+            detail = str(lease_receipt.get("blocked_reason") or "workflow control lease is blocked")
+            await log_refusal(status_code=423, detail=detail, lease=lease_result)
+            raise HTTPException(status_code=423, detail=detail)
+
+        recovery_result = await workflow_state_repository.build_v2_recovery_plan(
+            run_identity=run_identity,
+            owner=owner,
+            approval_context=run.get("current_approval_context") or run.get("approval_context"),
+        )
+        if recovery_result is None:
+            raise HTTPException(status_code=404, detail=f"Workflow run '{run_identity}' is not persisted yet")
+        recovery_receipt = recovery_result.get("receipt") if isinstance(recovery_result, dict) else None
+        if isinstance(recovery_receipt, dict) and recovery_receipt.get("status") == "blocked":
+            detail = str(recovery_receipt.get("blocked_reason") or "workflow recovery is blocked")
+            await log_refusal(status_code=409, detail=detail, lease=lease_result, recovery=recovery_result)
+            raise HTTPException(status_code=409, detail=detail)
+
+    control_result = await workflow_state_repository.record_v2_operator_recovery_control(
+        run_identity=run_identity,
+        action=action,
+        target=target,
+        operator_context=operator_context,
+        enabled=True,
+    )
+    if control_result is None:
+        raise HTTPException(status_code=404, detail=f"Workflow run '{run_identity}' is not persisted yet")
+
+    if action in {"resume", "retry", "repair", "branch", "replay"}:
+        transition_result = await workflow_state_repository.record_v2_transition(
+            run_identity=run_identity,
+            transition_key=f"operator:{action}:{req.step_id or 'run'}",
+            transition_type=action,
+            owner=owner,
+            step_id=req.step_id,
+        )
+        transition_receipt = transition_result.get("receipt") if isinstance(transition_result, dict) else None
+        if isinstance(transition_receipt, dict) and transition_receipt.get("status") == "blocked":
+            detail = str(transition_receipt.get("blocked_reason") or "workflow transition is blocked")
+            await log_refusal(
+                status_code=409,
+                detail=detail,
+                lease=lease_result,
+                recovery=recovery_result,
+                transition=transition_result,
+            )
+            raise HTTPException(status_code=409, detail=detail)
+
+    await audit_repository.log_event(
+        session_id=run.get("session_id") if isinstance(run.get("session_id"), str) else None,
+        actor="operator",
+        event_type="workflow_control",
+        tool_name=run.get("tool_name") if isinstance(run.get("tool_name"), str) else "workflow",
+        risk_level=str(run.get("risk_level") or "medium"),
+        policy_mode=get_current_tool_policy_mode(),
+        summary=f"Operator requested {action} for workflow {run.get('workflow_name') or run_identity}",
+        details={
+            "run_identity": run_identity,
+            "workflow_name": run.get("workflow_name"),
+            "action": action,
+            "target": target,
+            "step_id": req.step_id,
+            "external_action_allowed": False,
+            "control_receipt": control_result.get("receipt"),
+            "lease_receipt": lease_result.get("receipt") if isinstance(lease_result, dict) else None,
+            "recovery_receipt": recovery_result.get("receipt") if isinstance(recovery_result, dict) else None,
+            "transition_receipt": transition_result.get("receipt") if isinstance(transition_result, dict) else None,
+        },
+    )
+
+    refreshed_run = await _find_workflow_run_for_control(run_identity)
+    return {
+        "run_identity": run_identity,
+        "workflow_name": run.get("workflow_name"),
+        "action": action,
+        "status": "recorded",
+        "external_action_allowed": False,
+        "control_receipt": control_result.get("receipt"),
+        "lease_receipt": lease_result.get("receipt") if isinstance(lease_result, dict) else None,
+        "recovery_receipt": recovery_result.get("receipt") if isinstance(recovery_result, dict) else None,
+        "transition_receipt": transition_result.get("receipt") if isinstance(transition_result, dict) else None,
+        "resume_plan": resume_plan,
+        "run": refreshed_run or run,
     }

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -28,6 +28,7 @@ from src.agent.factory import get_tools
 from src.agent.session import SessionManager
 from src.audit.repository import audit_repository
 from src.tools.approval import ApprovalTool
+from src.workflows.durable_state import workflow_state_repository
 from src.workflows.run_identity import build_workflow_run_identity
 
 
@@ -2221,6 +2222,154 @@ async def test_workflow_resume_plan_endpoint_returns_structured_branch_metadata(
     assert payload["resume_plan"]["checkpoint_candidates"][1]["step_id"] == "save"
     assert '_seraph_resume_from_step="save"' in payload["resume_plan"]["draft"]
     assert "_seraph_parent_run_identity=" in payload["resume_plan"]["draft"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_control_records_live_operator_recovery_control(client, async_db):
+    run_identity = "session-live:workflow_web_brief_to_file:control"
+    await workflow_state_repository.create_run(
+        run_identity=run_identity,
+        workflow_name="web-brief-to-file",
+        tool_name="workflow_web_brief_to_file",
+        session_id="session-live",
+        run_fingerprint="control",
+        arguments={"query": "seraph", "file_path": "notes/brief.md"},
+        approval_context={"risk_level": "medium", "execution_boundaries": ["workspace_write"]},
+    )
+    await workflow_state_repository.record_step_started(
+        run_identity=run_identity,
+        workflow_name="web-brief-to-file",
+        step_id="write_file",
+        step_index=1,
+        tool_name="write_file",
+        arguments={"file_path": "notes/brief.md"},
+    )
+    await workflow_state_repository.record_step_failed(
+        run_identity=run_identity,
+        step_id="write_file",
+        result_summary="write_file blocked",
+        error_kind="policy_boundary",
+        error_summary="write_file blocked by policy",
+        checkpoint={"arguments": {"file_path": "notes/brief.md"}},
+    )
+    await workflow_state_repository.finish_run(
+        run_identity=run_identity,
+        status="failed",
+        checkpoint_context={"write_file": {"arguments": {"file_path": "notes/brief.md"}}},
+        continued_error_steps=["write_file"],
+        last_completed_step_id="write_file",
+        error="write_file blocked by policy",
+    )
+
+    with (
+        patch("src.api.workflows.audit_repository.list_events", return_value=[]),
+        patch(
+            "src.api.workflows.workflow_manager.get_tool_metadata",
+            return_value={
+                "risk_level": "medium",
+                "execution_boundaries": ["workspace_write"],
+                "accepts_secret_refs": False,
+            },
+        ),
+        patch("src.api.workflows.session_manager.list_sessions", return_value=[{"id": "session-live", "title": "Live work"}]),
+        patch("src.api.workflows.get_current_tool_policy_mode", return_value="balanced"),
+    ):
+        response = await client.post(
+            f"/api/workflows/runs/{run_identity}/control",
+            json={
+                "action": "retry",
+                "step_id": "write_file",
+                "target": "write_file",
+                "owner": "cockpit",
+                "operator_context": {"source": "cockpit"},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "recorded"
+    assert payload["action"] == "retry"
+    assert payload["external_action_allowed"] is False
+    assert payload["control_receipt"]["action"] == "retry"
+    assert payload["lease_receipt"]["status"] == "acquired"
+    assert payload["recovery_receipt"]["status"] == "ready"
+    assert payload["transition_receipt"]["status"] == "recorded"
+    assert payload["resume_plan"]["branch_kind"] == "retry_failed_step"
+    assert payload["resume_plan"]["resume_from_step"] == "write_file"
+    assert payload["run"]["run_identity"] == run_identity
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_control_refuses_blocked_live_lease_without_resume_plan(client, async_db):
+    run_identity = "session-live:workflow_web_brief_to_file:lease-blocked"
+    await workflow_state_repository.create_run(
+        run_identity=run_identity,
+        workflow_name="web-brief-to-file",
+        tool_name="workflow_web_brief_to_file",
+        session_id="session-live",
+        run_fingerprint="lease-blocked",
+        arguments={"query": "seraph", "file_path": "notes/brief.md"},
+        approval_context={"risk_level": "medium", "execution_boundaries": ["workspace_write"]},
+    )
+    await workflow_state_repository.record_step_started(
+        run_identity=run_identity,
+        workflow_name="web-brief-to-file",
+        step_id="write_file",
+        step_index=1,
+        tool_name="write_file",
+        arguments={"file_path": "notes/brief.md"},
+    )
+    await workflow_state_repository.record_step_failed(
+        run_identity=run_identity,
+        step_id="write_file",
+        result_summary="write_file blocked",
+        error_kind="policy_boundary",
+        error_summary="write_file blocked by policy",
+        checkpoint={"arguments": {"file_path": "notes/brief.md"}},
+    )
+    await workflow_state_repository.finish_run(
+        run_identity=run_identity,
+        status="failed",
+        checkpoint_context={"write_file": {"arguments": {"file_path": "notes/brief.md"}}},
+        continued_error_steps=["write_file"],
+        last_completed_step_id="write_file",
+        error="write_file blocked by policy",
+    )
+    await workflow_state_repository.acquire_or_renew_v2_lease(
+        run_identity=run_identity,
+        owner="another-worker",
+    )
+
+    with (
+        patch("src.api.workflows.audit_repository.list_events", return_value=[]),
+        patch(
+            "src.api.workflows.workflow_manager.get_tool_metadata",
+            return_value={
+                "risk_level": "medium",
+                "execution_boundaries": ["workspace_write"],
+                "accepts_secret_refs": False,
+            },
+        ),
+        patch("src.api.workflows.session_manager.list_sessions", return_value=[{"id": "session-live", "title": "Live work"}]),
+        patch("src.api.workflows.get_current_tool_policy_mode", return_value="balanced"),
+    ):
+        response = await client.post(
+            f"/api/workflows/runs/{run_identity}/control",
+            json={
+                "action": "retry",
+                "step_id": "write_file",
+                "target": "write_file",
+                "owner": "spoofed-worker",
+                "operator_context": {"source": "cockpit"},
+            },
+        )
+
+    assert response.status_code == 423
+    payload = response.json()
+    assert payload["detail"] == "active_lease_owned_by_another_worker"
+    assert "resume_plan" not in payload
+    events = await audit_repository.list_events(limit=10, session_id="session-live")
+    assert any(event["event_type"] == "workflow_control_refused" for event in events)
 
 
 @pytest.mark.asyncio

--- a/docs/implementation/17-full-production-parity-goal-prompt.md
+++ b/docs/implementation/17-full-production-parity-goal-prompt.md
@@ -2,8 +2,10 @@
 
 Use this prompt with the goal command when the objective is to complete the full production-grade Seraph parity and targeted-exceedance program tracked by parent issue [#475](https://github.com/seraph-quest/seraph/issues/475).
 
+This prompt is intentionally feature-only until parity is reached. The goal is not to produce more proof surfaces as the main work, and it is not to pair each feature with a minimal proof companion task. The goal is to ship the user-facing parity capabilities Seraph still lacks and make those capabilities coherent with the guardian-workspace vision. Receipts, expanded tests, claim-ledger updates, and docs happen only after the full feature-parity implementation is complete, as a separate honesty and claim-readiness pass.
+
 ```text
-Goal: complete the post-DP implementation gap-closure train needed to make production-grade feature-parity and targeted-exceedance claim-readiness possible for Seraph against Hermes, OpenClaw, and IronClaw, while preserving Seraph's guardian-workspace vision. Do not stop at planning. Complete the implementation train, board updates, PRs, reviews, docs, validation, and final claim-readiness gate.
+Goal: complete the post-DP implementation gap-closure train needed to make production-grade feature parity and targeted exceedance possible for Seraph against Hermes, OpenClaw, and IronClaw, while preserving Seraph's guardian-workspace vision. Work feature-only first: implement the operator-facing capabilities, workflows, controls, runtime behavior, recovery paths, channels, memory behavior, security behavior, marketplace flows, and browser/computer-use behavior before adding proof wrappers, expanded docs, or claim-readiness layers. Do not stop at planning. Complete the feature implementation train first, then run the separate honesty and claim-readiness pass.
 
 Ground rules:
 - Follow AGENTS.md exactly.
@@ -12,49 +14,57 @@ Ground rules:
 - Ready PRs only; no draft PRs.
 - Use parent issue #475 as the execution parent.
 - Do not create a new parent roadmap issue.
-- Do not reopen closed M0-M9, #476-#482, #491-#497, #505-#512, #522-#530, #540-#547, or #557-#564 work.
-- Treat #573-#580 as the active post-DP implementation gap-closure train.
+- Do not reopen closed M0-M9, #476-#482, #491-#497, #505-#512, #522-#530, #540-#547, #557-#564, or #573-#580 work.
+- Treat #573-#580 as closed bounded-proof/history, not active feature work. Before implementation, rescope the open post-DX board batches or create new huge PR-sized linked issues as a feature-only train.
 - Keep docs as shipped/strategic truth; GitHub issues, PRs, and the Project board are the live execution layer.
+- Prioritize user-facing feature work exclusively until the parity implementation train is complete. For every batch, identify the concrete user/operator experience that improves: the screen, command, API, workflow, control, recovery path, channel, memory behavior, security behavior, marketplace flow, or browser action that becomes better for a real user.
+- Do not add new proof surfaces, proof-only endpoints, proof-only benchmark suites, expanded docs, claim-ledger changes, or per-batch proof wrappers inside feature batches.
+- Do not create proof-only successor batches while material parity capabilities remain unimplemented.
+- After the full feature train is implemented, run one separate claim-readiness phase for receipts, focused tests, docs, board reconciliation, source refresh, and claim-ledger wording.
 - Do not claim production readiness, full parity, superiority, secure/private-by-default execution, IronClaw-class execution, OpenClaw-class reach, solved operator control, solved learning, production-secure marketplace, safe autonomous browser/computer-use, full browser parity, memory superiority, or reference-system exceedance unless the claim ledger permits exact wording after merged proof.
 
 Team model:
 - Act as team lead.
 - Create or update a role-fit team before each substantial batch.
 - Required roles across the train: Planner, Repo Explorer, Runtime Reliability Worker, Security/Trust Worker, Reach Worker, Guardian/Memory Worker, Operator UX Worker, Marketplace Worker, Browser/Execution Worker, Docs/Board Integrator, and independent Critic/Contrarian.
-- Delegate bounded implementation slices with explicit ownership, acceptance criteria, proof requirements, and expected output.
+- Delegate bounded implementation slices with explicit ownership, user-facing acceptance criteria, and expected output.
 - Run an independent Critic/Contrarian pass before each PR and before any issue/board/claim-finalization action.
 - Verify subagent claims before using them in docs, issue updates, PR bodies, commits, or final status.
 
 Execution batches:
-1. Complete #573 / Batch DQ: post-DP durable orchestration gap-closure implementation.
+1. Durable orchestration feature batch.
    - Implement real multi-session, multi-agent, scheduler interruption, crash/retry, idempotency, side-effect reconciliation, and operator recovery improvements.
-   - Add operator-visible receipts, benchmark-proof visibility, unsafe-resume blocks, duplicate-side-effect suppression, and false-claim scanning.
+   - User-facing first: make long-running work easier to resume, inspect, recover, and trust after interruption.
 
-2. Complete #574 / Batch DR: post-DP secure capability-host gap-closure implementation.
+2. Secure capability-host feature batch.
    - Harden runtime profile selection, deny-by-default egress, scoped credentials, package/browser/session boundaries, hostile chains, quarantine, revocation, and recovery authority.
-   - Add redaction, denial, hostile-chain, credential-broker, isolation, recovery, and false-claim proof.
+   - User-facing first: make risky tool, connector, browser, package, and credential paths visibly safer and easier to recover when blocked or quarantined.
 
-3. Complete #575 / Batch DS: post-DP reach and channel gap-closure implementation.
-   - Improve selected reach surfaces with pairing, revocation, consent, rate-limit/abuse handling, provider outage, offline/degraded recovery, continuity, and voice/media receipt surfaces where implemented.
+3. Reach and channel feature batch.
+   - Improve selected reach surfaces with pairing, revocation, consent, rate-limit/abuse handling, provider outage, offline/degraded recovery, continuity, and voice/media handoff behavior where implemented.
    - Preserve Seraph's selective guardian-aware reach vision rather than chasing raw channel count.
+   - User-facing first: make the selected channels genuinely usable for daily interruption, approval, recovery, and continuity.
 
-4. Complete #576 / Batch DT: post-DP guardian learning and memory gap-closure implementation.
+4. Guardian learning and memory feature batch.
    - Implement consented long-horizon learning, behavior-change ablations, reversible learning deltas, rollback, stale evidence decay, provider quarantine, delete/export propagation, and safety monitoring.
    - Keep memory and guardian claims evidence-bound and privacy-safe.
+   - User-facing first: make Seraph's memory visibly improve decisions, restraint, recall, correction, and provider conflict handling for the operator.
 
-5. Complete #577 / Batch DU: post-DP operator debugging and recovery-control gap-closure implementation.
+5. Operator debugging and recovery-control feature batch.
    - Make long-work operation dense and recoverable: inspect, pause, resume, retry, repair, branch, compare, revoke, quarantine, handoff, rollback, audit, search, replay, and runbook flows.
-   - Include stale approval blocking, safe denial, authority transfer, audit integrity, accessibility/keyboard proof, and operator effort evidence.
+   - User-facing first: make the cockpit feel like a real control surface for serious work, not a report viewer.
 
-6. Complete #578 / Batch DV: post-DP capability marketplace lifecycle gap-closure implementation.
+6. Capability marketplace lifecycle feature batch.
    - Implement safer install, update, downgrade, disable, rollback, quarantine, re-entry, provenance, signature, publisher trust, SBOM/dependency, vulnerability, compatibility, permission, and runtime-boundary diagnostics.
-   - Integrate marketplace lifecycle with secure capability-host policy and operator audit receipts.
+   - User-facing first: make installing and maintaining capabilities understandable, reversible, diagnosable, and safe for an operator.
+   - Integrate marketplace lifecycle with secure capability-host policy only where needed for the actual user-facing lifecycle flow.
 
-7. Complete #579 / Batch DW: post-DP browser/computer-use reliability gap-closure implementation.
+7. Browser/computer-use reliability feature batch.
    - Improve selected provider modes, live degradation handling, credentialed test-account recovery, partitioned session/profile/cookie/credential/file/network/private-data boundaries, site drift recovery, and hostile-page fail-closed behavior.
    - Keep dangerous-action denial and existing-session trust boundaries explicit.
+   - User-facing first: make browser/computer-use runs more reliable, explainable, recoverable, and bounded when sites drift or credentials/sessions are involved.
 
-8. Complete #580 / Batch DX only after #573-#579 are closed with Project fields Status=Done, PR=Merged, and Code Review=Passed.
+8. Claim-readiness phase only after the feature train has shipped.
    - Refresh current Hermes/OpenClaw/IronClaw sources with URLs and access dates.
    - Reconcile issues, PRs, Project fields, tests, docs, operator endpoints, benchmark proof, and claim ledger.
    - Run local and GitHub false-completion scans.
@@ -68,14 +78,17 @@ Project board contract:
 - When the PR merges, set PR=Merged and Status=Done.
 - Keep child slice issues only when separate ownership, blocker status, or separate reprioritization makes them necessary.
 
-Validation discipline:
+Feature-first discipline:
 - Do not wait on the full test suite before implementing the selected batch features.
-- Implement all features in the active batch first.
-- Then run focused tests, benchmark suites, operator API checks, false-claim scans, docs checks, and git diff --check.
-- Fix failing tests after implementation and before PR readiness.
-- PR bodies must include scope, validation, team roles, Critic/Contrarian disposition, linked issue, Project/board receipt, and blocked-claim posture.
+- Implement all user-facing features in the active batch first.
+- Do not turn a feature batch into a feature-plus-minimal-proof batch.
+- Do not spend feature-batch time building proof scaffolding, benchmark harnesses, claim scans, broad docs reconciliation, or claim-ledger changes.
+- Run only basic local build/smoke sanity when packaging a PR, and keep that work subordinate to the feature implementation rather than treating it as parity evidence.
+- Fix failures caused by the changed feature surface before PR readiness.
+- PR bodies must include scope, user-facing behavior shipped, team roles, Critic/Contrarian disposition, linked issue, Project/board receipt, and blocked-claim posture. They must not claim parity proof or claim-readiness during the feature-only phase.
 
 Completion definition:
 - The goal is not complete when issues are merely created or docs are updated.
-- The goal is complete only when #573-#580 are implemented, merged, board-reconciled, docs and claim ledger agree with shipped truth, current competitor sources are refreshed, false-completion scans pass, and DX permits exact final wording.
+- The feature phase is complete when the post-DX feature-only train ships its intended user-facing parity capabilities and is merged.
+- The overall goal is complete only after the separate DX claim-readiness phase reconciles board state, docs, tests, receipts, current competitor sources, false-completion scans, and exact claim-ledger wording.
 ```

--- a/frontend/src/components/cockpit/CockpitView.test.tsx
+++ b/frontend/src/components/cockpit/CockpitView.test.tsx
@@ -208,6 +208,127 @@ describe("CockpitView", () => {
     expect(within(consoleRegion).getByRole("button", { name: "install" })).toBeEnabled();
   });
 
+  it("does not queue stale workflow fallback drafts when live recovery control is refused", async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/workflows/runs/") && url.includes("/control")) {
+        return Promise.resolve(mockResponse({ detail: "approval_context_changed" }, false, 409));
+      }
+      if (url.includes("/api/sessions")) return Promise.resolve(mockResponse([{ id: "session-2", title: "Atlas thread" }]));
+      if (url.includes("/api/goals/tree")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/goals/dashboard")) {
+        return Promise.resolve(mockResponse({ domains: {}, active_count: 0, completed_count: 0, total_count: 0 }));
+      }
+      if (url.includes("/api/runtime/status")) {
+        return Promise.resolve(mockResponse({
+          version: "test",
+          build_id: "test",
+          provider: "test",
+          model: "test",
+          model_label: "test",
+        }));
+      }
+      if (url.includes("/api/observer/state")) return Promise.resolve(mockResponse({}));
+      if (url.includes("/api/audit/events")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/approvals/pending")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/observer/continuity")) {
+        return Promise.resolve(mockResponse({
+          daemon: { connected: false, pending_notification_count: 0, capture_mode: "balanced" },
+          notifications: [],
+          queued_insights: [],
+          queued_insight_count: 0,
+          recent_interventions: [],
+          reach: { route_statuses: [] },
+        }));
+      }
+      if (url.includes("/api/capabilities/overview")) return Promise.resolve(mockResponse(emptyCapabilityOverview()));
+      if (url.includes("/api/extensions")) return Promise.resolve(mockResponse({ extensions: [] }));
+      if (url.includes("/api/workflows/runs")) {
+        return Promise.resolve(mockResponse({
+          runs: [
+            {
+              id: "run-root",
+              tool_name: "workflow_web_brief_to_file",
+              workflow_name: "web-brief-to-file",
+              session_id: "session-2",
+              status: "degraded",
+              started_at: "2026-03-18T12:00:00Z",
+              updated_at: "2026-03-18T12:04:00Z",
+              summary: "workflow_web_brief_to_file failed at write_file",
+              step_tools: ["web_search", "write_file"],
+              step_records: [
+                {
+                  id: "write_file",
+                  index: 1,
+                  tool: "write_file",
+                  status: "failed",
+                  argument_keys: ["file_path"],
+                  artifact_paths: ["notes/brief.md"],
+                  error_summary: "write_file blocked by approval",
+                  is_recoverable: true,
+                },
+              ],
+              artifact_paths: ["notes/brief.md"],
+              continued_error_steps: ["write_file"],
+              risk_level: "medium",
+              pending_approval_count: 0,
+              pending_approval_ids: [],
+              thread_id: "session-2",
+              thread_label: "Atlas thread",
+              replay_allowed: true,
+              retry_from_step_draft: 'Retry step "write_file" for workflow "web-brief-to-file".',
+              run_identity: "root-1",
+              root_run_identity: "root-1",
+              checkpoint_context_available: true,
+            },
+          ],
+        }));
+      }
+      if (url.includes("/api/settings/tool-policy-mode")) return Promise.resolve(mockResponse({ mode: "balanced" }));
+      if (url.includes("/api/settings/mcp-policy-mode")) return Promise.resolve(mockResponse({ mode: "approval" }));
+      if (url.includes("/api/settings/approval-mode")) return Promise.resolve(mockResponse({ mode: "high_risk" }));
+      return Promise.resolve(mockResponse({}));
+    });
+
+    useCockpitLayoutStore.setState({
+      paneVisibility: {
+        ...getDefaultPaneVisibility("default"),
+        workflows_pane: true,
+      },
+      savedPaneVisibility: {
+        default: {
+          ...getDefaultPaneVisibility("default"),
+          workflows_pane: true,
+        },
+      },
+    });
+
+    render(<CockpitView onSend={() => {}} />);
+
+    const timelineTitle = await screen.findByText("Workflow timeline");
+    const timeline = timelineTitle.closest(".cockpit-window");
+    expect(timeline).not.toBeNull();
+    const workflowRow = await within(timeline as HTMLElement).findByText("web-brief-to-file");
+    const row = workflowRow.closest(".cockpit-row");
+    expect(row).not.toBeNull();
+
+    fireEvent.click(within(row as HTMLElement).getByRole("button", { name: "Retry step" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/workflows/runs/root-1/control"),
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"action":"retry"'),
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Live recovery control refused web-brief-to-file: approval_context_changed")).toBeInTheDocument(),
+    );
+    expect(screen.queryByDisplayValue('Retry step "write_file" for workflow "web-brief-to-file".')).not.toBeInTheDocument();
+  });
+
   it("renders degraded revoked extension state with rollback unavailable and guarded alternatives", async () => {
     mockCockpitBaselineFetch(fetchMock, {
       extensions: {
@@ -829,7 +950,7 @@ describe("CockpitView", () => {
     );
     fireEvent.click(screen.getAllByText("workflow_web_brief_to_file succeeded (2 steps)")[0]);
 
-    expect(screen.getByText("Draft Boundary-Aware Rerun")).toBeInTheDocument();
+    expect(screen.getByText("Plan Boundary-Aware Rerun")).toBeInTheDocument();
     expect(screen.getAllByText(/web_search succeeded · 2 web results/)).not.toHaveLength(0);
     expect(screen.getByRole("button", { name: "Retry step" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Branch web_search" })).toBeInTheDocument();
@@ -861,7 +982,7 @@ describe("CockpitView", () => {
   }, 30000);
 
   it("surfaces active triage for approvals, workflows, queued guardian items, and reach failures", async () => {
-    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/api/sessions")) {
         return Promise.resolve(mockResponse([
@@ -1292,6 +1413,32 @@ describe("CockpitView", () => {
           extension_packages: [],
         }));
       }
+      if (url.includes("/api/workflows/runs/") && url.includes("/control")) {
+        const body = typeof init?.body === "string" ? init.body : "";
+        if (body.includes('"action":"resume"')) {
+          const continueMessage = url.includes("branch-1")
+            ? "Continue Atlas branch"
+            : "Continue Atlas workflow";
+          return Promise.resolve(mockResponse({
+            status: "recorded",
+            action: "resume",
+            external_action_allowed: false,
+            resume_plan: {
+              continue_message: continueMessage,
+              resume_checkpoint_label: "approval gate",
+            },
+          }));
+        }
+        return Promise.resolve(mockResponse({
+          status: "recorded",
+          action: "retry",
+          external_action_allowed: false,
+          resume_plan: {
+            draft: 'Retry step "write_file" for workflow "web-brief-to-file".',
+            resume_checkpoint_label: "write_file",
+          },
+        }));
+      }
       if (url.includes("/api/workflows/runs")) {
         return Promise.resolve(mockResponse({
           runs: [
@@ -1627,6 +1774,15 @@ describe("CockpitView", () => {
     fireEvent.click(within(workflowRow as HTMLElement).getByRole("button", { name: "Retry step for workflow degraded: web-brief-to-file" }));
     await waitFor(() =>
       expect(screen.getByDisplayValue('Retry step "write_file" for workflow "web-brief-to-file".')).toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/workflows/runs/root-1/control"),
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"action":"retry"'),
+        }),
+      ),
     );
 
     fireEvent.click(within(workflowRow as HTMLElement).getByRole("button", { name: "Repair step for workflow degraded: web-brief-to-file" }));
@@ -7066,7 +7222,7 @@ describe("CockpitView", () => {
     expect(within(inspector).getByRole("button", { name: "Branch review_checkpoint from current run for checkpoint history review_checkpoint" })).toBeInTheDocument();
     expect(within(inspector).getByRole("button", { name: "Use output from current run lineage event workflow_succeeded" })).toBeInTheDocument();
     expect(within(inspector).getByRole("button", { name: "Use failure from best continuation lineage event workflow_degraded" })).toBeInTheDocument();
-    expect(within(inspector).getByRole("button", { name: "Draft retry from best continuation lineage event workflow_degraded" })).toBeInTheDocument();
+    expect(within(inspector).getByRole("button", { name: "Plan retry from best continuation lineage event workflow_degraded" })).toBeInTheDocument();
     expect(within(inspector).queryByRole("button", { name: "Use failure from current run lineage event workflow_succeeded" })).not.toBeInTheDocument();
     expect(within(inspector).getAllByText(/recovery ready/i).length).toBeGreaterThan(0);
 
@@ -7094,7 +7250,7 @@ describe("CockpitView", () => {
     await waitFor(() =>
       expect(screen.getByDisplayValue(/Review workflow "resume-review" step "review_checkpoint" \(read_file\)\./)).toBeInTheDocument(),
     );
-    fireEvent.click(within(inspector).getByRole("button", { name: "Draft retry from best continuation lineage event workflow_degraded" }));
+    fireEvent.click(within(inspector).getByRole("button", { name: "Plan retry from best continuation lineage event workflow_degraded" }));
     await waitFor(() =>
       expect(
         screen.getByDisplayValue(
@@ -8372,7 +8528,7 @@ describe("CockpitView", () => {
     expect(within(artifactRow as HTMLElement).getByRole("button", { name: "Run summarize-file from artifact output notes/brief.md" })).toBeInTheDocument();
 
     const traceRetryButton = within(inspectorWindow as HTMLElement).getByRole("button", {
-      name: "Draft retry from write_file for atlas-brief",
+      name: "Plan retry from write_file for atlas-brief",
     });
     const traceRow = traceRetryButton.closest(".cockpit-inspector-stack-row");
     expect(traceRow).not.toBeNull();

--- a/frontend/src/components/cockpit/CockpitView.tsx
+++ b/frontend/src/components/cockpit/CockpitView.tsx
@@ -5337,6 +5337,7 @@ interface WorkflowCheckpointHistoryEntry {
   key: string;
   createdAt: string;
   stepId: string;
+  kind: string;
   actionLabel: string;
   sourceWorkflow: WorkflowRunRecord;
   scopeLabel: string;
@@ -5356,11 +5357,11 @@ interface WorkflowLineageEventEntry {
 
 function workflowCheckpointActions(
   workflow: WorkflowRunRecord,
-): Array<{ stepId: string; draft: string; label: string }> {
+): Array<{ stepId: string; draft: string; label: string; kind: string }> {
   if (!Array.isArray(workflow.checkpointCandidates)) {
     return [];
   }
-  return workflow.checkpointCandidates.reduce<Array<{ stepId: string; draft: string; label: string }>>((actions, candidate) => {
+  return workflow.checkpointCandidates.reduce<Array<{ stepId: string; draft: string; label: string; kind: string }>>((actions, candidate) => {
     if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return actions;
     const record = candidate as Record<string, unknown>;
     const stepId = typeof record.step_id === "string" ? record.step_id : "";
@@ -5370,6 +5371,7 @@ function workflowCheckpointActions(
     actions.push({
       stepId,
       draft,
+      kind,
       label: kind === "retry_failed_step" ? `Retry ${stepId}` : `Branch ${stepId}`,
     });
     return actions;
@@ -7113,6 +7115,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
           key,
           createdAt: entry.updatedAt,
           stepId: action.stepId,
+          kind: action.kind,
           actionLabel: action.label,
           sourceWorkflow: entry,
           scopeLabel,
@@ -7129,6 +7132,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
             key,
             createdAt: entry.updatedAt,
             stepId,
+            kind: "retry_failed_step",
             actionLabel: "Retry Step",
             sourceWorkflow: entry,
             scopeLabel,
@@ -7245,28 +7249,116 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
     if (!workflow) return;
     setSelectedInspector({ kind: "workflow", workflow: resolveWorkflowRun(workflow) });
   }
+  function resumePlanFallbackDraft(workflow: WorkflowRunRecord): string | null {
+    const checkpointAction = workflowCheckpointActions(workflow)[0];
+    if (checkpointAction?.draft) return checkpointAction.draft;
+    if (workflow.retryFromStepDraft) return workflow.retryFromStepDraft;
+    if (workflow.replayAllowed !== false) return workflow.replayDraft ?? buildWorkflowReplayDraft(workflow);
+    return null;
+  }
+  async function queueLiveWorkflowResumePlan(
+    workflow: WorkflowRunRecord | null | undefined,
+    options: {
+      action?: string;
+      stepId?: string | null;
+      fallbackDraft?: string | null;
+      fallbackThreadId?: string | null;
+      label?: string;
+    } = {},
+  ) {
+    if (!workflow) return;
+    const resolved = resolveWorkflowRun(workflow);
+    const fallbackDraft = options.fallbackDraft ?? resumePlanFallbackDraft(resolved);
+    const queueFallbackDraft = async () => {
+      if (!fallbackDraft) return;
+      if (options.fallbackThreadId) {
+        await queueThreadDraft(fallbackDraft, options.fallbackThreadId);
+        return;
+      }
+      queueComposerDraft(fallbackDraft);
+    };
+    if (!resolved.runIdentity) {
+      await queueFallbackDraft();
+      return;
+    }
+    const label = options.label ?? resolved.workflowName;
+    setOperatorStatus(`Checking live recovery plan for ${label}...`);
+    try {
+      const action = options.action ?? "resume";
+      const response = await fetch(
+        `${API_URL}/api/workflows/runs/${encodeURIComponent(resolved.runIdentity)}/control`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action,
+            step_id: options.stepId ?? undefined,
+            target: options.stepId ?? resolved.workflowName,
+            owner: "cockpit",
+            operator_context: {
+              source: "cockpit",
+              workflow_name: resolved.workflowName,
+              status: resolved.status,
+              thread_id: resolved.threadId,
+            },
+          }),
+        },
+      );
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        const detail = payload && typeof payload === "object" && "detail" in payload
+          ? String((payload as { detail?: unknown }).detail)
+          : `Could not build a live recovery plan for ${label}`;
+        setOperatorStatus(`Live recovery control refused ${label}: ${detail}`);
+        return;
+      }
+      const plan = payload && typeof payload === "object"
+        ? (payload as { resume_plan?: unknown }).resume_plan
+        : null;
+      const planRecord = plan && typeof plan === "object" && !Array.isArray(plan)
+        ? plan as Record<string, unknown>
+        : null;
+      const draft = typeof planRecord?.draft === "string" && planRecord.draft.trim()
+        ? planRecord.draft
+        : (
+          typeof planRecord?.continue_message === "string" && planRecord.continue_message.trim()
+            ? planRecord.continue_message
+            : fallbackDraft
+        );
+      if (!draft) {
+        setOperatorStatus(`No recovery draft is available for ${label}`);
+        return;
+      }
+      const threadId = options.fallbackThreadId ?? resolved.threadId ?? resolved.sessionId;
+      if (typeof planRecord?.continue_message === "string" && planRecord.continue_message === draft && threadId) {
+        await queueThreadDraft(draft, threadId);
+      } else {
+        queueComposerDraft(draft);
+      }
+      const checkpointLabel = typeof planRecord?.resume_checkpoint_label === "string"
+        ? planRecord.resume_checkpoint_label
+        : null;
+      setOperatorStatus(
+        checkpointLabel
+          ? `Loaded live recovery plan for ${label}: ${checkpointLabel}`
+          : `Loaded live recovery plan for ${label}`,
+      );
+    } catch {
+      setOperatorStatus(`Could not reach workflow recovery controls for ${label}; no fallback draft was queued.`);
+    }
+  }
   function continueWorkflowRun(workflow: WorkflowRunRecord | null | undefined) {
     if (!workflow) return;
     const resolved = resolveWorkflowRun(workflow);
     const approval = approvalForWorkflow(resolved);
     const continueMessage = approval?.resume_message ?? resolved.threadContinueMessage;
     const threadId = approval?.thread_id ?? approval?.session_id ?? resolved.threadId ?? resolved.sessionId;
-    if (continueMessage && threadId) {
-      void queueThreadDraft(continueMessage, threadId);
-      return;
-    }
-    const checkpointAction = workflowCheckpointActions(resolved)[0];
-    if (checkpointAction?.draft) {
-      queueComposerDraft(checkpointAction.draft);
-      return;
-    }
-    if (resolved.retryFromStepDraft) {
-      queueComposerDraft(resolved.retryFromStepDraft);
-      return;
-    }
-    if (resolved.replayAllowed !== false) {
-      queueComposerDraft(resolved.replayDraft ?? buildWorkflowReplayDraft(resolved));
-    }
+    void queueLiveWorkflowResumePlan(resolved, {
+      action: "resume",
+      fallbackDraft: continueMessage ?? undefined,
+      fallbackThreadId: threadId,
+      label: resolved.workflowName,
+    });
   }
   function renderWorkflowCheckpointControls(
     workflow: WorkflowRunRecord,
@@ -7278,7 +7370,12 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
         key={`${keyPrefix}:${action.stepId}:${action.label}`}
         className="cockpit-feedback-button"
         aria-label={`${action.label} from ${scopeLabel} ${workflow.workflowName}`}
-        onClick={() => queueComposerDraft(action.draft)}
+        onClick={() => void queueLiveWorkflowResumePlan(workflow, {
+          action: action.kind === "retry_failed_step" ? "retry" : "branch",
+          stepId: action.stepId,
+          fallbackDraft: action.draft,
+          label: `${scopeLabel} ${workflow.workflowName}`,
+        })}
       >
         {action.label}
       </button>
@@ -7297,7 +7394,12 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
           key={`${keyPrefix}:retry-step`}
           className="cockpit-feedback-button"
           aria-label={`Retry step for ${scopeLabel} ${workflow.workflowName}`}
-          onClick={() => queueComposerDraft(workflow.retryFromStepDraft ?? "")}
+          onClick={() => void queueLiveWorkflowResumePlan(workflow, {
+            action: "retry",
+            stepId: failedStep?.id ?? workflow.resumeFromStep,
+            fallbackDraft: workflow.retryFromStepDraft,
+            label: `${scopeLabel} ${workflow.workflowName}`,
+          })}
         >
           Retry Step
         </button>,
@@ -8183,12 +8285,12 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
   }
   function continueOperatorTriageEntry(entry: OperatorTriageEntry | null | undefined) {
     if (!entry) return;
-    if (entry.continueMessage) {
-      void queueThreadDraft(entry.continueMessage, entry.threadId ?? undefined);
-      return;
-    }
     if (entry.workflow) {
       continueWorkflowRun(entry.workflow);
+      return;
+    }
+    if (entry.continueMessage) {
+      void queueThreadDraft(entry.continueMessage, entry.threadId ?? undefined);
     }
   }
   function draftOperatorTriageRepair(entry: OperatorTriageEntry | null | undefined) {
@@ -8249,12 +8351,12 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
   }
   function continueOperatorWorkflowOrchestrationEntry(entry: OperatorWorkflowOrchestrationEntry | null | undefined) {
     if (!entry) return;
-    if (entry.continueMessage) {
-      void queueThreadDraft(entry.continueMessage, entry.threadId ?? undefined);
-      return;
-    }
     if (entry.workflow) {
       continueWorkflowRun(entry.workflow);
+      return;
+    }
+    if (entry.continueMessage) {
+      void queueThreadDraft(entry.continueMessage, entry.threadId ?? undefined);
     }
   }
   function openOperatorWorkflowOrchestrationThread(entry: OperatorWorkflowOrchestrationEntry | null | undefined) {
@@ -8287,12 +8389,12 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
   }
   function continueOperatorBackgroundSupervisionEntry(entry: OperatorBackgroundSupervisionEntry | null | undefined) {
     if (!entry) return;
-    if (entry.continueMessage) {
-      void queueThreadDraft(entry.continueMessage, entry.threadId ?? undefined);
-      return;
-    }
     if (entry.workflow) {
       continueWorkflowRun(entry.workflow);
+      return;
+    }
+    if (entry.continueMessage) {
+      void queueThreadDraft(entry.continueMessage, entry.threadId ?? undefined);
     }
   }
   function openOperatorBackgroundSupervisionThread(entry: OperatorBackgroundSupervisionEntry | null | undefined) {
@@ -10390,12 +10492,23 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
   function queueWorkflowRecoveryDraft(workflow: WorkflowRunRecord | null | undefined) {
     if (!workflow) return;
     const resolved = resolveWorkflowRun(workflow);
+    const failedStep = failedWorkflowStep(resolved);
     if (resolved.retryFromStepDraft) {
-      queueComposerDraft(resolved.retryFromStepDraft);
+      void queueLiveWorkflowResumePlan(resolved, {
+        action: "retry",
+        stepId: failedStep?.id ?? resolved.resumeFromStep,
+        fallbackDraft: resolved.retryFromStepDraft,
+        label: resolved.workflowName,
+      });
       return;
     }
-    if (resolved.replayAllowed === false) return;
-    queueComposerDraft(resolved.replayDraft ?? buildWorkflowReplayDraft(resolved));
+    if (resolved.replayAllowed !== false) {
+      void queueLiveWorkflowResumePlan(resolved, {
+        action: "replay",
+        fallbackDraft: resolved.replayDraft ?? buildWorkflowReplayDraft(resolved),
+        label: resolved.workflowName,
+      });
+    }
   }
 
   function primaryWorkflowShortcutTarget(): WorkflowRunRecord | null {
@@ -10942,19 +11055,18 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
           <div className="cockpit-feedback-row">
             {selectedWorkflow.replayAllowed !== false ? (
               <>
-                <button
-                  className="cockpit-feedback-button"
-                  onClick={() =>
-                    queueComposerDraft(
-                      selectedWorkflow.replayDraft
-                        ?? buildWorkflowReplayDraft(selectedWorkflow),
-                    )
-                  }
-                >
-                  {selectedWorkflow.executionBoundaries?.length
-                    ? "Draft Boundary-Aware Rerun"
-                    : "Draft Rerun"}
-                </button>
+	                <button
+	                  className="cockpit-feedback-button"
+	                  onClick={() => void queueLiveWorkflowResumePlan(selectedWorkflow, {
+	                    action: "replay",
+	                    fallbackDraft: selectedWorkflow.replayDraft ?? buildWorkflowReplayDraft(selectedWorkflow),
+	                    label: selectedWorkflow.workflowName,
+	                  })}
+	                >
+	                  {selectedWorkflow.executionBoundaries?.length
+	                    ? "Plan Boundary-Aware Rerun"
+	                    : "Plan Rerun"}
+	                </button>
                 {(() => {
                   const checkpointActions = selectedWorkflowCheckpointActions.slice(0, 2);
                   if (checkpointActions.length > 0) {
@@ -10962,7 +11074,12 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                       <button
                         key={`${selectedWorkflow.id}:${action.stepId}`}
                         className="cockpit-feedback-button"
-                        onClick={() => queueComposerDraft(action.draft)}
+                        onClick={() => void queueLiveWorkflowResumePlan(selectedWorkflow, {
+                          action: action.kind === "retry_failed_step" ? "retry" : "branch",
+                          stepId: action.stepId,
+                          fallbackDraft: action.draft,
+                          label: selectedWorkflow.workflowName,
+                        })}
                       >
                         {action.label}
                       </button>
@@ -10974,12 +11091,12 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                   return (
                     <button
                       className="cockpit-feedback-button"
-                      onClick={() =>
-                        queueComposerDraft(
-                          selectedWorkflow.retryFromStepDraft
-                          ?? buildWorkflowReplayDraft(selectedWorkflow),
-                        )
-                      }
+                      onClick={() => void queueLiveWorkflowResumePlan(selectedWorkflow, {
+                        action: "retry",
+                        stepId: selectedWorkflow.resumeFromStep,
+                        fallbackDraft: selectedWorkflow.retryFromStepDraft ?? buildWorkflowReplayDraft(selectedWorkflow),
+                        label: selectedWorkflow.workflowName,
+                      })}
                     >
                       Retry From Step
                     </button>
@@ -11149,19 +11266,19 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                     : ""}
                 {` · ${selectedWorkflowApproval.risk_level} risk`}
               </div>
-              {selectedWorkflowApproval.resume_message && (
-                <button
-                  className="cockpit-feedback-button"
-                  aria-label={`Continue approval context for ${selectedWorkflowName}`}
-                  onClick={() =>
-                    void queueThreadDraft(
-                      selectedWorkflowApproval.resume_message ?? "",
-                      selectedWorkflowApproval.thread_id ?? selectedWorkflowApproval.session_id,
-                    )
-                  }
-                >
-                  Continue
-                </button>
+	              {selectedWorkflowApproval.resume_message && (
+	                <button
+	                  className="cockpit-feedback-button"
+	                  aria-label={`Continue approval context for ${selectedWorkflowName}`}
+	                  onClick={() => void queueLiveWorkflowResumePlan(selectedWorkflow, {
+	                    action: "resume",
+	                    fallbackDraft: selectedWorkflowApproval.resume_message,
+	                    fallbackThreadId: selectedWorkflowApproval.thread_id ?? selectedWorkflowApproval.session_id,
+	                    label: selectedWorkflowName,
+	                  })}
+	                >
+	                  Continue
+	                </button>
               )}
               {(() => {
                 const threadTarget = selectedWorkflowApproval.thread_id ?? selectedWorkflowApproval.session_id;
@@ -11273,15 +11390,20 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                   >
                     Use Context
                   </button>
-                  {checkpointDraft && (
-                    <button
-                      className="cockpit-feedback-button"
-                      aria-label={`Draft retry for step ${step.id} in ${selectedWorkflowName}`}
-                      onClick={() => queueComposerDraft(checkpointDraft)}
-                    >
-                      Draft Retry
-                    </button>
-                  )}
+	                  {checkpointDraft && (
+	                    <button
+	                      className="cockpit-feedback-button"
+	                      aria-label={`Plan retry for step ${step.id} in ${selectedWorkflowName}`}
+	                      onClick={() => void queueLiveWorkflowResumePlan(selectedWorkflow, {
+	                        action: "retry",
+	                        stepId: step.id,
+	                        fallbackDraft: checkpointDraft,
+	                        label: selectedWorkflowName,
+	                      })}
+	                    >
+	                      Plan Retry
+	                    </button>
+	                  )}
                   {step.recoveryActions?.length ? (
                     <button
                       className="cockpit-feedback-button"
@@ -11716,15 +11838,20 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                       {entry.stepId ? ` · ${entry.stepId}` : ""}
                       {entry.durationMs ? ` · ${entry.durationMs}ms` : ""}
                     </div>
-                    {checkpointDraft && (
-                      <button
-                        className="cockpit-feedback-button"
-                        aria-label={`Draft retry from ${checkpointStepId} for ${selectedWorkflowName}`}
-                        onClick={() => queueComposerDraft(checkpointDraft)}
-                      >
-                        Draft Retry
-                      </button>
-                    )}
+	                    {checkpointDraft && (
+	                      <button
+	                        className="cockpit-feedback-button"
+	                        aria-label={`Plan retry from ${checkpointStepId} for ${selectedWorkflowName}`}
+	                        onClick={() => void queueLiveWorkflowResumePlan(selectedWorkflow, {
+	                          action: "retry",
+	                          stepId: checkpointStepId,
+	                          fallbackDraft: checkpointDraft,
+	                          label: selectedWorkflowName,
+	                        })}
+	                      >
+	                        Plan Retry
+	                      </button>
+	                    )}
                   </div>
                 );
               })()
@@ -11825,13 +11952,18 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                       Continue
                     </button>
                   )}
-                  <button
-                    className="cockpit-feedback-button"
-                    aria-label={`${entry.actionLabel} from ${entry.scopeLabel} for checkpoint history ${entry.stepId}`}
-                    onClick={() => queueComposerDraft(entry.draft)}
-                  >
-                    {entry.actionLabel}
-                  </button>
+	                  <button
+	                    className="cockpit-feedback-button"
+	                    aria-label={`${entry.actionLabel} from ${entry.scopeLabel} for checkpoint history ${entry.stepId}`}
+	                    onClick={() => void queueLiveWorkflowResumePlan(entry.sourceWorkflow, {
+	                      action: entry.kind === "retry_failed_step" ? "retry" : "branch",
+	                      stepId: entry.stepId,
+	                      fallbackDraft: entry.draft,
+	                      label: `${entry.scopeLabel} ${entry.sourceWorkflow.workflowName}`,
+	                    })}
+	                  >
+	                    {entry.actionLabel}
+	                  </button>
                 </div>
               ))}
               {lineageEvents.map((entry, index) => (
@@ -11873,15 +12005,20 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                       Use Failure
                     </button>
                   )}
-                  {entry.checkpointDraft && (
-                    <button
-                      className="cockpit-feedback-button"
-                      aria-label={`Draft retry from ${entry.scopeLabel} lineage event ${entry.timelineEntry.kind}`}
-                      onClick={() => queueComposerDraft(entry.checkpointDraft ?? "")}
-                    >
-                      Draft Retry
-                    </button>
-                  )}
+	                  {entry.checkpointDraft && (
+	                    <button
+	                      className="cockpit-feedback-button"
+	                      aria-label={`Plan retry from ${entry.scopeLabel} lineage event ${entry.timelineEntry.kind}`}
+	                      onClick={() => void queueLiveWorkflowResumePlan(entry.sourceWorkflow, {
+	                        action: "retry",
+	                        stepId: entry.timelineEntry.stepId,
+	                        fallbackDraft: entry.checkpointDraft,
+	                        label: `${entry.scopeLabel} ${entry.sourceWorkflow.workflowName}`,
+	                      })}
+	                    >
+	                      Plan Retry
+	                    </button>
+	                  )}
                   {entry.failureStep?.recoveryActions?.length ? (
                     <button
                       className="cockpit-feedback-button"
@@ -13092,9 +13229,10 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                 </div>
               </div>
               <div className="cockpit-list">
-                {visibleActivityGroups.map((group) => {
-                  const actionTarget = activityGroupActionTarget(group);
-                  return (
+	                {visibleActivityGroups.map((group) => {
+	                  const actionTarget = activityGroupActionTarget(group);
+	                  const actionTargetWorkflow = workflowRuns.find((item) => item.threadId === actionTarget.thread_id);
+	                  return (
                     <div key={group.key} className="cockpit-row cockpit-ledger-group">
                       <button
                         className="cockpit-row-button cockpit-ledger-parent"
@@ -13150,15 +13288,21 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                           ) : null}
                         </div>
                       )}
-                      <div className="cockpit-feedback-row">
-                        {actionTarget.continue_message && (
-                          <button
-                            className="cockpit-feedback-button"
-                            onClick={() => void queueThreadDraft(actionTarget.continue_message ?? "", actionTarget.thread_id)}
-                          >
-                            Continue
-                          </button>
-                        )}
+	                      <div className="cockpit-feedback-row">
+	                        {actionTarget.continue_message && (
+	                          <button
+	                            className="cockpit-feedback-button"
+	                            onClick={() => {
+	                              if (actionTargetWorkflow) {
+	                                continueWorkflowRun(actionTargetWorkflow);
+	                                return;
+	                              }
+	                              void queueThreadDraft(actionTarget.continue_message ?? "", actionTarget.thread_id);
+	                            }}
+	                          >
+	                            Continue
+	                          </button>
+	                        )}
                         {canOpenLedgerThread(actionTarget.thread_id, sessionId, knownSessionIds) && (
                           <button
                             className="cockpit-feedback-button"
@@ -13167,12 +13311,16 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                             Open Thread
                           </button>
                         )}
-                        {actionTarget.replay_draft && actionTarget.replay_allowed !== false && (
-                          <button
-                            className="cockpit-feedback-button"
-                            onClick={() => queueComposerDraft(actionTarget.replay_draft ?? "")}
-                          >
-                            Replay
+	                        {actionTarget.replay_draft && actionTarget.replay_allowed !== false && actionTargetWorkflow && (
+	                          <button
+	                            className="cockpit-feedback-button"
+	                            onClick={() => void queueLiveWorkflowResumePlan(actionTargetWorkflow, {
+	                              action: "replay",
+	                              fallbackDraft: actionTarget.replay_draft,
+	                              label: actionTargetWorkflow.workflowName,
+	                            })}
+	                          >
+	                            Replay
                           </button>
                         )}
                         {actionTarget.recommended_actions?.length ? (
@@ -13281,18 +13429,13 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                         ) : null}
                       </button>
                       <div className="cockpit-feedback-row">
-                        {(approval?.resume_message || workflow.threadContinueMessage) && (
-                          <button
-                            className="cockpit-feedback-button"
-                            onClick={() =>
-                              void queueThreadDraft(
-                                approval?.resume_message ?? workflow.threadContinueMessage ?? "",
-                                approval?.thread_id ?? approval?.session_id ?? workflow.threadId ?? workflow.sessionId,
-                              )
-                            }
-                          >
-                            Continue
-                          </button>
+	                        {(approval?.resume_message || workflow.threadContinueMessage) && (
+	                          <button
+	                            className="cockpit-feedback-button"
+	                            onClick={() => continueWorkflowRun(workflow)}
+	                          >
+	                            Continue
+	                          </button>
                         )}
                         {approval && (
                           <>
@@ -13322,14 +13465,23 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                           <>
                             <button
                               className="cockpit-feedback-button"
-                              onClick={() => queueComposerDraft(workflow.replayDraft ?? buildWorkflowReplayDraft(workflow))}
+                              onClick={() => void queueLiveWorkflowResumePlan(workflow, {
+                                action: "replay",
+                                fallbackDraft: workflow.replayDraft ?? buildWorkflowReplayDraft(workflow),
+                                label: workflow.workflowName,
+                              })}
                             >
-                              Draft rerun
+                              Plan rerun
                             </button>
                             {workflow.retryFromStepDraft && (
                               <button
                                 className="cockpit-feedback-button"
-                                onClick={() => queueComposerDraft(workflow.retryFromStepDraft ?? buildWorkflowReplayDraft(workflow))}
+                                onClick={() => void queueLiveWorkflowResumePlan(workflow, {
+                                  action: "retry",
+                                  stepId: workflow.resumeFromStep,
+                                  fallbackDraft: workflow.retryFromStepDraft ?? buildWorkflowReplayDraft(workflow),
+                                  label: workflow.workflowName,
+                                })}
                               >
                                 Retry step
                               </button>
@@ -14275,7 +14427,12 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                         aria-label="Retry primary M7 workflow"
                         disabled={!m7PrimaryWorkflow?.retryFromStepDraft || !m7ControlEnabled("retry", Boolean(m7PrimaryWorkflow?.retryFromStepDraft))}
                         onClick={() => {
-                          if (m7PrimaryWorkflow?.retryFromStepDraft) queueComposerDraft(m7PrimaryWorkflow.retryFromStepDraft);
+                          if (m7PrimaryWorkflow?.retryFromStepDraft) void queueLiveWorkflowResumePlan(m7PrimaryWorkflow, {
+                            action: "retry",
+                            stepId: m7PrimaryWorkflow.resumeFromStep,
+                            fallbackDraft: m7PrimaryWorkflow.retryFromStepDraft,
+                            label: m7PrimaryWorkflow.workflowName,
+                          });
                         }}
                       >
                         retry
@@ -15046,7 +15203,12 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                               type="button"
                               className="cockpit-operator-button"
                               aria-label={`Retry step for ${entry.label}`}
-                              onClick={() => queueComposerDraft(triageWorkflow.retryFromStepDraft ?? "")}
+                              onClick={() => void queueLiveWorkflowResumePlan(triageWorkflow, {
+                                action: "retry",
+                                stepId: triageWorkflow.resumeFromStep,
+                                fallbackDraft: triageWorkflow.retryFromStepDraft,
+                                label: entry.label,
+                              })}
                             >
                               retry step
                             </button>
@@ -15550,7 +15712,12 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                                     type="button"
                                     className="cockpit-operator-button"
                                     aria-label={`Retry step for workflow orchestration ${entry.threadLabel}`}
-                                    onClick={() => queueComposerDraft(entry.workflow?.retryFromStepDraft ?? "")}
+                                    onClick={() => void queueLiveWorkflowResumePlan(entry.workflow, {
+                                      action: "retry",
+                                      stepId: entry.workflow?.resumeFromStep,
+                                      fallbackDraft: entry.workflow?.retryFromStepDraft,
+                                      label: `workflow orchestration ${entry.threadLabel}`,
+                                    })}
                                   >
                                     retry step
                                   </button>
@@ -15866,7 +16033,12 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                                 type="button"
                                 className="cockpit-operator-button"
                                 aria-label={`Retry step for workflow supervision ${entry.workflow.workflowName}`}
-                                onClick={() => queueComposerDraft(entry.workflow.retryFromStepDraft ?? "")}
+                                onClick={() => void queueLiveWorkflowResumePlan(entry.workflow, {
+                                  action: "retry",
+                                  stepId: entry.workflow.resumeFromStep,
+                                  fallbackDraft: entry.workflow.retryFromStepDraft,
+                                  label: `workflow supervision ${entry.workflow.workflowName}`,
+                                })}
                               >
                                 retry step
                               </button>


### PR DESCRIPTION
## Summary
- add a live `POST /api/workflows/runs/{run_identity}/control` endpoint for durable workflow-run recovery controls
- route cockpit retry, branch, replay, continue, approval-resume, activity-ledger, history, and keyboard recovery controls through live workflow control where a run can be resolved
- fail closed on blocked leases/recovery/transitions and on `/control` refusals without queuing stale local fallback drafts
- update the full-parity goal prompt to keep the train feature-only until parity features are shipped

Closes #597

## User-Facing Behavior
- Operators get live recovery planning from the cockpit instead of old local-only recovery drafts.
- Unsafe or stale workflow recovery paths show operator-visible refusal status and do not hand the operator a stale retry/replay draft.
- The feature remains manual and operator-mediated; the control API records/guards recovery planning and does not execute external side effects.

## Team / Review
- Lead/Integrator: Codex coordinated the batch, implementation, validation, GitHub issue rescope, and board update.
- Security/Trust reviewer: subagent PASS_WITH_NOTES after fixes; no blocking security/trust findings remained.
- Operator UX reviewer: subagent PASS_WITH_NOTES after fixes; no blocking UX findings remained.
- Critic/Contrarian: subagent critic tooling stalled twice; fallback named Critic/Contrarian pass completed as PASS_WITH_NOTES per AGENTS.md unavailable-tooling fallback.

## Critic Notes Carried Forward
- Activity-ledger workflow matching currently resolves by `threadId` where no run identity is exposed; prefer run-identity matching when the ledger can carry it.
- Early trust-boundary refusal can gain a refusal audit event later, but it does not mutate durable workflow state in this batch.
- This PR does not claim full parity, solved operator control, certification, production readiness, or reference-system exceedance.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest --no-cov tests/test_workflows.py::test_workflow_resume_plan_endpoint_returns_structured_branch_metadata tests/test_workflows.py::test_workflow_run_control_records_live_operator_recovery_control tests/test_workflows.py::test_workflow_run_control_refuses_blocked_live_lease_without_resume_plan -q`
- `npm test -- --run src/components/cockpit/CockpitView.test.tsx` (69/69)
- `npm run build`
- `git diff --check`

## Board
- Rescoped #597 from proof/certification wording to feature-only live operator workflow controls.
- Set #597 `Queue=Now` and `Status=In Progress`; PR and Code Review fields will be updated for this ready PR.
