### PR TITLE
Fix local Codex operator routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,12 @@ Seraph's provider setup is intentionally routing-oriented rather than provider-l
 
 - **Local Ollama** through `local-ollama` when `LOCAL_MODEL` and `LOCAL_LLM_API_BASE=http://localhost:11434/v1` are configured
 - **OpenRouter** through the `openrouter` built-in profile and `OPENROUTER_API_KEY`
-- **OpenAI/Codex-oriented operator routes** through `codex-openai` or `gpt-5.5-low`, using the LiteLLM-routable `openai/gpt-5.5` model id plus `reasoning_effort=low` as a request option
+- **Remote OpenAI API operator profiles** through `codex-openai` or `gpt-5.5-low`, using the LiteLLM-routable `openai/gpt-5.5` model id plus `reasoning_effort=low` as a request option. These profile names select cloud API routing for Seraph and are distinct from any local Codex command/operator process.
+- **Local Codex operator** through the command-backed `codex-local` operator adapter, which invokes the installed `codex exec` command on this machine and does not require `OPENAI_API_KEY`
 - **Anthropic/Claude-oriented operator routes** through `claude-anthropic` and `ANTHROPIC_API_KEY`
 - **Generic OpenAI-compatible endpoints** through `openai-compatible` or custom `LLM_PROVIDER_PROFILES` entries backed by `LLM_API_BASE`, `LLM_API_KEY`, and compatible model IDs
 
-These profiles only configure provider/operator routing, fallback, capability tags, and audit visibility. They do not claim provider parity or that one provider reproduces another provider's behavior.
+Provider profiles only configure LLM routing, fallback, capability tags, and audit visibility. Local operators such as `codex-local` are separate executable adapters with their own readiness, audit, timeout, and failure surfaces. Neither surface claims provider parity or that one provider reproduces another provider's behavior.
 
 ### Docker Dev Stack
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -72,7 +72,7 @@ Receive (streamed):
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENROUTER_API_KEY` | - | OpenRouter API key used by the default example profile |
-| `OPENAI_API_KEY` | - | OpenAI API key used by the `codex-openai` and `gpt-5.5-low` built-in profiles |
+| `OPENAI_API_KEY` | - | Remote OpenAI API key used by the `codex-openai` and `gpt-5.5-low` built-in profiles; this does not configure a local Codex command/operator process |
 | `ANTHROPIC_API_KEY` | - | Anthropic API key used by the `claude-anthropic` built-in profile |
 | `DEFAULT_MODEL` | `openrouter/anthropic/claude-sonnet-4` | LLM model identifier |
 | `LLM_API_KEY` | - | Generic primary API key override for LiteLLM-compatible providers |
@@ -86,6 +86,12 @@ Receive (streamed):
 | `LOCAL_MODEL` | - | Model id for the local runtime profile |
 | `LOCAL_LLM_API_KEY` | - | Optional API key for the local runtime profile |
 | `LOCAL_LLM_API_BASE` | - | API base for the local runtime profile |
+| `CODEX_LOCAL_ENABLED` | `true` | Enables the local command-backed Codex operator adapter |
+| `CODEX_LOCAL_COMMAND` | `codex` | Local Codex executable name or path |
+| `CODEX_LOCAL_MODEL` | `gpt-5.5` | Model option passed to `codex exec` |
+| `CODEX_LOCAL_SANDBOX` | `workspace-write` | Sandbox option passed to local `codex exec` |
+| `CODEX_LOCAL_APPROVAL_POLICY` | `never` | Approval policy option passed to local `codex exec` |
+| `CODEX_LOCAL_TIMEOUT_SECONDS` | `600` | Timeout for local Codex operator invocations |
 | `LOCAL_RUNTIME_PATHS` | - | Comma-separated runtime paths or glob patterns that should prefer the local profile |
 | `RUNTIME_PROFILE_PREFERENCES` | - | Semicolon-separated `runtime_path=profile_a|profile_b` chains; `runtime_path` may be an exact path or glob |
 | `RUNTIME_POLICY_INTENTS` | - | Semicolon-separated `runtime_path=intent_a|intent_b` entries for capability-aware routing; `runtime_path` may be an exact path or glob |
@@ -142,10 +148,21 @@ LLM_API_BASE=https://openrouter.ai/api/v1
 DEFAULT_MODEL=openrouter/anthropic/claude-sonnet-4
 FALLBACK_MODELS=openai/gpt-4.1-mini,openai/gpt-4.1-nano
 
-# OpenAI/Codex-oriented operator routes. The low reasoning setting is an
-# option on the profile, not part of the model id.
+# Remote OpenAI API operator profiles. `codex-openai` and `gpt-5.5-low`
+# select cloud API routing for Seraph; they are separate from any local Codex
+# command/operator process. The low reasoning setting is an option on the
+# profile, not part of the model id.
 OPENAI_API_KEY=your-openai-key
 RUNTIME_PROFILE_PREFERENCES=chat_agent=codex-openai|openrouter
+
+# Local Codex command-backed operator. This does not use OPENAI_API_KEY and is
+# exposed separately from provider profiles as codex-local.
+CODEX_LOCAL_ENABLED=true
+CODEX_LOCAL_COMMAND=codex
+CODEX_LOCAL_MODEL=gpt-5.5
+CODEX_LOCAL_SANDBOX=workspace-write
+CODEX_LOCAL_APPROVAL_POLICY=never
+CODEX_LOCAL_TIMEOUT_SECONDS=600
 
 # Anthropic/Claude-oriented routes.
 ANTHROPIC_API_KEY=your-anthropic-key
@@ -160,7 +177,7 @@ RUNTIME_PROFILE_PREFERENCES=chat_agent=openai-compatible|openrouter
 FALLBACK_MODELS=your-provider/smaller-model
 ```
 
-These examples configure routing and operator posture only. They do not assert that a local model, Codex-oriented route, Claude-oriented route, or generic endpoint has equivalent behavior.
+These examples configure routing and operator posture only. They do not assert that a local model, remote OpenAI API route, local Codex operator, Claude-oriented route, or generic endpoint has equivalent behavior.
 
 Runtime routing examples:
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -39,6 +39,12 @@ class Settings(BaseSettings):
     provider_task_classes: str = ""  # semicolon-separated model_or_glob=task_class entries
     provider_budget_classes: str = ""  # semicolon-separated model_or_glob=low|medium|high entries
     llm_target_cooldown_seconds: int = 300  # temporarily deprioritize failed LLM targets across requests
