### PR TITLE
Batch ED: live marketplace lifecycle controls

### DIFF
--- a/backend/src/api/extensions.py
+++ b/backend/src/api/extensions.py
@@ -26,13 +26,18 @@ from src.extensions.lifecycle import (
     configure_extension,
     disable_extension,
     enable_extension,
+    extension_lifecycle_status,
     get_extension,
     get_extension_connector,
     get_extension_source,
     install_extension_path,
     list_extension_connectors,
     list_extensions,
+    quarantine_extension,
+    record_extension_review,
+    reenter_extension,
     remove_extension,
+    rollback_extension,
     save_extension_source,
     set_extension_connector_enabled,
     update_extension_path,
@@ -141,6 +146,14 @@ class ExtensionScaffoldRequest(BaseModel):
 
 class ExtensionConfigRequest(BaseModel):
     config: dict[str, Any] = Field(default_factory=dict)
+
+
+class ExtensionLifecycleReasonRequest(BaseModel):
+    reason: str = ""
+
+
+class ExtensionRollbackRequest(BaseModel):
+    snapshot_id: str | None = None
 
 
 class ExtensionSourceSaveRequest(BaseModel):
@@ -543,6 +556,14 @@ def _approval_scope_summary(
             "requested_line_count": fingerprint_context.get("requested_line_count"),
             "draft_valid": fingerprint_context.get("draft_valid"),
         }
+    snapshot_id = fingerprint_context.get("snapshot_id")
+    if isinstance(snapshot_id, str) and snapshot_id.strip():
+        scope["rollback_scope"] = {
+            "snapshot_id": snapshot_id,
+            "restored_version": fingerprint_context.get("restored_version"),
+            "restored_digest": fingerprint_context.get("restored_digest"),
+            "snapshot_path_hash": fingerprint_context.get("snapshot_path_hash"),
+        }
     return scope
 
 
@@ -905,6 +926,188 @@ async def get_extension_package(extension_id: str):
         raise HTTPException(status_code=404, detail=f"Extension '{extension_id}' not found") from exc
 
 
+@router.get("/extensions/{extension_id}/lifecycle")
+async def get_extension_package_lifecycle(extension_id: str):
+    try:
+        return extension_lifecycle_status(extension_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=f"Extension '{extension_id}' not found") from exc
+
+
+@router.post("/extensions/{extension_id}/review")
+async def review_extension_package(extension_id: str, req: ExtensionLifecycleReasonRequest):
+    preview: dict[str, Any] | None = None
+    try:
+        preview = get_extension(extension_id)
+        await _require_extension_lifecycle_approval("review", preview)
+        result = record_extension_review(
+            extension_id,
+            reviewed_by="cockpit",
+            reason=req.reason,
+        )
+    except KeyError as exc:
+        await _log_extension_lifecycle_event(
+            action="review",
+            outcome="failed",
+            path=extension_id,
+            error=f"Extension '{extension_id}' not found",
+        )
+        raise HTTPException(status_code=404, detail=f"Extension '{extension_id}' not found") from exc
+    except ValueError as exc:
+        await _log_extension_lifecycle_event(
+            action="review",
+            outcome="failed",
+            preview=preview,
+            path=extension_id,
+            error=str(exc),
+        )
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    await _log_extension_lifecycle_event(
+        action="review",
+        outcome="succeeded",
+        preview=result.get("extension"),
+        path=extension_id,
+        extra_details={"receipt_id": result.get("receipt", {}).get("id")},
+    )
+    return result
+
+
+@router.post("/extensions/{extension_id}/quarantine")
+async def quarantine_extension_package(extension_id: str, req: ExtensionLifecycleReasonRequest):
+    preview: dict[str, Any] | None = None
+    try:
+        preview = get_extension(extension_id)
+        await _require_extension_lifecycle_approval("quarantine", preview)
+        result = quarantine_extension(
+            extension_id,
+            reason=req.reason or "operator quarantine",
+            actor="cockpit",
+        )
+    except KeyError as exc:
+        await _log_extension_lifecycle_event(
+            action="quarantine",
+            outcome="failed",
+            path=extension_id,
+            error=f"Extension '{extension_id}' not found",
+        )
+        raise HTTPException(status_code=404, detail=f"Extension '{extension_id}' not found") from exc
+    except ValueError as exc:
+        await _log_extension_lifecycle_event(
+            action="quarantine",
+            outcome="failed",
+            preview=preview,
+            path=extension_id,
+            error=str(exc),
+        )
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    await _log_extension_lifecycle_event(
+        action="quarantine",
+        outcome="succeeded",
+        preview=result.get("extension"),
+        path=extension_id,
+        extra_details={"receipt_id": result.get("receipt", {}).get("id")},
+    )
+    return result
+
+
+@router.post("/extensions/{extension_id}/reentry")
+async def reenter_extension_package(extension_id: str, req: ExtensionLifecycleReasonRequest):
+    preview: dict[str, Any] | None = None
+    try:
+        preview = get_extension(extension_id)
+        await _require_extension_lifecycle_approval("reentry", preview)
+        result = reenter_extension(
+            extension_id,
+            reviewed_by="cockpit",
+            reason=req.reason,
+        )
+    except KeyError as exc:
+        await _log_extension_lifecycle_event(
+            action="reentry",
+            outcome="failed",
+            path=extension_id,
+            error=f"Extension '{extension_id}' not found",
+        )
+        raise HTTPException(status_code=404, detail=f"Extension '{extension_id}' not found") from exc
+    except ValueError as exc:
+        await _log_extension_lifecycle_event(
+            action="reentry",
+            outcome="failed",
+            preview=preview,
+            path=extension_id,
+            error=str(exc),
+        )
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    await _log_extension_lifecycle_event(
+        action="reentry",
+        outcome="succeeded",
+        preview=result.get("extension"),
+        path=extension_id,
+        extra_details={"receipt_id": result.get("receipt", {}).get("id")},
+    )
+    return result
+
+
+@router.post("/extensions/{extension_id}/rollback")
+async def rollback_extension_package(extension_id: str, req: ExtensionRollbackRequest):
+    preview: dict[str, Any] | None = None
+    try:
+        preview = get_extension(extension_id)
+        lifecycle = extension_lifecycle_status(extension_id)
+        snapshots = lifecycle.get("rollback", {}).get("snapshots")
+        snapshot = next(
+            (
+                item for item in snapshots
+                if isinstance(item, dict)
+                and (not req.snapshot_id or item.get("id") == req.snapshot_id)
+            ),
+            None,
+        ) if isinstance(snapshots, list) else None
+        if not isinstance(snapshot, dict):
+            raise ValueError(f"extension '{extension_id}' has no rollback snapshot")
+        await _require_extension_lifecycle_approval(
+            "rollback",
+            {
+                **preview,
+                "target_reference": str(snapshot.get("id") or ""),
+                "target_name": str(snapshot.get("version") or "rollback snapshot"),
+                "target_type": "rollback_snapshot",
+            },
+            fingerprint_context={
+                "snapshot_id": snapshot.get("id"),
+                "restored_version": snapshot.get("version"),
+                "restored_digest": snapshot.get("digest"),
+                "snapshot_path_hash": _content_hash(str(snapshot.get("path") or "")),
+            },
+        )
+        result = rollback_extension(extension_id, snapshot_id=req.snapshot_id)
+    except KeyError as exc:
+        await _log_extension_lifecycle_event(
+            action="rollback",
+            outcome="failed",
+            path=extension_id,
+            error=f"Extension '{extension_id}' not found",
+        )
+        raise HTTPException(status_code=404, detail=f"Extension '{extension_id}' not found") from exc
+    except ValueError as exc:
+        await _log_extension_lifecycle_event(
+            action="rollback",
+            outcome="failed",
+            preview=preview,
+            path=extension_id,
+            error=str(exc),
+        )
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    await _log_extension_lifecycle_event(
+        action="rollback",
+        outcome="succeeded",
+        preview=result.get("extension"),
+        path=extension_id,
+        extra_details={"receipt_id": result.get("receipt", {}).get("id")},
+    )
+    return result
+
+
 @router.get("/extensions/{extension_id}/connectors")
 async def list_extension_package_connectors(extension_id: str):
     try:
@@ -1187,6 +1390,11 @@ async def update_extension_package(req: ExtensionPathRequest):
             raise ValueError(
                 f"extension '{extension_id}' is not updateable from this package path"
             )
+        if lifecycle_plan.get("version_relation") == "downgrade":
+            extension_id = preview.get("extension_id") or preview.get("id") or "extension"
+            raise ValueError(
+                f"extension '{extension_id}' downgrade requires explicit downgrade lifecycle control"
+            )
         await _require_extension_lifecycle_approval("update", preview)
         extension = update_extension_path(req.path)
     except KeyError as exc:
@@ -1226,6 +1434,10 @@ async def enable_extension_package(extension_id: str):
     try:
         preview = get_extension(extension_id)
         if preview.get("status") != "ready":
+            if preview.get("status") == "quarantined":
+                raise ValueError(
+                    f"extension '{extension_id}' is quarantined and requires re-entry review before enable"
+                )
             raise ValueError(
                 f"extension '{extension_id}' is degraded and cannot be enabled until validation issues are fixed"
             )

--- a/backend/src/extensions/lifecycle.py
+++ b/backend/src/extensions/lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import asdict
+from datetime import datetime, timezone
 import hashlib
 import os
 from pathlib import Path
@@ -31,6 +32,7 @@ from src.extensions.governance import (
     assert_governance_allows_lifecycle,
     build_capability_pack_hardening_receipt,
     build_governance_status,
+    extension_permission_fingerprint,
 )
 from src.extensions.layout import iter_extension_manifest_paths, resolve_package_reference
 from src.extensions.manifest import (
@@ -57,12 +59,18 @@ from src.extensions.registry import (
 )
 from src.extensions.scaffold import validate_extension_package
 from src.extensions.state import (
+    add_extension_rollback_snapshot,
+    append_extension_lifecycle_event,
     connector_enabled_override,
     connector_enabled_overrides,
+    extension_lifecycle_entry,
+    extension_quarantine_active,
     extension_state_entries,
     load_extension_state_payload,
+    mark_extension_governance_reviewed,
     save_extension_state_payload,
     set_connector_enabled_override,
+    set_extension_quarantine,
     state_path,
 )
 from src.runbooks.loader import scan_runbook_paths
@@ -185,6 +193,10 @@ def _extension_package_digest(root_path: str | None) -> str | None:
     if not root.exists() or not root.is_dir():
         return None
     return _hash_extension_directory(root)
+
+
+def _utc_now_compact() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S%f")
 
 
 def _extension_governance_status(
@@ -2038,6 +2050,7 @@ def _extension_payload(
     extension_load_errors = _extension_load_errors_for_extension(extension, load_errors)
     toggles = _toggle_targets(extension)
     state_entry = state_by_id.get(extension.id, {}) if isinstance(state_by_id.get(extension.id), dict) else {}
+    lifecycle_state = extension_lifecycle_entry(state_entry, create=False) or {}
     location = _location_for_extension(extension)
     package_digest = _extension_package_digest(extension.root_path)
     governance = _extension_governance_status(extension, state_entry)
@@ -2110,6 +2123,8 @@ def _extension_payload(
     status = "ready" if not issues and not extension_load_errors else "degraded"
     if governance.get("fail_closed"):
         status = "blocked"
+    if extension_quarantine_active(state_entry):
+        status = "quarantined"
     return {
         "id": extension.id,
         "display_name": extension.display_name,
@@ -2123,6 +2138,7 @@ def _extension_payload(
         "package_digest": package_digest,
         "manifest_path": extension.manifest_path,
         "governance": governance,
+        "lifecycle": lifecycle_state,
         "summary": extension.manifest.summary if extension.manifest is not None else None,
         "description": extension.manifest.description if extension.manifest is not None else None,
         "compatibility": compatibility,
@@ -2766,6 +2782,19 @@ def install_extension_path(path: str) -> dict[str, Any]:
         shutil.rmtree(target_root, ignore_errors=True)
         _refresh_runtime()
         raise
+    payload = _state_payload()
+    append_extension_lifecycle_event(
+        payload,
+        manifest.id,
+        action="install",
+        status="installed",
+        details={
+            "version": manifest.version,
+            "digest": _extension_package_digest(str(target_root)),
+            "path": str(target_root),
+        },
+    )
+    _save_state(payload)
     return get_extension(manifest.id)
 
 
@@ -2803,6 +2832,10 @@ def update_extension_path(path: str) -> dict[str, Any]:
     with tempfile.TemporaryDirectory(prefix="seraph-extension-update-") as temp_root:
         staging_root = Path(temp_root) / "package"
         backup_root = Path(temp_root) / "backup"
+        snapshot_id = f"{_slugify(manifest.id)}-{_utc_now_compact()}"
+        persistent_snapshot_root = (
+            Path(_workspace_root()) / ".seraph-extension-snapshots" / _slugify(manifest.id) / snapshot_id
+        )
         shutil.copytree(package_root, staging_root)
         shutil.move(target_root, backup_root)
         shutil.move(staging_root, target_root)
@@ -2812,12 +2845,39 @@ def update_extension_path(path: str) -> dict[str, Any]:
             if updated_extension is None:
                 raise ValueError(f"extension '{manifest.id}' did not load after update")
             _sync_mcp_servers_for_updated_extension(existing, updated_extension)
+            persistent_snapshot_root.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(backup_root, persistent_snapshot_root)
         except Exception:
             if target_root.exists():
                 shutil.rmtree(target_root, ignore_errors=True)
             shutil.move(backup_root, target_root)
             _refresh_runtime()
             raise
+    payload = _state_payload()
+    previous_version = existing.manifest.version if existing.manifest is not None else None
+    snapshot = add_extension_rollback_snapshot(
+        payload,
+        manifest.id,
+        snapshot_id=snapshot_id,
+        snapshot_path=str(persistent_snapshot_root),
+        version=previous_version,
+        digest=current_digest,
+        reason="pre_update",
+    )
+    append_extension_lifecycle_event(
+        payload,
+        manifest.id,
+        action="update" if _version_relation(manifest.version, previous_version) != "downgrade" else "downgrade",
+        status="updated",
+        details={
+            "previous_version": previous_version,
+            "previous_digest": current_digest,
+            "candidate_version": manifest.version,
+            "candidate_digest": candidate_digest,
+            "rollback_snapshot": snapshot,
+        },
+    )
+    _save_state(payload)
     return get_extension(manifest.id)
 
 
@@ -2829,6 +2889,10 @@ def _set_enabled(extension_id: str, enabled: bool) -> dict[str, Any]:
     if enabled:
         state_by_id = _state_payload()["extensions"]
         state_entry = state_by_id.get(extension.id, {}) if isinstance(state_by_id.get(extension.id), dict) else {}
+        if extension_quarantine_active(state_entry):
+            raise ValueError(
+                f"extension '{extension_id}' is quarantined and requires re-entry review before enable"
+            )
         _raise_if_governance_blocks_lifecycle(
             extension,
             action="enable",
@@ -3037,6 +3101,290 @@ def enable_extension(extension_id: str) -> dict[str, Any]:
 
 def disable_extension(extension_id: str) -> dict[str, Any]:
     return _set_enabled(extension_id, False)
+
+
+def extension_lifecycle_status(extension_id: str) -> dict[str, Any]:
+    extension = get_extension(extension_id)
+    lifecycle = extension.get("lifecycle") if isinstance(extension.get("lifecycle"), dict) else {}
+    rollback_snapshots = lifecycle.get("rollback_snapshots")
+    quarantine = lifecycle.get("quarantine")
+    return {
+        "extension": extension,
+        "lifecycle": lifecycle,
+        "rollback": {
+            "available": bool(rollback_snapshots),
+            "snapshots": rollback_snapshots if isinstance(rollback_snapshots, list) else [],
+        },
+        "quarantine": (
+            quarantine
+            if isinstance(quarantine, dict)
+            else {"active": False, "state": "clear"}
+        ),
+        "diagnostics": {
+            "status": extension.get("status"),
+            "compatibility": extension.get("compatibility"),
+            "diagnostics_summary": extension.get("diagnostics_summary"),
+            "permission_summary": extension.get("permission_summary"),
+            "governance": extension.get("governance"),
+            "vulnerability_state": "unknown",
+            "sbom_state": "unknown",
+        },
+    }
+
+
+def record_extension_review(
+    extension_id: str,
+    *,
+    reviewed_by: str = "operator",
+    reason: str = "",
+) -> dict[str, Any]:
+    snapshot = _registry().snapshot()
+    extension = snapshot.get_extension(extension_id)
+    if extension is None:
+        raise KeyError(extension_id)
+    if extension.manifest is None:
+        raise ValueError(f"extension '{extension_id}' does not expose a manifest")
+    digest = _extension_package_digest(extension.root_path)
+    if not digest:
+        raise ValueError(f"extension '{extension_id}' does not expose a package digest")
+    governance = _extension_governance_status(
+        extension,
+        _state_payload().get("extensions", {}).get(extension.id, {}),
+    )
+    key_id = str(governance.get("signing_key_id") or "local-manual-review")
+    permission_fingerprint = extension_permission_fingerprint(extension.manifest)
+    payload = _state_payload()
+    review = mark_extension_governance_reviewed(
+        payload,
+        extension.id,
+        digest=digest,
+        key_id=key_id,
+        permission_fingerprint=permission_fingerprint,
+        reviewed_by=reviewed_by,
+        reviewed_at=datetime.now(timezone.utc).isoformat(),
+    )
+    event = append_extension_lifecycle_event(
+        payload,
+        extension.id,
+        action="review",
+        status="reviewed",
+        actor=reviewed_by,
+        details={
+            "reason": reason,
+            "digest": digest,
+            "key_id": key_id,
+            "permission_fingerprint": permission_fingerprint,
+        },
+    )
+    _save_state(payload)
+    return {
+        "status": "reviewed",
+        "review": review,
+        "receipt": event,
+        **extension_lifecycle_status(extension.id),
+    }
+
+
+def quarantine_extension(
+    extension_id: str,
+    *,
+    reason: str,
+    actor: str = "operator",
+) -> dict[str, Any]:
+    snapshot = _registry().snapshot()
+    extension = snapshot.get_extension(extension_id)
+    if extension is None:
+        raise KeyError(extension_id)
+    digest = _extension_package_digest(extension.root_path)
+    version = extension.manifest.version if extension.manifest is not None else None
+    runtime_result = disable_extension(extension.id)
+    payload = _state_payload()
+    quarantine = set_extension_quarantine(
+        payload,
+        extension.id,
+        active=True,
+        reason=reason,
+        actor=actor,
+        digest=digest,
+        version=version,
+    )
+    event = append_extension_lifecycle_event(
+        payload,
+        extension.id,
+        action="quarantine",
+        status="quarantined",
+        actor=actor,
+        details={
+            "reason": reason,
+            "digest": digest,
+            "version": version,
+        },
+    )
+    _save_state(payload)
+    return {
+        "status": "quarantined",
+        "quarantine": quarantine,
+        "receipt": event,
+        "runtime_effects": runtime_result.get("changed", []),
+        **extension_lifecycle_status(extension.id),
+    }
+
+
+def reenter_extension(
+    extension_id: str,
+    *,
+    reviewed_by: str = "operator",
+    reason: str = "",
+) -> dict[str, Any]:
+    snapshot = _registry().snapshot()
+    extension = snapshot.get_extension(extension_id)
+    if extension is None:
+        raise KeyError(extension_id)
+    state_payload = _state_payload()
+    state_by_id = state_payload.get("extensions")
+    state_entry = (
+        state_by_id.get(extension.id)
+        if isinstance(state_by_id, dict) and isinstance(state_by_id.get(extension.id), dict)
+        else {}
+    )
+    governance = _extension_governance_status(extension, state_entry)
+    if governance.get("fail_closed"):
+        raise ValueError(
+            f"extension '{extension_id}' cannot re-enter while governance blocks runtime access: "
+            f"{governance.get('fail_closed_reason') or 'blocked'}"
+        )
+    doctor_report = doctor_snapshot(snapshot)
+    doctor_result = next(
+        (result for result in doctor_report.results if result.extension_id == extension_id),
+        None,
+    )
+    load_errors = _extension_load_errors_for_extension(extension, snapshot.load_errors)
+    if (doctor_result is not None and doctor_result.issues) or load_errors:
+        raise ValueError(f"extension '{extension_id}' cannot re-enter until diagnostics are clean")
+    review_result = record_extension_review(extension.id, reviewed_by=reviewed_by, reason=reason or "re-entry review")
+    payload = _state_payload()
+    digest = _extension_package_digest(extension.root_path)
+    version = extension.manifest.version if extension.manifest is not None else None
+    quarantine = set_extension_quarantine(
+        payload,
+        extension.id,
+        active=False,
+        reason=reason or "re-entry review accepted",
+        actor=reviewed_by,
+        digest=digest,
+        version=version,
+    )
+    event = append_extension_lifecycle_event(
+        payload,
+        extension.id,
+        action="reentry",
+        status="cleared",
+        actor=reviewed_by,
+        details={
+            "reason": reason,
+            "digest": digest,
+            "version": version,
+            "review_receipt": review_result.get("receipt", {}).get("id"),
+        },
+    )
+    _save_state(payload)
+    return {
+        "status": "reentry_cleared",
+        "quarantine": quarantine,
+        "receipt": event,
+        **extension_lifecycle_status(extension.id),
+    }
+
+
+def rollback_extension(extension_id: str, *, snapshot_id: str | None = None) -> dict[str, Any]:
+    snapshot = _registry().snapshot()
+    extension = snapshot.get_extension(extension_id)
+    if extension is None:
+        raise KeyError(extension_id)
+    if _location_for_extension(extension) != "workspace" or not extension.root_path:
+        raise ValueError(f"extension '{extension_id}' does not support rollback")
+    state_payload = _state_payload()
+    state_by_id = state_payload.get("extensions")
+    state_entry = (
+        state_by_id.get(extension.id)
+        if isinstance(state_by_id, dict) and isinstance(state_by_id.get(extension.id), dict)
+        else {}
+    )
+    lifecycle = extension_lifecycle_entry(state_entry, create=False) or {}
+    snapshots = lifecycle.get("rollback_snapshots")
+    snapshot_record = None
+    if isinstance(snapshots, list):
+        snapshot_record = next(
+            (
+                item
+                for item in snapshots
+                if isinstance(item, dict)
+                and (not snapshot_id or item.get("id") == snapshot_id)
+            ),
+            None,
+        )
+    if not isinstance(snapshot_record, dict):
+        raise ValueError(f"extension '{extension_id}' has no rollback snapshot")
+    snapshot_path = Path(str(snapshot_record.get("path") or "")).resolve()
+    workspace_root = Path(_workspace_root()).resolve()
+    if not snapshot_path.exists() or not snapshot_path.is_dir() or workspace_root not in snapshot_path.parents:
+        raise ValueError(f"rollback snapshot for extension '{extension_id}' is unavailable")
+    rollback_manifest = load_extension_manifest(str(snapshot_path / "manifest.yaml"))
+    if rollback_manifest.id != extension.id:
+        raise ValueError("rollback snapshot does not match extension id")
+    snapshot_digest = _hash_extension_directory(snapshot_path)
+    recorded_digest = snapshot_record.get("digest")
+    if isinstance(recorded_digest, str) and recorded_digest and recorded_digest != snapshot_digest:
+        raise ValueError("rollback snapshot digest does not match recorded restore point")
+    assert_governance_allows_lifecycle(
+        rollback_manifest,
+        root_path=snapshot_path,
+        state_entry=state_entry,
+        action="rollback",
+    )
+    target_root = Path(extension.root_path)
+    current_digest = _extension_package_digest(extension.root_path)
+    current_version = extension.manifest.version if extension.manifest is not None else None
+    with tempfile.TemporaryDirectory(prefix="seraph-extension-rollback-") as temp_root:
+        current_backup = Path(temp_root) / "current"
+        candidate = Path(temp_root) / "candidate"
+        shutil.copytree(target_root, current_backup)
+        shutil.copytree(snapshot_path, candidate)
+        if target_root.exists():
+            shutil.rmtree(target_root)
+        shutil.move(candidate, target_root)
+        try:
+            _refresh_runtime()
+            rolled_back = _registry().snapshot().get_extension(extension.id)
+            if rolled_back is None:
+                raise ValueError(f"extension '{extension_id}' did not load after rollback")
+            _sync_mcp_servers_for_updated_extension(extension, rolled_back)
+        except Exception:
+            if target_root.exists():
+                shutil.rmtree(target_root, ignore_errors=True)
+            shutil.move(current_backup, target_root)
+            _refresh_runtime()
+            raise
+    payload = _state_payload()
+    event = append_extension_lifecycle_event(
+        payload,
+        extension.id,
+        action="rollback",
+        status="rolled_back",
+        details={
+            "snapshot_id": snapshot_record.get("id"),
+            "previous_version": current_version,
+            "previous_digest": current_digest,
+            "restored_version": snapshot_record.get("version"),
+            "restored_digest": snapshot_record.get("digest"),
+        },
+    )
+    _save_state(payload)
+    return {
+        "status": "rolled_back",
+        "receipt": event,
+        **extension_lifecycle_status(extension.id),
+    }
 
 
 def configure_extension(extension_id: str, config: dict[str, Any]) -> dict[str, Any]:

--- a/backend/src/extensions/state.py
+++ b/backend/src/extensions/state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime, timezone
 from typing import Any
 
 from config.settings import settings
@@ -142,6 +143,124 @@ def revoke_extension_governance(
     if reason:
         governance["revocation_reason"] = reason
     return governance
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def extension_lifecycle_entry(
+    state_entry: dict[str, Any] | None,
+    *,
+    create: bool = False,
+) -> dict[str, Any] | None:
+    if not isinstance(state_entry, dict):
+        return None
+    lifecycle = state_entry.get("lifecycle")
+    if isinstance(lifecycle, dict):
+        return lifecycle
+    if not create:
+        return None
+    lifecycle = {}
+    state_entry["lifecycle"] = lifecycle
+    return lifecycle
+
+
+def append_extension_lifecycle_event(
+    payload: dict[str, Any],
+    extension_id: str,
+    *,
+    action: str,
+    status: str,
+    actor: str = "operator",
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    state_entry = extension_state_entry(payload, extension_id, create=True)
+    assert state_entry is not None
+    lifecycle = extension_lifecycle_entry(state_entry, create=True)
+    assert lifecycle is not None
+    events = lifecycle.get("events")
+    if not isinstance(events, list):
+        events = []
+        lifecycle["events"] = events
+    event = {
+        "id": f"extension-lifecycle:{extension_id}:{action}:{len(events) + 1}",
+        "action": action,
+        "status": status,
+        "actor": actor,
+        "created_at": _utc_now(),
+        "details": details or {},
+    }
+    events.append(event)
+    lifecycle["last_event"] = event
+    return event
+
+
+def add_extension_rollback_snapshot(
+    payload: dict[str, Any],
+    extension_id: str,
+    *,
+    snapshot_id: str,
+    snapshot_path: str,
+    version: str | None,
+    digest: str | None,
+    reason: str,
+    created_by: str = "system",
+) -> dict[str, Any]:
+    state_entry = extension_state_entry(payload, extension_id, create=True)
+    assert state_entry is not None
+    lifecycle = extension_lifecycle_entry(state_entry, create=True)
+    assert lifecycle is not None
+    snapshots = lifecycle.get("rollback_snapshots")
+    if not isinstance(snapshots, list):
+        snapshots = []
+        lifecycle["rollback_snapshots"] = snapshots
+    snapshot = {
+        "id": snapshot_id,
+        "path": snapshot_path,
+        "version": version,
+        "digest": digest,
+        "reason": reason,
+        "created_by": created_by,
+        "created_at": _utc_now(),
+    }
+    snapshots.insert(0, snapshot)
+    lifecycle["rollback_snapshots"] = snapshots[:10]
+    lifecycle["last_rollback_snapshot"] = snapshot
+    return snapshot
+
+
+def set_extension_quarantine(
+    payload: dict[str, Any],
+    extension_id: str,
+    *,
+    active: bool,
+    reason: str,
+    actor: str = "operator",
+    digest: str | None = None,
+    version: str | None = None,
+) -> dict[str, Any]:
+    state_entry = extension_state_entry(payload, extension_id, create=True)
+    assert state_entry is not None
+    lifecycle = extension_lifecycle_entry(state_entry, create=True)
+    assert lifecycle is not None
+    quarantine = {
+        "active": active,
+        "state": "quarantined" if active else "cleared",
+        "reason": reason,
+        "actor": actor,
+        "digest": digest,
+        "version": version,
+        "updated_at": _utc_now(),
+    }
+    lifecycle["quarantine"] = quarantine
+    return quarantine
+
+
+def extension_quarantine_active(state_entry: dict[str, Any] | None) -> bool:
+    lifecycle = extension_lifecycle_entry(state_entry, create=False)
+    quarantine = lifecycle.get("quarantine") if isinstance(lifecycle, dict) else None
+    return isinstance(quarantine, dict) and bool(quarantine.get("active"))
 
 
 def connector_state_entry(

--- a/backend/tests/test_extensions_api.py
+++ b/backend/tests/test_extensions_api.py
@@ -103,8 +103,8 @@ def _write_installable_extension(
     return package_dir
 
 
-def _write_high_risk_extension(root: Path) -> Path:
-    package_dir = root / "high-risk-pack"
+def _write_high_risk_extension(root: Path, *, package_name: str = "high-risk-pack") -> Path:
+    package_dir = root / package_name
     (package_dir / "workflows").mkdir(parents=True)
     (package_dir / "manifest.yaml").write_text(
         "id: seraph.high-risk-pack\n"
@@ -1361,6 +1361,195 @@ async def test_install_rejects_workspace_replacement_and_update_replaces_package
         )
         assert source_response.status_code == 200
         assert "Updated local installable workflow" in source_response.json()["content"]
+
+
+@pytest.mark.asyncio
+async def test_update_records_lifecycle_snapshot_and_rollback_restores_previous_package(client, extension_runtime, tmp_path):
+    package_dir = _write_installable_extension(tmp_path)
+    updated_package_dir = _write_installable_extension(
+        tmp_path,
+        package_name="installable-pack-update",
+        version="2026.4.01",
+        workflow_description="Updated local installable workflow",
+        workflow_content="Use the updated local workflow.\n",
+    )
+
+    with (
+        patch(
+            "src.extensions.lifecycle.get_base_tools_and_active_skills",
+            return_value=([SimpleNamespace(name="read_file")], [], "approval"),
+        ),
+        patch("src.api.extensions.log_integration_event", AsyncMock()),
+    ):
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 201
+
+        update_response = await client.post("/api/extensions/update", json={"path": str(updated_package_dir)})
+        assert update_response.status_code == 200
+        assert update_response.json()["extension"]["version"] == "2026.4.01"
+
+        lifecycle_response = await client.get("/api/extensions/seraph.test-installable/lifecycle")
+        assert lifecycle_response.status_code == 200
+        lifecycle = lifecycle_response.json()
+        assert lifecycle["rollback"]["available"] is True
+        snapshot = lifecycle["rollback"]["snapshots"][0]
+        assert snapshot["version"] == "2026.3.21"
+        assert Path(snapshot["path"]).is_dir()
+        assert lifecycle["diagnostics"]["vulnerability_state"] == "unknown"
+        assert lifecycle["diagnostics"]["sbom_state"] == "unknown"
+
+        rollback_response = await client.post(
+            "/api/extensions/seraph.test-installable/rollback",
+            json={"snapshot_id": snapshot["id"]},
+        )
+        assert rollback_response.status_code == 200
+        payload = rollback_response.json()
+        assert payload["status"] == "rolled_back"
+        assert payload["extension"]["version"] == "2026.3.21"
+        assert payload["receipt"]["action"] == "rollback"
+
+        source_response = await client.get(
+            "/api/extensions/seraph.test-installable/source",
+            params={"reference": "workflows/local-workflow.md"},
+        )
+        assert source_response.status_code == 200
+        assert "Local installable workflow" in source_response.json()["content"]
+        assert "Updated local installable workflow" not in source_response.json()["content"]
+
+
+@pytest.mark.asyncio
+async def test_generic_update_rejects_downgrade_without_explicit_control(client, extension_runtime, tmp_path):
+    package_dir = _write_installable_extension(tmp_path, version="2026.4.01")
+    downgrade_package_dir = _write_installable_extension(
+        tmp_path,
+        package_name="installable-pack-downgrade",
+        version="2026.3.21",
+        workflow_description="Older local installable workflow",
+        workflow_content="Use the older local workflow.\n",
+    )
+
+    with (
+        patch(
+            "src.extensions.lifecycle.get_base_tools_and_active_skills",
+            return_value=([SimpleNamespace(name="read_file")], [], "approval"),
+        ),
+        patch("src.api.extensions.log_integration_event", AsyncMock()),
+    ):
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 201
+
+        update_response = await client.post("/api/extensions/update", json={"path": str(downgrade_package_dir)})
+        assert update_response.status_code == 422
+        assert "downgrade requires explicit downgrade lifecycle control" in update_response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_rollback_approval_scope_is_bound_to_snapshot_target(client, extension_runtime, tmp_path):
+    package_dir = _write_high_risk_extension(tmp_path)
+    updated_package_dir = _write_high_risk_extension(tmp_path, package_name="high-risk-pack-update")
+    (updated_package_dir / "manifest.yaml").write_text(
+        (updated_package_dir / "manifest.yaml").read_text(encoding="utf-8").replace(
+            "version: 2026.3.21",
+            "version: 2026.4.01",
+        ),
+        encoding="utf-8",
+    )
+    (updated_package_dir / "workflows" / "write-note.md").write_text(
+        "---\n"
+        "name: write-note\n"
+        "description: Updated high risk workflow\n"
+        "requires:\n"
+        "  tools: [write_file]\n"
+        "steps:\n"
+        "  - id: save\n"
+        "    tool: write_file\n"
+        "    arguments:\n"
+        "      file_path: notes/high-risk-updated.md\n"
+        "      content: approved-updated\n"
+        "---\n\n"
+        "Write an updated note.\n",
+        encoding="utf-8",
+    )
+
+    with (
+        patch(
+            "src.extensions.lifecycle.get_base_tools_and_active_skills",
+            return_value=([SimpleNamespace(name="write_file")], [], "approval"),
+        ),
+        patch("src.api.extensions.log_integration_event", AsyncMock()),
+    ):
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 409
+        install_approval_id = install_response.json()["detail"]["approval_id"]
+        assert (await client.post(f"/api/approvals/{install_approval_id}/approve")).status_code == 200
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 201
+
+        update_response = await client.post("/api/extensions/update", json={"path": str(updated_package_dir)})
+        assert update_response.status_code == 409
+        update_approval_id = update_response.json()["detail"]["approval_id"]
+        assert (await client.post(f"/api/approvals/{update_approval_id}/approve")).status_code == 200
+        update_response = await client.post("/api/extensions/update", json={"path": str(updated_package_dir)})
+        assert update_response.status_code == 200
+
+        lifecycle_response = await client.get("/api/extensions/seraph.high-risk-pack/lifecycle")
+        snapshot = lifecycle_response.json()["rollback"]["snapshots"][0]
+        rollback_response = await client.post(
+            "/api/extensions/seraph.high-risk-pack/rollback",
+            json={"snapshot_id": snapshot["id"]},
+        )
+        assert rollback_response.status_code == 409
+        detail = rollback_response.json()["detail"]
+        assert detail["type"] == "approval_required"
+        assert detail["approval_scope"]["target"]["type"] == "rollback_snapshot"
+        assert detail["approval_scope"]["target"]["reference"] == snapshot["id"]
+        assert detail["approval_scope"]["rollback_scope"]["snapshot_id"] == snapshot["id"]
+        assert detail["approval_scope"]["rollback_scope"]["restored_digest"] == snapshot["digest"]
+
+
+@pytest.mark.asyncio
+async def test_quarantine_blocks_enable_until_reentry_review_clears_state(client, extension_runtime, tmp_path):
+    package_dir = _write_installable_extension(tmp_path)
+
+    with (
+        patch(
+            "src.extensions.lifecycle.get_base_tools_and_active_skills",
+            return_value=([SimpleNamespace(name="read_file")], [], "approval"),
+        ),
+        patch("src.api.extensions.log_integration_event", AsyncMock()),
+    ):
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 201
+
+        quarantine_response = await client.post(
+            "/api/extensions/seraph.test-installable/quarantine",
+            json={"reason": "suspicious update", "actor": "cockpit"},
+        )
+        assert quarantine_response.status_code == 200
+        quarantine_payload = quarantine_response.json()
+        assert quarantine_payload["status"] == "quarantined"
+        assert quarantine_payload["extension"]["status"] == "quarantined"
+        assert quarantine_payload["quarantine"]["active"] is True
+        assert skill_manager.get_skill("local-skill").enabled is False
+        assert workflow_manager.get_workflow("local-workflow").enabled is False
+
+        enable_response = await client.post("/api/extensions/seraph.test-installable/enable")
+        assert enable_response.status_code == 422
+        assert "requires re-entry review" in enable_response.json()["detail"]
+
+        reentry_response = await client.post(
+            "/api/extensions/seraph.test-installable/reentry",
+            json={"reason": "manual review passed", "actor": "cockpit"},
+        )
+        assert reentry_response.status_code == 200
+        reentry_payload = reentry_response.json()
+        assert reentry_payload["status"] == "reentry_cleared"
+        assert reentry_payload["quarantine"]["active"] is False
+        assert reentry_payload["extension"]["status"] == "ready"
+
+        enable_response = await client.post("/api/extensions/seraph.test-installable/enable")
+        assert enable_response.status_code == 200
+        assert enable_response.json()["extension"]["enabled"] is True
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/cockpit/CockpitView.test.tsx
+++ b/frontend/src/components/cockpit/CockpitView.test.tsx
@@ -443,9 +443,93 @@ describe("CockpitView", () => {
     expect(consoleRegion).toHaveTextContent(/error: Device connector is revoked/i);
     expect(consoleRegion).toHaveTextContent(/missing network, 1 tool, 1 boundary/i);
     expect(within(consoleRegion).getByRole("button", { name: "rollback unavailable" })).toBeDisabled();
-    expect(within(consoleRegion).getByRole("button", { name: "draft review" })).toBeEnabled();
+    expect(within(consoleRegion).getByRole("button", { name: "review" })).toBeEnabled();
     expect(within(consoleRegion).queryByRole("button", { name: "disable via studio" })).not.toBeInTheDocument();
     expect(within(consoleRegion).queryByRole("button", { name: "remove via studio" })).not.toBeInTheDocument();
+  });
+
+  it("runs governed extension console quarantine as a live backend action", async () => {
+    const extensionsPayload = {
+      extensions: [
+        {
+          id: "seraph.live-pack",
+          display_name: "Live Pack",
+          version: "1.0.0",
+          kind: "capability-pack",
+          trust: "local",
+          source: "workspace",
+          location: "workspace",
+          status: "ready",
+          publisher: { name: "Seraph" },
+          compatibility: { seraph: ">=0.9.0", current_version: "0.9.1", compatible: true },
+          diagnostics_summary: {
+            issue_count: 0,
+            error_issue_count: 0,
+            warning_issue_count: 0,
+            load_error_count: 0,
+            degraded_contribution_count: 0,
+            degraded_connector_count: 0,
+            state_counts: { ready: 1 },
+            highlighted_messages: [],
+          },
+          issues: [],
+          load_errors: [],
+          permission_summary: { status: "granted", ok: true, required: {}, missing: {}, risk_level: "low" },
+          connector_summary: { total: 0, ready: 0, states: {} },
+          disable_supported: true,
+          removable: true,
+          enable_supported: true,
+          enabled_scope: "extension",
+          configurable: false,
+          metadata_supported: true,
+          config_scope: "metadata_only",
+          enabled: true,
+          contributions: [],
+          studio_files: [],
+        },
+      ],
+    };
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/extensions/seraph.live-pack/quarantine")) {
+        return Promise.resolve(mockResponse({
+          status: "quarantined",
+          receipt: { id: "extension-lifecycle:seraph.live-pack:quarantine:1" },
+          extension: { display_name: "Live Pack" },
+        }));
+      }
+      if (url.includes("/api/sessions")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/goals/tree")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/goals/dashboard")) return Promise.resolve(mockResponse({ domains: {}, active_count: 0, completed_count: 0, total_count: 0 }));
+      if (url.includes("/api/runtime/status")) return Promise.resolve(mockResponse({ version: "test", build_id: "test", provider: "test", model: "test", model_label: "test" }));
+      if (url.includes("/api/observer/state")) return Promise.resolve(mockResponse({}));
+      if (url.includes("/api/audit/events")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/approvals/pending")) return Promise.resolve(mockResponse([]));
+      if (url.includes("/api/observer/continuity")) return Promise.resolve(mockResponse({ daemon: { connected: false, pending_notification_count: 0, capture_mode: "balanced" }, notifications: [], queued_insights: [], queued_insight_count: 0, recent_interventions: [], reach: { route_statuses: [] } }));
+      if (url.includes("/api/capabilities/overview")) return Promise.resolve(mockResponse(emptyCapabilityOverview()));
+      if (url.includes("/api/extensions")) return Promise.resolve(mockResponse(extensionsPayload));
+      if (url.includes("/api/workflows/runs")) return Promise.resolve(mockResponse({ runs: [] }));
+      if (url.includes("/api/settings/tool-policy-mode")) return Promise.resolve(mockResponse({ mode: "balanced" }));
+      if (url.includes("/api/settings/mcp-policy-mode")) return Promise.resolve(mockResponse({ mode: "approval" }));
+      if (url.includes("/api/settings/approval-mode")) return Promise.resolve(mockResponse({ mode: "high_risk" }));
+      return Promise.resolve(mockResponse({}));
+    });
+
+    render(<CockpitView onSend={() => {}} />);
+
+    const consoleRegion = await screen.findByRole("region", { name: "M9 governed extension console" });
+    fireEvent.click(within(consoleRegion).getByRole("button", { name: "quarantine" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/extensions/seraph.live-pack/quarantine"),
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining("cockpit operator quarantine"),
+        }),
+      ),
+    );
+    expect(await screen.findByText(/Live Pack quarantine complete/i)).toBeInTheDocument();
   });
 
   it("surfaces workflow runs in the cockpit inspector", async () => {

--- a/frontend/src/components/cockpit/CockpitView.tsx
+++ b/frontend/src/components/cockpit/CockpitView.tsx
@@ -1798,6 +1798,26 @@ interface ExtensionDiagnosticsSummary {
   highlighted_messages: string[];
 }
 
+interface ExtensionRollbackSnapshotInfo {
+  id: string;
+  path?: string | null;
+  version?: string | null;
+  digest?: string | null;
+  reason?: string | null;
+  created_at?: string | null;
+}
+
+interface ExtensionLifecycleInfo {
+  rollback_snapshots?: ExtensionRollbackSnapshotInfo[];
+  quarantine?: {
+    active?: boolean;
+    state?: string | null;
+    reason?: string | null;
+    updated_at?: string | null;
+  } | null;
+  last_event?: Record<string, unknown> | null;
+}
+
 interface ExtensionPackageInfo {
   id: string;
   display_name: string;
@@ -1830,6 +1850,7 @@ interface ExtensionPackageInfo {
   permission_summary?: ExtensionPermissionSummary | null;
   approval_profile?: ExtensionApprovalProfile | null;
   connector_summary?: ExtensionConnectorSummary | null;
+  lifecycle?: ExtensionLifecycleInfo | null;
   lifecycle_receipt_id?: string | null;
   rollback_receipt_id?: string | null;
   rollback_receipt_path?: string | null;
@@ -2129,6 +2150,7 @@ interface GovernedExtensionConsoleRow {
   actionReady: boolean;
   rollback: string;
   rollbackReceipt: string | null;
+  rollbackSnapshotId: string | null;
   reasons: string[];
   alternatives: string[];
   extensionPackage?: ExtensionPackageInfo;
@@ -2485,10 +2507,20 @@ function issueMessageFromUnknown(value: unknown): string | null {
 }
 
 function extensionPackageReceipt(extensionPackage: ExtensionPackageInfo): string | null {
-  return extensionPackage.rollback_receipt_id
+  return extensionPackage.lifecycle?.rollback_snapshots?.[0]?.id
+    ?? extensionPackage.rollback_receipt_id
     ?? extensionPackage.rollback_receipt_path
     ?? extensionPackage.lifecycle_receipt_id
     ?? null;
+}
+
+function extensionPackageRollbackSnapshotId(extensionPackage: ExtensionPackageInfo): string | null {
+  return extensionPackage.lifecycle?.rollback_snapshots?.[0]?.id ?? null;
+}
+
+function extensionPackageQuarantined(extensionPackage: ExtensionPackageInfo): boolean {
+  return extensionPackage.status === "quarantined"
+    || Boolean(extensionPackage.lifecycle?.quarantine?.active);
 }
 
 function extensionPackageRevoked(extensionPackage: ExtensionPackageInfo): boolean {
@@ -2501,7 +2533,9 @@ function buildInstalledExtensionConsoleRow(
   catalogItem: CatalogItemInfo | null,
 ): GovernedExtensionConsoleRow {
   const receipt = extensionPackageReceipt(extensionPackage);
+  const rollbackSnapshotId = extensionPackageRollbackSnapshotId(extensionPackage);
   const revoked = extensionPackageRevoked(extensionPackage);
+  const quarantined = extensionPackageQuarantined(extensionPackage);
   const issueReasons = [
     ...extensionPackage.issues.map((issue) => `${issue.severity}: ${issue.message}`),
     ...extensionPackage.load_errors.map((error) => `load ${error.phase}: ${error.message}`),
@@ -2511,13 +2545,16 @@ function buildInstalledExtensionConsoleRow(
     extensionPackage.approval_profile?.requires_lifecycle_approval ? "lifecycle review required before privileged change" : null,
     extensionPackage.approval_profile?.requires_runtime_approval ? `runtime approval ${extensionPackage.approval_profile.runtime_behavior}` : null,
     revoked ? `revocation ${extensionPackage.revocation_state ?? extensionPackage.status}` : null,
+    quarantined ? `quarantine ${extensionPackage.lifecycle?.quarantine?.reason ?? "active"}` : null,
   ].filter((reason): reason is string => Boolean(reason));
   const updateReady = Boolean(catalogItem?.update_available);
-  const actionReady = !revoked && extensionPackage.compatibility?.compatible !== false && extensionPackage.status === "ready";
+  const actionReady = !revoked && !quarantined && extensionPackage.compatibility?.compatible !== false && extensionPackage.status === "ready";
   const alternatives = [
-    extensionPackage.disable_supported && !revoked ? "disable via studio" : null,
-    extensionPackage.removable && !revoked ? "remove via studio" : null,
-    "draft review",
+    extensionPackage.disable_supported && !revoked && !quarantined ? "disable live" : null,
+    extensionPackage.removable && !revoked ? "remove live" : null,
+    !revoked && !quarantined ? "quarantine live" : null,
+    quarantined ? "re-entry review" : null,
+    "review live",
   ].filter((item): item is string => Boolean(item));
   return {
     id: `installed:${extensionPackage.id}`,
@@ -2550,10 +2587,12 @@ function buildInstalledExtensionConsoleRow(
     contributionFamilies: summarizeExtensionContributionFamilies(extensionPackage.contributions),
     actionReadiness: revoked
       ? "revoked · lifecycle actions blocked"
-      : updateReady
+      : quarantined
+        ? "quarantined · re-entry required"
+        : updateReady
         ? "update ready"
         : actionReady
-          ? "studio ready"
+          ? "live controls ready"
           : issueReasons.length
             ? "guarded · review required"
             : "action readiness unknown",
@@ -2562,6 +2601,7 @@ function buildInstalledExtensionConsoleRow(
       ? `rollback ready · receipt ${shortIdentifier(receipt, 18)}`
       : "rollback unavailable · no backend receipt",
     rollbackReceipt: receipt,
+    rollbackSnapshotId,
     reasons: issueReasons.length ? issueReasons : ["no blocking reasons reported"],
     alternatives,
     extensionPackage,
@@ -2633,6 +2673,7 @@ function buildCatalogExtensionConsoleRow(
     actionReady,
     rollback: "rollback unavailable · package not installed with receipt",
     rollbackReceipt: null,
+    rollbackSnapshotId: null,
     reasons: issueReasons.length ? issueReasons : ["no blocking reasons reported"],
     alternatives: ["draft review", ...(item.recommended_actions?.length ? ["repair action available"] : [])],
     catalogItem: item,
@@ -4920,6 +4961,45 @@ function normalizeExtensionContribution(value: Record<string, unknown>): Extensi
   };
 }
 
+function normalizeExtensionLifecycle(value: unknown): ExtensionLifecycleInfo | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const rollbackSnapshots = Array.isArray(record.rollback_snapshots)
+    ? record.rollback_snapshots.flatMap((entry): ExtensionRollbackSnapshotInfo[] => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+      const snapshot = entry as Record<string, unknown>;
+      if (typeof snapshot.id !== "string" || !snapshot.id.trim()) return [];
+      return [{
+        id: snapshot.id,
+        path: typeof snapshot.path === "string" ? snapshot.path : null,
+        version: typeof snapshot.version === "string" ? snapshot.version : null,
+        digest: typeof snapshot.digest === "string" ? snapshot.digest : null,
+        reason: typeof snapshot.reason === "string" ? snapshot.reason : null,
+        created_at: typeof snapshot.created_at === "string" ? snapshot.created_at : null,
+      }];
+    })
+    : [];
+  const quarantineRecord = (
+    record.quarantine && typeof record.quarantine === "object" && !Array.isArray(record.quarantine)
+      ? record.quarantine as Record<string, unknown>
+      : null
+  );
+  return {
+    rollback_snapshots: rollbackSnapshots,
+    quarantine: quarantineRecord
+      ? {
+        active: typeof quarantineRecord.active === "boolean" ? quarantineRecord.active : false,
+        state: typeof quarantineRecord.state === "string" ? quarantineRecord.state : null,
+        reason: typeof quarantineRecord.reason === "string" ? quarantineRecord.reason : null,
+        updated_at: typeof quarantineRecord.updated_at === "string" ? quarantineRecord.updated_at : null,
+      }
+      : null,
+    last_event: record.last_event && typeof record.last_event === "object" && !Array.isArray(record.last_event)
+      ? record.last_event as Record<string, unknown>
+      : null,
+  };
+}
+
 function normalizeExtensionPackage(value: Record<string, unknown>): ExtensionPackageInfo | null {
   if (
     typeof value.id !== "string"
@@ -5024,6 +5104,7 @@ function normalizeExtensionPackage(value: Record<string, unknown>): ExtensionPac
     permission_summary: normalizeExtensionPermissionSummary(value.permission_summary),
     approval_profile: normalizeExtensionApprovalProfile(value.approval_profile),
     connector_summary: normalizeExtensionConnectorSummary(value.connector_summary),
+    lifecycle: normalizeExtensionLifecycle(value.lifecycle),
     lifecycle_receipt_id: typeof value.lifecycle_receipt_id === "string" ? value.lifecycle_receipt_id : null,
     rollback_receipt_id: typeof value.rollback_receipt_id === "string" ? value.rollback_receipt_id : null,
     rollback_receipt_path: typeof value.rollback_receipt_path === "string" ? value.rollback_receipt_path : null,
@@ -9842,6 +9923,56 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
     }
   }
 
+  async function runExtensionConsoleLifecycleAction(
+    extensionPackage: ExtensionPackageInfo,
+    action: "enable" | "disable" | "remove" | "review" | "quarantine" | "reentry" | "rollback",
+    snapshotId?: string | null,
+  ) {
+    const label = extensionPackage.display_name;
+    const actionLabel = action === "reentry" ? "re-entry" : action;
+    setOperatorStatus(`${actionLabel} ${label}...`);
+    const encodedId = encodeURIComponent(extensionPackage.id);
+    const body = action === "review"
+      ? { reason: "cockpit lifecycle review" }
+      : action === "quarantine"
+        ? { reason: "cockpit operator quarantine" }
+        : action === "reentry"
+          ? { reason: "cockpit re-entry review" }
+          : action === "rollback"
+            ? { snapshot_id: snapshotId ?? null }
+            : null;
+    const endpoint = action === "remove"
+      ? `${API_URL}/api/extensions/${encodedId}`
+      : `${API_URL}/api/extensions/${encodedId}/${action}`;
+    try {
+      const response = await fetch(endpoint, {
+        method: action === "remove" ? "DELETE" : "POST",
+        headers: body ? { "Content-Type": "application/json" } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        const handled = await handleExtensionLifecycleFailure(
+          payload,
+          `Failed to ${actionLabel} ${label}`,
+          setOperatorStatus,
+        );
+        if (!handled) appendOperatorFeed(`Failed to ${actionLabel} ${label}`, "failed");
+        return;
+      }
+      await refreshCockpit();
+      const nextLabel = typeof payload?.extension?.display_name === "string"
+        ? payload.extension.display_name
+        : label;
+      const receiptId = typeof payload?.receipt?.id === "string" ? ` · ${shortIdentifier(payload.receipt.id, 18)}` : "";
+      setOperatorStatus(`${nextLabel} ${actionLabel} complete${receiptId}`);
+      appendOperatorFeed(`${nextLabel} ${actionLabel} complete${receiptId}`, "success");
+    } catch {
+      setOperatorStatus(`Failed to ${actionLabel} ${label}`);
+      appendOperatorFeed(`Failed to ${actionLabel} ${label}`, "failed");
+    }
+  }
+
   function saveRunbookMacro(runbook: RunbookInfo) {
     setSavedRunbooks((current) => {
       if (current.some((item) => item.id === runbook.id)) return current;
@@ -14307,49 +14438,63 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                             <button
                               type="button"
                               className="cockpit-operator-button"
-                              onClick={() => openExtensionStudio(
-                                studioEntries.find((entry) => entry.id === `extension:${row.extensionPackage?.id}`) ?? null,
-                              )}
+                              disabled={extensionPackageQuarantined(row.extensionPackage)}
+                              onClick={() => void runExtensionConsoleLifecycleAction(row.extensionPackage as ExtensionPackageInfo, "disable")}
                             >
-                              disable via studio
+                              disable
                             </button>
                           ) : null}
                           {row.extensionPackage?.removable && !extensionPackageRevoked(row.extensionPackage) ? (
                             <button
                               type="button"
                               className="cockpit-operator-button"
-                              onClick={() => openExtensionStudio(
-                                studioEntries.find((entry) => entry.id === `extension:${row.extensionPackage?.id}`) ?? null,
-                              )}
+                              onClick={() => void runExtensionConsoleLifecycleAction(row.extensionPackage as ExtensionPackageInfo, "remove")}
                             >
-                              remove via studio
+                              remove
+                            </button>
+                          ) : null}
+                          {row.extensionPackage && !extensionPackageRevoked(row.extensionPackage) && !extensionPackageQuarantined(row.extensionPackage) ? (
+                            <button
+                              type="button"
+                              className="cockpit-operator-button"
+                              onClick={() => void runExtensionConsoleLifecycleAction(row.extensionPackage as ExtensionPackageInfo, "quarantine")}
+                            >
+                              quarantine
+                            </button>
+                          ) : null}
+                          {row.extensionPackage && extensionPackageQuarantined(row.extensionPackage) ? (
+                            <button
+                              type="button"
+                              className="cockpit-operator-button"
+                              onClick={() => void runExtensionConsoleLifecycleAction(row.extensionPackage as ExtensionPackageInfo, "reentry")}
+                            >
+                              re-entry
                             </button>
                           ) : null}
                           <button
                             type="button"
                             className="cockpit-operator-button"
-                            disabled={!row.rollbackReceipt}
+                            disabled={!row.extensionPackage || !row.rollbackSnapshotId}
                             title={row.rollback}
                             onClick={() => {
-                              if (row.rollbackReceipt) {
-                                queueComposerDraft(
-                                  `Review rollback readiness for extension "${row.label}" using receipt ${row.rollbackReceipt}. Confirm impact, compatibility, and revocation posture before any lifecycle action.`,
-                                );
+                              if (row.extensionPackage && row.rollbackSnapshotId) {
+                                void runExtensionConsoleLifecycleAction(row.extensionPackage, "rollback", row.rollbackSnapshotId);
                               }
                             }}
                           >
-                            {row.rollbackReceipt ? "rollback receipt" : "rollback unavailable"}
+                            {row.rollbackSnapshotId ? "rollback" : "rollback unavailable"}
                           </button>
                           <button
                             type="button"
                             className="cockpit-operator-button"
-                            onClick={() => queueComposerDraft(
-                              row.extensionPackage
-                                ? buildExtensionPackageReviewDraft(row.extensionPackage, row.catalogItem ?? null)
-                                : `Review install readiness for extension pack "${row.label}". State: ${row.status}. Reasons: ${row.reasons.join("; ")}. Do not install until blocked, degraded, review-required, revoked, compatibility, permission, and rollback-readiness states are resolved or accepted.`,
-                            )}
+                            disabled={!row.extensionPackage}
+                            onClick={() => {
+                              if (row.extensionPackage) {
+                                void runExtensionConsoleLifecycleAction(row.extensionPackage, "review");
+                              }
+                            }}
                           >
-                            draft review
+                            review
                           </button>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- add durable extension lifecycle state for live marketplace/operator controls
- expose live extension review, quarantine, re-entry, rollback, and lifecycle-status APIs
- wire the cockpit governed extension console to live lifecycle actions instead of draft/studio-only controls

Closes #596.

## Feature Scope
- Feature-only batch for marketplace lifecycle controls.
- No proof-only endpoint, benchmark wrapper, claim-ledger lift, or parity/superiority claim added.
- Downgrades are explicitly refused by the generic update endpoint until a distinct downgrade lifecycle control is implemented.

## Team / Review
- Backend explorer: mapped existing extension API/runtime/state/governance surfaces and identified durable lifecycle gaps.
- Frontend explorer: mapped cockpit governed extension console and identified draft/studio-only action gaps.
- Security reviewer: required server-derived transitions, fail-closed quarantine, rollback restore-point validation, server-bound actor, and no optimistic UI success.
- Critic/Contrarian: found rollback approval scoping, generic downgrade, quarantine ordering, client actor, and missing live action test issues. All accepted and fixed.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_extensions_api.py -q -k "update_records_lifecycle_snapshot or quarantine_blocks_enable or generic_update_rejects_downgrade or rollback_approval_scope"`
- `npm test -- --run src/components/cockpit/CockpitView.test.tsx`
- `npm run build`
- `git diff --check`
