### PR TITLE
Fix backend CI regressions for PR 609

### DIFF
--- a/backend/src/api/browser.py
+++ b/backend/src/api/browser.py
@@ -48,6 +48,14 @@ def _capture_or_raise(url: str, capture: str) -> str:
     return content
 
 
+def _metadata_only_session_payload(payload: dict[str, object] | None) -> dict[str, object] | None:
+    if payload is None:
+        return None
+    metadata = dict(payload)
+    metadata.pop("content", None)
+    return metadata
+
+
 @router.get("/browser/providers")
 async def list_browser_providers():
     state_payload = load_extension_state_payload()
@@ -119,7 +127,7 @@ async def open_browser_session(request: BrowserSessionOpenRequest):
         capture=request.capture,
         content=content,
     )
-    return {"session": payload}
+    return {"session": _metadata_only_session_payload(payload)}
 
 
 @router.get("/browser/sessions/{session_id}")
@@ -127,7 +135,7 @@ async def get_browser_session(session_id: str, owner_session_id: str = Query(...
     payload = browser_session_runtime.get_session(session_id, owner_session_id=owner_session_id)
     if payload is None:
         raise HTTPException(status_code=404, detail="browser_session_not_found")
-    return {"session": payload}
+    return {"session": _metadata_only_session_payload(payload)}
 
 
 @router.post("/browser/sessions/{session_id}/snapshot")

--- a/backend/src/browser/sessions.py
+++ b/backend/src/browser/sessions.py
@@ -321,7 +321,9 @@ class BrowserSessionRuntime:
         with self._lock:
             self._sessions[session_id] = session
             self._refs[snapshot.ref] = (session_id, 0)
-        return session.as_summary()
+        payload = session.as_summary()
+        payload["content"] = snapshot.content
+        return payload
 
     def snapshot_session(
         self,
@@ -369,7 +371,9 @@ class BrowserSessionRuntime:
                     "artifact_handle": snapshot.artifact_provenance["handle"],
                 }
             )
-            return session.as_summary()
+            payload = session.as_summary()
+            payload["content"] = snapshot.content
+            return payload
 
     def get_session(self, session_id: str, *, owner_session_id: str) -> dict[str, object] | None:
         with self._lock:

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -4347,6 +4347,11 @@ def test_main_lists_available_benchmark_suites(capsys):
         "reference_system_source_refresh_v5",
         "false_completion_scan_v5",
         "post_dq_dw_critic_contrarian_no_block_v1",
+        "post_dx_final_board_pr_issue_reconciliation_v1",
+        "post_dx_final_claim_ledger_reconciliation_v1",
+        "reference_system_source_refresh_v6",
+        "false_completion_scan_v6",
+        "post_dx_final_critic_contrarian_no_block_v1",
     )
 
 


### PR DESCRIPTION
## Summary
- restore browser session snapshot content for the browser session tool output renderer
- keep REST browser session responses metadata-only by stripping internal content before returning API payloads
- update the eval harness suite list assertion for the post-DX final benchmark suites now registered in the catalog

## Validation
- cd backend && uv run pytest tests/test_browser_session_tool.py
- cd backend && uv run pytest tests/test_eval_harness.py::test_main_lists_available_benchmark_suites
- cd backend && uv run pytest tests/test_browser_session_tool.py tests/test_eval_harness.py::test_run_post_dx_final_claim_lift_benchmark_suites_pass
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/run_backend_test_shard.py --shard-count 10 --shard-index 8 --file-timeout-seconds 900

## Team / Review
- Lead fix pass: traced PR #609 backend failures to the tool payload/API payload split and stale eval suite assertion.
- Critic/Contrarian pass: accepted; checked that the runtime content field remains available only for tool rendering while REST responses stay metadata-only, and that the eval assertion change mirrors registered benchmark catalog state without broadening runtime behavior.