+    codex_local_enabled: bool = True
+    codex_local_command: str = "codex"
+    codex_local_model: str = "gpt-5.5"
+    codex_local_sandbox: str = "workspace-write"
+    codex_local_approval_policy: str = "never"
+    codex_local_timeout_seconds: int = 600
     model_temperature: float = 0.7
     model_max_tokens: int = 4096
     agent_max_steps: int = 10

--- a/backend/src/api/activity.py
+++ b/backend/src/api/activity.py
@@ -155,7 +155,7 @@ def _category_for_kind(kind: str) -> str:
         return "approval"
     if kind in {"notification", "queued_insight", "intervention"}:
         return "guardian"
-    if kind in {"agent_run", "tool_call", "tool_result", "tool_failed"}:
+    if kind in {"agent_run", "tool_call", "tool_result", "tool_failed", "local_operator"}:
         return "agent"
     return "system"
 
@@ -165,6 +165,12 @@ def _status_for_audit_event(event_type: str) -> str:
         return "running"
     if event_type == "tool_result":
         return "succeeded"
+    if event_type == "local_operator_started":
+        return "running"
+    if event_type == "local_operator_completed":
+        return "recorded"
+    if event_type == "local_operator_unavailable":
+        return "failed"
     if event_type.endswith("_failed") or event_type in {"tool_failed", "integration_failed", "llm_primary_failure", "llm_fallback_failure"}:
         return "failed"
     if event_type.endswith("_timed_out"):
@@ -197,6 +203,8 @@ def _title_for_audit_event(event: dict[str, Any]) -> str:
         return tool_name or "Scheduler job"
     if event_type.startswith("background_task_"):
         return tool_name or "Background task"
+    if event_type.startswith("local_operator_"):
+        return tool_name or "Local operator"
     if event_type.startswith("observer_delivery_"):
         return "Guardian delivery"
     if event_type.startswith("integration_"):
@@ -221,6 +229,8 @@ def _kind_for_audit_event(event: dict[str, Any]) -> str | None:
         return "scheduler_job"
     if event_type.startswith("background_task_"):
         return "background_task"
+    if event_type.startswith("local_operator_"):
+        return "local_operator"
     if event_type.startswith("observer_delivery_"):
         return "delivery"
     if event_type.startswith("integration_"):

--- a/backend/src/api/operator.py
+++ b/backend/src/api/operator.py
@@ -14,6 +14,12 @@ from config.settings import settings
 from src.agent.session import session_manager
 from src.app import _runtime_model_label, _runtime_provider_label
 from src.llm_runtime import provider_profile_statuses, resolve_runtime_profile
+from src.operators.local_codex import (
+    LocalCodexConfigurationError,
+    local_codex_status,
+    local_operator_statuses,
+    run_local_codex,
+)
 from src.extensions.lifecycle import list_extensions
 from src.llm_logger import list_recent_llm_calls
 from src.observer.manager import context_manager
@@ -171,10 +177,44 @@ class MemoryLiveControlActionRequest(BaseModel):
     privacy_boundary: str | None = None
 
 
+class LocalCodexExecRequest(BaseModel):
+    prompt: str = Field(..., min_length=1, max_length=40_000)
+    cwd: str | None = None
+    model: str | None = None
+    timeout_seconds: int | None = Field(default=None, ge=1, le=600)
+    session_id: str | None = None
+
+
 def _memory_live_control_acknowledgement(request: MemoryLiveControlActionRequest) -> bool:
     if str(request.action or "").strip().lower() == "rollback_memory":
         return request.acknowledge_rollback_boundary
     return request.acknowledged or request.acknowledge_rollback_boundary
+
+
+@router.get("/operator/local-codex/status")
+async def operator_local_codex_status():
+    return local_codex_status()
+
+
+@router.post("/operator/local-codex/exec")
+async def operator_local_codex_exec(request: LocalCodexExecRequest):
+    try:
+        return await run_local_codex(
+            request.prompt,
+            cwd=request.cwd,
+            model=request.model,
+            timeout_seconds=request.timeout_seconds,
+            session_id=request.session_id,
+        )
+    except LocalCodexConfigurationError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "adapter": "codex-local",
+                "status": "blocked",
+                "failure_reason": str(exc),
+            },
+        ) from exc
 
 
 _ENGINEERING_PULL_REQUEST_RE = re.compile(
@@ -1208,6 +1248,7 @@ def _runtime_status_payload() -> dict[str, Any]:
         "api_base": settings.llm_api_base.strip(),
         "active_profile": active_profile,
         "provider_profiles": provider_profile_statuses(),
+        "local_operators": local_operator_statuses(),
         "timezone": settings.user_timezone,
         "llm_logging_enabled": settings.llm_log_enabled,
     }

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -14,6 +14,7 @@ from src.extensions.registry import default_manifest_roots_for_workspace
 from src.llm_logger import init_llm_logging
 from src.llm_runtime import provider_profile_statuses, resolve_runtime_profile
 from src.memory.soul import ensure_soul_exists
+from src.operators.local_codex import local_operator_statuses
 from src.runbooks.manager import runbook_manager
 from src.scheduler.engine import init_scheduler, shutdown_scheduler, sync_scheduled_jobs
 from src.skills.manager import skill_manager
@@ -162,6 +163,7 @@ def create_app() -> FastAPI:
             "api_base": settings.llm_api_base.strip(),
             "active_profile": active_profile,
             "provider_profiles": provider_profile_statuses(),
+            "local_operators": local_operator_statuses(),
             "timezone": settings.user_timezone,
             "llm_logging_enabled": settings.llm_log_enabled,
         }

--- a/backend/src/operators/__init__.py
+++ b/backend/src/operators/__init__.py
@@ -1,0 +1,2 @@
+"""Local and external operator adapters."""
+

