### PR TITLE
Fix cockpit unmount refresh count test

### DIFF
--- a/frontend/src/components/cockpit/CockpitView.test.tsx
+++ b/frontend/src/components/cockpit/CockpitView.test.tsx
@@ -12122,7 +12122,7 @@ describe("CockpitView", () => {
   }, 15000);
 
   it("does not process refresh payloads after the cockpit unmounts", async () => {
-    const deferredResponses = Array.from({ length: 22 }, () => {
+    const deferredResponses = Array.from({ length: 27 }, () => {
       let resolve!: (value: { ok: boolean; json: () => Promise<unknown> }) => void;
       const promise = new Promise<{ ok: boolean; json: () => Promise<unknown> }>((res) => {
         resolve = res;
@@ -12147,7 +12147,7 @@ describe("CockpitView", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const view = render(<CockpitView onSend={vi.fn()} />);
 
-    await waitFor(() => expect(cockpitFetchCount).toBe(26));
+    await waitFor(() => expect(cockpitFetchCount).toBe(27));
     view.unmount();
 
     await act(async () => {


### PR DESCRIPTION
## Summary
- update the cockpit unmount safety test for the current refresh fan-out count
- expand deferred response coverage so the unmount guard test resolves every initial refresh payload it intercepts

## Root cause
- PR #609 CI frontend-tests failed because CockpitView now starts 27 deferred refresh fetches while the test still expected 26.

## Validation
- npm test -- --maxWorkers=1 src/components/cockpit/CockpitView.test.tsx