### PR TITLE
feat(observer): add local screen EOD reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,9 @@ The lead should incorporate the critique, explicitly reject it with rationale, o
 ## Review Rule
 
 - Every PR-sized slice must be reviewed before merge. Non-trivial PR-sized slices require an independent subagent review.
+- Every pushed update to an open PR that changes behavior, security/privacy posture, runtime wiring, settings, docs truth, tests, or workflow contract must receive a fresh independent Critic/Contrarian pass before the lead claims the PR is reviewed, updates the PR as review-passed, or asks to merge.
+- Small follow-up commits are not exempt when they affect the same PR's acceptance criteria or operator-visible behavior. Treat them as part of the PR-sized slice and re-run the critic on the cumulative diff or the changed follow-up scope.
+- A lead's own named "critic pass" is not a substitute when subagent tooling is available. Use an independent subagent critic; only fall back to a separate self-run critic pass when subagent tooling is unavailable, and state that limitation in the PR/final response.
 - Verify subagent claims before acting on them.
 - Record material review findings, or an explicit no-findings result, in the PR body and in affected implementation docs when the slice changes shipped truth or workflow contract.
 - Do not merge a PR until material review findings are either fixed, explicitly rejected with rationale, or turned into tracked follow-up work.

--- a/backend/README.md
+++ b/backend/README.md
@@ -92,6 +92,19 @@ Receive (streamed):
 | `CODEX_LOCAL_SANDBOX` | `workspace-write` | Sandbox option passed to local `codex exec` |
 | `CODEX_LOCAL_APPROVAL_POLICY` | `never` | Approval policy option passed to local `codex exec` |
 | `CODEX_LOCAL_TIMEOUT_SECONDS` | `600` | Timeout for local Codex operator invocations |
+| `END_OF_DAY_REPORT_ENABLED` | `true` | Enables the stored end-of-day goal report scheduler job |
+| `END_OF_DAY_REPORT_HOUR` | `21` | Local hour for the end-of-day goal report |
+| `END_OF_DAY_REPORT_LLM_ENABLED` | `false` | Enables LLM drafting for the report; default deterministic mode avoids sending screen-derived summaries to a provider |
+| `EMAIL_REPORTS_ENABLED` | `false` | Enables SMTP delivery for reports after local storage |
+| `EMAIL_REPORTS_PREVIEW_REQUIRED` | `true` | Blocks outbound report email until operator preview is deliberately disabled |
+| `EMAIL_REPORTS_TO` | - | Recipient for report email |
+| `EMAIL_REPORTS_TO_ALLOWLIST` | - | Comma-separated recipient allowlist; recipient must be present before sending |
+| `EMAIL_REPORTS_FROM` | - | Sender address for report email |
+| `SMTP_HOST` | - | SMTP host for report delivery |
+| `SMTP_PORT` | `587` | SMTP port for report delivery |
+| `SMTP_USERNAME` | - | SMTP username |
+| `SMTP_PASSWORD` | - | SMTP password |
+| `SMTP_USE_TLS` | `true` | Use STARTTLS before SMTP login/send |
 | `LOCAL_RUNTIME_PATHS` | - | Comma-separated runtime paths or glob patterns that should prefer the local profile |
 | `RUNTIME_PROFILE_PREFERENCES` | - | Semicolon-separated `runtime_path=profile_a|profile_b` chains; `runtime_path` may be an exact path or glob |
 | `RUNTIME_POLICY_INTENTS` | - | Semicolon-separated `runtime_path=intent_a|intent_b` entries for capability-aware routing; `runtime_path` may be an exact path or glob |

--- a/backend/README.md
+++ b/backend/README.md
@@ -92,6 +92,7 @@ Receive (streamed):
 | `CODEX_LOCAL_SANDBOX` | `workspace-write` | Sandbox option passed to local `codex exec` |
 | `CODEX_LOCAL_APPROVAL_POLICY` | `never` | Approval policy option passed to local `codex exec` |
 | `CODEX_LOCAL_TIMEOUT_SECONDS` | `600` | Timeout for local Codex operator invocations |
+| `SCREEN_CAPTURE_ARCHIVE_DIR` | `/tmp/seraph-screen-captures` | Local archive root for preserved screen capture images, redacted Codex output, and normalized JSON served by observer artifact endpoints |
 | `END_OF_DAY_REPORT_ENABLED` | `true` | Enables the stored end-of-day goal report scheduler job |
 | `END_OF_DAY_REPORT_HOUR` | `21` | Local hour for the end-of-day goal report |
 | `END_OF_DAY_REPORT_LLM_ENABLED` | `false` | Enables LLM drafting for the report; default deterministic mode avoids sending screen-derived summaries to a provider |

--- a/backend/README.md
+++ b/backend/README.md
@@ -92,7 +92,8 @@ Receive (streamed):
 | `CODEX_LOCAL_SANDBOX` | `workspace-write` | Sandbox option passed to local `codex exec` |
 | `CODEX_LOCAL_APPROVAL_POLICY` | `never` | Approval policy option passed to local `codex exec` |
 | `CODEX_LOCAL_TIMEOUT_SECONDS` | `600` | Timeout for local Codex operator invocations |
-| `SCREEN_CAPTURE_ARCHIVE_DIR` | `/tmp/seraph-screen-captures` | Local archive root for preserved screen capture images, redacted Codex output, and normalized JSON served by observer artifact endpoints |
+| `SCREEN_CAPTURE_ARCHIVE_DIR` | `~/Library/Application Support/Seraph/artifacts/screen-captures` | Durable local archive root for preserved screen capture images, redacted provider output, and normalized JSON served by localhost-only observer artifact endpoints |
+| `REPORT_ARCHIVE_DIR` | `$WORKSPACE_DIR/artifacts/reports` | Durable local archive root for stored report text/JSON artifacts used by future analysis |
 | `END_OF_DAY_REPORT_ENABLED` | `true` | Enables the stored end-of-day goal report scheduler job |
 | `END_OF_DAY_REPORT_HOUR` | `21` | Local hour for the end-of-day goal report |
 | `END_OF_DAY_REPORT_LLM_ENABLED` | `false` | Enables LLM drafting for the report; default deterministic mode avoids sending screen-derived summaries to a provider |

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -42,6 +42,7 @@ class Settings(BaseSettings):
     codex_local_enabled: bool = True
     codex_local_command: str = "codex"
     codex_local_model: str = "gpt-5.5"
+    codex_local_reasoning_effort: str = "low"
     codex_local_sandbox: str = "workspace-write"
     codex_local_approval_policy: str = "never"
     codex_local_timeout_seconds: int = 600
@@ -100,6 +101,20 @@ class Settings(BaseSettings):
     activity_digest_hour: int = 20                    # 8 PM daily digest
     weekly_review_hour: int = 18                      # 6 PM Sunday weekly review
     screen_observation_retention_days: int = 90        # keep 90 days of observations
+    end_of_day_report_enabled: bool = True
+    end_of_day_report_hour: int = 21
+    end_of_day_report_llm_enabled: bool = False
+    email_reports_enabled: bool = False
+    email_reports_preview_required: bool = True
+    email_reports_to: str = ""
+    email_reports_to_allowlist: str = ""
+    email_reports_from: str = ""
+    email_reports_reply_to: str = ""
+    smtp_host: str = ""
+    smtp_port: int = 587
+    smtp_username: str = ""
+    smtp_password: str = ""
+    smtp_use_tls: bool = True
 
     # Vault
     vault_encryption_key: str = ""  # Fernet key; auto-generates key file when empty

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -101,7 +101,8 @@ class Settings(BaseSettings):
     activity_digest_hour: int = 20                    # 8 PM daily digest
     weekly_review_hour: int = 18                      # 6 PM Sunday weekly review
     screen_observation_retention_days: int = 90        # keep 90 days of observations
-    screen_capture_archive_dir: str = "/tmp/seraph-screen-captures"
+    screen_capture_archive_dir: str = ""
+    report_archive_dir: str = ""
     end_of_day_report_enabled: bool = True
     end_of_day_report_hour: int = 21
     end_of_day_report_llm_enabled: bool = False

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -101,6 +101,7 @@ class Settings(BaseSettings):
     activity_digest_hour: int = 20                    # 8 PM daily digest
     weekly_review_hour: int = 18                      # 6 PM Sunday weekly review
     screen_observation_retention_days: int = 90        # keep 90 days of observations
+    screen_capture_archive_dir: str = "/tmp/seraph-screen-captures"
     end_of_day_report_enabled: bool = True
     end_of_day_report_hour: int = 21
     end_of_day_report_llm_enabled: bool = False

--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -1,14 +1,21 @@
 """Observer API — context state and daemon integration endpoints."""
 
+import json
 import logging
 from datetime import date, datetime, timezone
+from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import FileResponse, PlainTextResponse
 from pydantic import BaseModel
+from sqlmodel import col, select
 
+from config.settings import settings
 from src.audit.runtime import log_integration_event
 from src.agent.session import session_manager
+from src.db.engine import get_session
+from src.db.models import ScreenObservation
 from src.observer.manager import context_manager
 from src.observer.native_notification_queue import native_notification_queue
 
@@ -30,6 +37,7 @@ class ScreenObservationData(BaseModel):
     project: str | None = None
     summary: str | None = None
     details: list[str] | None = None
+    capture_artifacts: dict[str, Any] | None = None
     blocked: bool = False
 
 
@@ -348,13 +356,20 @@ async def post_screen_context(body: ScreenContextRequest):
                 else None
             )
 
+            details = list(obs_data.details or [])
+            if obs_data.capture_artifacts:
+                details.append(
+                    "capture_artifacts:"
+                    + json.dumps(obs_data.capture_artifacts, sort_keys=True, separators=(",", ":"))
+                )
+
             await screen_observation_repo.create(
                 app_name=obs_data.app or "",
                 window_title=obs_data.window_title or "",
                 activity_type=obs_data.activity or "other",
                 project=obs_data.project,
                 summary=obs_data.summary,
-                details=obs_data.details,
+                details=details or None,
                 blocked=obs_data.blocked,
                 timestamp=timestamp,
             )
@@ -384,6 +399,139 @@ async def post_screen_context(body: ScreenContextRequest):
             logger.exception("Failed to persist screen observation")
 
     return {"status": "ok"}
+
+
+def _screen_artifact_root() -> Path:
+    return Path(settings.screen_capture_archive_dir).expanduser().resolve()
+
+
+def _require_local_artifact_request(request: Request) -> None:
+    client_host = request.client.host if request.client is not None else ""
+    if client_host not in {"127.0.0.1", "::1", "localhost", "testclient"}:
+        raise HTTPException(status_code=403, detail="Screen artifacts are only available from localhost")
+
+
+def _screen_artifact_path(raw_path: str | None) -> Path:
+    if not raw_path:
+        raise HTTPException(status_code=404, detail="Screen artifact is missing")
+    root = _screen_artifact_root()
+    path = Path(raw_path).expanduser().resolve()
+    if not path.is_relative_to(root):
+        raise HTTPException(status_code=403, detail="Screen artifact is outside the configured archive")
+    if not path.exists() or not path.is_file():
+        raise HTTPException(status_code=404, detail="Screen artifact file not found")
+    return path
+
+
+def _screen_capture_artifacts(observation: ScreenObservation) -> dict[str, Any] | None:
+    if not observation.details_json:
+        return None
+    try:
+        details = json.loads(observation.details_json)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(details, list):
+        return None
+    for item in details:
+        if isinstance(item, str) and item.startswith("capture_artifacts:"):
+            try:
+                payload = json.loads(item.removeprefix("capture_artifacts:"))
+            except json.JSONDecodeError:
+                return None
+            return payload if isinstance(payload, dict) else None
+    return None
+
+
+def _screen_artifact_response(observation: ScreenObservation) -> dict[str, Any] | None:
+    artifacts = _screen_capture_artifacts(observation)
+    if artifacts is None:
+        return None
+    return {
+        "observation_id": observation.id,
+        "timestamp": observation.timestamp.isoformat(),
+        "app": observation.app_name,
+        "window_title": observation.window_title,
+        "activity": observation.activity_type,
+        "project": observation.project,
+        "summary": observation.summary,
+        "artifacts": {
+            "id": artifacts.get("id"),
+            "created_at": artifacts.get("created_at"),
+            "image_url": f"/api/observer/screen-artifacts/{observation.id}/image",
+            "codex_output_url": f"/api/observer/screen-artifacts/{observation.id}/codex-output",
+            "analysis_url": f"/api/observer/screen-artifacts/{observation.id}/analysis",
+        },
+    }
+
+
+async def _screen_artifact_observation(observation_id: str) -> ScreenObservation:
+    async with get_session() as db:
+        result = await db.execute(
+            select(ScreenObservation).where(col(ScreenObservation.id) == observation_id)
+        )
+        observation = result.scalar_one_or_none()
+    if observation is None or _screen_capture_artifacts(observation) is None:
+        raise HTTPException(status_code=404, detail="Screen artifact not found")
+    return observation
+
+
+@router.get("/observer/screen-artifacts")
+async def list_screen_artifacts(request: Request, limit: int = 20) -> dict[str, Any]:
+    """List recent preserved screen captures with links to image and Codex output."""
+    _require_local_artifact_request(request)
+    capped_limit = min(max(limit, 1), 100)
+    async with get_session() as db:
+        result = await db.execute(
+            select(ScreenObservation)
+            .where(col(ScreenObservation.details_json).contains("capture_artifacts:"))
+            .order_by(col(ScreenObservation.timestamp).desc())
+            .limit(capped_limit)
+        )
+        observations = list(result.scalars().all())
+
+    items = [
+        payload
+        for observation in observations
+        if (payload := _screen_artifact_response(observation)) is not None
+    ]
+    return {
+        "archive_dir": str(_screen_artifact_root()),
+        "items": items,
+    }
+
+
+@router.get("/observer/screen-artifacts/{observation_id}/image")
+async def get_screen_artifact_image(observation_id: str, request: Request) -> FileResponse:
+    """Return a preserved screenshot image for local operator inspection."""
+    _require_local_artifact_request(request)
+    observation = await _screen_artifact_observation(observation_id)
+    artifacts = _screen_capture_artifacts(observation) or {}
+    path = _screen_artifact_path(str(artifacts.get("image_path") or ""))
+    return FileResponse(path, media_type="image/png")
+
+
+@router.get("/observer/screen-artifacts/{observation_id}/codex-output")
+async def get_screen_artifact_codex_output(observation_id: str, request: Request) -> PlainTextResponse:
+    """Return the redacted local Codex text output for a preserved screenshot."""
+    _require_local_artifact_request(request)
+    observation = await _screen_artifact_observation(observation_id)
+    artifacts = _screen_capture_artifacts(observation) or {}
+    path = _screen_artifact_path(str(artifacts.get("codex_output_path") or ""))
+    return PlainTextResponse(path.read_text(encoding="utf-8"))
+
+
+@router.get("/observer/screen-artifacts/{observation_id}/analysis")
+async def get_screen_artifact_analysis(observation_id: str, request: Request) -> dict[str, Any]:
+    """Return the normalized JSON analysis saved beside the preserved screenshot."""
+    _require_local_artifact_request(request)
+    observation = await _screen_artifact_observation(observation_id)
+    artifacts = _screen_capture_artifacts(observation) or {}
+    path = _screen_artifact_path(str(artifacts.get("analysis_path") or ""))
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=500, detail="Saved analysis artifact is invalid") from exc
+    return payload if isinstance(payload, dict) else {"value": payload}
 
 
 @router.get("/observer/daemon-status", response_model=DaemonStatusResponse)

--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -402,7 +402,10 @@ async def post_screen_context(body: ScreenContextRequest):
 
 
 def _screen_artifact_root() -> Path:
-    return Path(settings.screen_capture_archive_dir).expanduser().resolve()
+    configured = settings.screen_capture_archive_dir.strip()
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return Path("~/Library/Application Support/Seraph/artifacts/screen-captures").expanduser().resolve()
 
 
 def _require_local_artifact_request(request: Request) -> None:
@@ -457,8 +460,10 @@ def _screen_artifact_response(observation: ScreenObservation) -> dict[str, Any] 
         "artifacts": {
             "id": artifacts.get("id"),
             "created_at": artifacts.get("created_at"),
+            "provider": artifacts.get("provider"),
             "image_url": f"/api/observer/screen-artifacts/{observation.id}/image",
             "codex_output_url": f"/api/observer/screen-artifacts/{observation.id}/codex-output",
+            "provider_output_url": f"/api/observer/screen-artifacts/{observation.id}/codex-output",
             "analysis_url": f"/api/observer/screen-artifacts/{observation.id}/analysis",
         },
     }