--- a/backend/src/operators/local_codex.py
+++ b/backend/src/operators/local_codex.py
@@ -1,0 +1,399 @@
+"""Local Codex command-backed operator adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+from typing import Any
+
+from config.settings import REPO_ROOT, settings
+from src.audit.repository import audit_repository
+
+_OUTPUT_LIMIT = 24_000
+_STATUS_TIMEOUT_SECONDS = 5
+_ENV_ALLOWLIST = {
+    "PATH",
+    "HOME",
+    "CODEX_HOME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TERM",
+    "TZ",
+}
+_APPROVAL_POLICIES = {"untrusted", "on-request", "never"}
+_SANDBOX_MODES = {"read-only", "workspace-write"}
+_SECRET_ENV_MARKERS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL", "AUTH")
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)\b(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*[^\s,;]+"),
+    re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+"),
+)
+
+
+class LocalCodexConfigurationError(RuntimeError):
+    """Raised when the local Codex operator is not usable."""
+
+
+@dataclass(frozen=True)
+class LocalCodexCommand:
+    argv: list[str]
+    cwd: Path
+    timeout_seconds: int
+
+    @property
+    def display(self) -> str:
+        return " ".join(_display_arg(arg) for arg in self.argv)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _display_arg(value: str) -> str:
+    if not value:
+        return "''"
+    if any(char.isspace() for char in value):
+        return repr(value)
+    return value
+
+
+def _safe_command_name(raw_command: str | None = None) -> str:
+    command = (raw_command if raw_command is not None else settings.codex_local_command).strip()
+    if not command:
+        raise LocalCodexConfigurationError("Local Codex command is not configured.")
+    if any(char in command for char in ("|", "&", ";", "<", ">", "`", "$", "\n", "\r", "\t")):
+        raise LocalCodexConfigurationError("Local Codex command must be a single executable path or name.")
+    return command
+
+
+def _workspace_root(raw_cwd: str | None = None) -> Path:
+    if raw_cwd and raw_cwd.strip():
+        candidate = Path(raw_cwd.strip())
+        root = candidate if candidate.is_absolute() else REPO_ROOT / candidate
+    else:
+        root = REPO_ROOT
+    root = root.resolve()
+    try:
+        root.relative_to(REPO_ROOT)
+    except ValueError as exc:
+        raise LocalCodexConfigurationError("Local Codex workspace root must stay inside the Seraph repo.") from exc
+    if not root.exists() or not root.is_dir():
+        raise LocalCodexConfigurationError("Local Codex workspace root must be an existing directory.")
+    return root
+
+
+def _timeout_seconds(raw_timeout: int | None = None) -> int:
+    timeout = raw_timeout if raw_timeout is not None else settings.codex_local_timeout_seconds
+    return min(max(int(timeout or 1), 1), 3600)
+
+
+def _codex_env() -> dict[str, str]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key in _ENV_ALLOWLIST and value
+    }
+    env.setdefault("PATH", os.defpath)
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    env["SERAPH_LOCAL_OPERATOR"] = "codex-local"
+    return env
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _truncate_output(value: str) -> tuple[str, bool]:
+    redacted = _redact_output(value)
+    if len(redacted) <= _OUTPUT_LIMIT:
+        return redacted, False
+    return redacted[:_OUTPUT_LIMIT] + "\n...[truncated]...", True
+
+
+def _redact_output(value: str) -> str:
+    redacted = value
+    configured_secrets = (
+        settings.llm_api_key,
+        settings.openrouter_api_key,
+        settings.openai_api_key,
+        settings.anthropic_api_key,
+        settings.local_llm_api_key,
+        settings.fallback_llm_api_key,
+    )
+    for secret in configured_secrets:
+        if secret:
+            redacted = redacted.replace(secret, "[redacted]")
+    for env_name, env_value in os.environ.items():
+        if env_value and any(marker in env_name.upper() for marker in _SECRET_ENV_MARKERS):
+            redacted = redacted.replace(env_value, "[redacted]")
+    for pattern in _SECRET_PATTERNS:
+        redacted = pattern.sub("[redacted]", redacted)
+    return redacted
+
+
+def _normalize_sandbox(value: str | None = None) -> str:
+    sandbox = (value if value is not None else settings.codex_local_sandbox).strip() or "workspace-write"
+    if sandbox not in _SANDBOX_MODES:
+        raise LocalCodexConfigurationError("Local Codex sandbox mode must be read-only or workspace-write.")
+    return sandbox
+
+
+def _normalize_approval_policy(value: str | None = None) -> str:
+    policy = (value if value is not None else settings.codex_local_approval_policy).strip() or "never"
+    if policy not in _APPROVAL_POLICIES:
+        raise LocalCodexConfigurationError("Local Codex approval policy is not allowed.")
+    return policy
+
+
+def _normalize_model(value: str | None = None) -> str:
+    return (value if value is not None else settings.codex_local_model).strip()
+
+
+def local_codex_command(
+    prompt: str,
+    *,
+    cwd: str | None = None,
+    model: str | None = None,
+    sandbox: str | None = None,
+    approval_policy: str | None = None,
+    timeout_seconds: int | None = None,
+) -> LocalCodexCommand:
+    if not prompt.strip():
+        raise LocalCodexConfigurationError("Local Codex prompt is required.")
+    command = _safe_command_name()
+    workspace = _workspace_root(cwd)
+    argv = [
+        command,
+        "--ask-for-approval",
+        _normalize_approval_policy(approval_policy),
+        "exec",
+        "-C",
+        str(workspace),
+        "--sandbox",
+        _normalize_sandbox(sandbox),
+    ]
+    selected_model = _normalize_model(model)
+    if selected_model:
+        argv.extend(["--model", selected_model])
+    argv.append(prompt)
+    return LocalCodexCommand(
+        argv=argv,
+        cwd=workspace,
+        timeout_seconds=_timeout_seconds(timeout_seconds),
+    )
+
+
+def local_codex_status() -> dict[str, Any]:
+    command = ""
+    try:
+        command = _safe_command_name()
+        configured_sandbox = _normalize_sandbox()
+        configured_approval_policy = _normalize_approval_policy()
+        resolved_command = shutil.which(command)
+    except LocalCodexConfigurationError as exc:
+        return {
+            "id": "codex-local",
+            "operator_kind": "local_command",
+            "enabled": settings.codex_local_enabled,
+            "ready": False,
+            "unavailable_reason": str(exc),
+            "command": command or None,
+            "model": settings.codex_local_model,
+            "sandbox": settings.codex_local_sandbox,
+            "approval_policy": settings.codex_local_approval_policy,
+        }
+
+    payload: dict[str, Any] = {
+        "id": "codex-local",
+        "operator_kind": "local_command",
+        "enabled": settings.codex_local_enabled,
+        "command": command,
+        "command_path": resolved_command,
+        "model": settings.codex_local_model,
+        "sandbox": configured_sandbox,
+        "approval_policy": configured_approval_policy,
+        "timeout_seconds": settings.codex_local_timeout_seconds,
+        "workspace_root": str(REPO_ROOT),
+        "requires_api_key": False,
+    }
+    if not settings.codex_local_enabled:
+        payload.update({"ready": False, "unavailable_reason": "local Codex operator is disabled"})
+        return payload
+    if not resolved_command:
+        payload.update({"ready": False, "unavailable_reason": "codex command was not found on PATH"})
+        return payload
+
+    try:
+        result = subprocess.run(
+            [command, "--version"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            shell=False,
+            env=_codex_env(),
+            timeout=_STATUS_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        payload.update({"ready": False, "unavailable_reason": "codex --version timed out"})
+        return payload
+    except OSError as exc:
+        payload.update({"ready": False, "unavailable_reason": str(exc)})
+        return payload
+
+    version_text = (result.stdout or result.stderr or "").strip()
+    payload.update({
+        "ready": result.returncode == 0,
+        "version": version_text,
+        "last_status_exit_code": result.returncode,
+    })
+    if result.returncode != 0:
+        payload["unavailable_reason"] = "codex --version failed"
+    return payload
+
+
+def local_operator_statuses() -> list[dict[str, Any]]:
+    return [local_codex_status()]
+
+
+async def run_local_codex(
+    prompt: str,
+    *,
+    cwd: str | None = None,
+    model: str | None = None,
+    sandbox: str | None = None,
+    approval_policy: str | None = None,
+    timeout_seconds: int | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    status = local_codex_status()
+    prompt_hash = _sha256_text(prompt)
+    audit_base = {
+        "operator_id": "codex-local",
+        "operator_kind": "local_command",
+        "prompt_sha256": prompt_hash,
+        "prompt_chars": len(prompt),
+        "model": model or settings.codex_local_model,
+        "workspace_root": str(REPO_ROOT),
+    }
+    if not status.get("ready"):
+        await audit_repository.log_event(
+            event_type="local_operator_unavailable",
+            summary="Local Codex operator unavailable",
+            actor="system",
+            tool_name="codex-local",
+            risk_level="medium",
+            session_id=session_id,
+            details={**audit_base, "reason": status.get("unavailable_reason")},
+        )
+        raise LocalCodexConfigurationError(str(status.get("unavailable_reason") or "Local Codex unavailable."))
+
+    command = local_codex_command(
+        prompt,
+        cwd=cwd,
+        model=model,
+        sandbox=sandbox,
+        approval_policy=approval_policy,
+        timeout_seconds=timeout_seconds,
+    )
+    started_at = _utc_now()
+    await audit_repository.log_event(
+        event_type="local_operator_started",
+        summary="Local Codex operator started",
+        actor="agent",
+        tool_name="codex-local",
+        risk_level="medium",
+        session_id=session_id,
+        details={
+            **audit_base,
+            "cwd": str(command.cwd),
+            "arg_count": len(command.argv),
+            "timeout_seconds": command.timeout_seconds,
+            "sandbox": _normalize_sandbox(sandbox),
+            "approval_policy": _normalize_approval_policy(approval_policy),
+        },
+    )
+    try:
+        result = await _run_codex_subprocess(command)
+        timed_out = False
+    except subprocess.TimeoutExpired:
+        result = None
+        timed_out = True
+    finished_at = _utc_now()
+
+    if timed_out:
+        payload = {
+            "ok": False,
+            "timed_out": True,
+            "exit_code": None,
+            "stdout": "",
+            "stderr": "",
+            "stdout_truncated": False,
+            "stderr_truncated": False,
+            "started_at": started_at.isoformat(),
+            "finished_at": finished_at.isoformat(),
+            "duration_ms": int((finished_at - started_at).total_seconds() * 1000),
+            "operator_id": "codex-local",
+            "model": model or settings.codex_local_model,
+            "display_command": "codex exec ...",
+        }
+    else:
+        assert result is not None
+        stdout, stdout_truncated = _truncate_output(result.stdout or "")
+        stderr, stderr_truncated = _truncate_output(result.stderr or "")
+        payload = {
+            "ok": result.returncode == 0,
+            "timed_out": False,
+            "exit_code": result.returncode,
+            "stdout": stdout,
+            "stderr": stderr,
+            "stdout_truncated": stdout_truncated,
+            "stderr_truncated": stderr_truncated,
+            "started_at": started_at.isoformat(),
+            "finished_at": finished_at.isoformat(),
+            "duration_ms": int((finished_at - started_at).total_seconds() * 1000),
+            "operator_id": "codex-local",
+            "model": model or settings.codex_local_model,
+            "display_command": "codex exec ...",
+        }
+
+    await audit_repository.log_event(
+        event_type="local_operator_completed",
+        summary="Local Codex operator completed" if payload["ok"] else "Local Codex operator failed",
+        actor="agent",
+        tool_name="codex-local",
+        risk_level="medium",
+        session_id=session_id,
+        details={
+            **audit_base,
+            "ok": payload["ok"],
+            "timed_out": payload["timed_out"],
+            "exit_code": payload["exit_code"],
+            "duration_ms": payload["duration_ms"],
+            "stdout_chars": len(payload["stdout"]),
+            "stderr_chars": len(payload["stderr"]),
+            "stdout_truncated": payload["stdout_truncated"],
+            "stderr_truncated": payload["stderr_truncated"],
+        },
+    )
+    return payload
+
+
+async def _run_codex_subprocess(command: LocalCodexCommand) -> subprocess.CompletedProcess[str]:
+    import asyncio
+
+    return await asyncio.to_thread(
+        subprocess.run,
+        command.argv,
+        cwd=str(command.cwd),
+        capture_output=True,
+        text=True,
+        shell=False,
+        env=_codex_env(),
+        timeout=command.timeout_seconds,
+    )

--- a/backend/tests/test_activity_api.py
+++ b/backend/tests/test_activity_api.py
@@ -3,12 +3,75 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from src.api.activity import _category_for_kind, _kind_for_audit_event, _status_for_audit_event
+
 
 NOW = datetime.now(timezone.utc).replace(microsecond=0)
 
 
 def _iso_offset(*, hours: int = 0, minutes: int = 0, seconds: int = 0) -> str:
     return (NOW + timedelta(hours=hours, minutes=minutes, seconds=seconds)).isoformat().replace("+00:00", "Z")
+
+
+def test_activity_classifier_keeps_local_operator_events_visible():
+    event = {
+        "event_type": "local_operator_completed",
+        "tool_name": "codex-local",
+        "details": {"operator_id": "codex-local"},
+    }
+
+    kind = _kind_for_audit_event(event)
+
+    assert kind == "local_operator"
+    assert _category_for_kind(kind) == "agent"
+    assert _status_for_audit_event("local_operator_unavailable") == "failed"
+
+
+@pytest.mark.asyncio
+async def test_activity_ledger_surfaces_local_operator_events(client):
+    with (
+        patch("src.api.activity._list_workflow_runs", AsyncMock(return_value=[])),
+        patch("src.api.activity.approval_repository.list_pending", AsyncMock(return_value=[])),
+        patch("src.api.activity.native_notification_queue.list", AsyncMock(return_value=[])),
+        patch("src.api.activity.insight_queue.peek_all", AsyncMock(return_value=[])),
+        patch("src.api.activity.guardian_feedback_repository.list_recent", AsyncMock(return_value=[])),
+        patch(
+            "src.api.activity.audit_repository.list_events",
+            AsyncMock(
+                return_value=[
+                    {
+                        "id": "audit-local-operator-1",
+                        "event_type": "local_operator_completed",
+                        "tool_name": "codex-local",
+                        "summary": "Local Codex operator completed",
+                        "created_at": _iso_offset(minutes=-1),
+                        "session_id": "session-1",
+                        "details": {
+                            "operator_id": "codex-local",
+                            "operator_kind": "local_command",
+                            "ok": True,
+                            "duration_ms": 123,
+                            "prompt_sha256": "abc123",
+                        },
+                    }
+                ]
+            ),
+        ),
+        patch("src.api.activity.list_recent_llm_calls", return_value=[]),
+        patch(
+            "src.api.activity.session_manager.list_sessions",
+            AsyncMock(return_value=[{"id": "session-1", "title": "Local operator thread"}]),
+        ),
+    ):
+        response = await client.get("/api/activity/ledger", params={"session_id": "session-1", "limit": 20})
+
+    assert response.status_code == 200
+    item = next(item for item in response.json()["items"] if item["id"] == "audit:audit-local-operator-1")
+    assert item["kind"] == "local_operator"
+    assert item["category"] == "agent"
+    assert item["title"] == "codex-local"
+    assert item["status"] == "recorded"
+    assert item["thread_label"] == "Local operator thread"
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -30,7 +30,9 @@ async def test_runtime_status_exposes_release_and_model(client):
     assert payload["model_label"] == settings.default_model.split("/")[-1]
     assert payload["active_profile"] == "default"
     assert isinstance(payload["provider_profiles"], list)
+    assert isinstance(payload["local_operators"], list)
     assert any(item["id"] == "openrouter" for item in payload["provider_profiles"])
+    assert any(item["id"] == "codex-local" for item in payload["local_operators"])
     assert all("api_key" not in item for item in payload["provider_profiles"])
 
 

--- a/backend/tests/test_local_codex_operator.py
+++ b/backend/tests/test_local_codex_operator.py
@@ -1,0 +1,262 @@
+import subprocess
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from config.settings import REPO_ROOT, settings
+from src.audit.repository import audit_repository
+from src.operators.local_codex import (
+    LocalCodexConfigurationError,
+    _truncate_output,
+    local_codex_command,
+    local_codex_status,
+    run_local_codex,
+)
+
+
+def test_local_codex_command_uses_local_exec_contract():
+    with (
+        patch.object(settings, "codex_local_command", "codex"),
+        patch.object(settings, "codex_local_model", "gpt-5.5"),
+        patch.object(settings, "codex_local_sandbox", "workspace-write"),
+        patch.object(settings, "codex_local_approval_policy", "never"),
+        patch.object(settings, "codex_local_timeout_seconds", 42),
+    ):
+        command = local_codex_command("fix the thing")
+
+    assert command.argv == [
+        "codex",
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "-C",
+        str(REPO_ROOT),
+        "--sandbox",
+        "workspace-write",
+        "--model",
+        "gpt-5.5",
+        "fix the thing",
+    ]
+    assert command.cwd == REPO_ROOT
+    assert command.timeout_seconds == 42
+
+
+@pytest.mark.parametrize("approval_policy", ["bogus", "always"])
+def test_local_codex_command_rejects_unknown_approval_policy(approval_policy):
+    with pytest.raises(LocalCodexConfigurationError):
+        local_codex_command("do it", approval_policy=approval_policy)
+
+
+def test_local_codex_command_rejects_danger_full_access_sandbox():
+    with pytest.raises(LocalCodexConfigurationError, match="read-only or workspace-write"):
+        local_codex_command("do it", sandbox="danger-full-access")
+
+
+def test_local_codex_command_rejects_shell_metacharacters():
+    with patch.object(settings, "codex_local_command", "codex; rm -rf /"):
+        with pytest.raises(LocalCodexConfigurationError):
+            local_codex_command("do it")
+
+
+def test_local_codex_command_rejects_cwd_outside_repo(tmp_path):
+    with pytest.raises(LocalCodexConfigurationError, match="inside the Seraph repo"):
+        local_codex_command("do it", cwd=str(tmp_path))
+
+
+def test_local_codex_status_fails_closed_when_binary_missing():
+    with (
+        patch.object(settings, "codex_local_enabled", True),
+        patch.object(settings, "codex_local_command", "missing-codex"),
+        patch("src.operators.local_codex.shutil.which", return_value=None),
+    ):
+        status = local_codex_status()
+
+    assert status["id"] == "codex-local"
+    assert status["operator_kind"] == "local_command"
+    assert status["ready"] is False
+    assert status["unavailable_reason"] == "codex command was not found on PATH"
+    assert status["requires_api_key"] is False
+
+
+def test_local_codex_status_fails_closed_when_sandbox_config_is_unsafe():
+    with (
+        patch.object(settings, "codex_local_enabled", True),
+        patch.object(settings, "codex_local_sandbox", "danger-full-access"),
+    ):
+        status = local_codex_status()
+
+    assert status["ready"] is False
+    assert status["unavailable_reason"] == "Local Codex sandbox mode must be read-only or workspace-write."
+
+
+def test_local_codex_status_reports_version_without_api_key_requirement():
+    completed = subprocess.CompletedProcess(["codex", "--version"], 0, stdout="codex 1.2.3\n", stderr="")
+    with (
+        patch.object(settings, "codex_local_enabled", True),
+        patch.object(settings, "codex_local_command", "codex"),
+        patch("src.operators.local_codex.shutil.which", return_value="/usr/local/bin/codex"),
+        patch("src.operators.local_codex.subprocess.run", return_value=completed) as mock_run,
+    ):
+        status = local_codex_status()
+
+    assert status["ready"] is True
+    assert status["command_path"] == "/usr/local/bin/codex"
+    assert status["version"] == "codex 1.2.3"
+    assert status["requires_api_key"] is False
+    assert mock_run.call_args.args[0] == ["codex", "--version"]
+    assert "OPENAI_API_KEY" not in mock_run.call_args.kwargs["env"]
+
+
+@pytest.mark.asyncio
+async def test_run_local_codex_audits_without_prompt_or_raw_output(async_db):
+    secret_value = "secret-value"
+    completed = subprocess.CompletedProcess(
+        ["codex", "exec"],
+        7,
+        stdout="done",
+        stderr=f"token: {secret_value}",
+    )
+    with (
+        patch.object(settings, "openai_api_key", secret_value),
+        patch("src.operators.local_codex.shutil.which", return_value="/usr/local/bin/codex"),
+        patch(
+            "src.operators.local_codex.subprocess.run",
+            side_effect=[
+                subprocess.CompletedProcess(["codex", "--version"], 0, stdout="codex 1.2.3\n", stderr=""),
+                completed,
+            ],
+        ),
+    ):
+        result = await run_local_codex("private task prompt")
+
+    assert result["ok"] is False
+    assert result["exit_code"] == 7
+    assert result["stdout"] == "done"
+    assert result["stderr"] == "[redacted]"
+
+    events = await audit_repository.list_events(limit=5)
+    local_events = [event for event in events if event["tool_name"] == "codex-local"]
+    assert [event["event_type"] for event in reversed(local_events)] == [
+        "local_operator_started",
+        "local_operator_completed",
+    ]
+    serialized = str(local_events)
+    assert "private task prompt" not in serialized
+    assert "[redacted]" not in serialized
+    assert "prompt_sha256" in serialized
+    assert "prompt_chars" in serialized
+
+
+@pytest.mark.asyncio
+async def test_run_local_codex_subprocess_env_strips_provider_api_keys(monkeypatch, async_db):
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-secret")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+    monkeypatch.setenv("LLM_API_KEY", "llm-secret")
+    completed = subprocess.CompletedProcess(["codex", "exec"], 0, stdout="ok", stderr="")
+    with (
+        patch("src.operators.local_codex.shutil.which", return_value="/usr/local/bin/codex"),
+        patch(
+            "src.operators.local_codex.subprocess.run",
+            side_effect=[
+                subprocess.CompletedProcess(["codex", "--version"], 0, stdout="codex 1.2.3\n", stderr=""),
+                completed,
+            ],
+        ) as mock_run,
+    ):
+        result = await run_local_codex("inspect local state")
+
+    assert result["ok"] is True
+    exec_env = mock_run.call_args_list[1].kwargs["env"]
+    assert "OPENAI_API_KEY" not in exec_env
+    assert "OPENROUTER_API_KEY" not in exec_env
+    assert "ANTHROPIC_API_KEY" not in exec_env
+    assert "LLM_API_KEY" not in exec_env
+    assert exec_env["SERAPH_LOCAL_OPERATOR"] == "codex-local"
+
+
+def test_local_codex_output_redaction_covers_env_configured_and_pattern_secrets(monkeypatch):
+    monkeypatch.setenv("CUSTOM_TOKEN", "env-token-value")
+    with patch.object(settings, "openai_api_key", "configured-secret"):
+        output, truncated = _truncate_output(
+            "api_key=inline-secret bearer abc.def configured-secret env-token-value"
+        )
+
+    assert truncated is False
+    assert "inline-secret" not in output
+    assert "abc.def" not in output
+    assert "configured-secret" not in output
+    assert "env-token-value" not in output
+    assert output.count("[redacted]") >= 4
+
+
+@pytest.mark.asyncio
+async def test_runtime_status_exposes_local_operator_separately_from_provider_profiles(client):
+    with patch("src.operators.local_codex.shutil.which", return_value=None):
+        response = await client.get("/api/runtime/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "local_operators" in payload
+    assert any(item["id"] == "codex-local" for item in payload["local_operators"])
+    assert all(item["id"] != "codex-local" for item in payload["provider_profiles"])
+
+
+@pytest.mark.asyncio
+async def test_operator_local_codex_status_endpoint_reports_blocked(client):
+    with (
+        patch.object(settings, "codex_local_command", "missing-codex"),
+        patch("src.operators.local_codex.shutil.which", return_value=None),
+    ):
+        response = await client.get("/api/operator/local-codex/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["operator_kind"] == "local_command"
+    assert payload["ready"] is False
+    assert payload["unavailable_reason"] == "codex command was not found on PATH"
+
+
+@pytest.mark.asyncio
+async def test_operator_local_codex_exec_endpoint_fails_closed_when_binary_missing(client):
+    with (
+        patch.object(settings, "codex_local_command", "missing-codex"),
+        patch("src.operators.local_codex.shutil.which", return_value=None),
+        patch("src.operators.local_codex.audit_repository.log_event", AsyncMock()) as mock_audit,
+    ):
+        response = await client.post(
+            "/api/operator/local-codex/exec",
+            json={"prompt": "hello"},
+        )
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["detail"]["adapter"] == "codex-local"
+    assert payload["detail"]["status"] == "blocked"
+    assert mock_audit.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_operator_local_codex_exec_endpoint_does_not_accept_sandbox_or_approval_overrides(client):
+    with patch(
+        "src.api.operator.run_local_codex",
+        AsyncMock(return_value={"ok": True, "operator_id": "codex-local"}),
+    ) as mock_run:
+        response = await client.post(
+            "/api/operator/local-codex/exec",
+            json={
+                "prompt": "hello",
+                "sandbox": "danger-full-access",
+                "approval_policy": "on-request",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    _, kwargs = mock_run.call_args
+    assert kwargs == {
+        "cwd": None,
+        "model": None,
+        "timeout_seconds": None,
+        "session_id": None,
+    }

--- a/docs/implementation/03-runtime-reliability.md
+++ b/docs/implementation/03-runtime-reliability.md
@@ -31,8 +31,9 @@
 - [x] workflow endurance now also has a replayable canary proof: the named `live_workflow_endurance_canary` suite and `/api/operator/live-workflow-endurance-canary` surface pin a deterministic multi-session receipt for delegated ownership, checkpoint/branch lineage, failure injection, repair, artifact comparison, approval preservation, trust-boundary drift blocking, and audit trail without claiming a durable workflow state machine
 - [x] governed improvement now also has a dedicated benchmark surface: the named `governed_improvement` suite proves anti-misevolution blocking, preference-diversity guardrails, canary-only rollout posture, rollback-ready receipt policy, and operator-visible recent saved proposal receipts instead of leaving self-improvement safety at the raw proposal endpoint
 - [x] Seraph now also has a dedicated computer-use benchmark surface: the named `computer_use_browser_desktop` suite plus the operator computer-use benchmark surface prove replayable browser task receipts, desktop notification action replay, shared browser/native continuity, operator-visible failure taxonomy, and CI-gated execution proof instead of leaving computer-use claims at the catalog-summary level
-- [x] named provider/operator profiles are first-class runtime configuration: built-ins cover OpenRouter, generic OpenAI-compatible routing, Codex/OpenAI-oriented routing with LiteLLM-routable `openai/gpt-5.5` plus `reasoning_effort=low` as an option, Anthropic/Claude-oriented routing with a pinned Anthropic Sonnet model id, and local Ollama when configured; custom `LLM_PROVIDER_PROFILES` entries separate provider kind, model, API base, env secret, request options, capability/cost/latency/task/budget metadata, fallback policy, enabled state, and safety notes while leaving tool permissions in the existing tool policy layer
-- [x] provider/operator profile examples are documented in `README.md`, `backend/README.md`, `env.dev.example`, and `env.prod.example` for local Ollama, OpenRouter, OpenAI/Codex-oriented routes, Anthropic/Claude-oriented routes, and generic OpenAI-compatible endpoints; the documented contract is configurable routing, fallback, capability tagging, guardrails, and audit visibility rather than provider parity
+- [x] named provider/operator profiles are first-class runtime configuration: built-ins cover OpenRouter, generic OpenAI-compatible routing, remote OpenAI API routing with LiteLLM-routable `openai/gpt-5.5` plus `reasoning_effort=low` as an option, Anthropic/Claude-oriented routing with a pinned Anthropic Sonnet model id, and local Ollama when configured; custom `LLM_PROVIDER_PROFILES` entries separate provider kind, model, API base, env secret, request options, capability/cost/latency/task/budget metadata, fallback policy, enabled state, and safety notes while leaving tool permissions in the existing tool policy layer
+- [x] local Codex is now represented separately from LiteLLM provider profiles as the command-backed `codex-local` operator adapter: it invokes the installed `codex exec` command, exposes readiness under runtime/operator status, fails closed when unavailable, records audit receipts without raw prompts or terminal output, and does not require `OPENAI_API_KEY`
+- [x] provider/operator profile examples are documented in `README.md`, `backend/README.md`, `env.dev.example`, and `env.prod.example` for local Ollama, OpenRouter, remote OpenAI API routes, Anthropic/Claude-oriented routes, generic OpenAI-compatible endpoints, and the separate command-backed local Codex operator; the documented contract is configurable routing, fallback, capability tagging, guardrails, audit visibility, and local-operator readiness rather than provider parity
 
 ## Working On Now
 
@@ -165,7 +166,7 @@ New runtime work should be activated through GitHub issues and the GitHub Projec
 
 - pretending the runtime is done because the fallback baseline works
 - live-provider eval dependence for every reliability check
-- claiming Codex/OpenAI, Claude/Anthropic, OpenRouter, local Ollama, or generic OpenAI-compatible endpoints are behaviorally equivalent just because they can be configured behind the same routing controls
+- claiming remote OpenAI API profiles, local Codex, Claude/Anthropic, OpenRouter, local Ollama, or generic OpenAI-compatible endpoints are behaviorally equivalent just because they can be configured behind Seraph controls
 
 ## Acceptance Checklist
 
@@ -173,6 +174,6 @@ New runtime work should be activated through GitHub issues and the GitHub Projec
 - [x] runtime paths can force distinct primary and fallback routing without changing the global baseline
 - [x] dynamic runtime paths can inherit wildcard routing rules without losing exact-path control
 - [x] a local or non-OpenRouter path is demonstrably possible across helper, all current scheduled completion jobs, core agent, delegation, and connected MCP-specialist flows
-- [x] env examples describe local Ollama, OpenRouter, OpenAI/Codex-oriented, Anthropic/Claude-oriented, and generic OpenAI-compatible setup as provider/operator routing profiles with bounded claims
+- [x] env examples describe local Ollama, OpenRouter, remote OpenAI API, Anthropic/Claude-oriented, generic OpenAI-compatible setup, and local Codex command-backed operation with bounded claims
 - [x] key flows are observable and easy to debug
 - [ ] the project has broad repeatable eval coverage for core guardian behavior beyond the shipped REST, WebSocket, observer refresh, delivery policy, consolidation, proactive, tool-policy guardrail, threaded workflow recovery, capability repair/bootstrap, delegated workflow, and workflow-composition behavioral contracts

--- a/env.dev.example
+++ b/env.dev.example
@@ -27,9 +27,10 @@ SANDBOX_URL=http://sandbox-dev:8060
 # Built-in named profiles include:
 #   openrouter, openai-compatible, codex-openai, claude-anthropic,
 #   gpt-5.5-low, and local-ollama when LOCAL_MODEL is configured.
-# `codex-openai` and `gpt-5.5-low` both use LiteLLM model id
-# openai/gpt-5.5 with reasoning_effort=low as an option, not as a
-# model-id suffix.
+# `codex-openai` and `gpt-5.5-low` are remote OpenAI API profiles for
+# Seraph routing. They are distinct from any local Codex command/operator
+# process. Both use LiteLLM model id openai/gpt-5.5 with reasoning_effort=low
+# as an option, not as a model-id suffix.
 
 # Optional typed profile config. JSON can be either {"profiles": {...}} or a
 # top-level object keyed by profile id.
@@ -44,9 +45,18 @@ SANDBOX_URL=http://sandbox-dev:8060
 # RUNTIME_PROFILE_PREFERENCES=session_title_generation=local|default;mcp_*=local|default
 # RUNTIME_POLICY_INTENTS=session_title_generation=local_first|fast|cheap;mcp_*=local_first|tool_use
 
-# OpenAI/Codex-oriented operator routing.
+# Remote OpenAI API operator routing for Seraph.
 # OPENAI_API_KEY=your-openai-key
 # RUNTIME_PROFILE_PREFERENCES=chat_agent=codex-openai|openrouter;session_title_generation=openai-compatible|openrouter
+
+# Local Codex command-backed operator. This invokes `codex exec` on this
+# machine and does not use OPENAI_API_KEY.
+CODEX_LOCAL_ENABLED=true
+CODEX_LOCAL_COMMAND=codex
+CODEX_LOCAL_MODEL=gpt-5.5
+CODEX_LOCAL_SANDBOX=workspace-write
+CODEX_LOCAL_APPROVAL_POLICY=never
+CODEX_LOCAL_TIMEOUT_SECONDS=600
 
 # Anthropic/Claude-oriented routing.
 # ANTHROPIC_API_KEY=your-anthropic-key

--- a/env.prod.example
+++ b/env.prod.example
@@ -35,9 +35,20 @@ SANDBOX_URL=http://sandbox:8060
 # thinks; runtime/tool policies decide what the selected route may do.
 # LLM_PROVIDER_PROFILES={"profiles":{"team-router":{"provider_kind":"openai_compatible","model":"team/model","api_base":"https://llm.example.com/v1","env_secret":"TEAM_LLM_API_KEY","options":{"reasoning_effort":"low"},"capabilities":["reasoning","tool_use"],"cost":"medium","latency":"low","task":"coding","budget":"medium","fallback":["team/small"],"enabled":true,"safety_notes":"Team-scoped profile; tool permissions remain separate."}}}
 
-# Codex/OpenAI-oriented cloud routing uses OPENAI_API_KEY and low reasoning as
-# a request option on codex-openai, not a model-id suffix.
+# Remote OpenAI API operator routing uses OPENAI_API_KEY. `codex-openai` and
+# `gpt-5.5-low` are Seraph cloud routing profiles, not the local Codex
+# command/operator process. Low reasoning is a request option on codex-openai,
+# not a model-id suffix.
 # RUNTIME_PROFILE_PREFERENCES=chat_agent=codex-openai|openrouter;session_title_generation=openai-compatible|openrouter
+
+# Local Codex command-backed operator. This invokes `codex exec` on the host
+# and does not use OPENAI_API_KEY.
+CODEX_LOCAL_ENABLED=true
+CODEX_LOCAL_COMMAND=codex
+CODEX_LOCAL_MODEL=gpt-5.5
+CODEX_LOCAL_SANDBOX=workspace-write
+CODEX_LOCAL_APPROVAL_POLICY=never
+CODEX_LOCAL_TIMEOUT_SECONDS=600
 
 # Anthropic/Claude-oriented cloud routing uses ANTHROPIC_API_KEY.
 # RUNTIME_PROFILE_PREFERENCES=chat_agent=claude-anthropic|openrouter
@@ -54,8 +65,8 @@ RUNTIME_TASK_CLASS=chat_agent=interactive;mcp_*=operator_tooling
 RUNTIME_MAX_BUDGET_CLASS=session_title_generation=low;mcp_*=medium
 
 # Provider tags are routing metadata for policy, fallback, and audit surfaces.
-# They do not assert equivalent behavior across OpenAI/Codex, Claude, local Ollama,
-# OpenRouter, or generic OpenAI-compatible providers.
+# They do not assert equivalent behavior across remote OpenAI API profiles,
+# Claude, local Ollama, OpenRouter, or generic OpenAI-compatible providers.
 PROVIDER_CAPABILITY_OVERRIDES=openrouter/anthropic/claude-sonnet-4=reasoning|tool_use;openai/gpt-4.1-mini=reasoning|tool_use;openai/gpt-4.1-nano=fast|cheap;ollama/*=local|fast|cheap
 PROVIDER_COST_TIERS=openrouter/anthropic/claude-sonnet-4=high;openai/gpt-4.1-mini=medium;openai/gpt-4.1-nano=low;ollama/*=low
 PROVIDER_LATENCY_TIERS=openrouter/anthropic/claude-sonnet-4=medium;openai/gpt-4.1-mini=medium;openai/gpt-4.1-nano=low;ollama/*=low


### PR DESCRIPTION
## Summary
- add a command-backed local Codex operator adapter that invokes the installed local codex exec process instead of treating Codex as an OpenAI API profile
- expose codex-local readiness separately from LiteLLM provider profiles in runtime/operator status
- add fail-closed sandbox, approval, workspace, command, credential, audit, activity-ledger, and endpoint tests
- update docs/env examples to distinguish remote OpenAI API profiles from the local Codex command operator

Closes #615

## Team / Review
- Explorer: mapped the existing LiteLLM provider-profile path and confirmed local Codex needed a separate operator surface
- Backend worker: implemented the local adapter, API endpoints, runtime visibility, and audit/activity surfaces
- Docs worker: corrected README, backend README, env examples, and runtime implementation truth
- Critic/Contrarian: found one P1 where request payloads could override sandbox/approval policy; fixed by removing HTTP-level sandbox/approval fields, rejecting danger-full-access, and adding regression tests

## Validation
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_local_codex_operator.py tests/test_app.py tests/test_activity_api.py::test_activity_classifier_keeps_local_operator_events_visible tests/test_activity_api.py::test_activity_ledger_surfaces_local_operator_events tests/test_llm_runtime.py -q -> 105 passed
- python -m py_compile backend/src/operators/local_codex.py backend/src/api/operator.py backend/src/api/activity.py
- git diff --check