@@ -516,7 +521,7 @@ async def get_screen_artifact_codex_output(observation_id: str, request: Request
     _require_local_artifact_request(request)
     observation = await _screen_artifact_observation(observation_id)
     artifacts = _screen_capture_artifacts(observation) or {}
-    path = _screen_artifact_path(str(artifacts.get("codex_output_path") or ""))
+    path = _screen_artifact_path(str(artifacts.get("codex_output_path") or artifacts.get("provider_output_path") or ""))
     return PlainTextResponse(path.read_text(encoding="utf-8"))
 
 

--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -89,10 +89,17 @@ class NotificationDismissAllResponse(BaseModel):
 
 class DaemonStatusResponse(BaseModel):
     connected: bool
+    daemon_alive: bool = False
     last_post: float | None
     active_window: str | None
     has_screen_context: bool
     capture_mode: str
+    daemon_state: str | None = None
+    daemon_status_updated_at: str | None = None
+    screen_analysis: str | None = None
+    capture_ready: bool = False
+    last_error: str | None = None
+    last_error_kind: str | None = None
     pending_notification_count: int
     last_native_notification_at: str | None = None
     last_native_notification_title: str | None = None
@@ -403,6 +410,16 @@ async def post_screen_context(body: ScreenContextRequest):
 
 
 def _screen_artifact_root() -> Path:
+    screen_analysis_path = Path(settings.workspace_dir).expanduser().resolve() / "screen-analysis-settings.json"
+    if screen_analysis_path.exists():
+        try:
+            payload = json.loads(screen_analysis_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            payload = {}
+        if isinstance(payload, dict):
+            configured = str(payload.get("archive_dir") or "").strip()
+            if configured:
+                return Path(configured).expanduser().resolve()
     seraph_configured = os.environ.get("SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR", "").strip()
     if seraph_configured:
         return Path(seraph_configured).expanduser().resolve()
@@ -568,14 +585,22 @@ def _continuity_surface(
 
 async def _daemon_status_payload() -> dict[str, str | int | float | bool | None]:
     ctx = context_manager.get_context()
+    daemon_status = _read_daemon_status_file()
     connected = context_manager.is_daemon_connected()
     pending_notification_count = await native_notification_queue.count()
     return {
         "connected": connected,
+        "daemon_alive": bool(daemon_status.get("alive")),
         "last_post": ctx.last_daemon_post,
         "active_window": ctx.active_window,
         "has_screen_context": bool(ctx.screen_context),
         "capture_mode": ctx.capture_mode,
+        "daemon_state": daemon_status.get("state"),
+        "daemon_status_updated_at": daemon_status.get("updated_at"),
+        "screen_analysis": daemon_status.get("screen_analysis"),
+        "capture_ready": daemon_status.get("capture_ready"),
+        "last_error": daemon_status.get("last_error"),
+        "last_error_kind": daemon_status.get("last_error_kind"),
         "pending_notification_count": pending_notification_count,
         "last_native_notification_at": (
             ctx.last_native_notification_at.isoformat()
@@ -585,6 +610,47 @@ async def _daemon_status_payload() -> dict[str, str | int | float | bool | None]
         "last_native_notification_title": ctx.last_native_notification_title,
         "last_native_notification_outcome": ctx.last_native_notification_outcome,
     }
+
+
+def _daemon_status_file_path() -> Path:
+    configured = os.environ.get("SERAPH_DAEMON_STATUS_FILE", "").strip()
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return Path(settings.workspace_dir).expanduser().resolve() / "daemon-status.json"
+
+
+def _read_daemon_status_file(max_age_seconds: float = 45) -> dict[str, object]:
+    path = _daemon_status_file_path()
+    status: dict[str, object] = {
+        "state": "unknown",
+        "screen_analysis": "unknown",
+        "capture_ready": False,
+        "alive": False,
+        "last_error": None,
+        "last_error_kind": None,
+        "updated_at": None,
+    }
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return status
+    if not isinstance(payload, dict):
+        return status
+    for key in ("state", "screen_analysis", "last_error", "last_error_kind", "updated_at"):
+        value = payload.get(key)
+        if value is None or isinstance(value, str):
+            status[key] = value
+    status["capture_ready"] = bool(payload.get("capture_ready", False))
+    updated_at = status["updated_at"]
+    if isinstance(updated_at, str) and status["state"] == "running":
+        try:
+            parsed = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            status["alive"] = (datetime.now(timezone.utc) - parsed).total_seconds() < max_age_seconds
+        except ValueError:
+            status["alive"] = False
+    return status
 
 
 def _thread_label(thread_id: str | None, session_titles: dict[str, str]) -> str | None:

--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -402,9 +403,12 @@ async def post_screen_context(body: ScreenContextRequest):
 
 
 def _screen_artifact_root() -> Path:
-    configured = settings.screen_capture_archive_dir.strip()
-    if configured:
-        return Path(configured).expanduser().resolve()
+    seraph_configured = os.environ.get("SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR", "").strip()
+    if seraph_configured:
+        return Path(seraph_configured).expanduser().resolve()
+    settings_configured = settings.screen_capture_archive_dir.strip()
+    if settings_configured:
+        return Path(settings_configured).expanduser().resolve()
     return Path("~/Library/Application Support/Seraph/artifacts/screen-captures").expanduser().resolve()
 
 

--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -54,21 +54,34 @@ def _env_enabled(name: str, default: bool = False) -> bool:
     return raw.strip().lower() in _TRUE_VALUES
 
 
-def _screen_archive_dir() -> tuple[str, str]:
+def _screen_archive_dir() -> tuple[Path, str]:
     configured = settings.screen_capture_archive_dir.strip()
     if configured:
-        return str(Path(configured).expanduser().resolve()), "SCREEN_CAPTURE_ARCHIVE_DIR"
+        return Path(configured).expanduser().resolve(), "SCREEN_CAPTURE_ARCHIVE_DIR"
     return (
-        str(Path("~/Library/Application Support/Seraph/artifacts/screen-captures").expanduser().resolve()),
+        Path("~/Library/Application Support/Seraph/artifacts/screen-captures").expanduser().resolve(),
         "default",
     )
 
 
-def _report_archive_dir() -> tuple[str, str]:
+def _report_archive_dir() -> tuple[Path, str]:
     configured = settings.report_archive_dir.strip()
     if configured:
-        return str(Path(configured).expanduser().resolve()), "REPORT_ARCHIVE_DIR"
-    return str(Path(settings.workspace_dir).expanduser().resolve() / "artifacts" / "reports"), "default"
+        return Path(configured).expanduser().resolve(), "REPORT_ARCHIVE_DIR"
+    return Path(settings.workspace_dir).expanduser().resolve() / "artifacts" / "reports", "default"
+
+
+def _archive_dir_status(path: Path) -> dict[str, object]:
+    creation_error = None
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        creation_error = str(exc)
+    return {
+        "exists": path.exists(),
+        "writable": path.is_dir() and os.access(path, os.W_OK),
+        "creation_error": creation_error,
+    }
 
 
 @router.get("/settings/interruption-mode")
@@ -153,11 +166,14 @@ async def get_artifact_storage_settings():
     """Return operator-visible evidence/report archive configuration."""
     screen_archive_dir, screen_archive_source = _screen_archive_dir()
     report_archive_dir, report_archive_source = _report_archive_dir()
+    screen_dir_status = _archive_dir_status(screen_archive_dir)
+    report_dir_status = _archive_dir_status(report_archive_dir)
     return {
         "screen": {
             "preservation_enabled": _env_enabled("SERAPH_PRESERVE_SCREEN_CAPTURES", False),
-            "archive_dir": screen_archive_dir,
+            "archive_dir": str(screen_archive_dir),
             "archive_dir_source": screen_archive_source,
+            **screen_dir_status,
             "stored_artifacts": ["image", "provider_output", "analysis_json"],
             "inspection_endpoint": "/api/observer/screen-artifacts",
             "inspection_visibility": "localhost_only",
@@ -170,8 +186,9 @@ async def get_artifact_storage_settings():
             "enabled": settings.end_of_day_report_enabled,
             "hour": settings.end_of_day_report_hour,
             "analysis_provider": "llm" if settings.end_of_day_report_llm_enabled else "deterministic-local",
-            "archive_dir": report_archive_dir,
+            "archive_dir": str(report_archive_dir),
             "archive_dir_source": report_archive_source,
+            **report_dir_status,
             "stored_artifacts": ["report_text", "report_json"],
             "control_env": {
                 "archive_dir": "REPORT_ARCHIVE_DIR",

--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -114,7 +114,19 @@ def _read_daemon_status(max_age_seconds: float = 45) -> dict[str, object]:
         return status
     if not isinstance(payload, dict):
         return status
-    for key in ("state", "screen_analysis", "last_error", "last_error_kind", "updated_at"):
+    for key in (
+        "state",
+        "screen_analysis",
+        "last_error",
+        "last_error_kind",
+        "updated_at",
+        "active_window",
+        "frontmost_app",
+        "window_title",
+        "last_poll_at",
+        "last_capture_at",
+        "last_context_post_at",
+    ):
         value = payload.get(key)
         if value is None or isinstance(value, str):
             status[key] = value

--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -1,12 +1,15 @@
 """Settings API — runtime mode management."""
 
 import logging
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from sqlmodel import select
 
+from config.settings import settings
 from src.db.engine import get_session as get_db
 from src.db.models import UserProfile
 from src.observer.manager import context_manager
@@ -41,6 +44,31 @@ _VALID_CAPTURE_MODES = {"on_switch", "balanced", "detailed"}
 _VALID_TOOL_POLICY_MODES = set(TOOL_POLICY_MODES)
 _VALID_MCP_POLICY_MODES = set(MCP_POLICY_MODES)
 _VALID_APPROVAL_MODES = {"off", "high_risk"}
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def _env_enabled(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in _TRUE_VALUES
+
+
+def _screen_archive_dir() -> tuple[str, str]:
+    configured = settings.screen_capture_archive_dir.strip()
+    if configured:
+        return str(Path(configured).expanduser().resolve()), "SCREEN_CAPTURE_ARCHIVE_DIR"
+    return (
+        str(Path("~/Library/Application Support/Seraph/artifacts/screen-captures").expanduser().resolve()),
+        "default",
+    )
+
+
+def _report_archive_dir() -> tuple[str, str]:
+    configured = settings.report_archive_dir.strip()
+    if configured:
+        return str(Path(configured).expanduser().resolve()), "REPORT_ARCHIVE_DIR"
+    return str(Path(settings.workspace_dir).expanduser().resolve() / "artifacts" / "reports"), "default"
 
 
 @router.get("/settings/interruption-mode")
@@ -118,6 +146,54 @@ async def set_capture_mode(body: CaptureModeRequest):
             db.add(profile)
 
     return {"mode": body.mode}
+
+
+@router.get("/settings/artifact-storage")
+async def get_artifact_storage_settings():
+    """Return operator-visible evidence/report archive configuration."""
+    screen_archive_dir, screen_archive_source = _screen_archive_dir()
+    report_archive_dir, report_archive_source = _report_archive_dir()
+    return {
+        "screen": {
+            "preservation_enabled": _env_enabled("SERAPH_PRESERVE_SCREEN_CAPTURES", False),
+            "archive_dir": screen_archive_dir,
+            "archive_dir_source": screen_archive_source,
+            "stored_artifacts": ["image", "provider_output", "analysis_json"],
+            "inspection_endpoint": "/api/observer/screen-artifacts",
+            "inspection_visibility": "localhost_only",
+            "control_env": {
+                "enabled": "SERAPH_PRESERVE_SCREEN_CAPTURES",
+                "archive_dir": "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR or SCREEN_CAPTURE_ARCHIVE_DIR",
+            },
+        },
+        "reports": {
+            "enabled": settings.end_of_day_report_enabled,
+            "hour": settings.end_of_day_report_hour,
+            "analysis_provider": "llm" if settings.end_of_day_report_llm_enabled else "deterministic-local",
+            "archive_dir": report_archive_dir,
+            "archive_dir_source": report_archive_source,
+            "stored_artifacts": ["report_text", "report_json"],
+            "control_env": {
+                "archive_dir": "REPORT_ARCHIVE_DIR",
+                "enabled": "END_OF_DAY_REPORT_ENABLED",
+                "llm": "END_OF_DAY_REPORT_LLM_ENABLED",
+            },
+        },
+        "email": {
+            "enabled": settings.email_reports_enabled,
+            "preview_required": settings.email_reports_preview_required,
+            "smtp_configured": bool(settings.smtp_host.strip()),
+            "recipient_configured": bool(settings.email_reports_to.strip()),
+            "allowlist_configured": bool(settings.email_reports_to_allowlist.strip()),
+            "control_env": {
+                "enabled": "EMAIL_REPORTS_ENABLED",
+                "preview_required": "EMAIL_REPORTS_PREVIEW_REQUIRED",
+                "smtp_host": "SMTP_HOST",
+                "recipient": "EMAIL_REPORTS_TO",
+                "allowlist": "EMAIL_REPORTS_TO_ALLOWLIST",
+            },
+        },
+    }
 
 
 @router.get("/settings/tool-policy-mode")

--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -55,9 +55,12 @@ def _env_enabled(name: str, default: bool = False) -> bool:
 
 
 def _screen_archive_dir() -> tuple[Path, str]:
-    configured = settings.screen_capture_archive_dir.strip()
-    if configured:
-        return Path(configured).expanduser().resolve(), "SCREEN_CAPTURE_ARCHIVE_DIR"
+    seraph_configured = os.environ.get("SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR", "").strip()
+    if seraph_configured:
+        return Path(seraph_configured).expanduser().resolve(), "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR"
+    settings_configured = settings.screen_capture_archive_dir.strip()
+    if settings_configured:
+        return Path(settings_configured).expanduser().resolve(), "SCREEN_CAPTURE_ARCHIVE_DIR"
     return (
         Path("~/Library/Application Support/Seraph/artifacts/screen-captures").expanduser().resolve(),
         "default",

--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -1,7 +1,9 @@
 """Settings API — runtime mode management."""
 
+import json
 import logging
 import os
+import stat
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -28,6 +30,14 @@ class CaptureModeRequest(BaseModel):
     mode: str
 
 
+class ScreenAnalysisSettingsRequest(BaseModel):
+    enabled: bool | None = None
+    provider: str | None = None
+    model: str | None = None
+    preserve_captures: bool | None = None
+    archive_dir: str | None = None
+
+
 class ToolPolicyModeRequest(BaseModel):
     mode: str
 
@@ -41,6 +51,7 @@ class McpPolicyModeRequest(BaseModel):
 
 
 _VALID_CAPTURE_MODES = {"on_switch", "balanced", "detailed"}
+_VALID_SCREEN_ANALYSIS_PROVIDERS = {"apple-vision", "codex-local", "openrouter"}
 _VALID_TOOL_POLICY_MODES = set(TOOL_POLICY_MODES)
 _VALID_MCP_POLICY_MODES = set(MCP_POLICY_MODES)
 _VALID_APPROVAL_MODES = {"off", "high_risk"}
@@ -74,6 +85,121 @@ def _report_archive_dir() -> tuple[Path, str]:
     return Path(settings.workspace_dir).expanduser().resolve() / "artifacts" / "reports", "default"
 
 
+def _screen_analysis_settings_path() -> Path:
+    return Path(settings.workspace_dir).expanduser().resolve() / "screen-analysis-settings.json"
+
+
+def _daemon_status_file_path() -> Path:
+    configured = os.environ.get("SERAPH_DAEMON_STATUS_FILE", "").strip()
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return Path(settings.workspace_dir).expanduser().resolve() / "daemon-status.json"
+
+
+def _read_daemon_status(max_age_seconds: float = 45) -> dict[str, object]:
+    path = _daemon_status_file_path()
+    status: dict[str, object] = {
+        "state": "unknown",
+        "screen_analysis": "unknown",
+        "capture_ready": False,
+        "connected": False,
+        "last_error": None,
+        "last_error_kind": None,
+        "updated_at": None,
+        "status_source": "daemon-status-file",
+    }
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return status
+    if not isinstance(payload, dict):
+        return status
+    for key in ("state", "screen_analysis", "last_error", "last_error_kind", "updated_at"):
+        value = payload.get(key)
+        if value is None or isinstance(value, str):
+            status[key] = value
+    status["capture_ready"] = bool(payload.get("capture_ready", False))
+    updated_at = status["updated_at"]
+    if isinstance(updated_at, str) and status["state"] == "running":
+        try:
+            parsed = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            status["connected"] = (datetime.now(timezone.utc) - parsed).total_seconds() < max_age_seconds
+        except ValueError:
+            status["connected"] = False
+    return status
+
+
+def _default_screen_analysis_settings() -> dict[str, object]:
+    screen_archive_dir, _ = _screen_archive_dir()
+    provider = os.environ.get("SERAPH_SCREEN_ANALYSIS_PROVIDER", "").strip() or "codex-local"
+    if provider not in _VALID_SCREEN_ANALYSIS_PROVIDERS:
+        provider = "codex-local"
+    return {
+        "enabled": _env_enabled("SERAPH_SCREEN_ANALYSIS_ENABLED", True),
+        "provider": provider,
+        "model": os.environ.get("SERAPH_SCREEN_ANALYSIS_MODEL", "").strip()
+        or settings.codex_local_model,
+        "preserve_captures": _env_enabled("SERAPH_PRESERVE_SCREEN_CAPTURES", True),
+        "archive_dir": str(screen_archive_dir),
+    }
+
+
+def _read_screen_analysis_settings() -> dict[str, object]:
+    payload = _default_screen_analysis_settings()
+    path = _screen_analysis_settings_path()
+    if path.exists():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            loaded = {}
+        if isinstance(loaded, dict):
+            for key in ("enabled", "provider", "model", "preserve_captures", "archive_dir"):
+                if key in loaded:
+                    payload[key] = loaded[key]
+    provider = str(payload.get("provider") or "codex-local")
+    if provider not in _VALID_SCREEN_ANALYSIS_PROVIDERS:
+        provider = "codex-local"
+    payload["provider"] = provider
+    payload["enabled"] = bool(payload.get("enabled"))
+    payload["preserve_captures"] = bool(payload.get("preserve_captures"))
+    payload["model"] = str(payload.get("model") or "")
+    payload["archive_dir"] = str(Path(str(payload.get("archive_dir") or "")).expanduser().resolve())
+    return payload
+
+
+def _write_screen_analysis_settings(payload: dict[str, object]) -> None:
+    path = _screen_analysis_settings_path()
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    path.chmod(0o600)
+
+
+def _screen_artifact_summary(archive_dir: Path) -> dict[str, object]:
+    if not archive_dir.exists():
+        return {"artifact_count": 0, "last_artifact_at": None}
+    try:
+        image_mtimes = []
+        for path in archive_dir.rglob("*.png"):
+            if not path.is_file():
+                continue
+            try:
+                image_mtimes.append(path.stat().st_mtime)
+            except OSError as exc:
+                logger.warning("Screen artifact stat skipped: %s", exc)
+    except OSError as exc:
+        logger.warning("Screen artifact filesystem summary failed: %s", exc)
+        return {"artifact_count": 0, "last_artifact_at": None}
+    if not image_mtimes:
+        return {"artifact_count": 0, "last_artifact_at": None}
+    latest_mtime = max(image_mtimes)
+    return {
+        "artifact_count": len(image_mtimes),
+        "last_artifact_at": datetime.fromtimestamp(latest_mtime, timezone.utc).isoformat(),
+    }
+
+
 def _archive_dir_status(path: Path) -> dict[str, object]:
     creation_error = None
     try:
@@ -81,9 +207,16 @@ def _archive_dir_status(path: Path) -> dict[str, object]:
         path.chmod(0o700)
     except OSError as exc:
         creation_error = str(exc)
+    mode_private = False
+    if path.exists() and path.is_dir():
+        try:
+            mode_private = stat.S_IMODE(path.stat().st_mode) == 0o700
+        except OSError:
+            mode_private = False
     return {
         "exists": path.exists(),
         "writable": path.is_dir() and os.access(path, os.W_OK),
+        "private": mode_private,
         "creation_error": creation_error,
     }
 
@@ -165,22 +298,86 @@ async def set_capture_mode(body: CaptureModeRequest):
     return {"mode": body.mode}
 
 
+@router.get("/settings/screen-analysis")
+async def get_screen_analysis_settings():
+    """Return runtime screen-analysis settings consumed by the native daemon."""
+    payload = _read_screen_analysis_settings()
+    ctx = context_manager.get_context()
+    daemon_status = _read_daemon_status()
+    payload.update(
+        {
+            "capture_mode": ctx.capture_mode,
+            "cadence_seconds": 60 if ctx.capture_mode == "detailed" else 300 if ctx.capture_mode == "balanced" else None,
+            "daemon_connected": bool(daemon_status["connected"]) or context_manager.is_daemon_connected(),
+            "artifact_count": 0,
+            "last_artifact_at": None,
+        }
+    )
+    return payload
+
+
+@router.put("/settings/screen-analysis")
+async def set_screen_analysis_settings(body: ScreenAnalysisSettingsRequest):
+    """Persist runtime screen-analysis settings for the native daemon."""
+    payload = _read_screen_analysis_settings()
+    if body.enabled is not None:
+        payload["enabled"] = body.enabled
+    if body.provider is not None:
+        if body.provider not in _VALID_SCREEN_ANALYSIS_PROVIDERS:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Invalid provider '{body.provider}'. Must be one of: "
+                    f"{', '.join(sorted(_VALID_SCREEN_ANALYSIS_PROVIDERS))}"
+                ),
+            )
+        payload["provider"] = body.provider
+    if body.model is not None:
+        payload["model"] = body.model.strip()
+    if body.preserve_captures is not None:
+        payload["preserve_captures"] = body.preserve_captures
+    if body.archive_dir is not None:
+        archive_dir = Path(body.archive_dir).expanduser().resolve()
+        archive_status = _archive_dir_status(archive_dir)
+        if (
+            archive_status["creation_error"]
+            or not archive_status["exists"]
+            or not archive_status["writable"]
+            or not archive_status["private"]
+        ):
+            raise HTTPException(status_code=422, detail="Screen archive directory must be private and writable")
+        payload["archive_dir"] = str(archive_dir)
+    _write_screen_analysis_settings(payload)
+    return await get_screen_analysis_settings()
+
+
 @router.get("/settings/artifact-storage")
 async def get_artifact_storage_settings():
     """Return operator-visible evidence/report archive configuration."""
-    screen_archive_dir, screen_archive_source = _screen_archive_dir()
     report_archive_dir, report_archive_source = _report_archive_dir()
-    screen_dir_status = _archive_dir_status(screen_archive_dir)
     report_dir_status = _archive_dir_status(report_archive_dir)
+    screen_analysis = await get_screen_analysis_settings()
+    screen_archive_dir = Path(str(screen_analysis["archive_dir"]))
+    screen_dir_status = _archive_dir_status(screen_archive_dir)
+    screen_summary = _screen_artifact_summary(screen_archive_dir)
     return {
         "screen": {
-            "preservation_enabled": _env_enabled("SERAPH_PRESERVE_SCREEN_CAPTURES", False),
-            "archive_dir": str(screen_archive_dir),
-            "archive_dir_source": screen_archive_source,
+            "analysis_enabled": screen_analysis["enabled"],
+            "provider": screen_analysis["provider"],
+            "model": screen_analysis["model"],
+            "capture_mode": screen_analysis["capture_mode"],
+            "cadence_seconds": screen_analysis["cadence_seconds"],
+            "daemon_connected": screen_analysis["daemon_connected"],
+            "artifact_count": screen_summary["artifact_count"],
+            "last_artifact_at": screen_summary["last_artifact_at"],
+            "preservation_enabled": screen_analysis["preserve_captures"],
+            "archive_dir": str(screen_analysis["archive_dir"]),
+            "archive_dir_source": "screen-analysis-settings",
             **screen_dir_status,
             "stored_artifacts": ["image", "provider_output", "analysis_json"],
             "inspection_endpoint": "/api/observer/screen-artifacts",
             "inspection_visibility": "localhost_only",
+            "daemon_status": _read_daemon_status(),
             "control_env": {
                 "enabled": "SERAPH_PRESERVE_SCREEN_CAPTURES",
                 "archive_dir": "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR or SCREEN_CAPTURE_ARCHIVE_DIR",

--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -77,7 +77,8 @@ def _report_archive_dir() -> tuple[Path, str]:
 def _archive_dir_status(path: Path) -> dict[str, object]:
     creation_error = None
     try:
-        path.mkdir(parents=True, exist_ok=True)
+        path.mkdir(parents=True, exist_ok=True, mode=0o700)
+        path.chmod(0o700)
     except OSError as exc:
         creation_error = str(exc)
     return {

--- a/backend/src/scheduler/engine.py
+++ b/backend/src/scheduler/engine.py
@@ -39,6 +39,21 @@ def _validate_timezone(tz_name: str) -> str:
         return "UTC"
 
 
+def _settings_int(name: str, default: int, *, minimum: int | None = None, maximum: int | None = None) -> int:
+    raw = getattr(settings, name, default)
+    if not isinstance(raw, (int, str)) or isinstance(raw, bool):
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    if minimum is not None and value < minimum:
+        return default
+    if maximum is not None and value > maximum:
+        return default
+    return value
+
+
 def init_scheduler() -> AsyncIOScheduler | None:
     """Create and start the background scheduler with all configured jobs.
 
@@ -122,7 +137,7 @@ def init_scheduler() -> AsyncIOScheduler | None:
         {
             "func": _async_job_wrapper(run_end_of_day_goal_report, loop),
             "trigger": CronTrigger(
-                hour=settings.end_of_day_report_hour,
+                hour=_settings_int("end_of_day_report_hour", 21, minimum=0, maximum=23),
                 timezone=validated_tz,
             ),
             "id": "end_of_day_goal_report",

--- a/backend/src/scheduler/engine.py
+++ b/backend/src/scheduler/engine.py
@@ -63,6 +63,7 @@ def init_scheduler() -> AsyncIOScheduler | None:
     from src.scheduler.jobs.daily_briefing import run_daily_briefing
     from src.scheduler.jobs.evening_review import run_evening_review
     from src.scheduler.jobs.activity_digest import run_activity_digest
+    from src.scheduler.jobs.end_of_day_goal_report import run_end_of_day_goal_report
     from src.scheduler.jobs.weekly_activity_review import run_weekly_activity_review
     from src.scheduler.jobs.screen_cleanup import run_screen_cleanup
 
@@ -117,6 +118,15 @@ def init_scheduler() -> AsyncIOScheduler | None:
             ),
             "id": "activity_digest",
             "name": "Activity digest",
+        },
+        {
+            "func": _async_job_wrapper(run_end_of_day_goal_report, loop),
+            "trigger": CronTrigger(
+                hour=settings.end_of_day_report_hour,
+                timezone=validated_tz,
+            ),
+            "id": "end_of_day_goal_report",
+            "name": "End-of-day goal report",
         },
         {
             "func": _async_job_wrapper(run_weekly_activity_review, loop),

--- a/backend/src/scheduler/jobs/end_of_day_goal_report.py
+++ b/backend/src/scheduler/jobs/end_of_day_goal_report.py
@@ -11,6 +11,7 @@ import smtplib
 from dataclasses import dataclass
 from datetime import date, datetime, time, timezone
 from email.message import EmailMessage
+from pathlib import Path
 from time import perf_counter
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -97,6 +98,49 @@ def _parse_csv(value: str) -> list[str]:
 
 def _recipient_hash(recipient: str) -> str:
     return hashlib.sha256(recipient.strip().lower().encode("utf-8")).hexdigest()[:16]
+
+
+def _report_archive_root() -> Path:
+    configured = settings.report_archive_dir.strip()
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return Path(settings.workspace_dir).expanduser().resolve() / "artifacts" / "reports"
+
+
+def _report_artifact_paths(report: dict[str, Any]) -> dict[str, str]:
+    report_date = str(report.get("date") or "unknown")
+    digest = hashlib.sha256(
+        json.dumps(report, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()[:16]
+    report_dir = _report_archive_root() / "end-of-day" / report_date
+    stem = f"end-of-day-{report_date}-{digest}"
+    return {
+        "report_text_path": str(report_dir / f"{stem}.txt"),
+        "report_json_path": str(report_dir / f"{stem}.json"),
+    }
+
+
+def archive_end_of_day_goal_report(report: dict[str, Any]) -> dict[str, Any]:
+    """Persist a durable report artifact bundle for future re-analysis."""
+    paths = _report_artifact_paths(report)
+    text_path = Path(paths["report_text_path"])
+    json_path = Path(paths["report_json_path"])
+    text_path.parent.mkdir(parents=True, exist_ok=True)
+
+    text_payload = str(report.get("body") or "")
+    json_payload = {
+        "artifact_schema": "seraph.end_of_day_goal_report.v1",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "report": report,
+    }
+    text_path.write_text(text_payload, encoding="utf-8")
+    json_path.write_text(json.dumps(json_payload, indent=2, sort_keys=True), encoding="utf-8")
+
+    return {
+        **paths,
+        "report_text_sha256": hashlib.sha256(text_payload.encode("utf-8")).hexdigest(),
+        "report_json_sha256": hashlib.sha256(json_path.read_bytes()).hexdigest(),
+    }
 
 
 def _safe_timezone() -> ZoneInfo:
@@ -332,12 +376,16 @@ async def build_end_of_day_goal_report(report_day: date | None = None) -> dict[s
         "goal_alignment": alignment,
         "completed_goal_count": len(completed_goals),
         "active_goal_count": len(active_goals),
+        "analysis_provider": "llm" if settings.end_of_day_report_llm_enabled else "deterministic-local",
+        "artifact_schema": "seraph.end_of_day_goal_report.v1",
     }
 
 
 async def store_end_of_day_goal_report(report: dict[str, Any]) -> str:
     from src.memory.repository import memory_repository
 
+    report_artifacts = archive_end_of_day_goal_report(report)
+    report["artifacts"] = report_artifacts
     episode = await memory_repository.create_episode(
         episode_type=MemoryEpisodeType.observer,
         summary=f"End-of-day goal report for {report['date']}",
@@ -354,6 +402,9 @@ async def store_end_of_day_goal_report(report: dict[str, Any]) -> str:
             "active_goal_count": report["active_goal_count"],
             "completed_goal_count": report["completed_goal_count"],
             "goal_alignment": report["goal_alignment"],
+            "analysis_provider": report.get("analysis_provider"),
+            "artifact_schema": report.get("artifact_schema"),
+            "artifacts": report_artifacts,
         },
     )
     return episode.id
@@ -444,6 +495,7 @@ async def run_end_of_day_goal_report() -> None:
                 "email_status": email_result.status,
                 "email_reason": email_result.reason,
                 "email_recipient_hash": email_result.recipient_hash,
+                "report_artifacts": report.get("artifacts"),
             },
         )
     except Exception as exc:

--- a/backend/src/scheduler/jobs/end_of_day_goal_report.py
+++ b/backend/src/scheduler/jobs/end_of_day_goal_report.py
@@ -1,0 +1,458 @@
+"""End-of-day goal report built from screen observations and goals."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import re
+import smtplib
+from dataclasses import dataclass
+from datetime import date, datetime, time, timezone
+from email.message import EmailMessage
+from time import perf_counter
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from config.settings import settings
+from src.audit.runtime import log_integration_event, log_scheduler_job_event
+from src.db.models import GoalStatus, MemoryEpisodeType, ScreenObservation
+from src.llm_runtime import completion_with_fallback
+
+logger = logging.getLogger(__name__)
+
+_REPORT_PROMPT = """\
+You are Seraph. Write an end-of-day report for the human.
+
+Use only the redacted structured inputs. Do not invent screen details.
+
+## Date
+{report_date}
+
+## Activity Summary
+- Total tracked time: {total_minutes} minutes
+- Context switches: {switch_count}
+- Activity mix:
+{activity_breakdown}
+- Project mix:
+{project_breakdown}
+
+## Goals
+Active goals:
+{active_goals}
+
+Completed today:
+{completed_goals}
+
+## Alignment Hints
+{alignment_hints}
+
+Write:
+1. A short summary of what the day was mostly about.
+2. A "Goals vs day" section that says what aligned, what drifted, and what is unclear.
+3. 3 practical tips for tomorrow.
+
+Keep it useful and concise. No private raw screen text, no copied secrets, no long logs."""
+
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*[^\s,;]+"),
+    re.compile(r"\b(sk-[A-Za-z0-9_-]{12,})\b"),
+    re.compile(r"\b([A-Za-z0-9_./+=-]{24,})\b"),
+)
+
+
+@dataclass(frozen=True)
+class EmailDeliveryResult:
+    status: str
+    reason: str | None = None
+    recipient_hash: str | None = None
+    provider_receipt: str | None = None
+
+
+def _redact_text(value: str | None, *, limit: int = 240) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return ""
+    text = " ".join(value.strip().split())
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub("[redacted]", text)
+    return text[:limit]
+
+
+def _redact_report_body(value: str | None, *, limit: int = 5000) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return ""
+    lines = []
+    for line in value.strip().splitlines():
+        text = " ".join(line.strip().split())
+        for pattern in _SECRET_PATTERNS:
+            text = pattern.sub("[redacted]", text)
+        lines.append(text)
+    return "\n".join(lines)[:limit]
+
+
+def _parse_csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _recipient_hash(recipient: str) -> str:
+    return hashlib.sha256(recipient.strip().lower().encode("utf-8")).hexdigest()[:16]
+
+
+def _safe_timezone() -> ZoneInfo:
+    try:
+        return ZoneInfo(settings.user_timezone)
+    except ZoneInfoNotFoundError:
+        return ZoneInfo("UTC")
+
+
+async def _screen_summary_for_local_day(report_day: date, tz: ZoneInfo) -> dict[str, Any]:
+    local_start = datetime.combine(report_day, time.min, tzinfo=tz)
+    local_end = datetime.combine(report_day, time.max, tzinfo=tz)
+    start_utc = local_start.astimezone(timezone.utc)
+    end_utc = local_end.astimezone(timezone.utc)
+
+    from sqlmodel import col, select
+    from src.db.engine import get_session
+
+    async with get_session() as db:
+        result = await db.execute(
+            select(ScreenObservation)
+            .where(col(ScreenObservation.timestamp) >= start_utc)
+            .where(col(ScreenObservation.timestamp) <= end_utc)
+            .where(col(ScreenObservation.blocked) == False)  # noqa: E712
+            .order_by(col(ScreenObservation.timestamp))
+        )
+        observations = list(result.scalars().all())
+
+    by_activity: dict[str, int] = {}
+    by_project: dict[str, int] = {}
+    by_app: dict[str, int] = {}
+    details: list[str] = []
+    total_seconds = 0
+    for obs in observations:
+        duration = obs.duration_s or 0
+        total_seconds += duration
+        by_activity[obs.activity_type] = by_activity.get(obs.activity_type, 0) + duration
+        by_app[obs.app_name] = by_app.get(obs.app_name, 0) + duration
+        if obs.project:
+            by_project[obs.project] = by_project.get(obs.project, 0) + duration
+        if obs.summary:
+            redacted = _redact_text(obs.summary, limit=160)
+            if redacted and redacted not in details:
+                details.append(redacted)
+
+    return {
+        "date": report_day.isoformat(),
+        "timezone": str(tz),
+        "total_observations": len(observations),
+        "total_tracked_minutes": total_seconds // 60,
+        "switch_count": len(observations),
+        "by_activity": dict(sorted(by_activity.items(), key=lambda item: -item[1])),
+        "by_project": dict(sorted(by_project.items(), key=lambda item: -item[1])),
+        "by_app": dict(sorted(by_app.items(), key=lambda item: -item[1])),
+        "redacted_samples": details[:8],
+    }
+
+
+async def _goals_for_report(report_day: date) -> tuple[list[Any], list[Any]]:
+    from src.goals.repository import goal_repository
+
+    active_goals, completed_goals = await asyncio.gather(
+        goal_repository.list_goals(status=GoalStatus.active.value),
+        goal_repository.list_goals(status=GoalStatus.completed.value),
+    )
+    completed_today = [
+        goal for goal in completed_goals
+        if goal.updated_at and goal.updated_at.date() == report_day
+    ]
+    return active_goals, completed_today
+
+
+def _tokens(value: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-z0-9]{3,}", value.lower())
+        if token not in {"the", "and", "for", "with", "today", "goal"}
+    }
+
+
+def _goal_alignment(summary: dict[str, Any], active_goals: list[Any]) -> list[dict[str, Any]]:
+    context_text = " ".join(
+        [
+            " ".join(summary.get("by_project", {}).keys()),
+            " ".join(summary.get("by_activity", {}).keys()),
+            " ".join(summary.get("by_app", {}).keys()),
+            " ".join(summary.get("redacted_samples", [])),
+        ]
+    )
+    context_tokens = _tokens(context_text)
+    results: list[dict[str, Any]] = []
+    for goal in active_goals:
+        goal_text = " ".join(
+            item for item in [goal.title, goal.description or "", goal.domain] if item
+        )
+        overlap = sorted(_tokens(goal_text) & context_tokens)
+        results.append(
+            {
+                "goal_id": goal.id,
+                "title": _redact_text(goal.title, limit=120),
+                "domain": goal.domain,
+                "status": "aligned" if overlap else "unclear",
+                "evidence_tokens": overlap[:6],
+            }
+        )
+    return results
+
+
+def _format_seconds_map(values: dict[str, int], *, empty: str) -> str:
+    if not values:
+        return empty
+    lines = []
+    for name, seconds in list(values.items())[:8]:
+        lines.append(f"- {_redact_text(name, limit=80)}: {seconds // 60}m")
+    return "\n".join(lines)
+
+
+def _format_goals(goals: list[Any]) -> str:
+    if not goals:
+        return "- None"
+    return "\n".join(
+        f"- {_redact_text(goal.title, limit=120)} ({goal.domain})"
+        for goal in goals[:12]
+    )
+
+
+def _format_alignment(alignment: list[dict[str, Any]]) -> str:
+    if not alignment:
+        return "- No active goals to compare."
+    lines = []
+    for item in alignment[:12]:
+        evidence = ", ".join(item["evidence_tokens"]) or "no clear screen-observation match"
+        lines.append(f"- {item['title']}: {item['status']} ({evidence})")
+    return "\n".join(lines)
+
+
+def _deterministic_report_body(
+    *,
+    report_day: date,
+    summary: dict[str, Any],
+    alignment: list[dict[str, Any]],
+    completed_goals: list[Any],
+) -> str:
+    activity = _format_seconds_map(summary.get("by_activity", {}), empty="- No tracked activity")
+    projects = _format_seconds_map(summary.get("by_project", {}), empty="- No project labels detected")
+    aligned = [item for item in alignment if item["status"] == "aligned"]
+    unclear = [item for item in alignment if item["status"] != "aligned"]
+    completed = _format_goals(completed_goals)
+
+    tips = [
+        "Start tomorrow by naming the one goal the first focus block should serve.",
+        "Keep high-switching work in a deliberate admin block so deep work stays protected.",
+        "If a goal stayed unclear today, add a visible project label or next action before starting.",
+    ]
+    if summary.get("total_tracked_minutes", 0) == 0:
+        tips[0] = "Start tomorrow by setting a concrete daily goal before opening work apps."
+    elif not summary.get("by_project"):
+        tips[2] = "Add clearer project labels or goal titles so Seraph can connect screen activity to commitments."
+
+    return "\n".join(
+        [
+            f"End-of-day report for {report_day.isoformat()}",
+            "",
+            f"Today had {summary.get('total_tracked_minutes', 0)} tracked minutes across "
+            f"{summary.get('switch_count', 0)} context switches.",
+            "",
+            "Activity mix:",
+            activity,
+            "",
+            "Project mix:",
+            projects,
+            "",
+            "Goals vs day:",
+            f"- Aligned goals: {len(aligned)}",
+            f"- Unclear goals: {len(unclear)}",
+            f"- Completed today: {len(completed_goals)}",
+            completed,
+            "",
+            "Useful tips for tomorrow:",
+            *(f"- {tip}" for tip in tips),
+        ]
+    )
+
+
+async def build_end_of_day_goal_report(report_day: date | None = None) -> dict[str, Any]:
+    tz = _safe_timezone()
+    target_day = report_day or datetime.now(tz).date()
+    summary, goal_results = await asyncio.gather(
+        _screen_summary_for_local_day(target_day, tz),
+        _goals_for_report(target_day),
+    )
+    active_goals, completed_goals = goal_results
+    alignment = _goal_alignment(summary, active_goals)
+
+    if settings.end_of_day_report_llm_enabled:
+        prompt = _REPORT_PROMPT.format(
+            report_date=target_day.isoformat(),
+            total_minutes=summary.get("total_tracked_minutes", 0),
+            switch_count=summary.get("switch_count", 0),
+            activity_breakdown=_format_seconds_map(summary.get("by_activity", {}), empty="- No tracked activity"),
+            project_breakdown=_format_seconds_map(summary.get("by_project", {}), empty="- No project labels detected"),
+            active_goals=_format_goals(active_goals),
+            completed_goals=_format_goals(completed_goals),
+            alignment_hints=_format_alignment(alignment),
+        )
+
+        response = await completion_with_fallback(
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.4,
+            max_tokens=900,
+            timeout=settings.agent_briefing_timeout,
+            runtime_path="end_of_day_goal_report",
+        )
+        body = _redact_report_body(response.choices[0].message.content, limit=5000)
+    else:
+        body = _redact_report_body(
+            _deterministic_report_body(
+                report_day=target_day,
+                summary=summary,
+                alignment=alignment,
+                completed_goals=completed_goals,
+            ),
+            limit=5000,
+        )
+    if not body:
+        body = "No report generated."
+
+    return {
+        "date": target_day.isoformat(),
+        "timezone": str(tz),
+        "body": body,
+        "summary": summary,
+        "goal_alignment": alignment,
+        "completed_goal_count": len(completed_goals),
+        "active_goal_count": len(active_goals),
+    }
+
+
+async def store_end_of_day_goal_report(report: dict[str, Any]) -> str:
+    from src.memory.repository import memory_repository
+
+    episode = await memory_repository.create_episode(
+        episode_type=MemoryEpisodeType.observer,
+        summary=f"End-of-day goal report for {report['date']}",
+        content=report["body"],
+        source_tool_name="end_of_day_goal_report",
+        salience=0.7,
+        confidence=0.8,
+        metadata={
+            "kind": "end_of_day_goal_report",
+            "date": report["date"],
+            "timezone": report["timezone"],
+            "screen_observation_count": report["summary"].get("total_observations", 0),
+            "total_tracked_minutes": report["summary"].get("total_tracked_minutes", 0),
+            "active_goal_count": report["active_goal_count"],
+            "completed_goal_count": report["completed_goal_count"],
+            "goal_alignment": report["goal_alignment"],
+        },
+    )
+    return episode.id
+
+
+async def deliver_report_email(report: dict[str, Any]) -> EmailDeliveryResult:
+    recipient = settings.email_reports_to.strip()
+    sender = settings.email_reports_from.strip()
+
+    if not settings.email_reports_enabled:
+        return EmailDeliveryResult(status="skipped", reason="email_reports_disabled")
+    if settings.email_reports_preview_required:
+        return EmailDeliveryResult(status="preview_required", reason="operator_preview_required")
+    if not recipient or not sender:
+        return EmailDeliveryResult(status="skipped", reason="missing_recipient_or_sender")
+    allowed = {_recipient_hash(item) for item in _parse_csv(settings.email_reports_to_allowlist)}
+    recipient_digest = _recipient_hash(recipient)
+    if recipient_digest not in allowed:
+        return EmailDeliveryResult(
+            status="blocked",
+            reason="recipient_not_allowlisted",
+            recipient_hash=recipient_digest,
+        )
+    if not settings.smtp_host:
+        return EmailDeliveryResult(
+            status="skipped",
+            reason="smtp_host_missing",
+            recipient_hash=recipient_digest,
+        )
+
+    message = EmailMessage()
+    message["Subject"] = f"Seraph end-of-day report: {report['date']}"
+    message["From"] = sender
+    message["To"] = recipient
+    if settings.email_reports_reply_to:
+        message["Reply-To"] = settings.email_reports_reply_to
+    message.set_content(report["body"])
+
+    try:
+        with smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=20) as smtp:
+            if settings.smtp_use_tls:
+                smtp.starttls()
+            if settings.smtp_username or settings.smtp_password:
+                smtp.login(settings.smtp_username, settings.smtp_password)
+            smtp.send_message(message)
+    except Exception as exc:
+        await log_integration_event(
+            integration_type="email_report",
+            name="smtp",
+            outcome="failed",
+            details={"reason": exc.__class__.__name__, "recipient_hash": recipient_digest},
+        )
+        raise
+
+    await log_integration_event(
+        integration_type="email_report",
+        name="smtp",
+        outcome="succeeded",
+        details={"recipient_hash": recipient_digest},
+    )
+    return EmailDeliveryResult(status="sent", recipient_hash=recipient_digest)
+
+
+async def run_end_of_day_goal_report() -> None:
+    if not settings.end_of_day_report_enabled:
+        await log_scheduler_job_event(
+            job_name="end_of_day_goal_report",
+            outcome="skipped",
+            details={"reason": "disabled"},
+        )
+        return
+
+    started_at = perf_counter()
+    try:
+        report = await build_end_of_day_goal_report()
+        episode_id = await store_end_of_day_goal_report(report)
+        email_result = await deliver_report_email(report)
+        await log_scheduler_job_event(
+            job_name="end_of_day_goal_report",
+            outcome="succeeded",
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "episode_id": episode_id,
+                "date": report["date"],
+                "total_tracked_minutes": report["summary"].get("total_tracked_minutes", 0),
+                "active_goal_count": report["active_goal_count"],
+                "completed_goal_count": report["completed_goal_count"],
+                "email_status": email_result.status,
+                "email_reason": email_result.reason,
+                "email_recipient_hash": email_result.recipient_hash,
+            },
+        )
+    except Exception as exc:
+        await log_scheduler_job_event(
+            job_name="end_of_day_goal_report",
+            outcome="failed",
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "error": exc.__class__.__name__,
+            },
+        )
+        logger.exception("end_of_day_goal_report failed")

--- a/backend/src/scheduler/jobs/end_of_day_goal_report.py
+++ b/backend/src/scheduler/jobs/end_of_day_goal_report.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import re
 import smtplib
 from dataclasses import dataclass
@@ -125,7 +126,8 @@ def archive_end_of_day_goal_report(report: dict[str, Any]) -> dict[str, Any]:
     paths = _report_artifact_paths(report)
     text_path = Path(paths["report_text_path"])
     json_path = Path(paths["report_json_path"])
-    text_path.parent.mkdir(parents=True, exist_ok=True)
+    text_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    text_path.parent.chmod(0o700)
 
     text_payload = str(report.get("body") or "")
     json_payload = {
@@ -133,14 +135,28 @@ def archive_end_of_day_goal_report(report: dict[str, Any]) -> dict[str, Any]:
         "created_at": datetime.now(timezone.utc).isoformat(),
         "report": report,
     }
-    text_path.write_text(text_payload, encoding="utf-8")
-    json_path.write_text(json.dumps(json_payload, indent=2, sort_keys=True), encoding="utf-8")
+    _write_private_text(text_path, text_payload)
+    _write_private_text(json_path, json.dumps(json_payload, indent=2, sort_keys=True))
 
     return {
         **paths,
         "report_text_sha256": hashlib.sha256(text_payload.encode("utf-8")).hexdigest(),
         "report_json_sha256": hashlib.sha256(json_path.read_bytes()).hexdigest(),
     }
+
+
+def _write_private_text(path: Path, content: str) -> None:
+    fd = open(
+        path,
+        "w",
+        encoding="utf-8",
+        opener=lambda file_path, flags: os.open(file_path, flags, 0o600),
+    )
+    try:
+        fd.write(content)
+    finally:
+        fd.close()
+        path.chmod(0o600)
 
 
 def _safe_timezone() -> ZoneInfo:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -31,6 +31,7 @@ _PATCH_TARGETS = [
     "src.audit.repository.get_session",
     "src.profile.service.get_db",
     "src.api.settings.get_db",  # aliased: `import get_session as get_db`
+    "src.api.observer.get_session",
     "src.scheduler.jobs.memory_consolidation.get_session",
     "src.scheduler.scheduled_jobs.get_session",
     "src.observer.insight_queue.get_session",

--- a/backend/tests/test_end_of_day_goal_report.py
+++ b/backend/tests/test_end_of_day_goal_report.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from datetime import date, datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -115,6 +117,43 @@ async def test_run_report_stores_episode_and_keeps_email_preview_only(async_db):
         and event["details"]["email_status"] == "preview_required"
         for event in events
     )
+
+
+@pytest.mark.asyncio
+async def test_store_report_writes_durable_artifacts(async_db, tmp_path):
+    from src.db.models import MemoryEpisode
+    from sqlmodel import select
+    from src.scheduler.jobs.end_of_day_goal_report import store_end_of_day_goal_report
+
+    report = {
+        "date": "2026-06-20",
+        "timezone": "UTC",
+        "body": "Stored durable EOD report",
+        "summary": {"total_observations": 2, "total_tracked_minutes": 45},
+        "goal_alignment": [{"goal_id": "g1", "status": "aligned"}],
+        "completed_goal_count": 0,
+        "active_goal_count": 1,
+        "analysis_provider": "deterministic-local",
+        "artifact_schema": "seraph.end_of_day_goal_report.v1",
+    }
+
+    with patch.object(settings, "report_archive_dir", str(tmp_path / "reports")):
+        episode_id = await store_end_of_day_goal_report(report)
+
+    async with async_db() as db:
+        episode = (await db.execute(select(MemoryEpisode))).scalar_one()
+
+    assert episode.id == episode_id
+    metadata = json.loads(episode.metadata_json or "{}")
+    artifacts = metadata["artifacts"]
+    text_path = Path(artifacts["report_text_path"])
+    json_path = Path(artifacts["report_json_path"])
+    assert text_path.read_text(encoding="utf-8") == "Stored durable EOD report"
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["artifact_schema"] == "seraph.end_of_day_goal_report.v1"
+    assert payload["report"]["analysis_provider"] == "deterministic-local"
+    assert artifacts["report_text_sha256"]
+    assert artifacts["report_json_sha256"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_end_of_day_goal_report.py
+++ b/backend/tests/test_end_of_day_goal_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import stat
 from pathlib import Path
 from datetime import date, datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -152,6 +153,9 @@ async def test_store_report_writes_durable_artifacts(async_db, tmp_path):
     payload = json.loads(json_path.read_text(encoding="utf-8"))
     assert payload["artifact_schema"] == "seraph.end_of_day_goal_report.v1"
     assert payload["report"]["analysis_provider"] == "deterministic-local"
+    assert stat.S_IMODE(text_path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(text_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(json_path.stat().st_mode) == 0o600
     assert artifacts["report_text_sha256"]
     assert artifacts["report_json_sha256"]
 

--- a/backend/tests/test_end_of_day_goal_report.py
+++ b/backend/tests/test_end_of_day_goal_report.py
@@ -1,0 +1,163 @@
+"""Tests for local-screen end-of-day goal reports."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from config.settings import settings
+from src.audit.repository import audit_repository
+
+
+@pytest.mark.asyncio
+async def test_build_report_uses_screen_observations_goals_and_redacts(async_db):
+    from src.db.models import Goal, ScreenObservation
+    from src.scheduler.jobs.end_of_day_goal_report import build_end_of_day_goal_report
+
+    async with async_db() as db:
+        db.add(
+            ScreenObservation(
+                timestamp=datetime(2026, 6, 20, 10, 0, tzinfo=timezone.utc),
+                app_name="Code",
+                window_title="Seraph",
+                activity_type="coding",
+                project="seraph",
+                summary="Implemented local Codex parsing with api_key=secret-value",
+                duration_s=3600,
+            )
+        )
+        db.add(
+            Goal(
+                id="goal1",
+                path="/",
+                level="daily",
+                title="Improve Seraph local screen parsing",
+                domain="productivity",
+                status="active",
+                sort_order=0,
+            )
+        )
+
+    response = MagicMock()
+    response.choices = [MagicMock(message=MagicMock(content="Useful report with token=hidden-value"))]
+
+    with patch.object(settings, "user_timezone", "UTC"), patch.object(
+        settings, "end_of_day_report_llm_enabled", True
+    ), patch(
+        "src.scheduler.jobs.end_of_day_goal_report.completion_with_fallback",
+        new=AsyncMock(return_value=response),
+    ) as completion:
+        report = await build_end_of_day_goal_report(date(2026, 6, 20))
+
+    assert report["summary"]["total_tracked_minutes"] == 60
+    assert report["goal_alignment"][0]["status"] == "aligned"
+    assert "secret-value" not in completion.await_args.kwargs["messages"][0]["content"]
+    assert "hidden-value" not in report["body"]
+    assert "[redacted]" in report["body"]
+    assert completion.await_args.kwargs["runtime_path"] == "end_of_day_goal_report"
+
+
+@pytest.mark.asyncio
+async def test_build_report_is_deterministic_by_default(async_db):
+    from src.scheduler.jobs.end_of_day_goal_report import build_end_of_day_goal_report
+
+    completion = AsyncMock()
+
+    with patch.object(settings, "user_timezone", "UTC"), patch.object(
+        settings, "end_of_day_report_llm_enabled", False
+    ), patch(
+        "src.scheduler.jobs.end_of_day_goal_report.completion_with_fallback",
+        new=completion,
+    ):
+        report = await build_end_of_day_goal_report(date(2026, 6, 20))
+
+    completion.assert_not_awaited()
+    assert report["body"].startswith("End-of-day report for 2026-06-20")
+
+
+@pytest.mark.asyncio
+async def test_run_report_stores_episode_and_keeps_email_preview_only(async_db):
+    from src.db.models import MemoryEpisode
+    from sqlmodel import select
+    from src.scheduler.jobs.end_of_day_goal_report import run_end_of_day_goal_report
+
+    with patch.object(settings, "end_of_day_report_enabled", True), patch.object(
+        settings, "email_reports_enabled", True
+    ), patch.object(settings, "email_reports_preview_required", True), patch(
+        "src.scheduler.jobs.end_of_day_goal_report.build_end_of_day_goal_report",
+        new=AsyncMock(
+            return_value={
+                "date": "2026-06-20",
+                "timezone": "UTC",
+                "body": "Stored EOD report",
+                "summary": {"total_observations": 2, "total_tracked_minutes": 45},
+                "goal_alignment": [],
+                "completed_goal_count": 0,
+                "active_goal_count": 1,
+            }
+        ),
+    ):
+        await run_end_of_day_goal_report()
+
+    async with async_db() as db:
+        episodes = list((await db.execute(select(MemoryEpisode))).scalars().all())
+
+    assert len(episodes) == 1
+    assert episodes[0].source_tool_name == "end_of_day_goal_report"
+    assert episodes[0].content == "Stored EOD report"
+
+    events = await audit_repository.list_events(limit=10)
+    assert any(
+        event["event_type"] == "scheduler_job_succeeded"
+        and event["tool_name"] == "end_of_day_goal_report"
+        and event["details"]["email_status"] == "preview_required"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_email_delivery_requires_allowlisted_recipient_hash():
+    from src.scheduler.jobs.end_of_day_goal_report import deliver_report_email
+
+    with patch.object(settings, "email_reports_enabled", True), patch.object(
+        settings, "email_reports_preview_required", False
+    ), patch.object(settings, "email_reports_to", "user@example.com"), patch.object(
+        settings, "email_reports_from", "seraph@example.com"
+    ), patch.object(settings, "email_reports_to_allowlist", "other@example.com"), patch.object(
+        settings, "smtp_host", "smtp.example.com"
+    ):
+        result = await deliver_report_email({"date": "2026-06-20", "body": "hello"})
+
+    assert result.status == "blocked"
+    assert result.reason == "recipient_not_allowlisted"
+    assert result.recipient_hash is not None
+
+
+@pytest.mark.asyncio
+async def test_email_delivery_sends_only_when_configured_and_preview_disabled():
+    from src.scheduler.jobs.end_of_day_goal_report import _recipient_hash, deliver_report_email
+
+    smtp = MagicMock()
+    smtp_context = MagicMock()
+    smtp_context.__enter__.return_value = smtp
+
+    with patch.object(settings, "email_reports_enabled", True), patch.object(
+        settings, "email_reports_preview_required", False
+    ), patch.object(settings, "email_reports_to", "user@example.com"), patch.object(
+        settings, "email_reports_from", "seraph@example.com"
+    ), patch.object(settings, "email_reports_to_allowlist", "user@example.com"), patch.object(
+        settings, "smtp_host", "smtp.example.com"
+    ), patch.object(settings, "smtp_port", 587), patch.object(
+        settings, "smtp_use_tls", True
+    ), patch.object(settings, "smtp_username", "user"), patch.object(
+        settings, "smtp_password", "pass"
+    ), patch("src.scheduler.jobs.end_of_day_goal_report.smtplib.SMTP", return_value=smtp_context):
+        result = await deliver_report_email({"date": "2026-06-20", "body": "hello"})
+
+    assert result.status == "sent"
+    assert result.recipient_hash == _recipient_hash("user@example.com")
+    smtp.starttls.assert_called_once()
+    smtp.login.assert_called_once_with("user", "pass")
+    smtp.send_message.assert_called_once()

--- a/backend/tests/test_observer_api.py
+++ b/backend/tests/test_observer_api.py
@@ -1,3 +1,4 @@
+import json
 import time
 import types
 from datetime import datetime, timezone
@@ -80,8 +81,9 @@ class TestObserverAPI:
         assert mgr.get_context().screen_context == "Editing"
 
     @pytest.mark.asyncio
-    async def test_daemon_status_disconnected(self, client):
+    async def test_daemon_status_disconnected(self, client, tmp_path, monkeypatch):
         """Daemon status returns disconnected when no POST received."""
+        monkeypatch.setenv("SERAPH_DAEMON_STATUS_FILE", str(tmp_path / "missing-daemon-status.json"))
         mgr = ContextManager()
         mgr.update_capture_mode("balanced")
         await native_notification_queue.clear()
@@ -101,8 +103,9 @@ class TestObserverAPI:
         assert data["last_native_notification_outcome"] is None
 
     @pytest.mark.asyncio
-    async def test_daemon_status_connected(self, client):
+    async def test_daemon_status_connected(self, client, tmp_path, monkeypatch):
         """Daemon status returns connected after a recent POST."""
+        monkeypatch.setenv("SERAPH_DAEMON_STATUS_FILE", str(tmp_path / "missing-daemon-status.json"))
         mgr = ContextManager()
         mgr.update_screen_context("VS Code — main.py", None)
         mgr.record_native_notification(title="Seraph desktop shell", outcome="queued_test")
@@ -130,8 +133,9 @@ class TestObserverAPI:
         await native_notification_queue.clear()
 
     @pytest.mark.asyncio
-    async def test_daemon_status_stale(self, client):
+    async def test_daemon_status_stale(self, client, tmp_path, monkeypatch):
         """Daemon status returns disconnected when last POST is too old."""
+        monkeypatch.setenv("SERAPH_DAEMON_STATUS_FILE", str(tmp_path / "missing-daemon-status.json"))
         mgr = ContextManager()
         mgr.update_screen_context("Terminal", None)
         # Simulate stale timestamp (60 seconds ago)
@@ -142,6 +146,35 @@ class TestObserverAPI:
         assert resp.status_code == 200
         data = resp.json()
         assert data["connected"] is False
+
+    @pytest.mark.asyncio
+    async def test_daemon_status_alive_from_fresh_status_file(self, client, tmp_path, monkeypatch):
+        """Daemon heartbeat proves the process is alive without implying transport connected."""
+        status_file = tmp_path / "daemon-status.json"
+        monkeypatch.setenv("SERAPH_DAEMON_STATUS_FILE", str(status_file))
+        status_file.write_text(
+            json.dumps(
+                {
+                    "state": "running",
+                    "screen_analysis": "active",
+                    "capture_ready": True,
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        mgr = ContextManager()
+        with patch("src.api.observer.context_manager", mgr):
+            resp = await client.get("/api/observer/daemon-status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["connected"] is False
+        assert data["daemon_alive"] is True
+        assert data["last_post"] is None
+        assert data["daemon_state"] == "running"
+        assert data["screen_analysis"] == "active"
+        assert data["capture_ready"] is True
 
     @pytest.mark.asyncio
     async def test_post_refresh(self, client):

--- a/backend/tests/test_observer_screen_artifacts.py
+++ b/backend/tests/test_observer_screen_artifacts.py
@@ -115,3 +115,15 @@ async def test_screen_artifact_endpoints_are_localhost_only(app, async_db, tmp_p
 
     assert resp.status_code == 403
     assert resp.json()["detail"] == "Screen artifacts are only available from localhost"
+
+
+@pytest.mark.asyncio
+async def test_screen_artifact_root_prefers_seraph_archive_env(tmp_path, monkeypatch):
+    from src.api.observer import _screen_artifact_root
+
+    preferred = tmp_path / "seraph-screen"
+    fallback = tmp_path / "fallback-screen"
+    monkeypatch.setenv("SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR", str(preferred))
+    monkeypatch.setattr("src.api.observer.settings.screen_capture_archive_dir", str(fallback))
+
+    assert _screen_artifact_root() == preferred.resolve()

--- a/backend/tests/test_observer_screen_artifacts.py
+++ b/backend/tests/test_observer_screen_artifacts.py
@@ -63,6 +63,7 @@ async def test_screen_artifacts_are_persisted_listed_and_served(async_db, client
     assert item["observation_id"] == observation.id
     assert item["artifacts"]["image_url"].endswith(f"/{observation.id}/image")
     assert item["artifacts"]["codex_output_url"].endswith(f"/{observation.id}/codex-output")
+    assert item["artifacts"]["provider_output_url"].endswith(f"/{observation.id}/codex-output")
 
     image_resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/image")
     assert image_resp.status_code == 200

--- a/backend/tests/test_observer_screen_artifacts.py
+++ b/backend/tests/test_observer_screen_artifacts.py
@@ -1,0 +1,116 @@
+"""Tests for preserved screen capture artifact inspection endpoints."""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
+
+from src.db.models import ScreenObservation
+
+
+@pytest.mark.asyncio
+async def test_screen_artifacts_are_persisted_listed_and_served(async_db, client, tmp_path, monkeypatch):
+    monkeypatch.setattr("src.api.observer.settings.screen_capture_archive_dir", str(tmp_path))
+    image_path = tmp_path / "capture.png"
+    output_path = tmp_path / "capture.codex.txt"
+    analysis_path = tmp_path / "capture.analysis.json"
+    image_path.write_bytes(b"png bytes")
+    output_path.write_text('{"summary":"Codex saw the editor"}', encoding="utf-8")
+    analysis_path.write_text(
+        json.dumps({"summary": "Codex saw the editor", "activity": "coding"}),
+        encoding="utf-8",
+    )
+
+    artifacts = {
+        "id": "artifact-1",
+        "image_path": str(image_path),
+        "codex_output_path": str(output_path),
+        "analysis_path": str(analysis_path),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    resp = await client.post(
+        "/api/observer/context",
+        json={
+            "active_window": "VS Code - seraph",
+            "observation": {
+                "app": "VS Code",
+                "window_title": "seraph",
+                "activity": "coding",
+                "project": "seraph",
+                "summary": "Codex saw the editor",
+                "details": ["editing screen artifacts"],
+                "capture_artifacts": artifacts,
+            },
+            "switch_timestamp": 1700000000.0,
+        },
+    )
+    assert resp.status_code == 200
+
+    async with async_db() as db:
+        result = await db.execute(select(ScreenObservation))
+        observation = result.scalar_one()
+
+    stored_details = json.loads(observation.details_json or "[]")
+    assert "editing screen artifacts" in stored_details
+    assert any(item.startswith("capture_artifacts:") for item in stored_details)
+
+    list_resp = await client.get("/api/observer/screen-artifacts")
+    assert list_resp.status_code == 200
+    item = list_resp.json()["items"][0]
+    assert item["observation_id"] == observation.id
+    assert item["artifacts"]["image_url"].endswith(f"/{observation.id}/image")
+    assert item["artifacts"]["codex_output_url"].endswith(f"/{observation.id}/codex-output")
+
+    image_resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/image")
+    assert image_resp.status_code == 200
+    assert image_resp.content == b"png bytes"
+    assert image_resp.headers["content-type"] == "image/png"
+
+    output_resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/codex-output")
+    assert output_resp.status_code == 200
+    assert output_resp.text == '{"summary":"Codex saw the editor"}'
+
+    analysis_resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/analysis")
+    assert analysis_resp.status_code == 200
+    assert analysis_resp.json()["summary"] == "Codex saw the editor"
+
+
+@pytest.mark.asyncio
+async def test_screen_artifact_endpoints_reject_paths_outside_archive(async_db, client, tmp_path, monkeypatch):
+    monkeypatch.setattr("src.api.observer.settings.screen_capture_archive_dir", str(tmp_path))
+    outside = tmp_path.parent / "outside.png"
+    outside.write_bytes(b"not allowed")
+    artifacts = {
+        "id": "artifact-2",
+        "image_path": str(outside),
+        "codex_output_path": str(tmp_path / "missing.txt"),
+        "analysis_path": str(tmp_path / "missing.json"),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    async with async_db() as db:
+        observation = ScreenObservation(
+            app_name="VS Code",
+            window_title="seraph",
+            activity_type="coding",
+            summary="Outside artifact path",
+            details_json=json.dumps(["capture_artifacts:" + json.dumps(artifacts)]),
+        )
+        db.add(observation)
+
+    resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/image")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_screen_artifact_endpoints_are_localhost_only(app, async_db, tmp_path, monkeypatch):
+    monkeypatch.setattr("src.api.observer.settings.screen_capture_archive_dir", str(tmp_path))
+    transport = ASGITransport(app=app, client=("192.0.2.10", 53210))
+    async with AsyncClient(transport=transport, base_url="http://test") as remote_client:
+        resp = await remote_client.get("/api/observer/screen-artifacts")
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Screen artifacts are only available from localhost"

--- a/backend/tests/test_observer_screen_artifacts.py
+++ b/backend/tests/test_observer_screen_artifacts.py
@@ -127,3 +127,21 @@ async def test_screen_artifact_root_prefers_seraph_archive_env(tmp_path, monkeyp
     monkeypatch.setattr("src.api.observer.settings.screen_capture_archive_dir", str(fallback))
 
     assert _screen_artifact_root() == preferred.resolve()
+
+
+@pytest.mark.asyncio
+async def test_screen_artifact_root_prefers_screen_analysis_settings(tmp_path, monkeypatch):
+    from src.api.observer import _screen_artifact_root
+
+    workspace = tmp_path / "workspace"
+    preferred = tmp_path / "settings-screen"
+    env_fallback = tmp_path / "env-screen"
+    workspace.mkdir()
+    (workspace / "screen-analysis-settings.json").write_text(
+        json.dumps({"archive_dir": str(preferred)}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("src.api.observer.settings.workspace_dir", str(workspace))
+    monkeypatch.setenv("SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR", str(env_fallback))
+
+    assert _screen_artifact_root() == preferred.resolve()

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -128,6 +128,7 @@ class TestSchedulerEngine:
                     "daily_briefing",
                     "evening_review",
                     "activity_digest",
+                    "end_of_day_goal_report",
                     "weekly_activity_review",
                     "screen_cleanup",
                 }

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -1,12 +1,15 @@
 """Tests for settings API — GET/PUT interruption mode."""
 
+import json
 import stat
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
 
 from config.settings import settings
+from src.api.settings import _screen_artifact_summary
 from src.db.models import UserProfile
 from src.observer.context import CurrentContext
 
@@ -115,11 +118,32 @@ async def test_artifact_storage_settings_exposes_safe_operator_posture(client, t
         patch.object(settings, "smtp_password", "secret-password"),
         patch.object(settings, "email_reports_to", "user@example.test"),
         patch.object(settings, "email_reports_to_allowlist", "hash-value"),
+        patch.object(settings, "workspace_dir", str(tmp_path / "workspace")),
+        patch("src.api.settings.context_manager.is_daemon_connected", return_value=False),
     ):
+        status_file = tmp_path / "workspace" / "daemon-status.json"
+        status_file.parent.mkdir(parents=True)
+        status_file.write_text(
+            json.dumps(
+                {
+                    "state": "running",
+                    "screen_analysis": "capture_error",
+                    "capture_ready": False,
+                    "last_error": "Grant Screen Recording permission.",
+                    "last_error_kind": "screen_capture_permission",
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ),
+            encoding="utf-8",
+        )
         resp = await client.get("/api/settings/artifact-storage")
 
     assert resp.status_code == 200
     data = resp.json()
+    assert data["screen"]["analysis_enabled"] is True
+    assert data["screen"]["provider"] == "codex-local"
+    assert data["screen"]["daemon_connected"] is True
+    assert data["screen"]["artifact_count"] == 0
     assert data["screen"]["preservation_enabled"] is True
     assert data["screen"]["archive_dir"].endswith("/screen")
     assert data["screen"]["exists"] is True
@@ -128,6 +152,10 @@ async def test_artifact_storage_settings_exposes_safe_operator_posture(client, t
     assert stat.S_IMODE((tmp_path / "screen").stat().st_mode) == 0o700
     assert data["screen"]["stored_artifacts"] == ["image", "provider_output", "analysis_json"]
     assert data["screen"]["inspection_visibility"] == "localhost_only"
+    assert data["screen"]["daemon_status"]["screen_analysis"] == "capture_error"
+    assert data["screen"]["daemon_status"]["last_error"] == "Grant Screen Recording permission."
+    assert data["screen"]["daemon_status"]["status_source"] == "daemon-status-file"
+    assert "status_file" not in data["screen"]["daemon_status"]
     assert data["reports"]["archive_dir"].endswith("/reports")
     assert data["reports"]["exists"] is True
     assert data["reports"]["writable"] is True
@@ -150,5 +178,62 @@ async def test_artifact_storage_prefers_seraph_screen_archive_env(client, tmp_pa
     assert resp.status_code == 200
     data = resp.json()
     assert data["screen"]["archive_dir"] == str(preferred)
-    assert data["screen"]["archive_dir_source"] == "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR"
+    assert data["screen"]["archive_dir_source"] == "screen-analysis-settings"
     assert data["screen"]["exists"] is True
+
+
+@pytest.mark.asyncio
+async def test_screen_analysis_settings_persist_and_drive_artifact_storage(client, tmp_path):
+    with patch.object(settings, "workspace_dir", str(tmp_path / "workspace")):
+        archive = tmp_path / "captures"
+        resp = await client.put(
+            "/api/settings/screen-analysis",
+            json={
+                "enabled": True,
+                "provider": "codex-local",
+                "model": "gpt-5.5",
+                "preserve_captures": True,
+                "archive_dir": str(archive),
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["provider"] == "codex-local"
+        assert data["model"] == "gpt-5.5"
+        assert data["preserve_captures"] is True
+        assert data["archive_dir"] == str(archive)
+
+        storage = (await client.get("/api/settings/artifact-storage")).json()
+        assert storage["screen"]["analysis_enabled"] is True
+        assert storage["screen"]["provider"] == "codex-local"
+        assert storage["screen"]["archive_dir"] == str(archive)
+        assert storage["screen"]["preservation_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_screen_analysis_settings_reject_invalid_provider(client, tmp_path):
+    with patch.object(settings, "workspace_dir", str(tmp_path / "workspace")):
+        resp = await client.put(
+            "/api/settings/screen-analysis",
+            json={"provider": "not-real"},
+        )
+
+    assert resp.status_code == 422
+
+
+def test_screen_artifact_summary_skips_files_deleted_during_stat(tmp_path, monkeypatch):
+    image = tmp_path / "capture.png"
+    image.write_bytes(b"not-really-a-png")
+    original_stat = type(image).stat
+
+    def flaky_stat(path, *args, **kwargs):
+        if path == image:
+            raise FileNotFoundError(str(path))
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(type(image), "is_file", lambda path: path == image)
+    monkeypatch.setattr(type(image), "stat", flaky_stat)
+
+    assert _screen_artifact_summary(tmp_path) == {"artifact_count": 0, "last_artifact_at": None}

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -1,8 +1,10 @@
 """Tests for settings API — GET/PUT interruption mode."""
 
+import stat
+from unittest.mock import patch
+
 import pytest
 import pytest_asyncio
-from unittest.mock import patch
 
 from config.settings import settings
 from src.db.models import UserProfile
@@ -123,12 +125,14 @@ async def test_artifact_storage_settings_exposes_safe_operator_posture(client, t
     assert data["screen"]["exists"] is True
     assert data["screen"]["writable"] is True
     assert data["screen"]["creation_error"] is None
+    assert stat.S_IMODE((tmp_path / "screen").stat().st_mode) == 0o700
     assert data["screen"]["stored_artifacts"] == ["image", "provider_output", "analysis_json"]
     assert data["screen"]["inspection_visibility"] == "localhost_only"
     assert data["reports"]["archive_dir"].endswith("/reports")
     assert data["reports"]["exists"] is True
     assert data["reports"]["writable"] is True
     assert data["reports"]["creation_error"] is None
+    assert stat.S_IMODE((tmp_path / "reports").stat().st_mode) == 0o700
     assert data["reports"]["analysis_provider"] == "deterministic-local"
     assert data["email"]["enabled"] is True
     assert data["email"]["smtp_configured"] is True

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -4,6 +4,7 @@ import pytest
 import pytest_asyncio
 from unittest.mock import patch
 
+from config.settings import settings
 from src.db.models import UserProfile
 from src.observer.context import CurrentContext
 
@@ -95,3 +96,34 @@ async def test_get_reflects_put(client, async_db):
 
     resp = await client.get("/api/settings/interruption-mode")
     assert resp.json()["mode"] == "focus"
+
+
+@pytest.mark.asyncio
+async def test_artifact_storage_settings_exposes_safe_operator_posture(client, tmp_path, monkeypatch):
+    monkeypatch.setenv("SERAPH_PRESERVE_SCREEN_CAPTURES", "true")
+    with (
+        patch.object(settings, "screen_capture_archive_dir", str(tmp_path / "screen")),
+        patch.object(settings, "report_archive_dir", str(tmp_path / "reports")),
+        patch.object(settings, "end_of_day_report_enabled", True),
+        patch.object(settings, "end_of_day_report_hour", 21),
+        patch.object(settings, "end_of_day_report_llm_enabled", False),
+        patch.object(settings, "email_reports_enabled", True),
+        patch.object(settings, "email_reports_preview_required", True),
+        patch.object(settings, "smtp_host", "smtp.example.test"),
+        patch.object(settings, "smtp_password", "secret-password"),
+        patch.object(settings, "email_reports_to", "user@example.test"),
+        patch.object(settings, "email_reports_to_allowlist", "hash-value"),
+    ):
+        resp = await client.get("/api/settings/artifact-storage")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["screen"]["preservation_enabled"] is True
+    assert data["screen"]["archive_dir"].endswith("/screen")
+    assert data["screen"]["stored_artifacts"] == ["image", "provider_output", "analysis_json"]
+    assert data["screen"]["inspection_visibility"] == "localhost_only"
+    assert data["reports"]["archive_dir"].endswith("/reports")
+    assert data["reports"]["analysis_provider"] == "deterministic-local"
+    assert data["email"]["enabled"] is True
+    assert data["email"]["smtp_configured"] is True
+    assert "secret-password" not in str(data)

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -120,9 +120,15 @@ async def test_artifact_storage_settings_exposes_safe_operator_posture(client, t
     data = resp.json()
     assert data["screen"]["preservation_enabled"] is True
     assert data["screen"]["archive_dir"].endswith("/screen")
+    assert data["screen"]["exists"] is True
+    assert data["screen"]["writable"] is True
+    assert data["screen"]["creation_error"] is None
     assert data["screen"]["stored_artifacts"] == ["image", "provider_output", "analysis_json"]
     assert data["screen"]["inspection_visibility"] == "localhost_only"
     assert data["reports"]["archive_dir"].endswith("/reports")
+    assert data["reports"]["exists"] is True
+    assert data["reports"]["writable"] is True
+    assert data["reports"]["creation_error"] is None
     assert data["reports"]["analysis_provider"] == "deterministic-local"
     assert data["email"]["enabled"] is True
     assert data["email"]["smtp_configured"] is True

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -133,3 +133,18 @@ async def test_artifact_storage_settings_exposes_safe_operator_posture(client, t
     assert data["email"]["enabled"] is True
     assert data["email"]["smtp_configured"] is True
     assert "secret-password" not in str(data)
+
+
+@pytest.mark.asyncio
+async def test_artifact_storage_prefers_seraph_screen_archive_env(client, tmp_path, monkeypatch):
+    preferred = tmp_path / "seraph-screen"
+    fallback = tmp_path / "fallback-screen"
+    monkeypatch.setenv("SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR", str(preferred))
+    with patch.object(settings, "screen_capture_archive_dir", str(fallback)):
+        resp = await client.get("/api/settings/artifact-storage")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["screen"]["archive_dir"] == str(preferred)
+    assert data["screen"]["archive_dir_source"] == "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR"
+    assert data["screen"]["exists"] is True

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -132,7 +132,7 @@ Examples:
 ./daemon/run.sh --ocr --ocr-provider codex-local --preserve-captures --verbose
 
 # Cloud analysis — OpenRouter with Gemini (structured JSON, ~$1.30/mo at ~150 switches/day)
-OPENROUTER_API_KEY=sk-or-... ./daemon/run.sh --ocr --ocr-provider openrouter --verbose
+OPENROUTER_API_KEY=<openrouter_api_key> ./daemon/run.sh --ocr --ocr-provider openrouter --verbose
 
 # With custom blocklist
 ./daemon/run.sh --ocr --ocr-provider openrouter --blocklist-file ~/blocklist.json --verbose

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -113,8 +113,8 @@ Screen analysis is opt-in and runs **on context switch** (not a timer). When you
 | `--ocr` | off | Enable screenshot analysis on context switch |
 | `--ocr-provider` | `apple-vision` | Provider: `apple-vision` (local), `codex-local` (local Codex CLI), or `openrouter` (cloud, structured JSON) |
 | `--ocr-model` | provider default | Model for OpenRouter or local Codex provider |
-| `--preserve-captures` | `$SERAPH_PRESERVE_SCREEN_CAPTURES` | Preserve allowed screenshots, redacted local Codex output, and normalized JSON artifacts |
-| `--capture-archive-dir` | `$SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR` or `/tmp/seraph-screen-captures` | Local directory for preserved artifacts |
+| `--preserve-captures` | `$SERAPH_PRESERVE_SCREEN_CAPTURES` | Preserve allowed screenshots, redacted provider output, and normalized JSON artifacts for future re-analysis |
+| `--capture-archive-dir` | `$SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR` or `~/Library/Application Support/Seraph/artifacts/screen-captures` | Durable local directory for preserved artifacts |
 | `--openrouter-api-key` | `$OPENROUTER_API_KEY` | API key for OpenRouter provider |
 | `--blocklist-file` | (none) | Path to JSON blocklist config (extends built-in defaults) |
 | `--ocr-interval` | (deprecated) | Ignored — OCR now runs on context switch |
@@ -191,7 +191,7 @@ OCR mode captures screenshots to extract visible text. This requires the Screen 
 | Window title | `main.py — seraph` | AppleScript (Accessibility) |
 | Idle duration | `312.5` seconds | `CGEventSource` (no permission) |
 
-**Not captured:** keystrokes, clipboard, file contents. When `--ocr` is enabled, screenshots are captured only to produce a structured activity observation. `apple-vision` keeps analysis local. `codex-local` invokes the local `codex exec` command and writes a temporary PNG for that command, then deletes it after analysis or failure unless capture preservation is enabled. With `--preserve-captures`, allowed screenshots, redacted local Codex output, and normalized JSON are archived under `--capture-archive-dir` for local inspection. `openrouter` sends the image to the configured OpenRouter model and should only be used when that external provider is acceptable.
+**Not captured:** keystrokes, clipboard, file contents. When `--ocr` is enabled, screenshots are captured only to produce a structured activity observation. `apple-vision` keeps analysis local. `codex-local` invokes the local `codex exec` command and writes a temporary PNG for that command, then deletes it after analysis or failure unless capture preservation is enabled. With `--preserve-captures`, allowed screenshots, redacted provider output, and normalized JSON are archived under `--capture-archive-dir` for future re-analysis by better models. The backend uses the same durable archive root by default, or `SCREEN_CAPTURE_ARCHIVE_DIR` when explicitly configured. `openrouter` sends the image to the configured OpenRouter model and should only be used when that external provider is acceptable.
 
 Preserved local Codex artifacts can be inspected through the backend from localhost only:
 
@@ -214,9 +214,9 @@ The daemon posts to `POST /api/observer/context`:
     "details": ["file: main.py", "language: Python"],
     "capture_artifacts": {
       "id": "artifact-digest",
-      "image_path": "/tmp/seraph-screen-captures/2026-06-20/120000-vs-code-artifact.png",
-      "codex_output_path": "/tmp/seraph-screen-captures/2026-06-20/120000-vs-code-artifact.codex.txt",
-      "analysis_path": "/tmp/seraph-screen-captures/2026-06-20/120000-vs-code-artifact.analysis.json"
+      "image_path": "~/Library/Application Support/Seraph/artifacts/screen-captures/2026-06-20/120000-vs-code-artifact.png",
+      "codex_output_path": "~/Library/Application Support/Seraph/artifacts/screen-captures/2026-06-20/120000-vs-code-artifact.codex.txt",
+      "analysis_path": "~/Library/Application Support/Seraph/artifacts/screen-captures/2026-06-20/120000-vs-code-artifact.analysis.json"
     }
   },
   "switch_timestamp": 1700000000.0

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -113,6 +113,8 @@ Screen analysis is opt-in and runs **on context switch** (not a timer). When you
 | `--ocr` | off | Enable screenshot analysis on context switch |
 | `--ocr-provider` | `apple-vision` | Provider: `apple-vision` (local), `codex-local` (local Codex CLI), or `openrouter` (cloud, structured JSON) |
 | `--ocr-model` | provider default | Model for OpenRouter or local Codex provider |
+| `--preserve-captures` | `$SERAPH_PRESERVE_SCREEN_CAPTURES` | Preserve allowed screenshots, redacted local Codex output, and normalized JSON artifacts |
+| `--capture-archive-dir` | `$SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR` or `/tmp/seraph-screen-captures` | Local directory for preserved artifacts |
 | `--openrouter-api-key` | `$OPENROUTER_API_KEY` | API key for OpenRouter provider |
 | `--blocklist-file` | (none) | Path to JSON blocklist config (extends built-in defaults) |
 | `--ocr-interval` | (deprecated) | Ignored — OCR now runs on context switch |
@@ -125,6 +127,9 @@ Examples:
 
 # Local structured analysis — Codex CLI on this machine
 ./daemon/run.sh --ocr --ocr-provider codex-local --verbose
+
+# Local Codex analysis with inspectable artifacts
+./daemon/run.sh --ocr --ocr-provider codex-local --preserve-captures --verbose
 
 # Cloud analysis — OpenRouter with Gemini (structured JSON, ~$1.30/mo at ~150 switches/day)
 OPENROUTER_API_KEY=sk-or-... ./daemon/run.sh --ocr --ocr-provider openrouter --verbose
@@ -186,7 +191,15 @@ OCR mode captures screenshots to extract visible text. This requires the Screen 
 | Window title | `main.py — seraph` | AppleScript (Accessibility) |
 | Idle duration | `312.5` seconds | `CGEventSource` (no permission) |
 
-**Not captured:** keystrokes, clipboard, file contents. When `--ocr` is enabled, screenshots are captured only to produce a structured activity observation. `apple-vision` keeps analysis local. `codex-local` invokes the local `codex exec` command and writes a temporary PNG for that command, then deletes it after analysis or failure. `openrouter` sends the image to the configured OpenRouter model and should only be used when that external provider is acceptable.
+**Not captured:** keystrokes, clipboard, file contents. When `--ocr` is enabled, screenshots are captured only to produce a structured activity observation. `apple-vision` keeps analysis local. `codex-local` invokes the local `codex exec` command and writes a temporary PNG for that command, then deletes it after analysis or failure unless capture preservation is enabled. With `--preserve-captures`, allowed screenshots, redacted local Codex output, and normalized JSON are archived under `--capture-archive-dir` for local inspection. `openrouter` sends the image to the configured OpenRouter model and should only be used when that external provider is acceptable.
+
+Preserved local Codex artifacts can be inspected through the backend from localhost only:
+
+```bash
+curl http://localhost:8004/api/observer/screen-artifacts
+curl http://localhost:8004/api/observer/screen-artifacts/{observation_id}/codex-output
+open http://localhost:8004/api/observer/screen-artifacts/{observation_id}/image
+```
 
 The daemon posts to `POST /api/observer/context`:
 ```json
@@ -198,7 +211,13 @@ The daemon posts to `POST /api/observer/context`:
     "activity": "coding",
     "project": "seraph",
     "summary": "Editing Python file in VS Code",
-    "details": ["file: main.py", "language: Python"]
+    "details": ["file: main.py", "language: Python"],
+    "capture_artifacts": {
+      "id": "artifact-digest",
+      "image_path": "/tmp/seraph-screen-captures/2026-06-20/120000-vs-code-artifact.png",
+      "codex_output_path": "/tmp/seraph-screen-captures/2026-06-20/120000-vs-code-artifact.codex.txt",
+      "analysis_path": "/tmp/seraph-screen-captures/2026-06-20/120000-vs-code-artifact.analysis.json"
+    }
   },
   "switch_timestamp": 1700000000.0
 }

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -111,8 +111,8 @@ Screen analysis is opt-in and runs **on context switch** (not a timer). When you
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--ocr` | off | Enable screenshot analysis on context switch |
-| `--ocr-provider` | `apple-vision` | Provider: `apple-vision` (local) or `openrouter` (cloud, structured JSON) |
-| `--ocr-model` | `google/gemini-2.5-flash-lite` | Model for OpenRouter provider |
+| `--ocr-provider` | `apple-vision` | Provider: `apple-vision` (local), `codex-local` (local Codex CLI), or `openrouter` (cloud, structured JSON) |
+| `--ocr-model` | provider default | Model for OpenRouter or local Codex provider |
 | `--openrouter-api-key` | `$OPENROUTER_API_KEY` | API key for OpenRouter provider |
 | `--blocklist-file` | (none) | Path to JSON blocklist config (extends built-in defaults) |
 | `--ocr-interval` | (deprecated) | Ignored — OCR now runs on context switch |
@@ -122,6 +122,9 @@ Examples:
 ```bash
 # Local analysis — Apple Vision framework (free, offline, ~200ms per capture)
 ./daemon/run.sh --ocr --verbose
+
+# Local structured analysis — Codex CLI on this machine
+./daemon/run.sh --ocr --ocr-provider codex-local --verbose
 
 # Cloud analysis — OpenRouter with Gemini (structured JSON, ~$1.30/mo at ~150 switches/day)
 OPENROUTER_API_KEY=sk-or-... ./daemon/run.sh --ocr --ocr-provider openrouter --verbose
@@ -183,7 +186,7 @@ OCR mode captures screenshots to extract visible text. This requires the Screen 
 | Window title | `main.py — seraph` | AppleScript (Accessibility) |
 | Idle duration | `312.5` seconds | `CGEventSource` (no permission) |
 
-**Not captured:** keystrokes, clipboard, file contents. Screenshots are only captured in memory when `--ocr` is enabled and are never written to disk.
+**Not captured:** keystrokes, clipboard, file contents. When `--ocr` is enabled, screenshots are captured only to produce a structured activity observation. `apple-vision` keeps analysis local. `codex-local` invokes the local `codex exec` command and writes a temporary PNG for that command, then deletes it after analysis or failure. `openrouter` sends the image to the configured OpenRouter model and should only be used when that external provider is acceptable.
 
 The daemon posts to `POST /api/observer/context`:
 ```json

--- a/daemon/ocr/__init__.py
+++ b/daemon/ocr/__init__.py
@@ -7,6 +7,8 @@ def create_provider(
     name: str,
     api_key: str | None = None,
     model: str | None = None,
+    preserve_captures: bool | None = None,
+    archive_dir: str | None = None,
 ) -> OCRProvider:
     """Create an OCR provider by name.
 
@@ -33,6 +35,10 @@ def create_provider(
     if name == "codex-local":
         from ocr.codex_local import CodexLocalProvider
 
-        return CodexLocalProvider(model=model)
+        return CodexLocalProvider(
+            model=model,
+            preserve_captures=preserve_captures,
+            archive_dir=archive_dir,
+        )
 
     raise ValueError(f"Unknown OCR provider: {name!r} (choose 'apple-vision', 'openrouter', or 'codex-local')")

--- a/daemon/ocr/__init__.py
+++ b/daemon/ocr/__init__.py
@@ -11,9 +11,9 @@ def create_provider(
     """Create an OCR provider by name.
 
     Args:
-        name: "apple-vision" or "openrouter"
+        name: "apple-vision", "openrouter", or "codex-local"
         api_key: Required for openrouter provider
-        model: Model name for openrouter (has default)
+        model: Model name for openrouter or codex-local (has provider defaults)
 
     Raises:
         ValueError: Unknown provider or missing api_key for openrouter
@@ -30,4 +30,9 @@ def create_provider(
 
         return OpenRouterProvider(api_key=api_key, model=model)
 
-    raise ValueError(f"Unknown OCR provider: {name!r} (choose 'apple-vision' or 'openrouter')")
+    if name == "codex-local":
+        from ocr.codex_local import CodexLocalProvider
+
+        return CodexLocalProvider(model=model)
+
+    raise ValueError(f"Unknown OCR provider: {name!r} (choose 'apple-vision', 'openrouter', or 'codex-local')")

--- a/daemon/ocr/codex_local.py
+++ b/daemon/ocr/codex_local.py
@@ -282,6 +282,26 @@ def _read_output(output_path: Path) -> str:
     return ""
 
 
+def _ensure_private_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with suppress(OSError):
+        path.chmod(0o700)
+
+
+def _write_private_bytes(path: Path, content: bytes) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(content)
+    finally:
+        with suppress(OSError):
+            os.chmod(path, 0o600)
+
+
+def _write_private_text(path: Path, content: str) -> None:
+    _write_private_bytes(path, content.encode("utf-8"))
+
+
 def _archive_capture(
     *,
     archive_dir: Path,
@@ -291,16 +311,17 @@ def _archive_capture(
     normalized: dict[str, Any],
 ) -> dict[str, str]:
     now = datetime.now(timezone.utc)
+    _ensure_private_dir(archive_dir)
     day_dir = archive_dir / now.strftime("%Y-%m-%d")
-    day_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_private_dir(day_dir)
     digest = hashlib.sha256(png_bytes + raw_output.encode("utf-8", errors="replace")).hexdigest()[:16]
     stem = f"{now.strftime('%H%M%S')}-{_slug(app_name)}-{digest}"
     image_path = day_dir / f"{stem}.png"
     raw_output_path = day_dir / f"{stem}.codex.txt"
     normalized_path = day_dir / f"{stem}.analysis.json"
-    image_path.write_bytes(png_bytes)
-    raw_output_path.write_text(raw_output, encoding="utf-8")
-    normalized_path.write_text(json.dumps(normalized, indent=2, sort_keys=True), encoding="utf-8")
+    _write_private_bytes(image_path, png_bytes)
+    _write_private_text(raw_output_path, raw_output)
+    _write_private_text(normalized_path, json.dumps(normalized, indent=2, sort_keys=True))
     return {
         "id": digest,
         "image_path": str(image_path),

--- a/daemon/ocr/codex_local.py
+++ b/daemon/ocr/codex_local.py
@@ -1,0 +1,328 @@
+"""Local Codex image analysis provider for the native daemon."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from contextlib import suppress
+from pathlib import Path
+import re
+import signal
+import tempfile
+import time
+from typing import Any
+
+from ocr.base import AnalysisResult, OCRProvider, OCRResult
+
+logger = logging.getLogger("seraph_daemon")
+
+_DEFAULT_MODEL = "gpt-5.5"
+_DEFAULT_REASONING_EFFORT = "low"
+_DEFAULT_TIMEOUT_SECONDS = 60
+_OUTPUT_LIMIT = 12_000
+_ENV_ALLOWLIST = {
+    "PATH",
+    "HOME",
+    "CODEX_HOME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TERM",
+    "TZ",
+}
+_SECRET_ENV_MARKERS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL", "AUTH")
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)\b(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*[^\s,;]+"),
+    re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+"),
+)
+_VALID_ACTIVITIES = {
+    "coding",
+    "browsing",
+    "communication",
+    "reading",
+    "design",
+    "terminal",
+    "entertainment",
+    "other",
+}
+
+_PROMPT = """\
+Analyze this desktop screenshot for Seraph's private local activity tracking.
+
+Return ONLY valid JSON with this exact shape:
+{{
+  "activity": "coding|browsing|communication|reading|design|terminal|entertainment|other",
+  "project": "project name or null",
+  "summary": "one sentence, max 100 chars",
+  "details": ["notable non-sensitive items, max 5"],
+  "sensitive_detected": true,
+  "confidence": 0.0
+}}
+
+Rules:
+- Do not copy passwords, API keys, tokens, private message bodies, financial details, or customer data.
+- If sensitive content is visible, set sensitive_detected=true and keep summary/details generic.
+- Prefer activity/project/focus patterns over verbatim screen text.
+- The frontmost app is: {app_name}
+"""
+
+
+class CodexLocalProvider(OCRProvider):
+    """Screen analysis using the local Codex CLI image input."""
+
+    def __init__(
+        self,
+        *,
+        command: str | None = None,
+        model: str | None = None,
+        reasoning_effort: str | None = None,
+        timeout_seconds: int | None = None,
+        temp_dir: str | None = None,
+    ) -> None:
+        self._command = _safe_command_name(command or os.environ.get("CODEX_LOCAL_COMMAND") or "codex")
+        self._model = model or os.environ.get("CODEX_LOCAL_MODEL") or _DEFAULT_MODEL
+        self._reasoning_effort = (
+            reasoning_effort
+            or os.environ.get("CODEX_LOCAL_REASONING_EFFORT")
+            or _DEFAULT_REASONING_EFFORT
+        )
+        self._timeout_seconds = _timeout_seconds(timeout_seconds)
+        self._temp_dir = Path(temp_dir).resolve() if temp_dir else None
+
+    @property
+    def name(self) -> str:
+        return "codex-local"
+
+    def is_available(self) -> bool:
+        try:
+            import shutil
+
+            return shutil.which(self._command) is not None
+        except Exception:
+            return False
+
+    async def extract_text(self, png_bytes: bytes) -> OCRResult:
+        start = time.monotonic()
+        analysis = await self.analyze_screen(png_bytes, "Unknown")
+        return OCRResult(
+            text=str(analysis.data.get("summary") or ""),
+            provider=self.name,
+            duration_ms=int((time.monotonic() - start) * 1000),
+            success=analysis.success,
+            error=analysis.error,
+        )
+
+    async def analyze_screen(self, png_bytes: bytes, app_name: str) -> AnalysisResult:
+        start = time.monotonic()
+        image_path: Path | None = None
+        output_path: Path | None = None
+        try:
+            image_path = _write_temp_png(png_bytes, temp_dir=self._temp_dir)
+            output_path = _make_temp_output(temp_dir=self._temp_dir)
+            raw_output = await self._run_codex(
+                image_path=image_path,
+                output_path=output_path,
+                prompt=_PROMPT.format(app_name=app_name),
+            )
+            parsed = _parse_json_output(raw_output)
+            return AnalysisResult(
+                success=True,
+                data=_normalize_analysis(parsed),
+                duration_ms=int((time.monotonic() - start) * 1000),
+            )
+        except Exception as exc:
+            logger.debug("codex-local analyze_screen failed: %s", exc)
+            return AnalysisResult(
+                success=False,
+                data={},
+                duration_ms=int((time.monotonic() - start) * 1000),
+                error=str(exc),
+            )
+        finally:
+            _cleanup_file(image_path)
+            _cleanup_file(output_path)
+
+    async def _run_codex(self, *, image_path: Path, output_path: Path, prompt: str) -> str:
+        argv = [
+            self._command,
+            "--ask-for-approval",
+            "never",
+            "exec",
+            "-C",
+            str(_repo_root()),
+            "--sandbox",
+            "read-only",
+            "--ephemeral",
+            "--ignore-rules",
+            "--ignore-user-config",
+            "--color",
+            "never",
+            "--image",
+            str(image_path),
+        ]
+        if self._model:
+            argv.extend(["--model", self._model])
+        if self._reasoning_effort:
+            argv.extend(["-c", f'model_reasoning_effort="{self._reasoning_effort}"'])
+        argv.extend(["--output-last-message", str(output_path), prompt])
+
+        process = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=str(_repo_root()),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=_codex_env(),
+            start_new_session=True,
+        )
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                process.communicate(input=b""),
+                timeout=self._timeout_seconds,
+            )
+        except asyncio.TimeoutError as exc:
+            await _terminate_process_group(process)
+            raise TimeoutError("codex-local screen analysis timed out") from exc
+
+        output_text = _read_output(output_path) or stdout_bytes.decode("utf-8", errors="replace")
+        stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+        if process.returncode != 0:
+            raise RuntimeError(_truncate(_redact(stderr_text or output_text or "codex-local failed")))
+        return _truncate(_redact(output_text))
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _safe_command_name(command: str) -> str:
+    normalized = command.strip()
+    if not normalized:
+        raise ValueError("Codex command is required.")
+    if any(char in normalized for char in ("|", "&", ";", "<", ">", "`", "$", "\n", "\r", "\t")):
+        raise ValueError("Codex command must be a single executable path or name.")
+    return normalized
+
+
+def _timeout_seconds(value: int | None) -> int:
+    if value is None:
+        value = int(os.environ.get("CODEX_LOCAL_SCREEN_TIMEOUT_SECONDS") or _DEFAULT_TIMEOUT_SECONDS)
+    return min(max(int(value or 1), 1), 600)
+
+
+def _codex_env() -> dict[str, str]:
+    env = {key: value for key, value in os.environ.items() if key in _ENV_ALLOWLIST and value}
+    env.setdefault("PATH", os.defpath)
+    env["SERAPH_LOCAL_OPERATOR"] = "codex-local-screen"
+    return env
+
+
+def _write_temp_png(png_bytes: bytes, *, temp_dir: Path | None = None) -> Path:
+    fd, name = tempfile.mkstemp(prefix="seraph-screen-", suffix=".png", dir=str(temp_dir) if temp_dir else None)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(png_bytes)
+        return Path(name)
+    except Exception:
+        with suppress(OSError):
+            os.close(fd)
+        _cleanup_file(Path(name))
+        raise
+
+
+def _make_temp_output(*, temp_dir: Path | None = None) -> Path:
+    fd, name = tempfile.mkstemp(prefix="seraph-codex-screen-", suffix=".txt", dir=str(temp_dir) if temp_dir else None)
+    os.close(fd)
+    return Path(name)
+
+
+def _cleanup_file(path: Path | None) -> None:
+    if path is not None:
+        with suppress(OSError):
+            path.unlink()
+
+
+def _read_output(output_path: Path) -> str:
+    with suppress(OSError, UnicodeDecodeError):
+        return output_path.read_text(encoding="utf-8").strip()
+    return ""
+
+
+async def _terminate_process_group(process: Any) -> None:
+    pid = int(process.pid)
+    with suppress(ProcessLookupError):
+        os.killpg(pid, signal.SIGTERM)
+    try:
+        await asyncio.wait_for(process.wait(), timeout=2)
+        return
+    except asyncio.TimeoutError:
+        pass
+    with suppress(ProcessLookupError):
+        os.killpg(pid, signal.SIGKILL)
+    with suppress(Exception):
+        await asyncio.wait_for(process.wait(), timeout=2)
+
+
+def _parse_json_output(raw_output: str) -> dict[str, Any]:
+    text = raw_output.strip()
+    if text.startswith("```"):
+        lines = [line for line in text.splitlines() if not line.strip().startswith("```")]
+        text = "\n".join(lines).strip()
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError("codex-local did not return valid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("codex-local JSON output must be an object")
+    return parsed
+
+
+def _normalize_analysis(parsed: dict[str, Any]) -> dict[str, Any]:
+    activity = str(parsed.get("activity") or "other").strip().lower()
+    if activity not in _VALID_ACTIVITIES:
+        activity = "other"
+    details = parsed.get("details")
+    if not isinstance(details, list):
+        details = []
+    return {
+        "activity": activity,
+        "project": _safe_optional_text(parsed.get("project"), max_chars=80),
+        "summary": _safe_optional_text(parsed.get("summary"), max_chars=200) or "",
+        "details": [_safe_optional_text(item, max_chars=120) for item in details[:5] if _safe_optional_text(item, max_chars=120)],
+        "sensitive_detected": bool(parsed.get("sensitive_detected")),
+        "confidence": _safe_confidence(parsed.get("confidence")),
+    }
+
+
+def _safe_optional_text(value: Any, *, max_chars: int) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or text.lower() == "null":
+        return None
+    return _redact(text)[:max_chars]
+
+
+def _safe_confidence(value: Any) -> float:
+    try:
+        return max(0.0, min(float(value), 1.0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _redact(value: str) -> str:
+    redacted = value
+    for env_name, env_value in os.environ.items():
+        if env_value and any(marker in env_name.upper() for marker in _SECRET_ENV_MARKERS):
+            redacted = redacted.replace(env_value, "[redacted]")
+    for pattern in _SECRET_PATTERNS:
+        redacted = pattern.sub("[redacted]", redacted)
+    return redacted
+
+
+def _truncate(value: str) -> str:
+    if len(value) <= _OUTPUT_LIMIT:
+        return value
+    return value[:_OUTPUT_LIMIT] + "\n...[truncated]..."

--- a/daemon/ocr/codex_local.py
+++ b/daemon/ocr/codex_local.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
 from contextlib import suppress
+from datetime import datetime, timezone
 from pathlib import Path
 import re
 import signal
@@ -21,6 +23,7 @@ logger = logging.getLogger("seraph_daemon")
 _DEFAULT_MODEL = "gpt-5.5"
 _DEFAULT_REASONING_EFFORT = "low"
 _DEFAULT_TIMEOUT_SECONDS = 60
+_DEFAULT_ARCHIVE_DIR = "/tmp/seraph-screen-captures"
 _OUTPUT_LIMIT = 12_000
 _ENV_ALLOWLIST = {
     "PATH",
@@ -80,6 +83,8 @@ class CodexLocalProvider(OCRProvider):
         reasoning_effort: str | None = None,
         timeout_seconds: int | None = None,
         temp_dir: str | None = None,
+        preserve_captures: bool | None = None,
+        archive_dir: str | None = None,
     ) -> None:
         self._command = _safe_command_name(command or os.environ.get("CODEX_LOCAL_COMMAND") or "codex")
         self._model = model or os.environ.get("CODEX_LOCAL_MODEL") or _DEFAULT_MODEL
@@ -90,6 +95,17 @@ class CodexLocalProvider(OCRProvider):
         )
         self._timeout_seconds = _timeout_seconds(timeout_seconds)
         self._temp_dir = Path(temp_dir).resolve() if temp_dir else None
+        self._preserve_captures = (
+            _env_bool("SERAPH_PRESERVE_SCREEN_CAPTURES", False)
+            if preserve_captures is None
+            else preserve_captures
+        )
+        self._archive_dir = Path(
+            archive_dir
+            or os.environ.get("SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR")
+            or os.environ.get("SCREEN_CAPTURE_ARCHIVE_DIR")
+            or _DEFAULT_ARCHIVE_DIR
+        ).expanduser().resolve()
 
     @property
     def name(self) -> str:
@@ -127,9 +143,18 @@ class CodexLocalProvider(OCRProvider):
                 prompt=_PROMPT.format(app_name=app_name),
             )
             parsed = _parse_json_output(raw_output)
+            data = _normalize_analysis(parsed)
+            if self._preserve_captures:
+                data["capture_artifacts"] = _archive_capture(
+                    archive_dir=self._archive_dir,
+                    png_bytes=png_bytes,
+                    app_name=app_name,
+                    raw_output=raw_output,
+                    normalized=data,
+                )
             return AnalysisResult(
                 success=True,
-                data=_normalize_analysis(parsed),
+                data=data,
                 duration_ms=int((time.monotonic() - start) * 1000),
             )
         except Exception as exc:
@@ -212,6 +237,13 @@ def _timeout_seconds(value: int | None) -> int:
     return min(max(int(value or 1), 1), 600)
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _codex_env() -> dict[str, str]:
     env = {key: value for key, value in os.environ.items() if key in _ENV_ALLOWLIST and value}
     env.setdefault("PATH", os.defpath)
@@ -248,6 +280,39 @@ def _read_output(output_path: Path) -> str:
     with suppress(OSError, UnicodeDecodeError):
         return output_path.read_text(encoding="utf-8").strip()
     return ""
+
+
+def _archive_capture(
+    *,
+    archive_dir: Path,
+    png_bytes: bytes,
+    app_name: str,
+    raw_output: str,
+    normalized: dict[str, Any],
+) -> dict[str, str]:
+    now = datetime.now(timezone.utc)
+    day_dir = archive_dir / now.strftime("%Y-%m-%d")
+    day_dir.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256(png_bytes + raw_output.encode("utf-8", errors="replace")).hexdigest()[:16]
+    stem = f"{now.strftime('%H%M%S')}-{_slug(app_name)}-{digest}"
+    image_path = day_dir / f"{stem}.png"
+    raw_output_path = day_dir / f"{stem}.codex.txt"
+    normalized_path = day_dir / f"{stem}.analysis.json"
+    image_path.write_bytes(png_bytes)
+    raw_output_path.write_text(raw_output, encoding="utf-8")
+    normalized_path.write_text(json.dumps(normalized, indent=2, sort_keys=True), encoding="utf-8")
+    return {
+        "id": digest,
+        "image_path": str(image_path),
+        "codex_output_path": str(raw_output_path),
+        "analysis_path": str(normalized_path),
+        "created_at": now.isoformat(),
+    }
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", value.strip().lower()).strip("-")
+    return slug[:40] or "screen"
 
 
 async def _terminate_process_group(process: Any) -> None:

--- a/daemon/ocr/codex_local.py
+++ b/daemon/ocr/codex_local.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("seraph_daemon")
 _DEFAULT_MODEL = "gpt-5.5"
 _DEFAULT_REASONING_EFFORT = "low"
 _DEFAULT_TIMEOUT_SECONDS = 60
-_DEFAULT_ARCHIVE_DIR = "/tmp/seraph-screen-captures"
+_DEFAULT_ARCHIVE_DIR = "~/Library/Application Support/Seraph/artifacts/screen-captures"
 _OUTPUT_LIMIT = 12_000
 _ENV_ALLOWLIST = {
     "PATH",

--- a/daemon/ocr/screenshot.py
+++ b/daemon/ocr/screenshot.py
@@ -13,6 +13,7 @@ logger = logging.getLogger("seraph_daemon")
 
 # Track whether we've already warned about missing permission
 _warned_no_permission = False
+_warned_screencapture_failed = False
 
 
 def capture_screen_png() -> bytes | None:
@@ -50,7 +51,7 @@ def capture_screen_png() -> bytes | None:
 
 def _capture_via_screencapture() -> bytes | None:
     """Capture using macOS screencapture CLI — most reliable on newer macOS."""
-    global _warned_no_permission
+    global _warned_screencapture_failed
 
     try:
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
@@ -64,16 +65,36 @@ def _capture_via_screencapture() -> bytes | None:
         )
 
         if result.returncode != 0:
-            logger.debug("screencapture exited with code %d", result.returncode)
+            stderr = result.stderr.decode("utf-8", errors="replace").strip()
+            if stderr:
+                logger.debug("screencapture stderr: %s", stderr[:500])
+            if not _warned_screencapture_failed:
+                logger.warning(
+                    "macOS screencapture failed with code %d. "
+                    "No screenshot artifact was created. Grant Screen Recording / Screen & System Audio Recording "
+                    "permission to the terminal/app running Seraph, then restart the daemon.",
+                    result.returncode,
+                )
+                _warned_screencapture_failed = True
+            else:
+                logger.debug("screencapture exited with code %d", result.returncode)
             tmp_path.unlink(missing_ok=True)
             return None
 
         if not tmp_path.exists() or tmp_path.stat().st_size == 0:
+            if not _warned_screencapture_failed:
+                logger.warning(
+                    "macOS screencapture produced no image. "
+                    "Grant Screen Recording / Screen & System Audio Recording permission to "
+                    "the terminal/app running Seraph, then restart the daemon."
+                )
+                _warned_screencapture_failed = True
             tmp_path.unlink(missing_ok=True)
             return None
 
         png_bytes = tmp_path.read_bytes()
         tmp_path.unlink(missing_ok=True)
+        _warned_screencapture_failed = False
         return png_bytes
 
     except FileNotFoundError:

--- a/daemon/run.sh
+++ b/daemon/run.sh
@@ -33,6 +33,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="$SCRIPT_DIR/.venv"
+export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/seraph-uv-cache}"
 
 # Create venv if it doesn't exist
 if [ ! -d "$VENV_DIR" ]; then

--- a/daemon/seraph_daemon.py
+++ b/daemon/seraph_daemon.py
@@ -15,8 +15,13 @@ Usage:
 
 import argparse
 import asyncio
+import hashlib
+import json
 import logging
 import os
+from datetime import datetime, timezone
+from pathlib import Path
+import re
 import signal
 import subprocess
 import sys
@@ -25,6 +30,51 @@ import time
 import httpx
 
 logger = logging.getLogger("seraph_daemon")
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", value.strip().lower()).strip("-")
+    return slug[:40] or "screen"
+
+
+def _archive_provider_capture(
+    *,
+    archive_dir: str,
+    png_bytes: bytes,
+    app_name: str,
+    provider_name: str,
+    analysis: dict,
+) -> dict[str, str]:
+    now = datetime.now(timezone.utc)
+    root = Path(archive_dir).expanduser().resolve()
+    day_dir = root / now.strftime("%Y-%m-%d")
+    day_dir.mkdir(parents=True, exist_ok=True)
+    analysis_json = json.dumps(analysis, indent=2, sort_keys=True)
+    digest = hashlib.sha256(
+        png_bytes + provider_name.encode("utf-8") + analysis_json.encode("utf-8")
+    ).hexdigest()[:16]
+    stem = f"{now.strftime('%H%M%S')}-{_slug(app_name)}-{digest}"
+    image_path = day_dir / f"{stem}.png"
+    provider_output_path = day_dir / f"{stem}.{_slug(provider_name)}.json"
+    analysis_path = day_dir / f"{stem}.analysis.json"
+    provider_payload = {
+        "artifact_schema": "seraph.screen_analysis.v1",
+        "provider": provider_name,
+        "app": app_name,
+        "created_at": now.isoformat(),
+        "analysis": analysis,
+    }
+    image_path.write_bytes(png_bytes)
+    provider_output_path.write_text(json.dumps(provider_payload, indent=2, sort_keys=True), encoding="utf-8")
+    analysis_path.write_text(analysis_json, encoding="utf-8")
+    return {
+        "id": digest,
+        "provider": provider_name,
+        "image_path": str(image_path),
+        "provider_output_path": str(provider_output_path),
+        "analysis_path": str(analysis_path),
+        "created_at": now.isoformat(),
+    }
 
 # ─── macOS helpers ────────────────────────────────────────
 
@@ -170,6 +220,8 @@ async def poll_loop(
     verbose: bool,
     ocr_provider: "ocr.base.OCRProvider | None" = None,
     blocklist: set[str] | None = None,
+    preserve_captures: bool = False,
+    capture_archive_dir: str = "",
 ) -> None:
     """Core polling loop — detect window changes, post to backend.
 
@@ -256,6 +308,14 @@ async def poll_loop(
                                 result = await ocr_provider.analyze_screen(png_bytes, app_name)
                                 if result.success:
                                     observation.update(result.data)
+                                    if preserve_captures and "capture_artifacts" not in observation:
+                                        observation["capture_artifacts"] = _archive_provider_capture(
+                                            archive_dir=capture_archive_dir,
+                                            png_bytes=png_bytes,
+                                            app_name=app_name,
+                                            provider_name=ocr_provider.name,
+                                            analysis=result.data,
+                                        )
                                     if verbose:
                                         ts = time.strftime("%H:%M:%S")
                                         logger.info(
@@ -303,6 +363,8 @@ async def periodic_capture_loop(
     verbose: bool,
     ocr_provider: "ocr.base.OCRProvider | None" = None,
     blocklist: set[str] | None = None,
+    preserve_captures: bool = False,
+    capture_archive_dir: str = "",
 ) -> None:
     """Periodic capture loop — takes screenshots at intervals within the same app.
 
@@ -367,6 +429,14 @@ async def periodic_capture_loop(
                             result = await ocr_provider.analyze_screen(png_bytes, app_name)
                             if result.success:
                                 observation.update(result.data)
+                                if preserve_captures and "capture_artifacts" not in observation:
+                                    observation["capture_artifacts"] = _archive_provider_capture(
+                                        archive_dir=capture_archive_dir,
+                                        png_bytes=png_bytes,
+                                        app_name=app_name,
+                                        provider_name=ocr_provider.name,
+                                        analysis=result.data,
+                                    )
                                 if verbose:
                                     ts = time.strftime("%H:%M:%S")
                                     logger.info(
@@ -465,8 +535,8 @@ async def main() -> None:
         "--capture-archive-dir",
         default=os.environ.get("SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR")
         or os.environ.get("SCREEN_CAPTURE_ARCHIVE_DIR")
-        or "/tmp/seraph-screen-captures",
-        help="Directory for preserved capture artifacts (default: /tmp/seraph-screen-captures)",
+        or "~/Library/Application Support/Seraph/artifacts/screen-captures",
+        help="Directory for preserved capture artifacts (default: ~/Library/Application Support/Seraph/artifacts/screen-captures)",
     )
     parser.add_argument(
         "--openrouter-api-key",
@@ -562,6 +632,8 @@ async def main() -> None:
             args.verbose,
             ocr_provider=ocr_provider,
             blocklist=blocklist,
+            preserve_captures=args.preserve_captures,
+            capture_archive_dir=args.capture_archive_dir,
         )
     )
     periodic_task = asyncio.create_task(
@@ -571,6 +643,8 @@ async def main() -> None:
             args.verbose,
             ocr_provider=ocr_provider,
             blocklist=blocklist,
+            preserve_captures=args.preserve_captures,
+            capture_archive_dir=args.capture_archive_dir,
         )
     ) if ocr_provider is not None else None
 

--- a/daemon/seraph_daemon.py
+++ b/daemon/seraph_daemon.py
@@ -16,6 +16,7 @@ Usage:
 import argparse
 import asyncio
 import hashlib
+import contextlib
 import json
 import logging
 import os
@@ -47,8 +48,13 @@ def _archive_provider_capture(
 ) -> dict[str, str]:
     now = datetime.now(timezone.utc)
     root = Path(archive_dir).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with contextlib.suppress(OSError):
+        root.chmod(0o700)
     day_dir = root / now.strftime("%Y-%m-%d")
-    day_dir.mkdir(parents=True, exist_ok=True)
+    day_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with contextlib.suppress(OSError):
+        day_dir.chmod(0o700)
     analysis_json = json.dumps(analysis, indent=2, sort_keys=True)
     digest = hashlib.sha256(
         png_bytes + provider_name.encode("utf-8") + analysis_json.encode("utf-8")
@@ -64,9 +70,9 @@ def _archive_provider_capture(
         "created_at": now.isoformat(),
         "analysis": analysis,
     }
-    image_path.write_bytes(png_bytes)
-    provider_output_path.write_text(json.dumps(provider_payload, indent=2, sort_keys=True), encoding="utf-8")
-    analysis_path.write_text(analysis_json, encoding="utf-8")
+    _write_private_bytes(image_path, png_bytes)
+    _write_private_text(provider_output_path, json.dumps(provider_payload, indent=2, sort_keys=True))
+    _write_private_text(analysis_path, analysis_json)
     return {
         "id": digest,
         "provider": provider_name,
@@ -75,6 +81,20 @@ def _archive_provider_capture(
         "analysis_path": str(analysis_path),
         "created_at": now.isoformat(),
     }
+
+
+def _write_private_bytes(path: Path, content: bytes) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(content)
+    finally:
+        with contextlib.suppress(OSError):
+            os.chmod(path, 0o600)
+
+
+def _write_private_text(path: Path, content: str) -> None:
+    _write_private_bytes(path, content.encode("utf-8"))
 
 # ─── macOS helpers ────────────────────────────────────────
 

--- a/daemon/seraph_daemon.py
+++ b/daemon/seraph_daemon.py
@@ -130,21 +130,7 @@ def _write_daemon_status(**updates: object) -> None:
 # ─── macOS helpers ────────────────────────────────────────
 
 
-def get_frontmost_app_name() -> str | None:
-    """Return the localized name of the frontmost application via NSWorkspace.
-
-    Requires no special permissions.
-    """
-    try:
-        from AppKit import NSWorkspace
-
-        app = NSWorkspace.sharedWorkspace().frontmostApplication()
-        app_name = app.localizedName() if app else None
-        if app_name:
-            return app_name
-    except Exception:
-        logger.debug("NSWorkspace call failed", exc_info=True)
-
+def _get_frontmost_app_name_from_system_events() -> str | None:
     try:
         result = subprocess.run(
             [
@@ -166,6 +152,29 @@ def get_frontmost_app_name() -> str | None:
     except Exception:
         logger.debug("System Events frontmost app lookup failed", exc_info=True)
     return None
+
+
+def _get_frontmost_app_name_from_workspace() -> str | None:
+    try:
+        from AppKit import NSWorkspace
+
+        app = NSWorkspace.sharedWorkspace().frontmostApplication()
+        app_name = app.localizedName() if app else None
+        if app_name:
+            return app_name
+    except Exception:
+        logger.debug("NSWorkspace call failed", exc_info=True)
+    return None
+
+
+def get_frontmost_app_name() -> str | None:
+    """Return the visible foreground app name from the same source as window title.
+
+    System Events tracks the Accessibility-observed foreground process that Seraph
+    also uses for the active window title. NSWorkspace is kept as a fallback, but
+    should not mask app switches with a stale value.
+    """
+    return _get_frontmost_app_name_from_system_events() or _get_frontmost_app_name_from_workspace()
 
 
 def get_window_title() -> str | None:
@@ -575,11 +584,16 @@ async def poll_loop(
                                     "Screen & System Audio Recording permission to the terminal/app running Seraph, "
                                     "then restart the daemon."
                                 )
+                                observation["capture_error_kind"] = "screen_capture_permission"
                                 _write_daemon_status(
                                     state="running",
                                     screen_analysis="capture_error",
                                     provider=screen_runtime.provider.name,
                                     capture_ready=False,
+                                    active_window=active_window,
+                                    frontmost_app=app_name,
+                                    window_title=window_title,
+                                    last_poll_at=poll_at,
                                     last_error=observation["capture_error"],
                                     last_error_kind="screen_capture_permission",
                                 )
@@ -619,6 +633,7 @@ async def poll_loop(
                                 else:
                                     logger.debug("Screen analysis failed: %s", result.error)
                                     observation["capture_error"] = result.error or "Screen analysis failed."
+                                    observation["capture_error_kind"] = "analysis_error"
                                     _write_daemon_status(
                                         state="running",
                                         screen_analysis="analysis_error",
@@ -630,6 +645,7 @@ async def poll_loop(
                         except Exception:
                             logger.debug("Screenshot/analysis error", exc_info=True)
                             observation["capture_error"] = "Screenshot or screen analysis failed unexpectedly."
+                            observation["capture_error_kind"] = "analysis_exception"
                             _write_daemon_status(
                                 state="running",
                                 screen_analysis="analysis_error",
@@ -659,18 +675,41 @@ async def poll_loop(
                     if verbose:
                         ts = time.strftime("%H:%M:%S")
                         logger.info("[%s] \u2192 %s", ts, active_window)
-                    _write_daemon_status(
-                        state="running",
-                        active_window=active_window,
-                        frontmost_app=app_name,
-                        window_title=window_title,
-                        capture_ready=bool(
+                    capture_error = (
+                        str(observation.get("capture_error"))
+                        if observation is not None and observation.get("capture_error")
+                        else None
+                    )
+                    capture_error_kind = (
+                        str(observation.get("capture_error_kind"))
+                        if observation is not None and observation.get("capture_error_kind")
+                        else "capture_error"
+                    )
+                    status_update = {
+                        "state": "running",
+                        "active_window": active_window,
+                        "frontmost_app": app_name,
+                        "window_title": window_title,
+                        "capture_ready": bool(
                             observation is not None
                             and not observation.get("blocked")
-                            and "capture_error" not in observation
+                            and capture_error is None
                         ),
-                        last_context_post_at=datetime.now(timezone.utc).isoformat(),
-                        last_poll_at=poll_at,
+                        "last_context_post_at": datetime.now(timezone.utc).isoformat(),
+                        "last_poll_at": poll_at,
+                    }
+                    if capture_error:
+                        status_update.update(
+                            {
+                                "screen_analysis": "analysis_error"
+                                if capture_error_kind.startswith("analysis")
+                                else "capture_error",
+                                "last_error": capture_error,
+                                "last_error_kind": capture_error_kind,
+                            }
+                        )
+                    _write_daemon_status(
+                        **status_update
                     )
                     last_posted = active_window
                 except httpx.ConnectError:

--- a/daemon/seraph_daemon.py
+++ b/daemon/seraph_daemon.py
@@ -439,7 +439,7 @@ async def main() -> None:
     )
     parser.add_argument(
         "--ocr-provider",
-        choices=["apple-vision", "openrouter"],
+        choices=["apple-vision", "openrouter", "codex-local"],
         default="apple-vision",
         help="OCR provider (default: apple-vision)",
     )
@@ -451,8 +451,8 @@ async def main() -> None:
     )
     parser.add_argument(
         "--ocr-model",
-        default="google/gemini-2.5-flash-lite",
-        help="Model for OpenRouter OCR (default: google/gemini-2.5-flash-lite)",
+        default=None,
+        help="Model for OCR provider (OpenRouter default: google/gemini-2.5-flash-lite; codex-local default: gpt-5.5)",
     )
     parser.add_argument(
         "--openrouter-api-key",
@@ -503,10 +503,14 @@ async def main() -> None:
         from blocklist import load_blocklist
         from ocr import create_provider
 
+        ocr_model = args.ocr_model
+        if ocr_model is None and args.ocr_provider == "openrouter":
+            ocr_model = "google/gemini-2.5-flash-lite"
+
         ocr_provider = create_provider(
             name=args.ocr_provider,
             api_key=args.openrouter_api_key,
-            model=args.ocr_model,
+            model=ocr_model,
         )
 
         if not ocr_provider.is_available():

--- a/daemon/seraph_daemon.py
+++ b/daemon/seraph_daemon.py
@@ -96,6 +96,37 @@ def _write_private_bytes(path: Path, content: bytes) -> None:
 def _write_private_text(path: Path, content: str) -> None:
     _write_private_bytes(path, content.encode("utf-8"))
 
+
+def _daemon_status_path() -> Path | None:
+    configured = os.environ.get("SERAPH_DAEMON_STATUS_FILE", "").strip()
+    if configured:
+        return Path(configured).expanduser().resolve()
+    workspace_dir = os.environ.get("WORKSPACE_DIR", "").strip()
+    if workspace_dir:
+        return Path(workspace_dir).expanduser().resolve() / "daemon-status.json"
+    return None
+
+
+def _write_daemon_status(**updates: object) -> None:
+    status_path = _daemon_status_path()
+    if status_path is None:
+        return
+    try:
+        status_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        payload: dict[str, object] = {}
+        if status_path.exists():
+            try:
+                existing = json.loads(status_path.read_text(encoding="utf-8"))
+                if isinstance(existing, dict):
+                    payload.update(existing)
+            except (OSError, json.JSONDecodeError):
+                payload = {}
+        payload.update(updates)
+        payload["updated_at"] = datetime.now(timezone.utc).isoformat()
+        _write_private_text(status_path, json.dumps(payload, indent=2, sort_keys=True))
+    except Exception:
+        logger.debug("Failed to write daemon status", exc_info=True)
+
 # ─── macOS helpers ────────────────────────────────────────
 
 
@@ -108,10 +139,33 @@ def get_frontmost_app_name() -> str | None:
         from AppKit import NSWorkspace
 
         app = NSWorkspace.sharedWorkspace().frontmostApplication()
-        return app.localizedName() if app else None
+        app_name = app.localizedName() if app else None
+        if app_name:
+            return app_name
     except Exception:
         logger.debug("NSWorkspace call failed", exc_info=True)
+
+    try:
+        result = subprocess.run(
+            [
+                "osascript",
+                "-e",
+                'tell application "System Events" to get name of first application process whose frontmost is true',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        app_name = result.stdout.strip()
+        if app_name:
+            return app_name
+        if result.stderr.strip():
+            logger.debug("System Events frontmost app lookup failed: %s", result.stderr.strip())
+    except (subprocess.TimeoutExpired, FileNotFoundError):
         return None
+    except Exception:
+        logger.debug("System Events frontmost app lookup failed", exc_info=True)
+    return None
 
 
 def get_window_title() -> str | None:
@@ -208,6 +262,18 @@ async def fetch_capture_mode(client: httpx.AsyncClient, url: str) -> str:
     return "on_switch"
 
 
+async def fetch_screen_analysis_settings(client: httpx.AsyncClient, url: str) -> dict | None:
+    """Fetch screen-analysis runtime settings from backend."""
+    try:
+        r = await client.get(f"{url}/api/settings/screen-analysis")
+        if r.status_code != 200:
+            return None
+        payload = r.json()
+        return payload if isinstance(payload, dict) else None
+    except Exception:
+        return None
+
+
 async def fetch_next_notification(client: httpx.AsyncClient, url: str) -> dict | None:
     """Fetch the next pending native notification from the backend."""
     try:
@@ -230,6 +296,159 @@ async def ack_notification(client: httpx.AsyncClient, url: str, notification_id:
     return False
 
 
+class ScreenAnalysisRuntime:
+    """Runtime screen-analysis config that follows backend Settings."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        provider: str,
+        model: str | None,
+        preserve_captures: bool,
+        archive_dir: str,
+        openrouter_api_key: str | None,
+        blocklist_file: str | None,
+    ) -> None:
+        self._fallback = {
+            "enabled": enabled,
+            "provider": provider,
+            "model": model or "",
+            "preserve_captures": preserve_captures,
+            "archive_dir": archive_dir,
+        }
+        self._openrouter_api_key = openrouter_api_key
+        self._blocklist_file = blocklist_file
+        self._signature: tuple[object, ...] | None = None
+        self._last_refresh = 0.0
+        self.provider = None
+        self.blocklist: set[str] = set()
+        self.enabled = False
+        self.preserve_captures = False
+        self.archive_dir = archive_dir
+
+    async def refresh(self, client: httpx.AsyncClient, url: str, *, force: bool = False) -> None:
+        now = time.time()
+        if not force and now - self._last_refresh < 30:
+            return
+        self._last_refresh = now
+        payload = await fetch_screen_analysis_settings(client, url) or self._fallback
+        enabled = bool(payload.get("enabled", self._fallback["enabled"]))
+        provider_name = str(payload.get("provider") or self._fallback["provider"])
+        if provider_name not in {"apple-vision", "openrouter", "codex-local"}:
+            provider_name = str(self._fallback["provider"])
+        model = str(payload.get("model") or self._fallback["model"] or "")
+        preserve = bool(payload.get("preserve_captures", self._fallback["preserve_captures"]))
+        archive_dir = str(payload.get("archive_dir") or self._fallback["archive_dir"])
+        signature = (enabled, provider_name, model, preserve, archive_dir)
+        if signature == self._signature:
+            return
+
+        if not enabled:
+            old_provider = self.provider
+            self.provider = None
+            self.enabled = False
+            self.preserve_captures = preserve
+            self.archive_dir = archive_dir
+            self._signature = signature
+            if old_provider is not None and hasattr(old_provider, "close"):
+                await old_provider.close()
+            logger.info("Screen analysis disabled by settings")
+            _write_daemon_status(
+                state="running",
+                screen_analysis="disabled",
+                provider=provider_name,
+                capture_ready=False,
+                last_error=None,
+                last_error_kind=None,
+            )
+            return
+
+        from blocklist import load_blocklist
+        from ocr import create_provider
+
+        provider_model = model or None
+        if provider_model is None and provider_name == "openrouter":
+            provider_model = "google/gemini-2.5-flash-lite"
+        try:
+            provider = create_provider(
+                name=provider_name,
+                api_key=self._openrouter_api_key,
+                model=provider_model,
+                preserve_captures=preserve,
+                archive_dir=archive_dir,
+            )
+        except Exception as exc:
+            logger.error("Failed to configure OCR provider %r from settings: %s", provider_name, exc)
+            old_provider = self.provider
+            self.provider = None
+            self.enabled = False
+            self.preserve_captures = preserve
+            self.archive_dir = archive_dir
+            if old_provider is not None and hasattr(old_provider, "close"):
+                await old_provider.close()
+            _write_daemon_status(
+                state="running",
+                screen_analysis="provider_error",
+                provider=provider_name,
+                capture_ready=False,
+                last_error=f"Failed to configure provider: {exc}",
+                last_error_kind="provider_configuration",
+            )
+            return
+        if not provider.is_available():
+            logger.error("OCR provider %r is not available — screen analysis paused", provider_name)
+            if hasattr(provider, "close"):
+                await provider.close()
+            old_provider = self.provider
+            self.provider = None
+            self.enabled = False
+            self.preserve_captures = preserve
+            self.archive_dir = archive_dir
+            if old_provider is not None and hasattr(old_provider, "close"):
+                await old_provider.close()
+            _write_daemon_status(
+                state="running",
+                screen_analysis="provider_unavailable",
+                provider=provider_name,
+                capture_ready=False,
+                last_error=f"OCR provider '{provider_name}' is not available.",
+                last_error_kind="provider_unavailable",
+            )
+            return
+
+        old_provider = self.provider
+        if old_provider is not None and old_provider is not provider and hasattr(old_provider, "close"):
+            await old_provider.close()
+        self.provider = provider
+        self.enabled = True
+        self.preserve_captures = preserve
+        self.archive_dir = archive_dir
+        self._signature = signature
+        self.blocklist = load_blocklist(self._blocklist_file)
+        logger.info(
+            "Screen analysis settings active — provider=%s, preserve=%s, archive=%s, blocked=%d apps",
+            provider.name,
+            preserve,
+            archive_dir,
+            len(self.blocklist),
+        )
+        _write_daemon_status(
+            state="running",
+            screen_analysis="active",
+            provider=provider.name,
+            preserve_captures=preserve,
+            archive_dir=archive_dir,
+            capture_ready=True,
+            last_error=None,
+            last_error_kind=None,
+        )
+
+    async def close(self) -> None:
+        if self.provider is not None and hasattr(self.provider, "close"):
+            await self.provider.close()
+
+
 # ─── Main loop ────────────────────────────────────────────
 
 
@@ -238,26 +457,24 @@ async def poll_loop(
     interval: float,
     idle_timeout: float,
     verbose: bool,
-    ocr_provider: "ocr.base.OCRProvider | None" = None,
-    blocklist: set[str] | None = None,
-    preserve_captures: bool = False,
-    capture_archive_dir: str = "",
+    screen_runtime: ScreenAnalysisRuntime | None = None,
 ) -> None:
     """Core polling loop — detect window changes, post to backend.
 
-    When ocr_provider is set, captures and analyzes the screen on each context
-    switch (not on a timer). Blocked apps are never screenshotted.
+    When Settings enables screen analysis, captures and analyzes the screen on
+    each context switch. Blocked apps are never screenshotted.
     """
-    from blocklist import is_blocked
-
     last_posted: str | None = None
     was_idle = False
-    _blocklist = blocklist or set()
     shown_notification_ids: set[str] = set()
 
     async with httpx.AsyncClient(timeout=10.0) as client:
+        if screen_runtime is not None:
+            await screen_runtime.refresh(client, url, force=True)
         while True:
             try:
+                if screen_runtime is not None:
+                    await screen_runtime.refresh(client, url)
                 notification = await fetch_next_notification(client, url)
                 if notification is not None:
                     notification_id = notification.get("id")
@@ -301,21 +518,49 @@ async def poll_loop(
                 app_name = get_frontmost_app_name()
                 window_title = get_window_title()
                 active_window = format_active_window(app_name, window_title)
+                poll_at = datetime.now(timezone.utc).isoformat()
+
+                if not active_window:
+                    _write_daemon_status(
+                        state="running",
+                        screen_analysis="frontmost_unavailable" if screen_runtime is not None else "window_unavailable",
+                        capture_ready=False,
+                        active_window=None,
+                        frontmost_app=None,
+                        window_title=None,
+                        last_poll_at=poll_at,
+                        last_error=(
+                            "Seraph cannot read the frontmost application, so on-switch screen capture is paused. "
+                            "Grant Accessibility/Automation permission to the terminal/app running Seraph, then restart."
+                        ),
+                        last_error_kind="frontmost_app_unavailable",
+                    )
+                    await asyncio.sleep(interval)
+                    continue
 
                 # Skip if unchanged
                 if active_window == last_posted:
+                    _write_daemon_status(
+                        state="running",
+                        active_window=active_window,
+                        frontmost_app=app_name,
+                        window_title=window_title,
+                        last_poll_at=poll_at,
+                    )
                     await asyncio.sleep(interval)
                     continue
 
                 # Build observation payload on context switch
                 observation = None
-                if ocr_provider is not None and app_name:
+                if screen_runtime is not None and screen_runtime.provider is not None and app_name:
                     observation = {
                         "app": app_name,
                         "window_title": window_title or "",
                     }
 
-                    if is_blocked(app_name, _blocklist):
+                    from blocklist import is_blocked
+
+                    if is_blocked(app_name, screen_runtime.blocklist):
                         observation["blocked"] = True
                         if verbose:
                             logger.info("Blocked app: %s — skipping screenshot", app_name)
@@ -324,16 +569,30 @@ async def poll_loop(
                             from ocr.screenshot import capture_screen_png
 
                             png_bytes = await asyncio.to_thread(capture_screen_png)
+                            if not png_bytes:
+                                observation["capture_error"] = (
+                                    "macOS screen capture returned no image. Grant Screen Recording / "
+                                    "Screen & System Audio Recording permission to the terminal/app running Seraph, "
+                                    "then restart the daemon."
+                                )
+                                _write_daemon_status(
+                                    state="running",
+                                    screen_analysis="capture_error",
+                                    provider=screen_runtime.provider.name,
+                                    capture_ready=False,
+                                    last_error=observation["capture_error"],
+                                    last_error_kind="screen_capture_permission",
+                                )
                             if png_bytes:
-                                result = await ocr_provider.analyze_screen(png_bytes, app_name)
+                                result = await screen_runtime.provider.analyze_screen(png_bytes, app_name)
                                 if result.success:
                                     observation.update(result.data)
-                                    if preserve_captures and "capture_artifacts" not in observation:
+                                    if screen_runtime.preserve_captures and "capture_artifacts" not in observation:
                                         observation["capture_artifacts"] = _archive_provider_capture(
-                                            archive_dir=capture_archive_dir,
+                                            archive_dir=screen_runtime.archive_dir,
                                             png_bytes=png_bytes,
                                             app_name=app_name,
-                                            provider_name=ocr_provider.name,
+                                            provider_name=screen_runtime.provider.name,
                                             analysis=result.data,
                                         )
                                     if verbose:
@@ -344,10 +603,45 @@ async def poll_loop(
                                             result.duration_ms,
                                             result.data.get("summary", "")[:80],
                                         )
+                                    _write_daemon_status(
+                                        state="running",
+                                        screen_analysis="active",
+                                        provider=screen_runtime.provider.name,
+                                        capture_ready=True,
+                                        active_window=active_window,
+                                        frontmost_app=app_name,
+                                        window_title=window_title,
+                                        last_capture_at=datetime.now(timezone.utc).isoformat(),
+                                        last_poll_at=poll_at,
+                                        last_error=None,
+                                        last_error_kind=None,
+                                    )
                                 else:
                                     logger.debug("Screen analysis failed: %s", result.error)
+                                    observation["capture_error"] = result.error or "Screen analysis failed."
+                                    _write_daemon_status(
+                                        state="running",
+                                        screen_analysis="analysis_error",
+                                        provider=screen_runtime.provider.name,
+                                        capture_ready=False,
+                                        last_error=observation["capture_error"],
+                                        last_error_kind="analysis_error",
+                                    )
                         except Exception:
                             logger.debug("Screenshot/analysis error", exc_info=True)
+                            observation["capture_error"] = "Screenshot or screen analysis failed unexpectedly."
+                            _write_daemon_status(
+                                state="running",
+                                screen_analysis="analysis_error",
+                                provider=screen_runtime.provider.name,
+                                capture_ready=False,
+                                active_window=active_window,
+                                frontmost_app=app_name,
+                                window_title=window_title,
+                                last_poll_at=poll_at,
+                                last_error=observation["capture_error"],
+                                last_error_kind="analysis_exception",
+                            )
 
                 # Post to backend
                 try:
@@ -365,6 +659,19 @@ async def poll_loop(
                     if verbose:
                         ts = time.strftime("%H:%M:%S")
                         logger.info("[%s] \u2192 %s", ts, active_window)
+                    _write_daemon_status(
+                        state="running",
+                        active_window=active_window,
+                        frontmost_app=app_name,
+                        window_title=window_title,
+                        capture_ready=bool(
+                            observation is not None
+                            and not observation.get("blocked")
+                            and "capture_error" not in observation
+                        ),
+                        last_context_post_at=datetime.now(timezone.utc).isoformat(),
+                        last_poll_at=poll_at,
+                    )
                     last_posted = active_window
                 except httpx.ConnectError:
                     logger.warning("Backend not reachable at %s — will retry", url)
@@ -381,10 +688,7 @@ async def periodic_capture_loop(
     url: str,
     idle_timeout: float,
     verbose: bool,
-    ocr_provider: "ocr.base.OCRProvider | None" = None,
-    blocklist: set[str] | None = None,
-    preserve_captures: bool = False,
-    capture_archive_dir: str = "",
+    screen_runtime: ScreenAnalysisRuntime | None = None,
 ) -> None:
     """Periodic capture loop — takes screenshots at intervals within the same app.
 
@@ -392,18 +696,19 @@ async def periodic_capture_loop(
     When mode is 'balanced' (300s) or 'detailed' (60s), captures periodic
     screenshots of the current app if it hasn't changed (poll_loop handles switches).
     """
-    from blocklist import is_blocked
-
-    _blocklist = blocklist or set()
     capture_mode = "on_switch"
     last_periodic = 0.0
     mode_poll_interval = 60  # poll setting every 60s
     check_interval = 10  # check timer every 10s
 
     async with httpx.AsyncClient(timeout=10.0) as client:
+        if screen_runtime is not None:
+            await screen_runtime.refresh(client, url, force=True)
         last_mode_poll = 0.0
         while True:
             try:
+                if screen_runtime is not None:
+                    await screen_runtime.refresh(client, url)
                 now = time.time()
 
                 # Poll capture mode from backend every 60s
@@ -429,52 +734,123 @@ async def periodic_capture_loop(
 
                 # Get current app
                 app_name = get_frontmost_app_name()
-                if not app_name or is_blocked(app_name, _blocklist):
+                poll_at = datetime.now(timezone.utc).isoformat()
+                if not app_name:
+                    _write_daemon_status(
+                        state="running",
+                        screen_analysis="frontmost_unavailable",
+                        capture_ready=False,
+                        active_window=None,
+                        frontmost_app=None,
+                        window_title=None,
+                        last_poll_at=poll_at,
+                        last_error=(
+                            "Seraph cannot read the frontmost application, so periodic screen capture is paused. "
+                            "Grant Accessibility/Automation permission to the terminal/app running Seraph, then restart."
+                        ),
+                        last_error_kind="frontmost_app_unavailable",
+                    )
+                    last_periodic = now
+                    await asyncio.sleep(check_interval)
+                    continue
+                from blocklist import is_blocked
+
+                if screen_runtime is None or screen_runtime.provider is None or is_blocked(app_name, screen_runtime.blocklist):
                     last_periodic = now
                     await asyncio.sleep(check_interval)
                     continue
 
                 # Take periodic screenshot
+                window_title = get_window_title() or ""
+                active_window = format_active_window(app_name, window_title)
                 observation = {
                     "app": app_name,
-                    "window_title": get_window_title() or "",
+                    "window_title": window_title,
                 }
 
-                if ocr_provider is not None:
-                    try:
-                        from ocr.screenshot import capture_screen_png
+                try:
+                    from ocr.screenshot import capture_screen_png
 
-                        png_bytes = await asyncio.to_thread(capture_screen_png)
-                        if png_bytes:
-                            result = await ocr_provider.analyze_screen(png_bytes, app_name)
-                            if result.success:
-                                observation.update(result.data)
-                                if preserve_captures and "capture_artifacts" not in observation:
-                                    observation["capture_artifacts"] = _archive_provider_capture(
-                                        archive_dir=capture_archive_dir,
-                                        png_bytes=png_bytes,
-                                        app_name=app_name,
-                                        provider_name=ocr_provider.name,
-                                        analysis=result.data,
-                                    )
-                                if verbose:
-                                    ts = time.strftime("%H:%M:%S")
-                                    logger.info(
-                                        "[%s] periodic (%s, %ds): %s",
-                                        ts,
-                                        capture_mode,
-                                        period,
-                                        result.data.get("summary", "")[:80],
-                                    )
-                            else:
-                                logger.debug("Periodic analysis failed: %s", result.error)
-                    except Exception:
-                        logger.debug("Periodic screenshot/analysis error", exc_info=True)
+                    png_bytes = await asyncio.to_thread(capture_screen_png)
+                    if not png_bytes:
+                        observation["capture_error"] = (
+                            "macOS screen capture returned no image. Grant Screen Recording / "
+                            "Screen & System Audio Recording permission to the terminal/app running Seraph, "
+                            "then restart the daemon."
+                        )
+                        _write_daemon_status(
+                            state="running",
+                            screen_analysis="capture_error",
+                            provider=screen_runtime.provider.name,
+                            capture_ready=False,
+                            last_error=observation["capture_error"],
+                            last_error_kind="screen_capture_permission",
+                        )
+                    if png_bytes:
+                        result = await screen_runtime.provider.analyze_screen(png_bytes, app_name)
+                        if result.success:
+                            observation.update(result.data)
+                            if screen_runtime.preserve_captures and "capture_artifacts" not in observation:
+                                observation["capture_artifacts"] = _archive_provider_capture(
+                                    archive_dir=screen_runtime.archive_dir,
+                                    png_bytes=png_bytes,
+                                    app_name=app_name,
+                                    provider_name=screen_runtime.provider.name,
+                                    analysis=result.data,
+                                )
+                            if verbose:
+                                ts = time.strftime("%H:%M:%S")
+                                logger.info(
+                                    "[%s] periodic (%s, %ds): %s",
+                                    ts,
+                                    capture_mode,
+                                    period,
+                                    result.data.get("summary", "")[:80],
+                                )
+                            _write_daemon_status(
+                                state="running",
+                                screen_analysis="active",
+                                provider=screen_runtime.provider.name,
+                                capture_ready=True,
+                                active_window=active_window,
+                                frontmost_app=app_name,
+                                window_title=window_title,
+                                last_capture_at=datetime.now(timezone.utc).isoformat(),
+                                last_poll_at=poll_at,
+                                last_error=None,
+                                last_error_kind=None,
+                            )
+                        else:
+                            logger.debug("Periodic analysis failed: %s", result.error)
+                            observation["capture_error"] = result.error or "Periodic screen analysis failed."
+                            _write_daemon_status(
+                                state="running",
+                                screen_analysis="analysis_error",
+                                provider=screen_runtime.provider.name,
+                                capture_ready=False,
+                                last_error=observation["capture_error"],
+                                last_error_kind="analysis_error",
+                            )
+                except Exception:
+                    logger.debug("Periodic screenshot/analysis error", exc_info=True)
+                    observation["capture_error"] = "Periodic screenshot or screen analysis failed unexpectedly."
+                    _write_daemon_status(
+                        state="running",
+                        screen_analysis="analysis_error",
+                        provider=screen_runtime.provider.name,
+                        capture_ready=False,
+                        active_window=active_window,
+                        frontmost_app=app_name,
+                        window_title=window_title,
+                        last_poll_at=poll_at,
+                        last_error=observation["capture_error"],
+                        last_error_kind="analysis_exception",
+                    )
 
                 # Post to backend
                 try:
                     payload: dict = {
-                        "active_window": format_active_window(app_name, observation.get("window_title")),
+                        "active_window": active_window,
                         "observation": observation,
                         "switch_timestamp": now,
                     }
@@ -482,6 +858,17 @@ async def periodic_capture_loop(
                     if verbose:
                         ts = time.strftime("%H:%M:%S")
                         logger.info("[%s] periodic capture → %s", ts, app_name)
+                    _write_daemon_status(
+                        state="running",
+                        active_window=active_window,
+                        frontmost_app=app_name,
+                        window_title=window_title,
+                        capture_ready=bool(
+                            not observation.get("blocked") and "capture_error" not in observation
+                        ),
+                        last_context_post_at=datetime.now(timezone.utc).isoformat(),
+                        last_poll_at=poll_at,
+                    )
                 except httpx.ConnectError:
                     logger.warning("Backend not reachable at %s — will retry", url)
                 except httpx.HTTPError as exc:
@@ -599,36 +986,15 @@ async def main() -> None:
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, _shutdown, sig)
 
-    # OCR + blocklist setup
-    ocr_provider = None
-    blocklist: set[str] = set()
-
-    if args.ocr:
-        from blocklist import load_blocklist
-        from ocr import create_provider
-
-        ocr_model = args.ocr_model
-        if ocr_model is None and args.ocr_provider == "openrouter":
-            ocr_model = "google/gemini-2.5-flash-lite"
-
-        ocr_provider = create_provider(
-            name=args.ocr_provider,
-            api_key=args.openrouter_api_key,
-            model=ocr_model,
-            preserve_captures=args.preserve_captures,
-            archive_dir=args.capture_archive_dir,
-        )
-
-        if not ocr_provider.is_available():
-            logger.error("OCR provider %r is not available — disabling OCR", args.ocr_provider)
-            ocr_provider = None
-        else:
-            blocklist = load_blocklist(args.blocklist_file)
-            logger.info(
-                "OCR enabled — provider=%s, mode=on-context-switch, blocked=%d apps",
-                ocr_provider.name,
-                len(blocklist),
-            )
+    screen_runtime = ScreenAnalysisRuntime(
+        enabled=args.ocr,
+        provider=args.ocr_provider,
+        model=args.ocr_model,
+        preserve_captures=args.preserve_captures,
+        archive_dir=args.capture_archive_dir,
+        openrouter_api_key=args.openrouter_api_key,
+        blocklist_file=args.blocklist_file,
+    )
 
     logger.info(
         "Seraph daemon started — polling every %gs, idle timeout %gs, backend %s",
@@ -636,11 +1002,22 @@ async def main() -> None:
         args.idle_timeout,
         args.url,
     )
+    _write_daemon_status(
+        state="running",
+        backend_url=args.url,
+        poll_interval=args.interval,
+        idle_timeout=args.idle_timeout,
+        screen_analysis="starting",
+        capture_ready=False,
+        last_error=None,
+        last_error_kind=None,
+    )
 
-    async def heartbeat_loop(heartbeat_interval: float = 300) -> None:
+    async def heartbeat_loop(heartbeat_interval: float = 15) -> None:
         """Log a periodic heartbeat to confirm daemon is alive."""
         while True:
             await asyncio.sleep(heartbeat_interval)
+            _write_daemon_status(state="running")
             logger.info("heartbeat — daemon alive (poll every %gs)", args.interval)
 
     heartbeat_task = asyncio.create_task(heartbeat_loop())
@@ -650,10 +1027,7 @@ async def main() -> None:
             args.interval,
             args.idle_timeout,
             args.verbose,
-            ocr_provider=ocr_provider,
-            blocklist=blocklist,
-            preserve_captures=args.preserve_captures,
-            capture_archive_dir=args.capture_archive_dir,
+            screen_runtime=screen_runtime,
         )
     )
     periodic_task = asyncio.create_task(
@@ -661,34 +1035,27 @@ async def main() -> None:
             args.url,
             args.idle_timeout,
             args.verbose,
-            ocr_provider=ocr_provider,
-            blocklist=blocklist,
-            preserve_captures=args.preserve_captures,
-            capture_archive_dir=args.capture_archive_dir,
+            screen_runtime=screen_runtime,
         )
-    ) if ocr_provider is not None else None
+    )
 
     await stop_event.wait()
 
     heartbeat_task.cancel()
     poll_task.cancel()
-    if periodic_task is not None:
-        periodic_task.cancel()
+    periodic_task.cancel()
 
-    tasks = [heartbeat_task, poll_task]
-    if periodic_task is not None:
-        tasks.append(periodic_task)
+    tasks = [heartbeat_task, poll_task, periodic_task]
     for t in tasks:
         try:
             await t
         except asyncio.CancelledError:
             pass
 
-    # Clean up provider resources
-    if ocr_provider is not None and hasattr(ocr_provider, "close"):
-        await ocr_provider.close()
+    await screen_runtime.close()
 
     logger.info("Daemon stopped")
+    _write_daemon_status(state="stopped", capture_ready=False, screen_analysis="stopped")
 
 
 if __name__ == "__main__":

--- a/daemon/seraph_daemon.py
+++ b/daemon/seraph_daemon.py
@@ -455,6 +455,20 @@ async def main() -> None:
         help="Model for OCR provider (OpenRouter default: google/gemini-2.5-flash-lite; codex-local default: gpt-5.5)",
     )
     parser.add_argument(
+        "--preserve-captures",
+        action="store_true",
+        default=os.environ.get("SERAPH_PRESERVE_SCREEN_CAPTURES", "").strip().lower()
+        in {"1", "true", "yes", "on"},
+        help="Preserve allowed screenshots, local Codex output, and normalized analysis artifacts",
+    )
+    parser.add_argument(
+        "--capture-archive-dir",
+        default=os.environ.get("SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR")
+        or os.environ.get("SCREEN_CAPTURE_ARCHIVE_DIR")
+        or "/tmp/seraph-screen-captures",
+        help="Directory for preserved capture artifacts (default: /tmp/seraph-screen-captures)",
+    )
+    parser.add_argument(
         "--openrouter-api-key",
         default=os.environ.get("OPENROUTER_API_KEY"),
         help="OpenRouter API key (or set OPENROUTER_API_KEY env var)",
@@ -511,6 +525,8 @@ async def main() -> None:
             name=args.ocr_provider,
             api_key=args.openrouter_api_key,
             model=ocr_model,
+            preserve_captures=args.preserve_captures,
+            archive_dir=args.capture_archive_dir,
         )
 
         if not ocr_provider.is_available():

--- a/daemon/tests/test_codex_local_ocr.py
+++ b/daemon/tests/test_codex_local_ocr.py
@@ -1,0 +1,106 @@
+"""Tests for the local Codex screen OCR provider."""
+
+import os
+import platform
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Darwin",
+    reason="Daemon tests require macOS",
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ocr import create_provider
+from ocr.codex_local import CodexLocalProvider
+
+
+def test_factory_creates_codex_local_provider():
+    provider = create_provider("codex-local", model="gpt-5.5")
+
+    assert isinstance(provider, CodexLocalProvider)
+    assert provider.name == "codex-local"
+
+
+@pytest.mark.asyncio
+async def test_codex_local_provider_parses_structured_json_and_cleans_temp_files(tmp_path):
+    provider = CodexLocalProvider(model="gpt-5.5", temp_dir=str(tmp_path))
+
+    async def fake_run(*, image_path: Path, output_path: Path, prompt: str) -> str:
+        assert image_path.exists()
+        assert image_path.read_bytes() == b"valid png bytes"
+        assert output_path.exists()
+        assert "frontmost app is: VS Code" in prompt
+        return (
+            '{"activity":"coding","project":"Seraph","summary":"Editing daemon OCR provider",'
+            '"details":["daemon/ocr/codex_local.py","unit tests"],'
+            '"sensitive_detected":false,"confidence":0.82}'
+        )
+
+    with patch.object(provider, "_run_codex", new=AsyncMock(side_effect=fake_run)) as mock_run:
+        result = await provider.analyze_screen(b"valid png bytes", "VS Code")
+
+    assert result.success is True
+    assert result.data == {
+        "activity": "coding",
+        "project": "Seraph",
+        "summary": "Editing daemon OCR provider",
+        "details": ["daemon/ocr/codex_local.py", "unit tests"],
+        "sensitive_detected": False,
+        "confidence": 0.82,
+    }
+    mock_run.assert_awaited_once()
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_codex_local_provider_cleans_temp_files_on_failure(tmp_path):
+    provider = CodexLocalProvider(model="gpt-5.5", temp_dir=str(tmp_path))
+
+    with patch.object(provider, "_run_codex", new=AsyncMock(side_effect=RuntimeError("boom"))):
+        result = await provider.analyze_screen(b"valid png bytes", "VS Code")
+
+    assert result.success is False
+    assert result.error == "boom"
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_codex_local_provider_redacts_secret_like_output(tmp_path):
+    provider = CodexLocalProvider(model="gpt-5.5", temp_dir=str(tmp_path))
+
+    with patch.object(
+        provider,
+        "_run_codex",
+        new=AsyncMock(
+            return_value=(
+                '{"activity":"terminal","project":null,'
+                '"summary":"Reviewing API_KEY=abc123 terminal output",'
+                '"details":["bearer token-value"],'
+                '"sensitive_detected":true,"confidence":1.4}'
+            )
+        ),
+    ):
+        result = await provider.analyze_screen(b"valid png bytes", "Terminal")
+
+    assert result.success is True
+    assert result.data["summary"] == "Reviewing [redacted] terminal output"
+    assert result.data["details"] == ["[redacted]"]
+    assert result.data["sensitive_detected"] is True
+    assert result.data["confidence"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_codex_local_provider_rejects_non_json_output(tmp_path):
+    provider = CodexLocalProvider(model="gpt-5.5", temp_dir=str(tmp_path))
+
+    with patch.object(provider, "_run_codex", new=AsyncMock(return_value="not json")):
+        result = await provider.analyze_screen(b"valid png bytes", "Safari")
+
+    assert result.success is False
+    assert "valid JSON" in str(result.error)
+    assert list(tmp_path.iterdir()) == []

--- a/daemon/tests/test_codex_local_ocr.py
+++ b/daemon/tests/test_codex_local_ocr.py
@@ -3,6 +3,7 @@
 import json
 import os
 import platform
+import stat
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -88,6 +89,11 @@ async def test_codex_local_provider_preserves_capture_artifacts_when_enabled(tmp
     analysis = json.loads(analysis_path.read_text(encoding="utf-8"))
     assert analysis["summary"] == "Reviewing preserved captures"
     assert analysis["confidence"] == 0.91
+    assert stat.S_IMODE(archive_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(image_path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(image_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(codex_output_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(analysis_path.stat().st_mode) == 0o600
     assert list(temp_dir.iterdir()) == []
 
 

--- a/daemon/tests/test_codex_local_ocr.py
+++ b/daemon/tests/test_codex_local_ocr.py
@@ -1,5 +1,6 @@
 """Tests for the local Codex screen OCR provider."""
 
+import json
 import os
 import platform
 import sys
@@ -55,6 +56,39 @@ async def test_codex_local_provider_parses_structured_json_and_cleans_temp_files
     }
     mock_run.assert_awaited_once()
     assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_codex_local_provider_preserves_capture_artifacts_when_enabled(tmp_path):
+    temp_dir = tmp_path / "tmp"
+    archive_dir = tmp_path / "archive"
+    temp_dir.mkdir()
+    provider = CodexLocalProvider(
+        model="gpt-5.5",
+        temp_dir=str(temp_dir),
+        preserve_captures=True,
+        archive_dir=str(archive_dir),
+    )
+    raw_output = (
+        '{"activity":"coding","project":"Seraph","summary":"Reviewing preserved captures",'
+        '"details":["screen artifact API"],'
+        '"sensitive_detected":false,"confidence":0.91}'
+    )
+
+    with patch.object(provider, "_run_codex", new=AsyncMock(return_value=raw_output)):
+        result = await provider.analyze_screen(b"valid png bytes", "VS Code")
+
+    assert result.success is True
+    artifacts = result.data["capture_artifacts"]
+    image_path = Path(artifacts["image_path"])
+    codex_output_path = Path(artifacts["codex_output_path"])
+    analysis_path = Path(artifacts["analysis_path"])
+    assert image_path.read_bytes() == b"valid png bytes"
+    assert codex_output_path.read_text(encoding="utf-8") == raw_output
+    analysis = json.loads(analysis_path.read_text(encoding="utf-8"))
+    assert analysis["summary"] == "Reviewing preserved captures"
+    assert analysis["confidence"] == 0.91
+    assert list(temp_dir.iterdir()) == []
 
 
 @pytest.mark.asyncio

--- a/daemon/tests/test_daemon_offline.py
+++ b/daemon/tests/test_daemon_offline.py
@@ -5,9 +5,11 @@ They are automatically skipped on non-macOS platforms (e.g., GitHub CI on Linux)
 """
 
 import asyncio
+import json
 import platform
 import sys
 import os
+from pathlib import Path
 from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
@@ -26,6 +28,14 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from seraph_daemon import poll_loop, format_active_window
 
 
+class _NoopScreenRuntime:
+    provider = type("Provider", (), {"name": "test-provider"})()
+    blocklist: set[str] = set()
+
+    async def refresh(self, *args, **kwargs):
+        return None
+
+
 class TestFormatActiveWindow:
     def test_with_both(self):
         assert format_active_window("VS Code", "main.py") == "VS Code \u2014 main.py"
@@ -41,6 +51,127 @@ class TestFormatActiveWindow:
 
 
 class TestPollLoopOfflineBackend:
+    @pytest.mark.asyncio
+    async def test_frontmost_app_unavailable_updates_status_without_posting_context(self, tmp_path, monkeypatch):
+        """On-switch mode should expose frontmost-app failures instead of silently appearing ready."""
+        status_file = tmp_path / "daemon-status.json"
+        monkeypatch.setenv("SERAPH_DAEMON_STATUS_FILE", str(status_file))
+        status_file.write_text(
+            json.dumps(
+                {
+                    "state": "running",
+                    "screen_analysis": "active",
+                    "capture_ready": True,
+                    "active_window": "OldApp",
+                    "last_capture_at": "2026-06-21T08:00:00+00:00",
+                    "last_error": None,
+                    "last_error_kind": None,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        async def mock_get(*args, **kwargs):
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"notification": None}
+            return response
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("seraph_daemon.get_frontmost_app_name", return_value=None), \
+             patch("seraph_daemon.get_window_title", return_value=None), \
+             patch("seraph_daemon.get_idle_seconds", return_value=0.0), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+
+            task = asyncio.create_task(
+                poll_loop(
+                    "http://localhost:9999",
+                    interval=0.05,
+                    idle_timeout=300,
+                    verbose=False,
+                    screen_runtime=_NoopScreenRuntime(),
+                )
+            )
+            await asyncio.sleep(0.12)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        mock_client.post.assert_not_called()
+        status = json.loads(Path(status_file).read_text(encoding="utf-8"))
+        assert status["capture_ready"] is False
+        assert status["active_window"] is None
+        assert status["screen_analysis"] == "frontmost_unavailable"
+        assert status["last_error_kind"] == "frontmost_app_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_capture_exception_clears_stale_ready_status(self, tmp_path, monkeypatch):
+        """Screenshot exceptions should not leave Settings showing an old ready capture state."""
+        status_file = tmp_path / "daemon-status.json"
+        monkeypatch.setenv("SERAPH_DAEMON_STATUS_FILE", str(status_file))
+        status_file.write_text(
+            json.dumps(
+                {
+                    "state": "running",
+                    "screen_analysis": "active",
+                    "capture_ready": True,
+                    "active_window": "OldApp",
+                    "last_capture_at": "2026-06-21T08:00:00+00:00",
+                    "last_error": None,
+                    "last_error_kind": None,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        async def mock_get(*args, **kwargs):
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"notification": None}
+            return response
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("seraph_daemon.get_frontmost_app_name", return_value="TestApp"), \
+             patch("seraph_daemon.get_window_title", return_value="TestWindow"), \
+             patch("seraph_daemon.get_idle_seconds", return_value=0.0), \
+             patch("blocklist.is_blocked", return_value=False), \
+             patch("ocr.screenshot.capture_screen_png", side_effect=RuntimeError("boom")), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+
+            task = asyncio.create_task(
+                poll_loop(
+                    "http://localhost:9999",
+                    interval=0.05,
+                    idle_timeout=300,
+                    verbose=False,
+                    screen_runtime=_NoopScreenRuntime(),
+                )
+            )
+            await asyncio.sleep(0.12)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        status = json.loads(Path(status_file).read_text(encoding="utf-8"))
+        assert status["capture_ready"] is False
+        assert status["active_window"] == "TestApp — TestWindow"
+        assert status["screen_analysis"] == "analysis_error"
+        assert status["last_error_kind"] == "analysis_exception"
+
     @pytest.mark.asyncio
     async def test_continues_after_connect_error(self):
         """Poll loop should log a warning and continue when backend is unreachable."""

--- a/daemon/tests/test_daemon_offline.py
+++ b/daemon/tests/test_daemon_offline.py
@@ -25,7 +25,7 @@ httpx = pytest.importorskip("httpx")
 # We need to import the daemon module; adjust sys.path for the daemon directory
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from seraph_daemon import poll_loop, format_active_window
+from seraph_daemon import format_active_window, get_frontmost_app_name, poll_loop
 
 
 class _NoopScreenRuntime:
@@ -48,6 +48,18 @@ class TestFormatActiveWindow:
 
     def test_both_none(self):
         assert format_active_window(None, None) is None
+
+
+class TestFrontmostAppLookup:
+    def test_prefers_system_events_over_workspace_fallback(self):
+        with patch("seraph_daemon._get_frontmost_app_name_from_system_events", return_value="Brave Browser"), \
+             patch("seraph_daemon._get_frontmost_app_name_from_workspace", return_value="iTerm2"):
+            assert get_frontmost_app_name() == "Brave Browser"
+
+    def test_falls_back_to_workspace_when_system_events_unavailable(self):
+        with patch("seraph_daemon._get_frontmost_app_name_from_system_events", return_value=None), \
+             patch("seraph_daemon._get_frontmost_app_name_from_workspace", return_value="iTerm2"):
+            assert get_frontmost_app_name() == "iTerm2"
 
 
 class TestPollLoopOfflineBackend:
@@ -171,6 +183,67 @@ class TestPollLoopOfflineBackend:
         assert status["active_window"] == "TestApp — TestWindow"
         assert status["screen_analysis"] == "analysis_error"
         assert status["last_error_kind"] == "analysis_exception"
+
+    @pytest.mark.asyncio
+    async def test_empty_screenshot_clears_stale_ready_status_after_context_post(self, tmp_path, monkeypatch):
+        """Screen Recording denial should stay visible after the context post succeeds."""
+        status_file = tmp_path / "daemon-status.json"
+        monkeypatch.setenv("SERAPH_DAEMON_STATUS_FILE", str(status_file))
+        status_file.write_text(
+            json.dumps(
+                {
+                    "state": "running",
+                    "screen_analysis": "active",
+                    "capture_ready": True,
+                    "active_window": "OldApp",
+                    "last_capture_at": "2026-06-21T08:00:00+00:00",
+                    "last_error": None,
+                    "last_error_kind": None,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        async def mock_get(*args, **kwargs):
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"notification": None}
+            return response
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("seraph_daemon.get_frontmost_app_name", return_value="TestApp"), \
+             patch("seraph_daemon.get_window_title", return_value="TestWindow"), \
+             patch("seraph_daemon.get_idle_seconds", return_value=0.0), \
+             patch("blocklist.is_blocked", return_value=False), \
+             patch("ocr.screenshot.capture_screen_png", return_value=None), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+
+            task = asyncio.create_task(
+                poll_loop(
+                    "http://localhost:9999",
+                    interval=0.05,
+                    idle_timeout=300,
+                    verbose=False,
+                    screen_runtime=_NoopScreenRuntime(),
+                )
+            )
+            await asyncio.sleep(0.12)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        status = json.loads(Path(status_file).read_text(encoding="utf-8"))
+        assert status["capture_ready"] is False
+        assert status["active_window"] == "TestApp — TestWindow"
+        assert status["screen_analysis"] == "capture_error"
+        assert status["last_error_kind"] == "screen_capture_permission"
 
     @pytest.mark.asyncio
     async def test_continues_after_connect_error(self):

--- a/daemon/tests/test_periodic_capture.py
+++ b/daemon/tests/test_periodic_capture.py
@@ -11,6 +11,7 @@ import stat
 import sys
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
@@ -24,7 +25,44 @@ httpx = pytest.importorskip("httpx")
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from seraph_daemon import _archive_provider_capture, fetch_capture_mode, periodic_capture_loop
+from seraph_daemon import (
+    ScreenAnalysisRuntime,
+    _archive_provider_capture,
+    fetch_capture_mode,
+    periodic_capture_loop,
+)
+from ocr.base import AnalysisResult
+
+
+class _RuntimeSettingsResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _RuntimeSettingsClient:
+    def __init__(self, payload):
+        self.payload = payload
+
+    async def get(self, _url):
+        return _RuntimeSettingsResponse(self.payload)
+
+
+class _FakeProvider:
+    def __init__(self, name="codex-local", available=True):
+        self.name = name
+        self.available = available
+        self.closed = False
+
+    def is_available(self):
+        return self.available
+
+    async def close(self):
+        self.closed = True
 
 
 def test_archive_provider_capture_stores_image_and_analysis_for_any_provider(tmp_path):
@@ -51,6 +89,116 @@ def test_archive_provider_capture_stores_image_and_analysis_for_any_provider(tmp
     assert stat.S_IMODE(image_path.stat().st_mode) == 0o600
     assert stat.S_IMODE(output_path.stat().st_mode) == 0o600
     assert stat.S_IMODE(analysis_path.stat().st_mode) == 0o600
+
+
+@pytest.mark.asyncio
+async def test_screen_analysis_runtime_refreshes_provider_and_archive_from_settings(tmp_path):
+    created_providers = []
+
+    def fake_create_provider(**kwargs):
+        provider = _FakeProvider(kwargs["name"])
+        created_providers.append((kwargs, provider))
+        return provider
+
+    runtime = ScreenAnalysisRuntime(
+        enabled=False,
+        provider="apple-vision",
+        model=None,
+        preserve_captures=False,
+        archive_dir=str(tmp_path / "fallback"),
+        openrouter_api_key=None,
+        blocklist_file=None,
+    )
+    first_archive = tmp_path / "first"
+    first_client = _RuntimeSettingsClient(
+        {
+            "enabled": True,
+            "provider": "codex-local",
+            "model": "gpt-5.5",
+            "preserve_captures": True,
+            "archive_dir": str(first_archive),
+        }
+    )
+
+    with patch("ocr.create_provider", side_effect=fake_create_provider), patch(
+        "blocklist.load_blocklist", return_value={"SecretApp"}
+    ):
+        await runtime.refresh(first_client, "http://localhost:8004", force=True)
+
+        assert runtime.provider is not None
+        assert runtime.provider.name == "codex-local"
+        assert runtime.preserve_captures is True
+        assert runtime.archive_dir == str(first_archive)
+        assert runtime.blocklist == {"SecretApp"}
+
+        second_archive = tmp_path / "second"
+        second_client = _RuntimeSettingsClient(
+            {
+                "enabled": True,
+                "provider": "apple-vision",
+                "model": "",
+                "preserve_captures": False,
+                "archive_dir": str(second_archive),
+            }
+        )
+        old_provider = runtime.provider
+        await runtime.refresh(second_client, "http://localhost:8004", force=True)
+
+    assert old_provider.closed is True
+    assert runtime.provider is not None
+    assert runtime.provider.name == "apple-vision"
+    assert runtime.preserve_captures is False
+    assert runtime.archive_dir == str(second_archive)
+
+
+@pytest.mark.asyncio
+async def test_screen_analysis_runtime_pauses_on_unavailable_settings_provider(tmp_path):
+    providers = [_FakeProvider("codex-local"), _FakeProvider("openrouter", available=False)]
+
+    def fake_create_provider(**_kwargs):
+        return providers.pop(0)
+
+    runtime = ScreenAnalysisRuntime(
+        enabled=True,
+        provider="codex-local",
+        model=None,
+        preserve_captures=True,
+        archive_dir=str(tmp_path / "fallback"),
+        openrouter_api_key=None,
+        blocklist_file=None,
+    )
+    first_client = _RuntimeSettingsClient(
+        {
+            "enabled": True,
+            "provider": "codex-local",
+            "model": "gpt-5.5",
+            "preserve_captures": True,
+            "archive_dir": str(tmp_path / "first"),
+        }
+    )
+    second_client = _RuntimeSettingsClient(
+        {
+            "enabled": True,
+            "provider": "openrouter",
+            "model": "google/gemini-2.5-flash-lite",
+            "preserve_captures": True,
+            "archive_dir": str(tmp_path / "second"),
+        }
+    )
+
+    with patch("ocr.create_provider", side_effect=fake_create_provider), patch(
+        "blocklist.load_blocklist", return_value=set()
+    ):
+        await runtime.refresh(first_client, "http://localhost:8004", force=True)
+        old_provider = runtime.provider
+
+        await runtime.refresh(second_client, "http://localhost:8004", force=True)
+
+    assert old_provider is not None
+    assert old_provider.closed is True
+    assert runtime.provider is None
+    assert runtime.enabled is False
+    assert runtime.archive_dir == str(tmp_path / "second")
 
 
 class TestFetchCaptureMode:
@@ -126,7 +274,7 @@ class TestPeriodicCaptureLoop:
                     "http://localhost:8004",
                     idle_timeout=300,
                     verbose=False,
-                    ocr_provider=None,
+                    screen_runtime=None,
                 )
             )
             await asyncio.sleep(0.3)
@@ -138,6 +286,71 @@ class TestPeriodicCaptureLoop:
 
         # No posts should have been made
         assert len(posts) == 0
+
+    @pytest.mark.asyncio
+    async def test_detailed_mode_posts_preserved_capture_artifacts(self, tmp_path):
+        """Detailed mode should periodically analyze and preserve screenshots."""
+        posts = []
+        provider = SimpleNamespace(
+            name="codex-local",
+            analyze_screen=AsyncMock(
+                return_value=AnalysisResult(
+                    success=True,
+                    data={
+                        "activity": "coding",
+                        "project": "seraph",
+                        "summary": "Editing Seraph settings.",
+                        "details": ["settings"],
+                    },
+                    duration_ms=12,
+                )
+            ),
+        )
+        screen_runtime = SimpleNamespace(
+            provider=provider,
+            preserve_captures=True,
+            archive_dir=str(tmp_path),
+            blocklist=set(),
+            refresh=AsyncMock(),
+        )
+
+        async def mock_get(url, **kwargs):
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {"mode": "detailed"}
+            return resp
+
+        async def mock_post(url, **kwargs):
+            posts.append(kwargs.get("json", {}))
+            raise asyncio.CancelledError()
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = mock_post
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("seraph_daemon.get_frontmost_app_name", return_value="VS Code"), \
+             patch("seraph_daemon.get_window_title", return_value="settings.py"), \
+             patch("seraph_daemon.get_idle_seconds", return_value=0.0), \
+             patch("ocr.screenshot.capture_screen_png", return_value=b"png bytes"), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+
+            with pytest.raises(asyncio.CancelledError):
+                await periodic_capture_loop(
+                    "http://localhost:8004",
+                    idle_timeout=300,
+                    verbose=False,
+                    screen_runtime=screen_runtime,
+                )
+
+        assert len(posts) == 1
+        observation = posts[0]["observation"]
+        assert observation["summary"] == "Editing Seraph settings."
+        assert observation["capture_artifacts"]["provider"] == "codex-local"
+        assert Path(observation["capture_artifacts"]["image_path"]).read_bytes() == b"png bytes"
+        assert provider.analyze_screen.await_count == 1
+        assert screen_runtime.refresh.await_count >= 1
 
     @pytest.mark.asyncio
     async def test_skips_when_idle(self):
@@ -170,7 +383,7 @@ class TestPeriodicCaptureLoop:
                     "http://localhost:8004",
                     idle_timeout=300,
                     verbose=False,
-                    ocr_provider=None,
+                    screen_runtime=None,
                 )
             )
             await asyncio.sleep(0.3)

--- a/daemon/tests/test_periodic_capture.py
+++ b/daemon/tests/test_periodic_capture.py
@@ -7,6 +7,7 @@ They are automatically skipped on non-macOS platforms.
 import asyncio
 import json
 import platform
+import stat
 import sys
 import os
 from pathlib import Path
@@ -45,6 +46,11 @@ def test_archive_provider_capture_stores_image_and_analysis_for_any_provider(tmp
     assert provider_payload["analysis"]["summary"] == "Reading a PDF"
     analysis_payload = json.loads(analysis_path.read_text(encoding="utf-8"))
     assert analysis_payload["activity"] == "reading"
+    assert stat.S_IMODE(tmp_path.stat().st_mode) == 0o700
+    assert stat.S_IMODE(image_path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(image_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(output_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(analysis_path.stat().st_mode) == 0o600
 
 
 class TestFetchCaptureMode:

--- a/daemon/tests/test_periodic_capture.py
+++ b/daemon/tests/test_periodic_capture.py
@@ -5,9 +5,11 @@ They are automatically skipped on non-macOS platforms.
 """
 
 import asyncio
+import json
 import platform
 import sys
 import os
+from pathlib import Path
 from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
@@ -21,7 +23,28 @@ httpx = pytest.importorskip("httpx")
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from seraph_daemon import fetch_capture_mode, periodic_capture_loop
+from seraph_daemon import _archive_provider_capture, fetch_capture_mode, periodic_capture_loop
+
+
+def test_archive_provider_capture_stores_image_and_analysis_for_any_provider(tmp_path):
+    artifacts = _archive_provider_capture(
+        archive_dir=str(tmp_path),
+        png_bytes=b"png bytes",
+        app_name="Preview",
+        provider_name="apple-vision",
+        analysis={"activity": "reading", "summary": "Reading a PDF"},
+    )
+
+    image_path = Path(artifacts["image_path"])
+    output_path = Path(artifacts["provider_output_path"])
+    analysis_path = Path(artifacts["analysis_path"])
+    assert artifacts["provider"] == "apple-vision"
+    assert image_path.read_bytes() == b"png bytes"
+    provider_payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert provider_payload["provider"] == "apple-vision"
+    assert provider_payload["analysis"]["summary"] == "Reading a PDF"
+    analysis_payload = json.loads(analysis_path.read_text(encoding="utf-8"))
+    assert analysis_payload["activity"] == "reading"
 
 
 class TestFetchCaptureMode:

--- a/daemon/tests/test_screenshot.py
+++ b/daemon/tests/test_screenshot.py
@@ -1,0 +1,47 @@
+"""Tests for macOS screenshot diagnostics."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ocr import screenshot
+
+
+def test_screencapture_permission_failure_logs_operator_warning(caplog):
+    screenshot._warned_screencapture_failed = False
+    failed = subprocess.CompletedProcess(
+        args=["screencapture"],
+        returncode=1,
+        stdout=b"",
+        stderr=b"",
+    )
+
+    with patch("subprocess.run", return_value=failed), caplog.at_level(logging.WARNING):
+        assert screenshot._capture_via_screencapture() is None
+
+    assert "macOS screencapture failed with code 1" in caplog.text
+    assert "No screenshot artifact was created" in caplog.text
+    assert "Screen Recording / Screen & System Audio Recording" in caplog.text
+
+
+def test_screencapture_permission_warning_is_not_spammed(caplog):
+    screenshot._warned_screencapture_failed = False
+    failed = subprocess.CompletedProcess(
+        args=["screencapture"],
+        returncode=1,
+        stdout=b"",
+        stderr=b"permission denied",
+    )
+
+    with patch("subprocess.run", return_value=failed), caplog.at_level(logging.WARNING):
+        assert screenshot._capture_via_screencapture() is None
+        assert screenshot._capture_via_screencapture() is None
+
+    assert caplog.text.count("macOS screencapture failed") == 1
+    assert "permission denied" not in caplog.text

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -21,6 +21,8 @@ services:
       - ./shared:/app/shared
     env_file:
       - .env.dev
+    environment:
+      SERAPH_DAEMON_STATUS_FILE: /app/data/daemon-status.json
     networks:
       - seraph-network-dev
     ports:

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -21,7 +21,7 @@ Complete instructions for getting Seraph fully running with all features.
 All settings live in `.env.dev` at the project root. The only **required** value is your API key:
 
 ```bash
-OPENROUTER_API_KEY=sk-or-v1-your-key-here
+OPENROUTER_API_KEY=<openrouter_api_key>
 ```
 
 ### Optional model settings
@@ -309,7 +309,7 @@ Sensitive apps (password managers, banking, crypto wallets) are automatically bl
 ./daemon/run.sh --ocr --verbose
 
 # OpenRouter cloud analysis (Gemini 2.5 Flash Lite, structured JSON, ~$1.30/mo)
-OPENROUTER_API_KEY=sk-or-... ./daemon/run.sh --ocr --ocr-provider openrouter --verbose
+OPENROUTER_API_KEY=<openrouter_api_key> ./daemon/run.sh --ocr --ocr-provider openrouter --verbose
 
 # With custom app blocklist
 ./daemon/run.sh --ocr --ocr-provider openrouter --blocklist-file ~/blocklist.json --verbose

--- a/docs/implementation/04-presence-and-reach.md
+++ b/docs/implementation/04-presence-and-reach.md
@@ -13,7 +13,8 @@
 - [x] browser-based guardian cockpit as the only supported browser shell
 - [x] WebSocket conversation path
 - [x] native macOS observer daemon for screen and OCR ingest
-- [x] daemon screen analysis can now choose local Apple Vision, local `codex exec`, or explicit OpenRouter cloud OCR; local Codex writes only a temporary PNG for the CLI invocation and deletes it after analysis or failure
+- [x] daemon screen analysis can now choose local Apple Vision, local `codex exec`, or explicit OpenRouter cloud OCR; local Codex writes only a temporary PNG for the CLI invocation and deletes it after analysis or failure unless local capture preservation is explicitly enabled
+- [x] local Codex screen captures can be preserved as inspectable local artifacts, pairing each allowed image with redacted Codex text output and normalized JSON behind read-only observer artifact endpoints
 - [x] observer refresh pipeline across time, calendar, git, goals, and screen context
 - [x] proactive delivery gating and queued-bundle delivery inside the current product
 - [x] first coherent desktop presence surface built on daemon status, capture-mode visibility, pending native-notification state, a safe test-notification path, desktop-notification fallback when browser delivery is unavailable, browser-side controls for pending native notifications, a first learning-driven native-channel preference layer, one continuity snapshot that exposes daemon state, deferred bundle items, pending native notifications, and recent interventions together, plus action-card continuation payloads and an actionable cockpit desktop-shell card with dismiss/follow-up/continue controls

--- a/docs/implementation/04-presence-and-reach.md
+++ b/docs/implementation/04-presence-and-reach.md
@@ -13,6 +13,7 @@
 - [x] browser-based guardian cockpit as the only supported browser shell
 - [x] WebSocket conversation path
 - [x] native macOS observer daemon for screen and OCR ingest
+- [x] daemon screen analysis can now choose local Apple Vision, local `codex exec`, or explicit OpenRouter cloud OCR; local Codex writes only a temporary PNG for the CLI invocation and deletes it after analysis or failure
 - [x] observer refresh pipeline across time, calendar, git, goals, and screen context
 - [x] proactive delivery gating and queued-bundle delivery inside the current product
 - [x] first coherent desktop presence surface built on daemon status, capture-mode visibility, pending native-notification state, a safe test-notification path, desktop-notification fallback when browser delivery is unavailable, browser-side controls for pending native notifications, a first learning-driven native-channel preference layer, one continuity snapshot that exposes daemon state, deferred bundle items, pending native notifications, and recent interventions together, plus action-card continuation payloads and an actionable cockpit desktop-shell card with dismiss/follow-up/continue controls

--- a/docs/implementation/04-presence-and-reach.md
+++ b/docs/implementation/04-presence-and-reach.md
@@ -14,7 +14,7 @@
 - [x] WebSocket conversation path
 - [x] native macOS observer daemon for screen and OCR ingest
 - [x] daemon screen analysis can now choose local Apple Vision, local `codex exec`, or explicit OpenRouter cloud OCR; local Codex writes only a temporary PNG for the CLI invocation and deletes it after analysis or failure unless local capture preservation is explicitly enabled
-- [x] local Codex screen captures can be preserved as inspectable local artifacts, pairing each allowed image with redacted Codex text output and normalized JSON behind read-only observer artifact endpoints
+- [x] screen captures can be preserved as durable local artifacts for future re-analysis, pairing each allowed image with redacted provider output and normalized JSON behind localhost-only observer artifact endpoints
 - [x] observer refresh pipeline across time, calendar, git, goals, and screen context
 - [x] proactive delivery gating and queued-bundle delivery inside the current product
 - [x] first coherent desktop presence surface built on daemon status, capture-mode visibility, pending native-notification state, a safe test-notification path, desktop-notification fallback when browser delivery is unavailable, browser-side controls for pending native notifications, a first learning-driven native-channel preference layer, one continuity snapshot that exposes daemon state, deferred bundle items, pending native notifications, and recent interventions together, plus action-card continuation payloads and an actionable cockpit desktop-shell card with dismiss/follow-up/continue controls

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -17,6 +17,7 @@
 - [x] strategist agent with restricted guardian tool set
 - [x] daily briefing, evening review, activity digest, and weekly activity review foundations
 - [x] end-of-day goal report generation now compares local screen-derived activity summaries with active/completed goals, stores the redacted report as an observer memory episode, defaults to deterministic local drafting unless `END_OF_DAY_REPORT_LLM_ENABLED=true`, and can deliver by SMTP only when email is explicitly configured, preview is deliberately disabled, and the recipient is allowlisted
+- [x] preserved local Codex screen artifacts give the end-of-day loop an operator-inspectable evidence trail: allowed images, redacted Codex output, and normalized analysis JSON stay local under the configured archive root
 - [x] observer-driven user-state and attention-budget modeling
 - [x] observer salience, confidence, and interruption-cost scoring that feeds guardian state and proactive policy
 - [x] explicit guardian-state synthesis that unifies observer context, memory, current session, recent sessions, confidence, and observer salience signals for downstream agent paths

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -16,6 +16,7 @@
 - [x] hierarchical goals and progress tracking
 - [x] strategist agent with restricted guardian tool set
 - [x] daily briefing, evening review, activity digest, and weekly activity review foundations
+- [x] end-of-day goal report generation now compares local screen-derived activity summaries with active/completed goals, stores the redacted report as an observer memory episode, defaults to deterministic local drafting unless `END_OF_DAY_REPORT_LLM_ENABLED=true`, and can deliver by SMTP only when email is explicitly configured, preview is deliberately disabled, and the recipient is allowlisted
 - [x] observer-driven user-state and attention-budget modeling
 - [x] observer salience, confidence, and interruption-cost scoring that feeds guardian state and proactive policy
 - [x] explicit guardian-state synthesis that unifies observer context, memory, current session, recent sessions, confidence, and observer salience signals for downstream agent paths

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -17,7 +17,7 @@
 - [x] strategist agent with restricted guardian tool set
 - [x] daily briefing, evening review, activity digest, and weekly activity review foundations
 - [x] end-of-day goal report generation now compares local screen-derived activity summaries with active/completed goals, stores the redacted report as an observer memory episode, defaults to deterministic local drafting unless `END_OF_DAY_REPORT_LLM_ENABLED=true`, and can deliver by SMTP only when email is explicitly configured, preview is deliberately disabled, and the recipient is allowlisted
-- [x] preserved local Codex screen artifacts give the end-of-day loop an operator-inspectable evidence trail: allowed images, redacted Codex output, and normalized analysis JSON stay local under the configured archive root
+- [x] preserved screen artifacts and end-of-day report artifacts give the learning loop a durable local evidence trail: allowed images, redacted provider output, normalized analysis JSON, report text, and report JSON stay under configured archive roots for future re-analysis
 - [x] observer-driven user-state and attention-budget modeling
 - [x] observer salience, confidence, and interruption-cost scoring that feeds guardian state and proactive policy
 - [x] explicit guardian-state synthesis that unifies observer context, memory, current session, recent sessions, confidence, and observer salience signals for downstream agent paths

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -209,7 +209,7 @@ High-risk strategic wording in this status page remains governed by [19. Strateg
 - [x] browser-based guardian workspace as the only supported browser shell
 - [x] FastAPI backend with chat, WebSocket, goals, tools, observer, settings, audit, approvals, vault, skills, and MCP APIs
 - [x] native macOS observer daemon for screen/window ingest
-- [x] screen analysis provider choice now includes local Apple Vision, local Codex CLI parsing, and explicit OpenRouter cloud OCR, with local Codex temp-image cleanup documented
+- [x] screen analysis provider choice now includes local Apple Vision, local Codex CLI parsing, and explicit OpenRouter cloud OCR, with local Codex temp-image cleanup documented and optional preserved local image/output artifacts available through observer inspection endpoints
 - [x] persistent guardian record, vector memory, sessions, and goal storage
 
 ### Trust and control

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -209,7 +209,7 @@ High-risk strategic wording in this status page remains governed by [19. Strateg
 - [x] browser-based guardian workspace as the only supported browser shell
 - [x] FastAPI backend with chat, WebSocket, goals, tools, observer, settings, audit, approvals, vault, skills, and MCP APIs
 - [x] native macOS observer daemon for screen/window ingest
-- [x] screen analysis provider choice now includes local Apple Vision, local Codex CLI parsing, and explicit OpenRouter cloud OCR, with local Codex temp-image cleanup documented and optional preserved local image/output artifacts available through observer inspection endpoints
+- [x] screen analysis provider choice now includes local Apple Vision, local Codex CLI parsing, and explicit OpenRouter cloud OCR, with local Codex temp-image cleanup documented and optional durable local image/output/analysis artifacts available through localhost-only observer inspection endpoints
 - [x] persistent guardian record, vector memory, sessions, and goal storage
 
 ### Trust and control

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -209,6 +209,7 @@ High-risk strategic wording in this status page remains governed by [19. Strateg
 - [x] browser-based guardian workspace as the only supported browser shell
 - [x] FastAPI backend with chat, WebSocket, goals, tools, observer, settings, audit, approvals, vault, skills, and MCP APIs
 - [x] native macOS observer daemon for screen/window ingest
+- [x] screen analysis provider choice now includes local Apple Vision, local Codex CLI parsing, and explicit OpenRouter cloud OCR, with local Codex temp-image cleanup documented
 - [x] persistent guardian record, vector memory, sessions, and goal storage
 
 ### Trust and control
@@ -292,7 +293,7 @@ High-risk strategic wording in this status page remains governed by [19. Strateg
 - [x] deterministic guardian behavioral proof that grounded high-salience observer state can still deliver through high interruption cost while degraded observer confidence defers before transport
 - [x] deterministic guardian behavioral proof that strategist tick can use learned direct/native-delivery bias and still surface the resulting intervention through continuity state
 - [x] strategist agent and strategist scheduler tick
-- [x] daily briefing, evening review, activity digest, and weekly review surfaces
+- [x] daily briefing, evening review, activity digest, end-of-day goal report, and weekly review surfaces
 - [x] observer refresh across time, calendar, git, goals, and screen context
 - [x] proactive delivery gating and queued-bundle behavior
 - [x] first coherent desktop presence surface with daemon status, capture-mode visibility, pending native-notification state, a safe test-notification path, native-notification fallback delivery when browser sockets are unavailable but the daemon is connected, browser-side inspect/dismiss controls for queued desktop notifications, runtime route-health visibility for ready/fallback/unavailable delivery, a unified continuity snapshot for daemon state, queued bundle items, route reachability, and recent interventions, and an actionable cockpit desktop-shell card for follow-up, dismiss, continue, and fallback inspection flows

--- a/env.dev.example
+++ b/env.dev.example
@@ -58,6 +58,24 @@ CODEX_LOCAL_SANDBOX=workspace-write
 CODEX_LOCAL_APPROVAL_POLICY=never
 CODEX_LOCAL_TIMEOUT_SECONDS=600
 
+# Local-screen end-of-day report. The report is stored in Seraph memory.
+# Email delivery is off by default and, when enabled, still requires the
+# preview gate to be deliberately disabled plus an allowlisted recipient.
+END_OF_DAY_REPORT_ENABLED=true
+END_OF_DAY_REPORT_HOUR=21
+END_OF_DAY_REPORT_LLM_ENABLED=false
+EMAIL_REPORTS_ENABLED=false
+EMAIL_REPORTS_PREVIEW_REQUIRED=true
+EMAIL_REPORTS_TO=
+EMAIL_REPORTS_TO_ALLOWLIST=
+EMAIL_REPORTS_FROM=
+EMAIL_REPORTS_REPLY_TO=
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_USE_TLS=true
+
 # Anthropic/Claude-oriented routing.
 # ANTHROPIC_API_KEY=your-anthropic-key
 # RUNTIME_PROFILE_PREFERENCES=chat_agent=claude-anthropic|openrouter

--- a/env.prod.example
+++ b/env.prod.example
@@ -50,6 +50,24 @@ CODEX_LOCAL_SANDBOX=workspace-write
 CODEX_LOCAL_APPROVAL_POLICY=never
 CODEX_LOCAL_TIMEOUT_SECONDS=600
 
+# Local-screen end-of-day report. The report is stored in Seraph memory.
+# Email delivery is off by default and, when enabled, still requires the
+# preview gate to be deliberately disabled plus an allowlisted recipient.
+END_OF_DAY_REPORT_ENABLED=true
+END_OF_DAY_REPORT_HOUR=21
+END_OF_DAY_REPORT_LLM_ENABLED=false
+EMAIL_REPORTS_ENABLED=false
+EMAIL_REPORTS_PREVIEW_REQUIRED=true
+EMAIL_REPORTS_TO=
+EMAIL_REPORTS_TO_ALLOWLIST=
+EMAIL_REPORTS_FROM=
+EMAIL_REPORTS_REPLY_TO=
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_USE_TLS=true
+
 # Anthropic/Claude-oriented cloud routing uses ANTHROPIC_API_KEY.
 # RUNTIME_PROFILE_PREFERENCES=chat_agent=claude-anthropic|openrouter
 

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -9,6 +9,7 @@ import { McpPolicyModeToggle } from "./settings/McpPolicyModeToggle";
 import { ApprovalModeToggle } from "./settings/ApprovalModeToggle";
 import { AuditLogPanel } from "./settings/AuditLogPanel";
 import { WorkflowPanel } from "./settings/WorkflowPanel";
+import { ArtifactStoragePanel } from "./settings/ArtifactStoragePanel";
 
 interface SkillInfo {
   name: string;
@@ -636,6 +637,8 @@ export function SettingsPanel() {
           <DaemonStatus />
 
           <CaptureModeToggle />
+
+          <ArtifactStoragePanel />
 
           <ToolPolicyModeToggle />
 

--- a/frontend/src/components/cockpit/CockpitOverlays.test.tsx
+++ b/frontend/src/components/cockpit/CockpitOverlays.test.tsx
@@ -14,6 +14,54 @@ function mockResponse(data: unknown, ok = true) {
   };
 }
 
+const artifactStoragePayload = {
+  screen: {
+    preservation_enabled: true,
+    archive_dir: "/Users/test/Library/Application Support/Seraph/artifacts/screen-captures",
+    archive_dir_source: "default",
+    exists: true,
+    writable: true,
+    creation_error: null,
+    stored_artifacts: ["image", "provider_output", "analysis_json"],
+    inspection_endpoint: "/api/observer/screen-artifacts",
+    inspection_visibility: "localhost_only",
+    control_env: {
+      enabled: "SERAPH_PRESERVE_SCREEN_CAPTURES",
+      archive_dir: "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR or SCREEN_CAPTURE_ARCHIVE_DIR",
+    },
+  },
+  reports: {
+    enabled: true,
+    hour: 21,
+    analysis_provider: "deterministic-local",
+    archive_dir: "/tmp/seraph-dev-data/artifacts/reports",
+    archive_dir_source: "default",
+    exists: true,
+    writable: true,
+    creation_error: null,
+    stored_artifacts: ["report_text", "report_json"],
+    control_env: {
+      archive_dir: "REPORT_ARCHIVE_DIR",
+      enabled: "END_OF_DAY_REPORT_ENABLED",
+      llm: "END_OF_DAY_REPORT_LLM_ENABLED",
+    },
+  },
+  email: {
+    enabled: false,
+    preview_required: true,
+    smtp_configured: false,
+    recipient_configured: false,
+    allowlist_configured: false,
+    control_env: {
+      enabled: "EMAIL_REPORTS_ENABLED",
+      preview_required: "EMAIL_REPORTS_PREVIEW_REQUIRED",
+      smtp_host: "SMTP_HOST",
+      recipient: "EMAIL_REPORTS_TO",
+      allowlist: "EMAIL_REPORTS_TO_ALLOWLIST",
+    },
+  },
+};
+
 describe("cockpit overlays", () => {
   const fetchMock = vi.fn();
 
@@ -53,6 +101,7 @@ describe("cockpit overlays", () => {
       if (url.includes("/api/skills")) return Promise.resolve(mockResponse({ skills: [] }));
       if (url.includes("/api/mcp/servers")) return Promise.resolve(mockResponse({ servers: [] }));
       if (url.includes("/api/catalog")) return Promise.resolve(mockResponse({ items: [] }));
+      if (url.includes("/api/settings/artifact-storage")) return Promise.resolve(mockResponse(artifactStoragePayload));
       if (url.includes("/api/settings/")) return Promise.resolve(mockResponse({ mode: "balanced" }));
       if (url.includes("/api/audit/log")) return Promise.resolve(mockResponse({ entries: [] }));
       if (url.includes("/api/workflows")) return Promise.resolve(mockResponse({ workflows: [] }));
@@ -79,6 +128,7 @@ describe("cockpit overlays", () => {
       if (url.includes("/api/skills")) return Promise.resolve(mockResponse({ skills: [] }));
       if (url.includes("/api/mcp/servers")) return Promise.resolve(mockResponse({ servers: [] }));
       if (url.includes("/api/catalog")) return Promise.resolve(mockResponse({ items: [] }));
+      if (url.includes("/api/settings/artifact-storage")) return Promise.resolve(mockResponse(artifactStoragePayload));
       if (url.includes("/api/settings/")) return Promise.resolve(mockResponse({ mode: "balanced" }));
       if (url.includes("/api/audit/log")) return Promise.resolve(mockResponse({ entries: [] }));
       if (url.includes("/api/workflows")) return Promise.resolve(mockResponse({ workflows: [] }));

--- a/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ArtifactStoragePanel } from "./ArtifactStoragePanel";
@@ -7,6 +7,84 @@ function mockResponse(data: unknown, ok = true) {
   return {
     ok,
     json: async () => data,
+  };
+}
+
+function settingsFromScreenAnalysisFixture(screen: {
+  enabled: boolean;
+  provider: string;
+  model: string;
+  preserve_captures: boolean;
+  archive_dir: string;
+  capture_mode: string;
+  cadence_seconds: number | null;
+  daemon_connected: boolean;
+  artifact_count: number;
+  last_artifact_at: string | null;
+}) {
+  return {
+    screen: {
+      analysis_enabled: screen.enabled,
+      provider: screen.provider,
+      model: screen.model,
+      capture_mode: screen.capture_mode,
+      cadence_seconds: screen.cadence_seconds,
+      daemon_connected: screen.daemon_connected,
+      artifact_count: screen.artifact_count,
+      last_artifact_at: screen.last_artifact_at,
+      preservation_enabled: screen.preserve_captures,
+      archive_dir: screen.archive_dir,
+      archive_dir_source: "screen-analysis-settings",
+      exists: true,
+      writable: true,
+      creation_error: null,
+      stored_artifacts: ["image", "provider_output", "analysis_json"],
+      inspection_endpoint: "/api/observer/screen-artifacts",
+      inspection_visibility: "localhost_only",
+      daemon_status: {
+        state: "running",
+        screen_analysis: "active",
+        capture_ready: true,
+        last_error: null,
+        last_error_kind: null,
+        updated_at: "2026-06-20T18:34:25Z",
+        status_source: "daemon-status-file",
+      },
+      control_env: {
+        enabled: "SERAPH_PRESERVE_SCREEN_CAPTURES",
+        archive_dir: "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR or SCREEN_CAPTURE_ARCHIVE_DIR",
+      },
+    },
+    reports: {
+      enabled: false,
+      hour: 21,
+      analysis_provider: "deterministic-local",
+      archive_dir: "/tmp/seraph-dev-data/artifacts/reports",
+      archive_dir_source: "default",
+      exists: true,
+      writable: true,
+      creation_error: null,
+      stored_artifacts: ["report_text", "report_json"],
+      control_env: {
+        archive_dir: "REPORT_ARCHIVE_DIR",
+        enabled: "END_OF_DAY_REPORT_ENABLED",
+        llm: "END_OF_DAY_REPORT_LLM_ENABLED",
+      },
+    },
+    email: {
+      enabled: false,
+      preview_required: true,
+      smtp_configured: false,
+      recipient_configured: false,
+      allowlist_configured: false,
+      control_env: {
+        enabled: "EMAIL_REPORTS_ENABLED",
+        preview_required: "EMAIL_REPORTS_PREVIEW_REQUIRED",
+        smtp_host: "SMTP_HOST",
+        recipient: "EMAIL_REPORTS_TO",
+        allowlist: "EMAIL_REPORTS_TO_ALLOWLIST",
+      },
+    },
   };
 }
 
@@ -26,15 +104,32 @@ describe("ArtifactStoragePanel", () => {
     fetchMock.mockResolvedValueOnce(
       mockResponse({
         screen: {
+          analysis_enabled: true,
+          provider: "codex-local",
+          model: "gpt-5.5",
+          capture_mode: "detailed",
+          cadence_seconds: 60,
+          daemon_connected: false,
+          artifact_count: 1,
+          last_artifact_at: "2026-06-20T18:34:25.918618",
           preservation_enabled: true,
           archive_dir: "/Users/test/Library/Application Support/Seraph/artifacts/screen-captures",
-          archive_dir_source: "default",
+          archive_dir_source: "screen-analysis-settings",
           exists: true,
           writable: true,
           creation_error: null,
           stored_artifacts: ["image", "provider_output", "analysis_json"],
           inspection_endpoint: "/api/observer/screen-artifacts",
           inspection_visibility: "localhost_only",
+          daemon_status: {
+            state: "running",
+            screen_analysis: "capture_error",
+            capture_ready: false,
+            last_error: "Grant Screen Recording permission to the terminal/app running Seraph.",
+            last_error_kind: "screen_capture_permission",
+            updated_at: "2026-06-20T18:34:25Z",
+            status_source: "daemon-status-file",
+          },
           control_env: {
             enabled: "SERAPH_PRESERVE_SCREEN_CAPTURES",
             archive_dir: "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR or SCREEN_CAPTURE_ARCHIVE_DIR",
@@ -75,9 +170,14 @@ describe("ArtifactStoragePanel", () => {
 
     render(<ArtifactStoragePanel />);
 
-    await waitFor(() => expect(screen.getByText("Screen capture preservation")).toBeInTheDocument());
-    expect(screen.getByText("Evidence Archive")).toBeInTheDocument();
-    expect(screen.getByText("images, provider output, analysis JSON")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Screen analysis")).toBeInTheDocument());
+    expect(screen.getByText("Screen Capture")).toBeInTheDocument();
+    expect(screen.getByText("screenshots, provider output, analysis JSON")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("codex-local")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("detailed / 60s")).toBeInTheDocument();
+    expect(screen.getByText("offline - no new captures")).toBeInTheDocument();
+    expect(screen.getByText("Grant Screen Recording permission to the terminal/app running Seraph.")).toBeInTheDocument();
+    expect(screen.getByText(/1 captures/)).toBeInTheDocument();
     expect(screen.getByText("/api/observer/screen-artifacts (localhost only)")).toBeInTheDocument();
     expect(screen.getByText("SERAPH_PRESERVE_SCREEN_CAPTURES")).toBeInTheDocument();
     expect(screen.getAllByText("ready")).toHaveLength(2);
@@ -87,4 +187,403 @@ describe("ArtifactStoragePanel", () => {
     expect(screen.getByText("SMTP")).toBeInTheDocument();
     expect(screen.getAllByText("Missing")).toHaveLength(2);
   });
+
+  it("updates capture mode from settings", async () => {
+    const artifactStorage = {
+      screen: {
+        analysis_enabled: true,
+        provider: "codex-local",
+        model: "gpt-5.5",
+        capture_mode: "on_switch",
+        cadence_seconds: null,
+        daemon_connected: true,
+        artifact_count: 0,
+        last_artifact_at: null,
+        preservation_enabled: true,
+        archive_dir: "/tmp/seraph-dev-data/artifacts/screen-captures",
+        archive_dir_source: "screen-analysis-settings",
+        exists: true,
+        writable: true,
+        creation_error: null,
+        stored_artifacts: ["image", "provider_output", "analysis_json"],
+        inspection_endpoint: "/api/observer/screen-artifacts",
+        inspection_visibility: "localhost_only",
+        daemon_status: {
+          state: "running",
+          screen_analysis: "active",
+          capture_ready: true,
+          last_error: null,
+          last_error_kind: null,
+          updated_at: "2026-06-20T18:34:25Z",
+          status_source: "daemon-status-file",
+        },
+        control_env: {
+          enabled: "SERAPH_PRESERVE_SCREEN_CAPTURES",
+          archive_dir: "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR or SCREEN_CAPTURE_ARCHIVE_DIR",
+        },
+      },
+      reports: {
+        enabled: false,
+        hour: 21,
+        analysis_provider: "deterministic-local",
+        archive_dir: "/tmp/seraph-dev-data/artifacts/reports",
+        archive_dir_source: "default",
+        exists: true,
+        writable: true,
+        creation_error: null,
+        stored_artifacts: ["report_text", "report_json"],
+        control_env: {
+          archive_dir: "REPORT_ARCHIVE_DIR",
+          enabled: "END_OF_DAY_REPORT_ENABLED",
+          llm: "END_OF_DAY_REPORT_LLM_ENABLED",
+        },
+      },
+      email: {
+        enabled: false,
+        preview_required: true,
+        smtp_configured: false,
+        recipient_configured: false,
+        allowlist_configured: false,
+        control_env: {
+          enabled: "EMAIL_REPORTS_ENABLED",
+          preview_required: "EMAIL_REPORTS_PREVIEW_REQUIRED",
+          smtp_host: "SMTP_HOST",
+          recipient: "EMAIL_REPORTS_TO",
+          allowlist: "EMAIL_REPORTS_TO_ALLOWLIST",
+        },
+      },
+    };
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(artifactStorage))
+      .mockResolvedValueOnce(mockResponse({ mode: "detailed" }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ...artifactStorage,
+          screen: { ...artifactStorage.screen, capture_mode: "detailed", cadence_seconds: 60 },
+        }),
+      );
+
+    render(<ArtifactStoragePanel />);
+
+    const modeSelect = await screen.findByDisplayValue("on_switch");
+    fireEvent.change(modeSelect, { target: { value: "detailed" } });
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/settings/capture-mode"),
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ mode: "detailed" }),
+        }),
+      ),
+    );
+    await waitFor(() => expect(screen.getByDisplayValue("detailed / 60s")).toBeInTheDocument());
+  });
+
+  it("does not refresh settings after a save resolves on an unmounted panel", async () => {
+    const artifactStorage = {
+      screen: {
+        analysis_enabled: true,
+        provider: "codex-local",
+        model: "gpt-5.5",
+        capture_mode: "on_switch",
+        cadence_seconds: null,
+        daemon_connected: true,
+        artifact_count: 0,
+        last_artifact_at: null,
+        preservation_enabled: true,
+        archive_dir: "/tmp/seraph-dev-data/artifacts/screen-captures",
+        archive_dir_source: "screen-analysis-settings",
+        exists: true,
+        writable: true,
+        creation_error: null,
+        stored_artifacts: ["image", "provider_output", "analysis_json"],
+        inspection_endpoint: "/api/observer/screen-artifacts",
+        inspection_visibility: "localhost_only",
+        daemon_status: {
+          state: "running",
+          screen_analysis: "active",
+          capture_ready: true,
+          last_error: null,
+          last_error_kind: null,
+          updated_at: "2026-06-20T18:34:25Z",
+          status_source: "daemon-status-file",
+        },
+        control_env: {
+          enabled: "SERAPH_PRESERVE_SCREEN_CAPTURES",
+          archive_dir: "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR or SCREEN_CAPTURE_ARCHIVE_DIR",
+        },
+      },
+      reports: {
+        enabled: false,
+        hour: 21,
+        analysis_provider: "deterministic-local",
+        archive_dir: "/tmp/seraph-dev-data/artifacts/reports",
+        archive_dir_source: "default",
+        exists: true,
+        writable: true,
+        creation_error: null,
+        stored_artifacts: ["report_text", "report_json"],
+        control_env: {
+          archive_dir: "REPORT_ARCHIVE_DIR",
+          enabled: "END_OF_DAY_REPORT_ENABLED",
+          llm: "END_OF_DAY_REPORT_LLM_ENABLED",
+        },
+      },
+      email: {
+        enabled: false,
+        preview_required: true,
+        smtp_configured: false,
+        recipient_configured: false,
+        allowlist_configured: false,
+        control_env: {
+          enabled: "EMAIL_REPORTS_ENABLED",
+          preview_required: "EMAIL_REPORTS_PREVIEW_REQUIRED",
+          smtp_host: "SMTP_HOST",
+          recipient: "EMAIL_REPORTS_TO",
+          allowlist: "EMAIL_REPORTS_TO_ALLOWLIST",
+        },
+      },
+    };
+    let resolveSave: (value: ReturnType<typeof mockResponse>) => void = () => {};
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(artifactStorage))
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSave = resolve;
+          }),
+      );
+
+    const { unmount } = render(<ArtifactStoragePanel />);
+
+    const modeSelect = await screen.findByDisplayValue("on_switch");
+    fetchMock.mockClear();
+    fireEvent.change(modeSelect, { target: { value: "detailed" } });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    unmount();
+    resolveSave(mockResponse({ mode: "detailed" }));
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("explains on_switch mode even when the daemon is capture-ready", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        screen: {
+          analysis_enabled: true,
+          provider: "codex-local",
+          model: "gpt-5.5",
+          capture_mode: "on_switch",
+          cadence_seconds: null,
+          daemon_connected: true,
+          artifact_count: 2,
+          last_artifact_at: "2026-06-21T05:43:55",
+          preservation_enabled: true,
+          archive_dir: "/tmp/seraph-dev-data/artifacts/screen-captures",
+          archive_dir_source: "screen-analysis-settings",
+          exists: true,
+          writable: true,
+          creation_error: null,
+          stored_artifacts: ["image", "provider_output", "analysis_json"],
+          inspection_endpoint: "/api/observer/screen-artifacts",
+          inspection_visibility: "localhost_only",
+          daemon_status: {
+            state: "running",
+            screen_analysis: "active",
+            capture_ready: true,
+            last_error: null,
+            last_error_kind: null,
+            updated_at: "2026-06-21T06:02:58Z",
+            status_source: "daemon-status-file",
+          },
+          control_env: {
+            enabled: "SERAPH_PRESERVE_SCREEN_CAPTURES",
+            archive_dir: "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR or SCREEN_CAPTURE_ARCHIVE_DIR",
+          },
+        },
+        reports: {
+          enabled: false,
+          hour: 21,
+          analysis_provider: "deterministic-local",
+          archive_dir: "/tmp/seraph-dev-data/artifacts/reports",
+          archive_dir_source: "default",
+          exists: true,
+          writable: true,
+          creation_error: null,
+          stored_artifacts: ["report_text", "report_json"],
+          control_env: {
+            archive_dir: "REPORT_ARCHIVE_DIR",
+            enabled: "END_OF_DAY_REPORT_ENABLED",
+            llm: "END_OF_DAY_REPORT_LLM_ENABLED",
+          },
+        },
+        email: {
+          enabled: false,
+          preview_required: true,
+          smtp_configured: false,
+          recipient_configured: false,
+          allowlist_configured: false,
+          control_env: {
+            enabled: "EMAIL_REPORTS_ENABLED",
+            preview_required: "EMAIL_REPORTS_PREVIEW_REQUIRED",
+            smtp_host: "SMTP_HOST",
+            recipient: "EMAIL_REPORTS_TO",
+            allowlist: "EMAIL_REPORTS_TO_ALLOWLIST",
+          },
+        },
+      }),
+    );
+
+    render(<ArtifactStoragePanel />);
+
+    const captureState = await screen.findByText("waiting for app/window switch");
+    expect(captureState).toBeInTheDocument();
+    expect(captureState).toHaveAttribute("title", "waiting for app/window switch");
+  });
+
+  it("keeps screen capture controls visible when artifact metadata is unavailable", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({
+          enabled: true,
+          provider: "codex-local",
+          model: "gpt-5.5",
+          preserve_captures: true,
+          archive_dir: "/tmp/seraph-dev-data/artifacts/screen-captures",
+          capture_mode: "on_switch",
+          cadence_seconds: null,
+          daemon_connected: true,
+          artifact_count: 7,
+          last_artifact_at: "2026-06-21T08:42:52Z",
+        }),
+      )
+      .mockRejectedValueOnce(new Error("artifact endpoint timed out"));
+
+    render(<ArtifactStoragePanel />);
+
+    expect(await screen.findByText("Screen analysis", undefined, { timeout: 1_000 })).toBeInTheDocument();
+    expect(screen.getByDisplayValue("codex-local")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("on_switch")).toBeInTheDocument();
+    expect(screen.getByText("Archive metadata degraded; screen capture controls are still live.")).toBeInTheDocument();
+    expect(screen.queryByText("Artifact storage settings unavailable.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Screen capture settings unavailable.")).not.toBeInTheDocument();
+  });
+
+  it("shows degraded metadata warning when artifact metadata has an invalid shape", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({
+          enabled: true,
+          provider: "codex-local",
+          model: "gpt-5.5",
+          preserve_captures: true,
+          archive_dir: "/tmp/seraph-dev-data/artifacts/screen-captures",
+          capture_mode: "on_switch",
+          cadence_seconds: null,
+          daemon_connected: true,
+          artifact_count: 0,
+          last_artifact_at: null,
+        }),
+      )
+      .mockResolvedValueOnce(mockResponse({ screen: { archive_dir: "/tmp/broken" } }));
+
+    render(<ArtifactStoragePanel />);
+
+    expect(await screen.findByText("Screen analysis", undefined, { timeout: 1_000 })).toBeInTheDocument();
+    expect(
+      await screen.findByText("Archive metadata degraded; screen capture controls are still live."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Archive metadata loading; screen capture controls are live.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Screen capture settings unavailable.")).not.toBeInTheDocument();
+  });
+
+  it("ignores stale artifact metadata after a newer save refresh", async () => {
+    let resolveInitialArtifact: (value: ReturnType<typeof mockResponse>) => void = () => {};
+    const screenInitial = {
+      enabled: true,
+      provider: "codex-local",
+      model: "gpt-5.5",
+      preserve_captures: true,
+      archive_dir: "/tmp/seraph-dev-data/artifacts/screen-captures",
+      capture_mode: "on_switch",
+      cadence_seconds: null,
+      daemon_connected: true,
+      artifact_count: 0,
+      last_artifact_at: null,
+    };
+    const screenDetailed = {
+      ...screenInitial,
+      capture_mode: "detailed",
+      cadence_seconds: 60,
+    };
+    const staleArtifactStorage = settingsFromScreenAnalysisFixture(screenInitial);
+    const detailedArtifactStorage = settingsFromScreenAnalysisFixture(screenDetailed);
+
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(screenInitial))
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveInitialArtifact = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(mockResponse({ mode: "detailed" }))
+      .mockResolvedValueOnce(mockResponse(screenDetailed))
+      .mockResolvedValueOnce(mockResponse(detailedArtifactStorage));
+
+    render(<ArtifactStoragePanel />);
+
+    const modeSelect = await screen.findByDisplayValue("on_switch");
+    fireEvent.change(modeSelect, { target: { value: "detailed" } });
+
+    await waitFor(() => expect(screen.getByDisplayValue("detailed / 60s")).toBeInTheDocument());
+    resolveInitialArtifact(mockResponse(staleArtifactStorage));
+    await Promise.resolve();
+
+    expect(screen.getByDisplayValue("detailed / 60s")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("on_switch")).not.toBeInTheDocument();
+  });
+
+  it("aborts hung artifact metadata and keeps screen capture controls visible", async () => {
+    let artifactSignal: AbortSignal | undefined;
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({
+          enabled: true,
+          provider: "codex-local",
+          model: "gpt-5.5",
+          preserve_captures: true,
+          archive_dir: "/tmp/seraph-dev-data/artifacts/screen-captures",
+          capture_mode: "on_switch",
+          cadence_seconds: null,
+          daemon_connected: true,
+          artifact_count: 0,
+          last_artifact_at: null,
+        }),
+      )
+      .mockImplementationOnce((_url: string, init?: RequestInit) => {
+        artifactSignal = init?.signal ?? undefined;
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+        });
+      });
+
+    render(<ArtifactStoragePanel />);
+
+    expect(await screen.findByText("Screen analysis", undefined, { timeout: 5_000 })).toBeInTheDocument();
+    expect(screen.getByDisplayValue("codex-local")).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "Archive metadata degraded; screen capture controls are still live.",
+        undefined,
+        { timeout: 5_000 },
+      ),
+    ).toBeInTheDocument();
+    expect(artifactSignal?.aborted).toBe(true);
+    expect(screen.queryByText("Artifact storage settings unavailable.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Screen capture settings unavailable.")).not.toBeInTheDocument();
+  }, 7_000);
 });

--- a/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ArtifactStoragePanel } from "./ArtifactStoragePanel";
+
+function mockResponse(data: unknown, ok = true) {
+  return {
+    ok,
+    json: async () => data,
+  };
+}
+
+describe("ArtifactStoragePanel", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders screen, report, and email artifact configuration", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        screen: {
+          preservation_enabled: true,
+          archive_dir: "/Users/test/Library/Application Support/Seraph/artifacts/screen-captures",
+          archive_dir_source: "default",
+          stored_artifacts: ["image", "provider_output", "analysis_json"],
+          inspection_endpoint: "/api/observer/screen-artifacts",
+          inspection_visibility: "localhost_only",
+          control_env: {
+            enabled: "SERAPH_PRESERVE_SCREEN_CAPTURES",
+            archive_dir: "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR or SCREEN_CAPTURE_ARCHIVE_DIR",
+          },
+        },
+        reports: {
+          enabled: true,
+          hour: 21,
+          analysis_provider: "deterministic-local",
+          archive_dir: "/tmp/seraph-dev-data/artifacts/reports",
+          archive_dir_source: "default",
+          stored_artifacts: ["report_text", "report_json"],
+          control_env: {
+            archive_dir: "REPORT_ARCHIVE_DIR",
+            enabled: "END_OF_DAY_REPORT_ENABLED",
+            llm: "END_OF_DAY_REPORT_LLM_ENABLED",
+          },
+        },
+        email: {
+          enabled: false,
+          preview_required: true,
+          smtp_configured: false,
+          recipient_configured: false,
+          allowlist_configured: false,
+          control_env: {
+            enabled: "EMAIL_REPORTS_ENABLED",
+            preview_required: "EMAIL_REPORTS_PREVIEW_REQUIRED",
+            smtp_host: "SMTP_HOST",
+            recipient: "EMAIL_REPORTS_TO",
+            allowlist: "EMAIL_REPORTS_TO_ALLOWLIST",
+          },
+        },
+      }),
+    );
+
+    render(<ArtifactStoragePanel />);
+
+    await waitFor(() => expect(screen.getByText("Screen capture preservation")).toBeInTheDocument());
+    expect(screen.getByText("Evidence Archive")).toBeInTheDocument();
+    expect(screen.getByText("images, provider output, analysis JSON")).toBeInTheDocument();
+    expect(screen.getByText("/api/observer/screen-artifacts (localhost only)")).toBeInTheDocument();
+    expect(screen.getByText("SERAPH_PRESERVE_SCREEN_CAPTURES")).toBeInTheDocument();
+    expect(screen.getByText("End-of-day reports")).toBeInTheDocument();
+    expect(screen.getByText("deterministic-local")).toBeInTheDocument();
+    expect(screen.getByText("Email delivery")).toBeInTheDocument();
+    expect(screen.getByText("SMTP")).toBeInTheDocument();
+    expect(screen.getAllByText("Missing")).toHaveLength(2);
+  });
+});

--- a/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
@@ -29,6 +29,9 @@ describe("ArtifactStoragePanel", () => {
           preservation_enabled: true,
           archive_dir: "/Users/test/Library/Application Support/Seraph/artifacts/screen-captures",
           archive_dir_source: "default",
+          exists: true,
+          writable: true,
+          creation_error: null,
           stored_artifacts: ["image", "provider_output", "analysis_json"],
           inspection_endpoint: "/api/observer/screen-artifacts",
           inspection_visibility: "localhost_only",
@@ -43,6 +46,9 @@ describe("ArtifactStoragePanel", () => {
           analysis_provider: "deterministic-local",
           archive_dir: "/tmp/seraph-dev-data/artifacts/reports",
           archive_dir_source: "default",
+          exists: true,
+          writable: true,
+          creation_error: null,
           stored_artifacts: ["report_text", "report_json"],
           control_env: {
             archive_dir: "REPORT_ARCHIVE_DIR",
@@ -74,6 +80,7 @@ describe("ArtifactStoragePanel", () => {
     expect(screen.getByText("images, provider output, analysis JSON")).toBeInTheDocument();
     expect(screen.getByText("/api/observer/screen-artifacts (localhost only)")).toBeInTheDocument();
     expect(screen.getByText("SERAPH_PRESERVE_SCREEN_CAPTURES")).toBeInTheDocument();
+    expect(screen.getAllByText("ready")).toHaveLength(2);
     expect(screen.getByText("End-of-day reports")).toBeInTheDocument();
     expect(screen.getByText("deterministic-local")).toBeInTheDocument();
     expect(screen.getByText("Email delivery")).toBeInTheDocument();

--- a/frontend/src/components/settings/ArtifactStoragePanel.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.tsx
@@ -27,6 +27,12 @@ interface ArtifactStorageSettings {
       last_error: string | null;
       last_error_kind: string | null;
       updated_at: string | null;
+      active_window?: string | null;
+      frontmost_app?: string | null;
+      window_title?: string | null;
+      last_poll_at?: string | null;
+      last_capture_at?: string | null;
+      last_context_post_at?: string | null;
       status_source: string;
     };
     control_env: Record<string, string>;
@@ -428,6 +434,16 @@ export function ArtifactStoragePanel() {
               label="Capture"
               value={captureStateLabel(settings.screen)}
               tone={captureStateTone(settings.screen)}
+            />
+            <ArtifactRow
+              label="Active"
+              value={settings.screen.daemon_status.active_window ?? "not observed"}
+              tone={settings.screen.daemon_status.active_window ? "normal" : "warn"}
+            />
+            <ArtifactRow
+              label="Last capture"
+              value={settings.screen.daemon_status.last_capture_at ?? "none"}
+              tone={settings.screen.daemon_status.last_capture_at ? "good" : "warn"}
             />
             <ArtifactRow
               label="Stored"

--- a/frontend/src/components/settings/ArtifactStoragePanel.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.tsx
@@ -6,6 +6,9 @@ interface ArtifactStorageSettings {
     preservation_enabled: boolean;
     archive_dir: string;
     archive_dir_source: string;
+    exists: boolean;
+    writable: boolean;
+    creation_error: string | null;
     stored_artifacts: string[];
     inspection_endpoint: string;
     inspection_visibility: string;
@@ -17,6 +20,9 @@ interface ArtifactStorageSettings {
     analysis_provider: string;
     archive_dir: string;
     archive_dir_source: string;
+    exists: boolean;
+    writable: boolean;
+    creation_error: string | null;
     stored_artifacts: string[];
     control_env: Record<string, string>;
   };
@@ -36,6 +42,17 @@ function boolLabel(value: boolean): string {
 
 function sourceLabel(value: string): string {
   return value === "default" ? "default" : value;
+}
+
+function dirStateLabel(exists: boolean, writable: boolean, creationError: string | null): string {
+  if (creationError) return `creation failed: ${creationError}`;
+  if (!exists) return "missing";
+  return writable ? "ready" : "read-only";
+}
+
+function dirStateTone(exists: boolean, writable: boolean, creationError: string | null): "normal" | "good" | "warn" {
+  if (creationError || !exists || !writable) return "warn";
+  return "good";
 }
 
 function ArtifactRow({
@@ -118,6 +135,11 @@ export function ArtifactStoragePanel() {
             </div>
 
             <ArtifactRow label="Screen dir" value={settings.screen.archive_dir} />
+            <ArtifactRow
+              label="Dir state"
+              value={dirStateLabel(settings.screen.exists, settings.screen.writable, settings.screen.creation_error)}
+              tone={dirStateTone(settings.screen.exists, settings.screen.writable, settings.screen.creation_error)}
+            />
             <ArtifactRow label="Source" value={sourceLabel(settings.screen.archive_dir_source)} />
             <ArtifactRow
               label="Inspect"
@@ -134,6 +156,11 @@ export function ArtifactStoragePanel() {
                 </div>
               </div>
               <ArtifactRow label="Report dir" value={settings.reports.archive_dir} />
+              <ArtifactRow
+                label="Dir state"
+                value={dirStateLabel(settings.reports.exists, settings.reports.writable, settings.reports.creation_error)}
+                tone={dirStateTone(settings.reports.exists, settings.reports.writable, settings.reports.creation_error)}
+              />
               <ArtifactRow label="Provider" value={settings.reports.analysis_provider} />
               <ArtifactRow label="Hour" value={`${settings.reports.hour}:00`} />
             </div>

--- a/frontend/src/components/settings/ArtifactStoragePanel.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.tsx
@@ -55,6 +55,18 @@ function dirStateTone(exists: boolean, writable: boolean, creationError: string 
   return "good";
 }
 
+function isArtifactStorageSettings(value: unknown): value is ArtifactStorageSettings {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<ArtifactStorageSettings>;
+  return (
+    typeof candidate.screen?.archive_dir === "string" &&
+    typeof candidate.screen?.preservation_enabled === "boolean" &&
+    typeof candidate.reports?.archive_dir === "string" &&
+    typeof candidate.reports?.enabled === "boolean" &&
+    typeof candidate.email?.enabled === "boolean"
+  );
+}
+
 function ArtifactRow({
   label,
   value,
@@ -90,10 +102,14 @@ export function ArtifactStoragePanel() {
           if (!cancelled) setFailed(true);
           return;
         }
-        const data = (await response.json()) as ArtifactStorageSettings;
+        const data = await response.json();
         if (!cancelled) {
-          setSettings(data);
-          setFailed(false);
+          if (isArtifactStorageSettings(data)) {
+            setSettings(data);
+            setFailed(false);
+          } else {
+            setFailed(true);
+          }
         }
       } catch {
         if (!cancelled) setFailed(true);

--- a/frontend/src/components/settings/ArtifactStoragePanel.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState } from "react";
+import { API_URL } from "../../config/constants";
+
+interface ArtifactStorageSettings {
+  screen: {
+    preservation_enabled: boolean;
+    archive_dir: string;
+    archive_dir_source: string;
+    stored_artifacts: string[];
+    inspection_endpoint: string;
+    inspection_visibility: string;
+    control_env: Record<string, string>;
+  };
+  reports: {
+    enabled: boolean;
+    hour: number;
+    analysis_provider: string;
+    archive_dir: string;
+    archive_dir_source: string;
+    stored_artifacts: string[];
+    control_env: Record<string, string>;
+  };
+  email: {
+    enabled: boolean;
+    preview_required: boolean;
+    smtp_configured: boolean;
+    recipient_configured: boolean;
+    allowlist_configured: boolean;
+    control_env: Record<string, string>;
+  };
+}
+
+function boolLabel(value: boolean): string {
+  return value ? "On" : "Off";
+}
+
+function sourceLabel(value: string): string {
+  return value === "default" ? "default" : value;
+}
+
+function ArtifactRow({
+  label,
+  value,
+  tone = "normal",
+}: {
+  label: string;
+  value: string;
+  tone?: "normal" | "good" | "warn";
+}) {
+  const toneClass =
+    tone === "good" ? "text-green-400" : tone === "warn" ? "text-yellow-400" : "text-retro-text";
+
+  return (
+    <div className="grid grid-cols-[92px_minmax(0,1fr)] gap-2 text-[9px]">
+      <div className="text-retro-text/30 uppercase tracking-wider">{label}</div>
+      <div className={`${toneClass} min-w-0 truncate`} title={value}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export function ArtifactStoragePanel() {
+  const [settings, setSettings] = useState<ArtifactStorageSettings | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchSettings() {
+      try {
+        const response = await fetch(`${API_URL}/api/settings/artifact-storage`);
+        if (!response.ok) {
+          if (!cancelled) setFailed(true);
+          return;
+        }
+        const data = (await response.json()) as ArtifactStorageSettings;
+        if (!cancelled) {
+          setSettings(data);
+          setFailed(false);
+        }
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    }
+
+    void fetchSettings();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="px-1">
+      <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-2">
+        Evidence Archive
+      </div>
+      <div className="border border-retro-text/10 rounded px-2 py-2 flex flex-col gap-2">
+        {failed ? (
+          <div className="text-[9px] text-red-400">Artifact storage settings unavailable.</div>
+        ) : settings === null ? (
+          <div className="text-[9px] text-retro-text/40">Loading artifact storage settings...</div>
+        ) : (
+          <>
+            <div className="flex items-center justify-between gap-2">
+              <div className="min-w-0">
+                <div className="text-[10px] text-retro-text">Screen capture preservation</div>
+                <div className="text-[9px] text-retro-text/40 truncate">
+                  images, provider output, analysis JSON
+                </div>
+              </div>
+              <div
+                className={`text-[9px] uppercase tracking-wider ${
+                  settings.screen.preservation_enabled ? "text-green-400" : "text-retro-text/40"
+                }`}
+              >
+                {boolLabel(settings.screen.preservation_enabled)}
+              </div>
+            </div>
+
+            <ArtifactRow label="Screen dir" value={settings.screen.archive_dir} />
+            <ArtifactRow label="Source" value={sourceLabel(settings.screen.archive_dir_source)} />
+            <ArtifactRow
+              label="Inspect"
+              value={`${settings.screen.inspection_endpoint} (${settings.screen.inspection_visibility.replace(/_/g, " ")})`}
+              tone="good"
+            />
+            <ArtifactRow label="Enable via" value={settings.screen.control_env.enabled} />
+
+            <div className="border-t border-retro-text/10 pt-2 mt-1">
+              <div className="flex items-center justify-between gap-2 mb-1">
+                <div className="text-[10px] text-retro-text">End-of-day reports</div>
+                <div className={`text-[9px] uppercase tracking-wider ${settings.reports.enabled ? "text-green-400" : "text-retro-text/40"}`}>
+                  {boolLabel(settings.reports.enabled)}
+                </div>
+              </div>
+              <ArtifactRow label="Report dir" value={settings.reports.archive_dir} />
+              <ArtifactRow label="Provider" value={settings.reports.analysis_provider} />
+              <ArtifactRow label="Hour" value={`${settings.reports.hour}:00`} />
+            </div>
+
+            <div className="border-t border-retro-text/10 pt-2 mt-1">
+              <div className="text-[10px] text-retro-text mb-1">Email delivery</div>
+              <div className="flex flex-col gap-1">
+                <ArtifactRow
+                  label="Email"
+                  value={boolLabel(settings.email.enabled)}
+                  tone={settings.email.enabled ? "good" : "normal"}
+                />
+                <ArtifactRow
+                  label="Preview"
+                  value={settings.email.preview_required ? "Required" : "Not required"}
+                  tone={settings.email.preview_required ? "warn" : "normal"}
+                />
+                <ArtifactRow
+                  label="SMTP"
+                  value={settings.email.smtp_configured ? "Configured" : "Missing"}
+                  tone={settings.email.smtp_configured ? "good" : "warn"}
+                />
+                <ArtifactRow
+                  label="Allowlist"
+                  value={settings.email.allowlist_configured ? "Configured" : "Missing"}
+                  tone={settings.email.allowlist_configured ? "good" : "warn"}
+                />
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/ArtifactStoragePanel.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.tsx
@@ -1,8 +1,16 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { API_URL } from "../../config/constants";
 
 interface ArtifactStorageSettings {
   screen: {
+    analysis_enabled: boolean;
+    provider: string;
+    model: string;
+    capture_mode: string;
+    cadence_seconds: number | null;
+    daemon_connected: boolean;
+    artifact_count: number;
+    last_artifact_at: string | null;
     preservation_enabled: boolean;
     archive_dir: string;
     archive_dir_source: string;
@@ -12,6 +20,15 @@ interface ArtifactStorageSettings {
     stored_artifacts: string[];
     inspection_endpoint: string;
     inspection_visibility: string;
+    daemon_status: {
+      state: string | null;
+      screen_analysis: string | null;
+      capture_ready: boolean;
+      last_error: string | null;
+      last_error_kind: string | null;
+      updated_at: string | null;
+      status_source: string;
+    };
     control_env: Record<string, string>;
   };
   reports: {
@@ -36,6 +53,19 @@ interface ArtifactStorageSettings {
   };
 }
 
+interface ScreenAnalysisSettings {
+  enabled: boolean;
+  provider: string;
+  model: string;
+  preserve_captures: boolean;
+  archive_dir: string;
+  capture_mode: string;
+  cadence_seconds: number | null;
+  daemon_connected: boolean;
+  artifact_count: number;
+  last_artifact_at: string | null;
+}
+
 function boolLabel(value: boolean): string {
   return value ? "On" : "Off";
 }
@@ -55,16 +85,126 @@ function dirStateTone(exists: boolean, writable: boolean, creationError: string 
   return "good";
 }
 
+function captureStateLabel(settings: ArtifactStorageSettings["screen"]): string {
+  if (!settings.analysis_enabled) return "disabled";
+  if (settings.daemon_status.last_error) return settings.daemon_status.last_error;
+  if (!settings.daemon_connected) return "daemon offline";
+  if (settings.capture_mode === "on_switch") return "waiting for app/window switch";
+  if (settings.daemon_status.capture_ready) return "ready";
+  return "waiting for next capture";
+}
+
+function captureStateTone(settings: ArtifactStorageSettings["screen"]): "normal" | "good" | "warn" {
+  if (settings.daemon_status.last_error || !settings.daemon_connected) return "warn";
+  if (settings.capture_mode === "on_switch") return "normal";
+  return settings.daemon_status.capture_ready ? "good" : "warn";
+}
+
 function isArtifactStorageSettings(value: unknown): value is ArtifactStorageSettings {
   if (typeof value !== "object" || value === null) return false;
   const candidate = value as Partial<ArtifactStorageSettings>;
   return (
     typeof candidate.screen?.archive_dir === "string" &&
+    typeof candidate.screen?.analysis_enabled === "boolean" &&
+    typeof candidate.screen?.provider === "string" &&
     typeof candidate.screen?.preservation_enabled === "boolean" &&
     typeof candidate.reports?.archive_dir === "string" &&
     typeof candidate.reports?.enabled === "boolean" &&
     typeof candidate.email?.enabled === "boolean"
   );
+}
+
+function isScreenAnalysisSettings(value: unknown): value is ScreenAnalysisSettings {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<ScreenAnalysisSettings>;
+  return (
+    typeof candidate.enabled === "boolean" &&
+    typeof candidate.provider === "string" &&
+    typeof candidate.model === "string" &&
+    typeof candidate.preserve_captures === "boolean" &&
+    typeof candidate.archive_dir === "string" &&
+    typeof candidate.capture_mode === "string" &&
+    typeof candidate.daemon_connected === "boolean"
+  );
+}
+
+async function fetchJsonWithTimeout(path: string, timeoutMs = 3_000): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${API_URL}${path}`, { signal: controller.signal });
+    if (!response.ok) throw new Error(`Request failed: ${response.status}`);
+    return await response.json();
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}
+
+function settingsFromScreenAnalysis(screen: ScreenAnalysisSettings): ArtifactStorageSettings {
+  return {
+    screen: {
+      analysis_enabled: screen.enabled,
+      provider: screen.provider,
+      model: screen.model,
+      capture_mode: screen.capture_mode,
+      cadence_seconds: screen.cadence_seconds,
+      daemon_connected: screen.daemon_connected,
+      artifact_count: screen.artifact_count ?? 0,
+      last_artifact_at: screen.last_artifact_at ?? null,
+      preservation_enabled: screen.preserve_captures,
+      archive_dir: screen.archive_dir,
+      archive_dir_source: "screen-analysis-settings",
+      exists: true,
+      writable: true,
+      creation_error: null,
+      stored_artifacts: ["image", "provider_output", "analysis_json"],
+      inspection_endpoint: "/api/observer/screen-artifacts",
+      inspection_visibility: "localhost_only",
+      daemon_status: {
+        state: screen.daemon_connected ? "running" : "unknown",
+        screen_analysis: screen.enabled ? "active" : "disabled",
+        capture_ready: screen.daemon_connected,
+        last_error: null,
+        last_error_kind: null,
+        updated_at: null,
+        status_source: "screen-analysis",
+      },
+      control_env: {
+        enabled: "SERAPH_PRESERVE_SCREEN_CAPTURES",
+        archive_dir: "SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR or SCREEN_CAPTURE_ARCHIVE_DIR",
+      },
+    },
+    reports: {
+      enabled: false,
+      hour: 21,
+      analysis_provider: "metadata unavailable",
+      archive_dir: "metadata unavailable",
+      archive_dir_source: "metadata unavailable",
+      exists: false,
+      writable: false,
+      creation_error: "Archive metadata unavailable.",
+      stored_artifacts: ["report_text", "report_json"],
+      control_env: {
+        archive_dir: "REPORT_ARCHIVE_DIR",
+        enabled: "END_OF_DAY_REPORT_ENABLED",
+        llm: "END_OF_DAY_REPORT_LLM_ENABLED",
+      },
+    },
+    email: {
+      enabled: false,
+      preview_required: true,
+      smtp_configured: false,
+      recipient_configured: false,
+      allowlist_configured: false,
+      control_env: {
+        enabled: "EMAIL_REPORTS_ENABLED",
+        preview_required: "EMAIL_REPORTS_PREVIEW_REQUIRED",
+        smtp_host: "SMTP_HOST",
+        recipient: "EMAIL_REPORTS_TO",
+        allowlist: "EMAIL_REPORTS_TO_ALLOWLIST",
+      },
+    },
+  };
 }
 
 function ArtifactRow({
@@ -90,66 +230,225 @@ function ArtifactRow({
 }
 
 export function ArtifactStoragePanel() {
+  const mountedRef = useRef(true);
+  const fetchGenerationRef = useRef(0);
   const [settings, setSettings] = useState<ArtifactStorageSettings | null>(null);
   const [failed, setFailed] = useState(false);
+  const [metadataWarning, setMetadataWarning] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function fetchSettings(isCancelled: () => boolean = () => !mountedRef.current) {
+    const generation = fetchGenerationRef.current + 1;
+    fetchGenerationRef.current = generation;
+    const canPublish = () => !isCancelled() && fetchGenerationRef.current === generation;
+    try {
+      let data: ArtifactStorageSettings | null = null;
+      let hasArtifactMetadata = false;
+      try {
+        const screenData = await fetchJsonWithTimeout("/api/settings/screen-analysis");
+        if (isScreenAnalysisSettings(screenData)) {
+          data = settingsFromScreenAnalysis(screenData);
+        } else if (isArtifactStorageSettings(screenData)) {
+          data = screenData;
+          hasArtifactMetadata = true;
+        } else {
+          throw new Error("Screen analysis settings response is invalid.");
+        }
+      } catch {
+        const artifactData = await fetchJsonWithTimeout("/api/settings/artifact-storage");
+        if (!isArtifactStorageSettings(artifactData)) throw new Error("Artifact storage response is invalid.");
+        data = artifactData;
+        hasArtifactMetadata = true;
+      }
+      if (data === null) throw new Error("Screen capture settings response is unavailable.");
+      if (canPublish()) {
+        setSettings(data);
+        setMetadataWarning(hasArtifactMetadata ? null : "Archive metadata loading; screen capture controls are live.");
+        setFailed(false);
+      }
+      if (!hasArtifactMetadata) {
+        void fetchJsonWithTimeout("/api/settings/artifact-storage")
+          .then((artifactData) => {
+            if (!canPublish()) return;
+            if (isArtifactStorageSettings(artifactData)) {
+              setSettings(artifactData);
+              setMetadataWarning(null);
+            } else {
+              setMetadataWarning("Archive metadata degraded; screen capture controls are still live.");
+            }
+          })
+          .catch(() => {
+            if (canPublish()) {
+              setMetadataWarning("Archive metadata degraded; screen capture controls are still live.");
+            }
+          });
+      }
+    } catch {
+      if (canPublish()) {
+        setFailed(true);
+        setMetadataWarning(null);
+      }
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
-    async function fetchSettings() {
-      try {
-        const response = await fetch(`${API_URL}/api/settings/artifact-storage`);
-        if (!response.ok) {
-          if (!cancelled) setFailed(true);
-          return;
-        }
-        const data = await response.json();
-        if (!cancelled) {
-          if (isArtifactStorageSettings(data)) {
-            setSettings(data);
-            setFailed(false);
-          } else {
-            setFailed(true);
-          }
-        }
-      } catch {
-        if (!cancelled) setFailed(true);
-      }
-    }
+    mountedRef.current = true;
 
-    void fetchSettings();
+    void fetchSettings(() => cancelled);
     return () => {
       cancelled = true;
+      mountedRef.current = false;
     };
   }, []);
+
+  const updateScreenAnalysis = async (patch: Record<string, unknown>) => {
+    if (settings === null || saving) return;
+    setSaving(true);
+    try {
+      const response = await fetch(`${API_URL}/api/settings/screen-analysis`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (!response.ok) {
+        if (mountedRef.current) setMetadataWarning("Save failed; screen capture settings were not updated.");
+        return;
+      }
+      if (!mountedRef.current) return;
+      await fetchSettings(() => !mountedRef.current);
+    } catch {
+      if (mountedRef.current) setMetadataWarning("Save failed; screen capture settings were not updated.");
+    } finally {
+      if (mountedRef.current) setSaving(false);
+    }
+  };
+
+  const updateCaptureMode = async (mode: string) => {
+    if (settings === null || saving) return;
+    setSaving(true);
+    try {
+      const response = await fetch(`${API_URL}/api/settings/capture-mode`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode }),
+      });
+      if (!response.ok) {
+        if (mountedRef.current) setMetadataWarning("Save failed; capture mode was not updated.");
+        return;
+      }
+      if (!mountedRef.current) return;
+      await fetchSettings(() => !mountedRef.current);
+    } catch {
+      if (mountedRef.current) setMetadataWarning("Save failed; capture mode was not updated.");
+    } finally {
+      if (mountedRef.current) setSaving(false);
+    }
+  };
 
   return (
     <div className="px-1">
       <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-2">
-        Evidence Archive
+        Screen Capture
       </div>
       <div className="border border-retro-text/10 rounded px-2 py-2 flex flex-col gap-2">
         {failed ? (
-          <div className="text-[9px] text-red-400">Artifact storage settings unavailable.</div>
+          <div className="flex flex-col gap-2">
+            <div className="text-[9px] text-red-400">Screen capture settings unavailable.</div>
+            <button
+              type="button"
+              onClick={() => void fetchSettings()}
+              className="w-fit border border-retro-text/20 px-2 py-1 text-[9px] uppercase tracking-wider text-retro-text/60 hover:text-retro-text"
+            >
+              Retry
+            </button>
+          </div>
         ) : settings === null ? (
-          <div className="text-[9px] text-retro-text/40">Loading artifact storage settings...</div>
+          <div className="text-[9px] text-retro-text/40">Loading screen capture settings...</div>
         ) : (
           <>
+            {metadataWarning && (
+              <div className="border border-yellow-400/40 px-2 py-1 text-[9px] text-yellow-400">
+                {metadataWarning}
+              </div>
+            )}
             <div className="flex items-center justify-between gap-2">
               <div className="min-w-0">
-                <div className="text-[10px] text-retro-text">Screen capture preservation</div>
+                <div className="text-[10px] text-retro-text">Screen analysis</div>
                 <div className="text-[9px] text-retro-text/40 truncate">
-                  images, provider output, analysis JSON
+                  screenshots, provider output, analysis JSON
                 </div>
               </div>
-              <div
-                className={`text-[9px] uppercase tracking-wider ${
-                  settings.screen.preservation_enabled ? "text-green-400" : "text-retro-text/40"
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() => void updateScreenAnalysis({ enabled: !settings.screen.analysis_enabled })}
+                className={`border px-2 py-1 text-[9px] uppercase tracking-wider ${
+                  settings.screen.analysis_enabled
+                    ? "border-green-400 text-green-400"
+                    : "border-retro-text/20 text-retro-text/40"
+                }`}
+              >
+                {boolLabel(settings.screen.analysis_enabled)}
+              </button>
+            </div>
+
+            <div className="grid grid-cols-[92px_minmax(0,1fr)] gap-2 text-[9px]">
+              <div className="text-retro-text/30 uppercase tracking-wider">Provider</div>
+              <select
+                value={settings.screen.provider}
+                disabled={saving}
+                onChange={(event) => void updateScreenAnalysis({ provider: event.target.value })}
+                className="min-w-0 border border-retro-text/20 bg-retro-bg px-1 py-0.5 text-retro-text"
+              >
+                <option value="codex-local">codex-local</option>
+                <option value="apple-vision">apple-vision</option>
+                <option value="openrouter">openrouter</option>
+              </select>
+            </div>
+            <div className="grid grid-cols-[92px_minmax(0,1fr)] gap-2 text-[9px]">
+              <div className="text-retro-text/30 uppercase tracking-wider">Mode</div>
+              <select
+                value={settings.screen.capture_mode}
+                disabled={saving}
+                onChange={(event) => void updateCaptureMode(event.target.value)}
+                className="min-w-0 border border-retro-text/20 bg-retro-bg px-1 py-0.5 text-retro-text"
+              >
+                <option value="on_switch">on_switch</option>
+                <option value="balanced">balanced / 300s</option>
+                <option value="detailed">detailed / 60s</option>
+              </select>
+            </div>
+            <ArtifactRow
+              label="Daemon"
+              value={settings.screen.daemon_connected ? "linked" : "offline - no new captures"}
+              tone={settings.screen.daemon_connected ? "good" : "warn"}
+            />
+            <ArtifactRow
+              label="Capture"
+              value={captureStateLabel(settings.screen)}
+              tone={captureStateTone(settings.screen)}
+            />
+            <ArtifactRow
+              label="Stored"
+              value={`${settings.screen.artifact_count} captures${settings.screen.last_artifact_at ? ` · latest ${settings.screen.last_artifact_at}` : ""}`}
+              tone={settings.screen.artifact_count > 0 ? "good" : "warn"}
+            />
+            <div className="grid grid-cols-[92px_minmax(0,1fr)] gap-2 text-[9px]">
+              <div className="text-retro-text/30 uppercase tracking-wider">Preserve</div>
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() => void updateScreenAnalysis({ preserve_captures: !settings.screen.preservation_enabled })}
+                className={`w-fit border px-2 py-1 uppercase tracking-wider ${
+                  settings.screen.preservation_enabled
+                    ? "border-green-400 text-green-400"
+                    : "border-retro-text/20 text-retro-text/40"
                 }`}
               >
                 {boolLabel(settings.screen.preservation_enabled)}
-              </div>
+              </button>
             </div>
-
             <ArtifactRow label="Screen dir" value={settings.screen.archive_dir} />
             <ArtifactRow
               label="Dir state"
@@ -157,6 +456,7 @@ export function ArtifactStoragePanel() {
               tone={dirStateTone(settings.screen.exists, settings.screen.writable, settings.screen.creation_error)}
             />
             <ArtifactRow label="Source" value={sourceLabel(settings.screen.archive_dir_source)} />
+            <ArtifactRow label="Status" value={sourceLabel(settings.screen.daemon_status.status_source)} />
             <ArtifactRow
               label="Inspect"
               value={`${settings.screen.inspection_endpoint} (${settings.screen.inspection_visibility.replace(/_/g, " ")})`}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
+    testTimeout: 20000,
   },
 });

--- a/manage.sh
+++ b/manage.sh
@@ -15,7 +15,7 @@
 #   ./manage.sh -e [dev|prod] down      - Stop Docker services + daemon.
 #   ./manage.sh -e [dev|prod] logs      - View Docker logs.
 #   ./manage.sh -e [dev|prod] build     - Build or rebuild Docker services.
-#   ./manage.sh -e [dev|prod] local up|down|status|logs     - Manage the direct local frontend/backend stack.
+#   ./manage.sh -e [dev|prod] local up|down|status|logs|run - Manage the direct local frontend/backend stack.
 #   ./manage.sh -e [dev|prod] daemon start|stop|status|logs - Manage screen daemon.
 #   ./manage.sh -e [dev|prod] proxy start|stop|status|logs  - Manage stdio MCP proxy.
 #
@@ -63,7 +63,7 @@ function display_help() {
     echo "          Also stops daemon if running."
     echo "  logs    Follow log output (e.g., 'logs -f backend')."
     echo "  build   Build or rebuild services."
-    echo "  local   Manage the direct local frontend/backend stack: up, down, status, logs."
+    echo "  local   Manage the direct local frontend/backend stack: up, down, status, logs, run."
     echo "  daemon  Manage screen daemon: start, stop, status, logs."
     echo "  proxy   Manage stdio-to-HTTP MCP proxy: start, stop, status, logs."
     echo
@@ -72,6 +72,7 @@ function display_help() {
     echo "  $PROG_NAME -e prod down"
     echo "  $PROG_NAME -e dev logs -f backend"
     echo "  $PROG_NAME -e dev local up"
+    echo "  $PROG_NAME -e dev local run"
     echo "  $PROG_NAME -e dev local status"
     echo "  $PROG_NAME -e dev daemon start"
     echo "  $PROG_NAME -e dev daemon status"
@@ -91,23 +92,101 @@ function ensure_runtime_dirs() {
     mkdir -p "$PID_DIR" "$LOG_DIR"
 }
 
+function process_command() {
+    local pid="$1"
+    ps -p "$pid" -o command= 2>/dev/null || true
+}
+
+function process_command_with_env() {
+    local pid="$1"
+    ps eww -p "$pid" -o command= 2>/dev/null || true
+}
+
+function process_cwd() {
+    local pid="$1"
+    lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1
+}
+
+function command_matches_marker() {
+    local pid="$1"
+    local marker="$2"
+    if echo "$marker" | grep -F "cwd:" >/dev/null 2>&1; then
+        local expected_cwd="${marker#cwd:}"
+        [ "$(process_cwd "$pid")" = "$expected_cwd" ]
+        return $?
+    fi
+    local command
+    command=$(process_command "$pid")
+    [ -n "$marker" ] && echo "$command" | grep -F "$marker" >/dev/null 2>&1
+}
+
 function pid_is_running() {
     local pid_file="$1"
+    local marker="${2:-}"
     if [ -f "$pid_file" ]; then
         local pid
         pid=$(cat "$pid_file")
         if kill -0 "$pid" 2>/dev/null; then
-            return 0
+            if [ -z "$marker" ] || command_matches_marker "$pid" "$marker"; then
+                return 0
+            fi
+            echo "Ignoring stale PID file $pid_file: PID $pid is not $marker"
+            rm -f "$pid_file"
+            return 1
         fi
         rm -f "$pid_file"
     fi
     return 1
 }
 
+function collect_process_tree() {
+    local root_pid="$1"
+    local child
+    echo "$root_pid"
+    for child in $(pgrep -P "$root_pid" 2>/dev/null || true); do
+        collect_process_tree "$child"
+    done
+}
+
+function any_pid_running() {
+    local pid
+    for pid in "$@"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+function kill_process_tree() {
+    local root_pid="$1"
+    local label="$2"
+    local signal="${3:-TERM}"
+    local pids
+    pids=$(collect_process_tree "$root_pid" | awk '!seen[$0]++')
+    if [ -z "$pids" ]; then
+        return 0
+    fi
+
+    local pid
+    # Children first, then the recorded parent. This catches uvicorn --reload and Vite workers
+    # before they can become orphaned listeners.
+    for pid in $(echo "$pids" | awk '{ values[NR] = $0 } END { for (idx = NR; idx >= 1; idx--) print values[idx] }'); do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill "-$signal" "$pid" 2>/dev/null || true
+        fi
+    done
+
+    if [ "$signal" = "KILL" ]; then
+        echo "$label process tree force-killed: $(echo "$pids" | tr '\n' ' ')"
+    fi
+}
+
 function stop_pid() {
     local pid_file="$1"
     local label="$2"
-    if ! pid_is_running "$pid_file"; then
+    local marker="${3:-}"
+    if ! pid_is_running "$pid_file" "$marker"; then
         echo "$label is not running"
         rm -f "$pid_file"
         return 0
@@ -116,21 +195,102 @@ function stop_pid() {
     local pid
     pid=$(cat "$pid_file")
     echo "Stopping $label (PID $pid)..."
-    kill "$pid" 2>/dev/null
+    local captured_pids
+    captured_pids=$(collect_process_tree "$pid" | awk '!seen[$0]++')
+    kill_process_tree "$pid" "$label" TERM
 
     local waited=0
-    while kill -0 "$pid" 2>/dev/null && [ $waited -lt 10 ]; do
+    while any_pid_running $captured_pids && [ $waited -lt 10 ]; do
         sleep 1
         waited=$((waited + 1))
     done
 
-    if kill -0 "$pid" 2>/dev/null; then
+    if any_pid_running $captured_pids; then
         echo "$label did not stop gracefully, sending SIGKILL..."
-        kill -9 "$pid" 2>/dev/null
+        local child_pid
+        for child_pid in $captured_pids; do
+            if kill -0 "$child_pid" 2>/dev/null; then
+                kill -KILL "$child_pid" 2>/dev/null || true
+            fi
+        done
+        sleep 1
+        if any_pid_running $captured_pids; then
+            echo "$label may still have live process(es): $(echo "$captured_pids" | tr '\n' ' ')" >&2
+            return 1
+        fi
     fi
 
     rm -f "$pid_file"
     echo "$label stopped"
+}
+
+function pids_listening_on_port() {
+    local port="$1"
+    lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null | awk '!seen[$0]++'
+}
+
+function seraph_local_port_owner() {
+    local pid="$1"
+    local service="$2"
+    process_command_with_env "$pid" | grep -F "SERAPH_LOCAL_SERVICE=$service" >/dev/null 2>&1
+}
+
+function pid_is_descendant_of() {
+    local needle="$1"
+    local root="$2"
+    collect_process_tree "$root" | awk -v needle="$needle" '$0 == needle { found = 1 } END { exit found ? 0 : 1 }'
+}
+
+function stop_port_listeners() {
+    local port="$1"
+    local label="$2"
+    local service="$3"
+    local pids
+    pids=$(pids_listening_on_port "$port")
+    if [ -z "$pids" ]; then
+        return 0
+    fi
+
+    local owned_pids=""
+    local pid
+    for pid in $pids; do
+        if seraph_local_port_owner "$pid" "$service"; then
+            owned_pids="$owned_pids $pid"
+        fi
+    done
+
+    if [ -z "$owned_pids" ]; then
+        echo "$label port $port is still in use by a non-Seraph process; leaving it untouched." >&2
+        lsof -nP -iTCP:"$port" -sTCP:LISTEN >&2 || true
+        return 1
+    fi
+
+    echo "Stopping stale $label listener(s) on port $port:$owned_pids"
+    for pid in $owned_pids; do
+        kill_process_tree "$pid" "$label listener" TERM
+    done
+
+    local waited=0
+    while [ -n "$(pids_listening_on_port "$port")" ] && [ $waited -lt 10 ]; do
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    pids=$(pids_listening_on_port "$port")
+    if [ -n "$pids" ]; then
+        echo "Stale $label listener(s) did not stop gracefully, sending SIGKILL..."
+        for pid in $pids; do
+            if seraph_local_port_owner "$pid" "$service"; then
+                kill_process_tree "$pid" "$label listener" KILL
+            fi
+        done
+    fi
+
+    if [ -n "$(pids_listening_on_port "$port")" ]; then
+        echo "$label port $port is still in use after cleanup." >&2
+        lsof -nP -iTCP:"$port" -sTCP:LISTEN >&2 || true
+        return 1
+    fi
 }
 
 function require_free_port() {
@@ -139,6 +299,48 @@ function require_free_port() {
     if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
         error_exit "$label port $port is already in use"
     fi
+}
+
+function wait_for_pid_and_port() {
+    local pid_file="$1"
+    local port="$2"
+    local label="$3"
+    local log_file="$4"
+    local marker="$5"
+    local service="$6"
+    local timeout="${7:-20}"
+    local waited=0
+
+    while [ $waited -lt "$timeout" ]; do
+        if ! pid_is_running "$pid_file" "$marker"; then
+            echo "$label exited during startup. Last log lines:" >&2
+            tail -n 60 "$log_file" >&2 2>/dev/null || true
+            return 1
+        fi
+        local supervisor_pid listener_pid listener_pids owned_listener_found
+        supervisor_pid=$(cat "$pid_file")
+        listener_pids=$(pids_listening_on_port "$port")
+        owned_listener_found=false
+        for listener_pid in $listener_pids; do
+            if pid_is_descendant_of "$listener_pid" "$supervisor_pid" || seraph_local_port_owner "$listener_pid" "$service"; then
+                owned_listener_found=true
+            else
+                echo "$label port $port was taken by an unrelated process during startup:" >&2
+                lsof -nP -iTCP:"$port" -sTCP:LISTEN >&2 || true
+                return 1
+            fi
+        done
+        if [ "$owned_listener_found" = true ]; then
+            echo "$label is listening on http://127.0.0.1:$port"
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    echo "$label did not begin listening on port $port within ${waited}s. Last log lines:" >&2
+    tail -n 60 "$log_file" >&2 2>/dev/null || true
+    return 1
 }
 
 # --- Daemon Functions ---
@@ -170,6 +372,13 @@ function start_daemon() {
     nohup "$DAEMON_DIR/run.sh" $daemon_args >> "$DAEMON_LOG_FILE" 2>&1 &
     local pid=$!
     echo "$pid" > "$DAEMON_PID_FILE"
+    sleep 1
+    if ! kill -0 "$pid" 2>/dev/null; then
+        rm -f "$DAEMON_PID_FILE"
+        echo "Daemon failed to stay running; recent log output:"
+        tail -n 40 "$DAEMON_LOG_FILE" 2>/dev/null || true
+        return 1
+    fi
     echo "Daemon started (PID $pid), logging to $DAEMON_LOG_FILE"
 }
 
@@ -317,10 +526,20 @@ function start_local_backend() {
     require_free_port "$LOCAL_BACKEND_PORT" "Local backend"
     mkdir -p "$LOCAL_WORKSPACE_DIR" "$LOCAL_LLM_LOG_DIR"
     echo "Starting local backend on http://127.0.0.1:$LOCAL_BACKEND_PORT ..."
-    nohup /bin/bash -c "cd \"$SCRIPT_DIR/backend\" && export WORKSPACE_DIR=\"$LOCAL_WORKSPACE_DIR\" LLM_LOG_DIR=\"$LOCAL_LLM_LOG_DIR\" UV_CACHE_DIR=\"$LOCAL_UV_CACHE_DIR\" && exec uv run uvicorn src.app:create_app --factory --host 0.0.0.0 --port \"$LOCAL_BACKEND_PORT\" --reload" >> "$LOCAL_BACKEND_LOG_FILE" 2>&1 &
+    nohup /bin/bash -c '
+        cd "$1" || exit 1
+        export WORKSPACE_DIR="$2" LLM_LOG_DIR="$3" UV_CACHE_DIR="$4" DEFAULT_MODEL="$5" SERAPH_LOCAL_SERVICE=backend
+        exec uv run uvicorn src.app:create_app --factory --host 0.0.0.0 --port "$6"
+    ' seraph-local-backend "$SCRIPT_DIR/backend" "$LOCAL_WORKSPACE_DIR" "$LOCAL_LLM_LOG_DIR" "$LOCAL_UV_CACHE_DIR" "$LOCAL_DEFAULT_MODEL" "$LOCAL_BACKEND_PORT" </dev/null >> "$LOCAL_BACKEND_LOG_FILE" 2>&1 &
     local pid=$!
     echo "$pid" > "$LOCAL_BACKEND_PID_FILE"
-    echo "Local backend started (PID $pid), logging to $LOCAL_BACKEND_LOG_FILE"
+    disown "$pid" 2>/dev/null || true
+    if wait_for_pid_and_port "$LOCAL_BACKEND_PID_FILE" "$LOCAL_BACKEND_PORT" "Local backend" "$LOCAL_BACKEND_LOG_FILE" "" backend 75; then
+        echo "Local backend started (PID $pid), logging to $LOCAL_BACKEND_LOG_FILE"
+        return 0
+    fi
+    stop_pid "$LOCAL_BACKEND_PID_FILE" "Local backend"
+    return 1
 }
 
 function start_local_frontend() {
@@ -333,21 +552,53 @@ function start_local_frontend() {
 
     require_free_port "$LOCAL_FRONTEND_PORT" "Local frontend"
     echo "Starting local frontend on http://127.0.0.1:$LOCAL_FRONTEND_PORT ..."
-    nohup /bin/bash -c "cd \"$SCRIPT_DIR/frontend\" && export VITE_API_URL=\"http://127.0.0.1:$LOCAL_BACKEND_PORT\" VITE_WS_URL=\"ws://127.0.0.1:$LOCAL_BACKEND_PORT/ws/chat\" && exec npm run dev -- --host 0.0.0.0 --port \"$LOCAL_FRONTEND_PORT\"" >> "$LOCAL_FRONTEND_LOG_FILE" 2>&1 &
+    nohup /bin/bash -c '
+        cd "$1" || exit 1
+        export VITE_API_URL="$2" VITE_WS_URL="$3" SERAPH_LOCAL_SERVICE=frontend
+        if [ -x ./node_modules/.bin/vite ]; then
+            exec ./node_modules/.bin/vite --host 0.0.0.0 --port "$4"
+        fi
+        exec npm run dev -- --host 0.0.0.0 --port "$4"
+    ' seraph-local-frontend "$SCRIPT_DIR/frontend" "http://localhost:$LOCAL_BACKEND_PORT" "ws://localhost:$LOCAL_BACKEND_PORT/ws/chat" "$LOCAL_FRONTEND_PORT" </dev/null >> "$LOCAL_FRONTEND_LOG_FILE" 2>&1 &
     local pid=$!
     echo "$pid" > "$LOCAL_FRONTEND_PID_FILE"
-    echo "Local frontend started (PID $pid), logging to $LOCAL_FRONTEND_LOG_FILE"
+    disown "$pid" 2>/dev/null || true
+    if wait_for_pid_and_port "$LOCAL_FRONTEND_PID_FILE" "$LOCAL_FRONTEND_PORT" "Local frontend" "$LOCAL_FRONTEND_LOG_FILE" "" frontend; then
+        echo "Local frontend started (PID $pid), logging to $LOCAL_FRONTEND_LOG_FILE"
+        return 0
+    fi
+    stop_pid "$LOCAL_FRONTEND_PID_FILE" "Local frontend"
+    return 1
 }
 
 function local_up() {
     ensure_runtime_dirs
-    start_local_backend
-    start_local_frontend
+    if ! start_local_backend; then
+        echo "Local stack failed: backend did not start cleanly." >&2
+        return 1
+    fi
+    if ! start_local_frontend; then
+        echo "Local stack failed: frontend did not start cleanly; stopping backend." >&2
+        stop_pid "$LOCAL_BACKEND_PID_FILE" "Local backend"
+        stop_port_listeners "$LOCAL_BACKEND_PORT" "Local backend" backend || true
+        return 1
+    fi
+    echo "Local stack is running: frontend http://127.0.0.1:$LOCAL_FRONTEND_PORT, backend http://127.0.0.1:$LOCAL_BACKEND_PORT"
+    if [ "${DAEMON_ENABLED:-false}" = "true" ]; then
+        if ! start_daemon; then
+            echo "Local stack warning: screen daemon did not start; Settings will show daemon offline." >&2
+        fi
+    else
+        echo "Screen daemon disabled (set DAEMON_ENABLED=true in $ENV_FILE to enable)"
+    fi
 }
 
 function local_down() {
+    stop_daemon
     stop_pid "$LOCAL_FRONTEND_PID_FILE" "Local frontend"
     stop_pid "$LOCAL_BACKEND_PID_FILE" "Local backend"
+    stop_port_listeners "$LOCAL_FRONTEND_PORT" "Local frontend" frontend
+    stop_port_listeners "$LOCAL_BACKEND_PORT" "Local backend" backend
 }
 
 function local_status() {
@@ -366,6 +617,11 @@ function local_status() {
     else
         echo "Local frontend: stopped"
     fi
+    if daemon_is_running; then
+        echo "Screen daemon: running (PID $(cat "$DAEMON_PID_FILE"))"
+    else
+        echo "Screen daemon: stopped"
+    fi
 }
 
 function local_logs() {
@@ -380,14 +636,25 @@ function local_logs() {
             touch "$LOCAL_FRONTEND_LOG_FILE"
             tail -f "$LOCAL_FRONTEND_LOG_FILE"
             ;;
+        daemon)
+            touch "$DAEMON_LOG_FILE"
+            tail -f "$DAEMON_LOG_FILE"
+            ;;
         all)
-            touch "$LOCAL_BACKEND_LOG_FILE" "$LOCAL_FRONTEND_LOG_FILE"
-            tail -f "$LOCAL_BACKEND_LOG_FILE" "$LOCAL_FRONTEND_LOG_FILE"
+            touch "$LOCAL_BACKEND_LOG_FILE" "$LOCAL_FRONTEND_LOG_FILE" "$DAEMON_LOG_FILE"
+            tail -f "$LOCAL_BACKEND_LOG_FILE" "$LOCAL_FRONTEND_LOG_FILE" "$DAEMON_LOG_FILE"
             ;;
         *)
-            error_exit "Unknown local logs target '$target'. Use: backend, frontend, all"
+            error_exit "Unknown local logs target '$target'. Use: backend, frontend, daemon, all"
             ;;
     esac
+}
+
+function local_run() {
+    if ! local_up; then
+        return 1
+    fi
+    local_logs all
 }
 
 # --- Main Script Logic ---
@@ -437,17 +704,43 @@ if [ ! -f "$ENV_FILE" ]; then
     error_exit "$ENV_FILE not found. Please create it by copying from $SCRIPT_DIR/env.$ENV.example and filling in the values."
 fi
 
-# Source env file for daemon config
+# Source env file for daemon config without leaking values when bash xtrace is enabled.
+TRACE_WAS_ENABLED=false
+case "$-" in
+    *x*)
+        TRACE_WAS_ENABLED=true
+        set +x
+        ;;
+esac
 set -a
 # shellcheck disable=SC1090
 source "$ENV_FILE"
 set +a
+if [ "$TRACE_WAS_ENABLED" = true ]; then
+    set -x
+fi
 
 LOCAL_BACKEND_PORT="${LOCAL_BACKEND_PORT:-8004}"
 LOCAL_FRONTEND_PORT="${LOCAL_FRONTEND_PORT:-3001}"
-LOCAL_WORKSPACE_DIR="${LOCAL_WORKSPACE_DIR:-/tmp/seraph-dev-data}"
+if [ "$COMMAND" = "local" ]; then
+    LOCAL_WORKSPACE_DIR="${LOCAL_WORKSPACE_DIR:-/tmp/seraph-dev-data}"
+else
+    LOCAL_WORKSPACE_DIR="${LOCAL_WORKSPACE_DIR:-${BACKEND_DATA_PATH_DEV:-/tmp/seraph-dev-data}}"
+fi
+if [[ "$LOCAL_WORKSPACE_DIR" != /* ]]; then
+    LOCAL_WORKSPACE_DIR="$SCRIPT_DIR/$LOCAL_WORKSPACE_DIR"
+fi
 LOCAL_LLM_LOG_DIR="${LOCAL_LLM_LOG_DIR:-/tmp/seraph-dev-logs}"
 LOCAL_UV_CACHE_DIR="${LOCAL_UV_CACHE_DIR:-/tmp/uv-cache}"
+LOCAL_DEFAULT_MODEL="${LOCAL_DEFAULT_MODEL:-codex-local}"
+SCREEN_CAPTURE_ARCHIVE_DIR="${SCREEN_CAPTURE_ARCHIVE_DIR:-$LOCAL_WORKSPACE_DIR/artifacts/screen-captures}"
+SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR="${SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR:-$SCREEN_CAPTURE_ARCHIVE_DIR}"
+SERAPH_DAEMON_STATUS_FILE="${SERAPH_DAEMON_STATUS_FILE:-$LOCAL_WORKSPACE_DIR/daemon-status.json}"
+REPORT_ARCHIVE_DIR="${REPORT_ARCHIVE_DIR:-$LOCAL_WORKSPACE_DIR/artifacts/reports}"
+export SCREEN_CAPTURE_ARCHIVE_DIR SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR SERAPH_DAEMON_STATUS_FILE REPORT_ARCHIVE_DIR
+if [ "$COMMAND" = "local" ]; then
+    DEFAULT_MODEL="$LOCAL_DEFAULT_MODEL"
+fi
 
 # --- Execution ---
 
@@ -456,6 +749,9 @@ if [ "$COMMAND" = "local" ]; then
     case "$LOCAL_SUB" in
         up)
             local_up
+            ;;
+        run)
+            local_run
             ;;
         down)
             local_down
@@ -468,7 +764,7 @@ if [ "$COMMAND" = "local" ]; then
             local_logs "${1:-all}"
             ;;
         *)
-            error_exit "Unknown local subcommand '$LOCAL_SUB'. Use: up, down, status, logs"
+            error_exit "Unknown local subcommand '$LOCAL_SUB'. Use: up, down, status, logs, run"
             ;;
     esac
     exit 0

--- a/scripts/vlm_benchmark.py
+++ b/scripts/vlm_benchmark.py
@@ -2,7 +2,7 @@
 """VLM Screenshot Benchmark — benchmark Gemini 2.5 Flash Lite on real screenshots.
 
 Usage:
-    OPENROUTER_API_KEY=sk-or-... python scripts/vlm_benchmark.py
+    OPENROUTER_API_KEY=<openrouter_api_key> python scripts/vlm_benchmark.py
     python scripts/vlm_benchmark.py --screenshots-dir ~/Desktop/screen
 """
 


### PR DESCRIPTION
## Summary
- Adds a daemon OCR provider, `codex-local`, that invokes the local `codex exec` command for screenshot analysis and deletes temp PNG/output files after success or failure unless preservation is explicitly enabled.
- Adds optional durable local capture preservation for allowed screenshots, pairing each image with provider output and normalized analysis JSON so future/better models can re-analyze the same evidence.
- Adds provider-agnostic capture artifacts for non-Codex OCR providers, while keeping the local Codex redacted text output path for CLI runs.
- Adds localhost-only observer artifact endpoints to list preserved captures and inspect the image, provider/Codex output, and normalized analysis.
- Adds an end-of-day goal report scheduler job that compares local screen-derived activity with active/completed goals, stores the report as an observer memory episode, and persists report text/JSON artifacts with hashes.
- Adds guarded SMTP delivery for reports: disabled by default, preview-required by default, recipient allowlist required before send.
- Adds a Settings > Evidence Archive section backed by `/api/settings/artifact-storage`, showing screen preservation status, archive roots, directory readiness, localhost inspection endpoint, report storage posture, and email readiness without exposing secrets.
- Creates configured screen/report archive roots as private directories and writes preserved screenshot/provider-output/analysis artifacts as private files.
- Updates daemon/backend/env/implementation docs to state the real privacy boundaries for local Codex temp files, preserved artifacts, OpenRouter cloud OCR, report storage, and email configuration.

Closes #618

## Agent Team / Review
- Explorer pass mapped the daemon OCR seam and confirmed provider registration points in `daemon/ocr` and `daemon/seraph_daemon.py`.
- Scheduler/storage pass mapped the existing APScheduler jobs, screen observation summaries, goals repository, and memory episode storage.
- Durable evidence pass added long-lived image/provider-output/analysis archives and report text/JSON artifact storage for later re-analysis.
- Settings pass surfaced env-backed artifact/report/email posture in the operator settings page as read-only configuration visibility.
- Critic pass flagged privacy blockers: stale docs claiming screenshots are never written to disk, report drafting potentially sending screen-derived summaries to the default LLM provider, artifact endpoints being too sensitive for a backend that can bind `0.0.0.0`, a backend/daemon archive-root mismatch, and default filesystem permissions for preserved screenshots/raw outputs.
- Disposition: accepted and fixed. Docs now describe temp PNG/preserved artifact behavior, `END_OF_DAY_REPORT_LLM_ENABLED=false` keeps report drafting deterministic/local unless explicitly enabled, artifact inspection endpoints are restricted to localhost with regression coverage, daemon/backend default to the same durable screen archive root, archive dirs are forced to `0700`, and preserved artifact files are forced to `0600`.
- Independent critic re-review: PASS on pushed head `4cafa5d`.
- CI-fix critic re-review: PASS on final pushed head `25dc261`; no remaining changes requested.

## Validation
- `python3 -m py_compile backend/src/api/settings.py daemon/seraph_daemon.py daemon/ocr/codex_local.py backend/tests/test_settings_api.py daemon/tests/test_codex_local_ocr.py daemon/tests/test_periodic_capture.py`
- Clean PR-head worktree: `backend/.venv/bin/pytest backend/tests/test_end_of_day_goal_report.py backend/tests/test_observer_screen_artifacts.py backend/tests/test_settings_api.py -q` - 18 passed
- Clean PR-head worktree: `daemon/.venv/bin/pytest daemon/tests/test_codex_local_ocr.py daemon/tests/test_periodic_capture.py -q` - 13 passed
- Clean PR-head worktree: `npm run build` - passed
- Clean PR-head worktree earlier after timeout fix: `npm run test` - 22 files / 194 tests passed
- CI failure reproduction/fix: `backend/.venv/bin/pytest backend/tests/test_scheduler.py::TestSchedulerEngine::test_enabled_starts_and_registers_jobs backend/tests/test_scheduler.py::TestSchedulerEngine::test_sync_scheduled_jobs_registers_and_removes_dynamic_jobs backend/tests/test_scheduled_jobs.py::test_sync_scheduled_jobs_skips_invalid_rows_and_keeps_valid_jobs -q` - 3 passed
- Affected scheduler suites: `backend/.venv/bin/pytest backend/tests/test_scheduler.py backend/tests/test_scheduled_jobs.py -q` - 23 passed
- `git diff --check` - passed
- GitHub checks after final push were not yet attached to the new head when checked; the previous run's frontend-tests passed, and the failing backend shards were traced to mocked `end_of_day_report_hour` and fixed in `25dc261`.

## Notes
- Durable screen captures default to `~/Library/Application Support/Seraph/artifacts/screen-captures` unless `SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR` / `SCREEN_CAPTURE_ARCHIVE_DIR` overrides it.
- Durable reports default to `$WORKSPACE_DIR/artifacts/reports` unless `REPORT_ARCHIVE_DIR` overrides it.
- The main local workspace still has unrelated unstaged changes in cockpit/local-Codex/runtime files. Clean PR-head validation was run from `/private/tmp/seraph-pr619-final` to avoid that contamination.

## Issue #620 Settings Fix Addendum
- Fixes the Settings > Screen Capture panel regression where artifact metadata failure could collapse the whole section into `Artifact storage settings unavailable`.
- Adds lightweight `/api/settings/screen-analysis` as the first UI read path; artifact archive metadata now enriches in the background via `/api/settings/artifact-storage`.
- If artifact metadata hangs or fails, screen capture controls stay visible and the UI shows `Archive metadata degraded; screen capture controls are still live.`
- Save-triggered refreshes now use mounted/unmounted guards, matching initial load and background enrichment.

Issue: #620
Commit: `9e657b5`

### #620 Critic / Review
- Independent critic first found two issues: the hung metadata test did not prove abort behavior, and save-triggered refreshes could still set state after unmount.
- Both findings were accepted and fixed.
- Final independent critic re-review found no findings for those two fixes. Caveat: the shortened final review was scoped to `backend/src/api/settings.py`, `frontend/src/components/settings/ArtifactStoragePanel.tsx`, and `frontend/src/components/settings/ArtifactStoragePanel.test.tsx`.

### #620 Verification
- `npm test -- --run src/components/settings/ArtifactStoragePanel.test.tsx` - 5 passed.
- `backend/.venv/bin/pytest backend/tests/test_settings_api.py::test_artifact_storage_settings_exposes_safe_operator_posture` - passed.
- `git diff --check` - passed.
- `./manage.sh -e dev local status` - backend, frontend, and screen daemon running.
- Live probes with `curl --max-time 3` outside the sandbox network boundary:
  - `/api/settings/screen-analysis` returned `provider=codex-local`, `model=gpt-5.5`, `daemon_connected=true`, `capture_mode=on_switch`.
  - `/api/settings/artifact-storage` returned `daemon_connected=true`, private/writable archive dir, and `artifact_count=9`.


## Issue #621 Daemon / Capture Lifecycle Addendum
- Fixes daemon/status drift where screen capture could fail but stale `capture_ready=true` remained visible after a successful context post.
- Uses System Events as the preferred foreground app source, with NSWorkspace only as fallback, so on-switch capture follows visible app switches more reliably.
- Adds `daemon_alive` to observer daemon status while keeping `connected` scoped to an actual recent backend context post.
- Makes `local up` start the screen daemon when `DAEMON_ENABLED=true`; `local run` now means `local up` plus log tailing, so quiet local app start uses `local up`.
- Hardens report artifact storage by forcing report date directories to `0700` and report text/JSON files to `0600`.
- Redacts OpenRouter example keys in daemon/setup/benchmark docs.

Issue: #621
Commit: `b80c3e8`

### #621 Critic / Review
- Independent critic first found one P1 issue: daemon heartbeat freshness was being reported as `connected=true`, even without a backend context post.
- Finding accepted and fixed by splitting heartbeat status into `daemon_alive` and preserving `connected` for real transport/context-post connectivity.
- Final independent critic re-review: PASS on amended head `b80c3e8`.

### #621 Verification
- `backend/.venv/bin/pytest backend/tests/test_observer_api.py backend/tests/test_observer_screen_artifacts.py backend/tests/test_end_of_day_goal_report.py -q` - 42 passed.
- `daemon/.venv/bin/pytest daemon/tests/test_daemon_offline.py daemon/tests/test_periodic_capture.py daemon/tests/test_screenshot.py -q` - 25 passed.
- `python3 -m py_compile backend/src/api/observer.py backend/src/scheduler/jobs/end_of_day_goal_report.py backend/tests/test_observer_api.py && git diff --check` - passed.
- `bash -n manage.sh && git diff --check` - passed.
