### PR TITLE
Add screen report controls and capture budgets

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -93,12 +93,16 @@ Receive (streamed):
 | `CODEX_LOCAL_APPROVAL_POLICY` | `never` | Approval policy option passed to local `codex exec` |
 | `CODEX_LOCAL_TIMEOUT_SECONDS` | `600` | Timeout for local Codex operator invocations |
 | `SCREEN_CAPTURE_ARCHIVE_DIR` | `~/Library/Application Support/Seraph/artifacts/screen-captures` | Durable local archive root for preserved screen capture images, redacted provider output, and normalized JSON served by localhost-only observer artifact endpoints |
+| `SCREEN_ANALYSIS_MIN_SECONDS_BETWEEN_CAPTURES` | `0` | Minimum seconds between screen-analysis captures; `0` disables this throttle |
+| `SCREEN_ANALYSIS_MAX_DAILY_CAPTURES` | `0` | Daily screen-analysis capture cap; `0` means unlimited |
+| `SCREEN_CAPTURE_ARCHIVE_RETENTION_DAYS` | `365` | Operator-visible retention posture for preserved captures |
+| `SCREEN_CAPTURE_ARCHIVE_MAX_MB` | `0` | Operator-visible archive size budget; `0` means unlimited |
 | `REPORT_ARCHIVE_DIR` | `$WORKSPACE_DIR/artifacts/reports` | Durable local archive root for stored report text/JSON artifacts used by future analysis |
 | `END_OF_DAY_REPORT_ENABLED` | `true` | Enables the stored end-of-day goal report scheduler job |
 | `END_OF_DAY_REPORT_HOUR` | `21` | Local hour for the end-of-day goal report |
 | `END_OF_DAY_REPORT_LLM_ENABLED` | `false` | Enables LLM drafting for the report; default deterministic mode avoids sending screen-derived summaries to a provider |
 | `EMAIL_REPORTS_ENABLED` | `false` | Enables SMTP delivery for reports after local storage |
-| `EMAIL_REPORTS_PREVIEW_REQUIRED` | `true` | Blocks outbound report email until operator preview is deliberately disabled |
+| `EMAIL_REPORTS_PREVIEW_REQUIRED` | `true` | Blocks scheduled outbound report email unless operator preview is acknowledged for manual sends or deliberately disabled for scheduled delivery |
 | `EMAIL_REPORTS_TO` | - | Recipient for report email |
 | `EMAIL_REPORTS_TO_ALLOWLIST` | - | Comma-separated recipient allowlist; recipient must be present before sending |
 | `EMAIL_REPORTS_FROM` | - | Sender address for report email |

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -102,6 +102,10 @@ class Settings(BaseSettings):
     weekly_review_hour: int = 18                      # 6 PM Sunday weekly review
     screen_observation_retention_days: int = 90        # keep 90 days of observations
     screen_capture_archive_dir: str = ""
+    screen_analysis_min_seconds_between_captures: int = 0
+    screen_analysis_max_daily_captures: int = 0
+    screen_capture_archive_retention_days: int = 365
+    screen_capture_archive_max_mb: int = 0
     report_archive_dir: str = ""
     end_of_day_report_enabled: bool = True
     end_of_day_report_hour: int = 21

--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import stat
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
@@ -36,6 +36,16 @@ class ScreenAnalysisSettingsRequest(BaseModel):
     model: str | None = None
     preserve_captures: bool | None = None
     archive_dir: str | None = None
+    min_seconds_between_captures: int | None = None
+    max_daily_captures: int | None = None
+    archive_retention_days: int | None = None
+    archive_max_mb: int | None = None
+
+
+class ManualReportRequest(BaseModel):
+    send_email: bool = False
+    preview_acknowledged: bool = False
+    report_date: date | None = None
 
 
 class ToolPolicyModeRequest(BaseModel):
@@ -102,7 +112,7 @@ def _read_daemon_status(max_age_seconds: float = 45) -> dict[str, object]:
         "state": "unknown",
         "screen_analysis": "unknown",
         "capture_ready": False,
-        "connected": False,
+        "alive": False,
         "last_error": None,
         "last_error_kind": None,
         "updated_at": None,
@@ -137,9 +147,9 @@ def _read_daemon_status(max_age_seconds: float = 45) -> dict[str, object]:
             parsed = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
             if parsed.tzinfo is None:
                 parsed = parsed.replace(tzinfo=timezone.utc)
-            status["connected"] = (datetime.now(timezone.utc) - parsed).total_seconds() < max_age_seconds
+            status["alive"] = (datetime.now(timezone.utc) - parsed).total_seconds() < max_age_seconds
         except ValueError:
-            status["connected"] = False
+            status["alive"] = False
     return status
 
 
@@ -155,6 +165,10 @@ def _default_screen_analysis_settings() -> dict[str, object]:
         or settings.codex_local_model,
         "preserve_captures": _env_enabled("SERAPH_PRESERVE_SCREEN_CAPTURES", True),
         "archive_dir": str(screen_archive_dir),
+        "min_seconds_between_captures": max(0, settings.screen_analysis_min_seconds_between_captures),
+        "max_daily_captures": max(0, settings.screen_analysis_max_daily_captures),
+        "archive_retention_days": max(1, settings.screen_capture_archive_retention_days),
+        "archive_max_mb": max(0, settings.screen_capture_archive_max_mb),
     }
 
 
@@ -167,7 +181,17 @@ def _read_screen_analysis_settings() -> dict[str, object]:
         except (OSError, json.JSONDecodeError):
             loaded = {}
         if isinstance(loaded, dict):
-            for key in ("enabled", "provider", "model", "preserve_captures", "archive_dir"):
+            for key in (
+                "enabled",
+                "provider",
+                "model",
+                "preserve_captures",
+                "archive_dir",
+                "min_seconds_between_captures",
+                "max_daily_captures",
+                "archive_retention_days",
+                "archive_max_mb",
+            ):
                 if key in loaded:
                     payload[key] = loaded[key]
     provider = str(payload.get("provider") or "codex-local")
@@ -178,6 +202,19 @@ def _read_screen_analysis_settings() -> dict[str, object]:
     payload["preserve_captures"] = bool(payload.get("preserve_captures"))
     payload["model"] = str(payload.get("model") or "")
     payload["archive_dir"] = str(Path(str(payload.get("archive_dir") or "")).expanduser().resolve())
+    for key in (
+        "min_seconds_between_captures",
+        "max_daily_captures",
+        "archive_max_mb",
+    ):
+        try:
+            payload[key] = max(0, int(payload.get(key) or 0))
+        except (TypeError, ValueError):
+            payload[key] = 0
+    try:
+        payload["archive_retention_days"] = max(1, int(payload.get("archive_retention_days") or 365))
+    except (TypeError, ValueError):
+        payload["archive_retention_days"] = 365
     return payload
 
 
@@ -209,6 +246,26 @@ def _screen_artifact_summary(archive_dir: Path) -> dict[str, object]:
     return {
         "artifact_count": len(image_mtimes),
         "last_artifact_at": datetime.fromtimestamp(latest_mtime, timezone.utc).isoformat(),
+    }
+
+
+def _report_receipt_summary(report_dir: Path) -> dict[str, object]:
+    receipts_dir = report_dir / "receipts"
+    if not receipts_dir.exists():
+        return {"receipt_count": 0, "last_receipt_at": None}
+    receipt_mtimes = []
+    try:
+        for path in receipts_dir.rglob("*.json"):
+            if path.is_file():
+                receipt_mtimes.append(path.stat().st_mtime)
+    except OSError as exc:
+        logger.warning("Report receipt filesystem summary failed: %s", exc)
+        return {"receipt_count": 0, "last_receipt_at": None}
+    if not receipt_mtimes:
+        return {"receipt_count": 0, "last_receipt_at": None}
+    return {
+        "receipt_count": len(receipt_mtimes),
+        "last_receipt_at": datetime.fromtimestamp(max(receipt_mtimes), timezone.utc).isoformat(),
     }
 
 
@@ -320,7 +377,8 @@ async def get_screen_analysis_settings():
         {
             "capture_mode": ctx.capture_mode,
             "cadence_seconds": 60 if ctx.capture_mode == "detailed" else 300 if ctx.capture_mode == "balanced" else None,
-            "daemon_connected": bool(daemon_status["connected"]) or context_manager.is_daemon_connected(),
+            "daemon_connected": context_manager.is_daemon_connected(),
+            "daemon_alive": bool(daemon_status["alive"]),
             "artifact_count": 0,
             "last_artifact_at": None,
         }
@@ -359,6 +417,20 @@ async def set_screen_analysis_settings(body: ScreenAnalysisSettingsRequest):
         ):
             raise HTTPException(status_code=422, detail="Screen archive directory must be private and writable")
         payload["archive_dir"] = str(archive_dir)
+    for field_name in (
+        "min_seconds_between_captures",
+        "max_daily_captures",
+        "archive_max_mb",
+    ):
+        value = getattr(body, field_name)
+        if value is not None:
+            if value < 0:
+                raise HTTPException(status_code=422, detail=f"{field_name} must be >= 0")
+            payload[field_name] = value
+    if body.archive_retention_days is not None:
+        if body.archive_retention_days < 1:
+            raise HTTPException(status_code=422, detail="archive_retention_days must be >= 1")
+        payload["archive_retention_days"] = body.archive_retention_days
     _write_screen_analysis_settings(payload)
     return await get_screen_analysis_settings()
 
@@ -368,6 +440,7 @@ async def get_artifact_storage_settings():
     """Return operator-visible evidence/report archive configuration."""
     report_archive_dir, report_archive_source = _report_archive_dir()
     report_dir_status = _archive_dir_status(report_archive_dir)
+    report_receipts = _report_receipt_summary(report_archive_dir)
     screen_analysis = await get_screen_analysis_settings()
     screen_archive_dir = Path(str(screen_analysis["archive_dir"]))
     screen_dir_status = _archive_dir_status(screen_archive_dir)
@@ -380,8 +453,15 @@ async def get_artifact_storage_settings():
             "capture_mode": screen_analysis["capture_mode"],
             "cadence_seconds": screen_analysis["cadence_seconds"],
             "daemon_connected": screen_analysis["daemon_connected"],
+            "daemon_alive": screen_analysis["daemon_alive"],
             "artifact_count": screen_summary["artifact_count"],
             "last_artifact_at": screen_summary["last_artifact_at"],
+            "budget": {
+                "min_seconds_between_captures": screen_analysis["min_seconds_between_captures"],
+                "max_daily_captures": screen_analysis["max_daily_captures"],
+                "archive_retention_days": screen_analysis["archive_retention_days"],
+                "archive_max_mb": screen_analysis["archive_max_mb"],
+            },
             "preservation_enabled": screen_analysis["preserve_captures"],
             "archive_dir": str(screen_analysis["archive_dir"]),
             "archive_dir_source": "screen-analysis-settings",
@@ -403,6 +483,8 @@ async def get_artifact_storage_settings():
             "archive_dir_source": report_archive_source,
             **report_dir_status,
             "stored_artifacts": ["report_text", "report_json"],
+            "receipt_count": report_receipts["receipt_count"],
+            "last_receipt_at": report_receipts["last_receipt_at"],
             "control_env": {
                 "archive_dir": "REPORT_ARCHIVE_DIR",
                 "enabled": "END_OF_DAY_REPORT_ENABLED",
@@ -415,6 +497,7 @@ async def get_artifact_storage_settings():
             "smtp_configured": bool(settings.smtp_host.strip()),
             "recipient_configured": bool(settings.email_reports_to.strip()),
             "allowlist_configured": bool(settings.email_reports_to_allowlist.strip()),
+            "sender_configured": bool(settings.email_reports_from.strip()),
             "control_env": {
                 "enabled": "EMAIL_REPORTS_ENABLED",
                 "preview_required": "EMAIL_REPORTS_PREVIEW_REQUIRED",
@@ -424,6 +507,26 @@ async def get_artifact_storage_settings():
             },
         },
     }
+
+
+@router.post("/settings/end-of-day-report/manual")
+async def run_manual_end_of_day_report(body: ManualReportRequest):
+    """Build/store a manual end-of-day report preview or operator-acknowledged send."""
+    from src.scheduler.jobs.end_of_day_goal_report import run_manual_end_of_day_goal_report
+
+    return await run_manual_end_of_day_goal_report(
+        send_email=body.send_email,
+        preview_acknowledged=body.preview_acknowledged,
+        report_day=body.report_date,
+    )
+
+
+@router.post("/settings/end-of-day-report/test-email")
+async def send_end_of_day_report_test_email():
+    """Send a guarded test email using the configured report email transport."""
+    from src.scheduler.jobs.end_of_day_goal_report import send_end_of_day_report_test_email
+
+    return await send_end_of_day_report_test_email()
 
 
 @router.get("/settings/tool-policy-mode")

--- a/backend/src/scheduler/jobs/end_of_day_goal_report.py
+++ b/backend/src/scheduler/jobs/end_of_day_goal_report.py
@@ -108,6 +108,10 @@ def _report_archive_root() -> Path:
     return Path(settings.workspace_dir).expanduser().resolve() / "artifacts" / "reports"
 
 
+def _report_receipt_dir(report_date: str) -> Path:
+    return _report_archive_root() / "receipts" / report_date
+
+
 def _report_artifact_paths(report: dict[str, Any]) -> dict[str, str]:
     report_date = str(report.get("date") or "unknown")
     digest = hashlib.sha256(
@@ -142,6 +146,84 @@ def archive_end_of_day_goal_report(report: dict[str, Any]) -> dict[str, Any]:
         **paths,
         "report_text_sha256": hashlib.sha256(text_payload.encode("utf-8")).hexdigest(),
         "report_json_sha256": hashlib.sha256(json_path.read_bytes()).hexdigest(),
+    }
+
+
+def archive_end_of_day_report_receipt(
+    *,
+    action: str,
+    report: dict[str, Any] | None = None,
+    episode_id: str | None = None,
+    email_result: EmailDeliveryResult | None = None,
+    status: str = "succeeded",
+    reason: str | None = None,
+) -> dict[str, Any]:
+    """Persist a private operator receipt for manual/scheduled report actions."""
+    report_date = str((report or {}).get("date") or datetime.now(timezone.utc).date().isoformat())
+    created_at = datetime.now(timezone.utc).isoformat()
+    digest_input = json.dumps(
+        {
+            "action": action,
+            "created_at": created_at,
+            "report_date": report_date,
+            "episode_id": episode_id,
+            "email_status": email_result.status if email_result else None,
+        },
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(digest_input.encode("utf-8")).hexdigest()[:16]
+    receipt_dir = _report_receipt_dir(report_date)
+    receipt_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    receipt_dir.chmod(0o700)
+    receipt_path = receipt_dir / f"{action}-{report_date}-{digest}.json"
+    payload = {
+        "artifact_schema": "seraph.end_of_day_report_receipt.v1",
+        "created_at": created_at,
+        "action": action,
+        "status": status,
+        "reason": reason,
+        "report_date": report_date,
+        "episode_id": episode_id,
+        "report_artifacts": (report or {}).get("artifacts"),
+        "analysis_provider": (report or {}).get("analysis_provider"),
+        "email": {
+            "status": email_result.status if email_result else None,
+            "reason": email_result.reason if email_result else None,
+            "recipient_hash": email_result.recipient_hash if email_result else None,
+            "provider_receipt": email_result.provider_receipt if email_result else None,
+        },
+    }
+    _write_private_text(receipt_path, json.dumps(payload, indent=2, sort_keys=True))
+    return {
+        "receipt_id": receipt_path.stem,
+        "receipt_path": str(receipt_path),
+        "receipt_sha256": hashlib.sha256(receipt_path.read_bytes()).hexdigest(),
+        "status": status,
+        "reason": reason,
+    }
+
+
+def public_report_artifacts(artifacts: dict[str, Any] | None) -> dict[str, Any]:
+    """Return report artifact metadata without exposing private filesystem paths."""
+    if not isinstance(artifacts, dict):
+        return {}
+    return {
+        "report_text_sha256": artifacts.get("report_text_sha256"),
+        "report_json_sha256": artifacts.get("report_json_sha256"),
+        "raw_artifact_path_exposed": False,
+    }
+
+
+def public_report_receipt(receipt: dict[str, Any] | None) -> dict[str, Any]:
+    """Return receipt metadata that is safe for API/audit surfaces."""
+    if not isinstance(receipt, dict):
+        return {}
+    return {
+        "receipt_id": receipt.get("receipt_id"),
+        "receipt_sha256": receipt.get("receipt_sha256"),
+        "status": receipt.get("status"),
+        "reason": receipt.get("reason"),
+        "raw_receipt_path_exposed": False,
     }
 
 
@@ -426,13 +508,17 @@ async def store_end_of_day_goal_report(report: dict[str, Any]) -> str:
     return episode.id
 
 
-async def deliver_report_email(report: dict[str, Any]) -> EmailDeliveryResult:
+async def deliver_report_email(
+    report: dict[str, Any],
+    *,
+    preview_acknowledged: bool = False,
+) -> EmailDeliveryResult:
     recipient = settings.email_reports_to.strip()
     sender = settings.email_reports_from.strip()
 
     if not settings.email_reports_enabled:
         return EmailDeliveryResult(status="skipped", reason="email_reports_disabled")
-    if settings.email_reports_preview_required:
+    if settings.email_reports_preview_required and not preview_acknowledged:
         return EmailDeliveryResult(status="preview_required", reason="operator_preview_required")
     if not recipient or not sender:
         return EmailDeliveryResult(status="skipped", reason="missing_recipient_or_sender")
@@ -484,6 +570,71 @@ async def deliver_report_email(report: dict[str, Any]) -> EmailDeliveryResult:
     return EmailDeliveryResult(status="sent", recipient_hash=recipient_digest)
 
 
+async def run_manual_end_of_day_goal_report(
+    *,
+    send_email: bool = False,
+    preview_acknowledged: bool = False,
+    report_day: date | None = None,
+) -> dict[str, Any]:
+    report = await build_end_of_day_goal_report(report_day)
+    episode_id = await store_end_of_day_goal_report(report)
+    email_result = (
+        await deliver_report_email(report, preview_acknowledged=preview_acknowledged)
+        if send_email
+        else EmailDeliveryResult(status="preview_only", reason="manual_preview")
+    )
+    receipt = archive_end_of_day_report_receipt(
+        action="manual-send" if send_email else "manual-preview",
+        report=report,
+        episode_id=episode_id,
+        email_result=email_result,
+    )
+    return {
+        "status": "ok",
+        "action": "manual-send" if send_email else "manual-preview",
+        "report": {
+            "date": report["date"],
+            "timezone": report["timezone"],
+            "body": report["body"],
+            "summary": report["summary"],
+            "goal_alignment": report["goal_alignment"],
+            "analysis_provider": report.get("analysis_provider"),
+            "artifacts": public_report_artifacts(report.get("artifacts")),
+        },
+        "episode_id": episode_id,
+        "email": {
+            "status": email_result.status,
+            "reason": email_result.reason,
+            "recipient_hash": email_result.recipient_hash,
+        },
+        "receipt": public_report_receipt(receipt),
+    }
+
+
+async def send_end_of_day_report_test_email() -> dict[str, Any]:
+    test_report = {
+        "date": datetime.now(_safe_timezone()).date().isoformat(),
+        "timezone": str(_safe_timezone()),
+        "body": "Seraph test email: end-of-day report delivery is configured.",
+        "analysis_provider": "deterministic-local",
+        "artifact_schema": "seraph.end_of_day_report_test_email.v1",
+    }
+    email_result = await deliver_report_email(test_report, preview_acknowledged=True)
+    receipt = archive_end_of_day_report_receipt(
+        action="test-email",
+        report=test_report,
+        email_result=email_result,
+        status=email_result.status,
+        reason=email_result.reason,
+    )
+    return {
+        "status": email_result.status,
+        "reason": email_result.reason,
+        "recipient_hash": email_result.recipient_hash,
+        "receipt": public_report_receipt(receipt),
+    }
+
+
 async def run_end_of_day_goal_report() -> None:
     if not settings.end_of_day_report_enabled:
         await log_scheduler_job_event(
@@ -498,6 +649,12 @@ async def run_end_of_day_goal_report() -> None:
         report = await build_end_of_day_goal_report()
         episode_id = await store_end_of_day_goal_report(report)
         email_result = await deliver_report_email(report)
+        receipt = archive_end_of_day_report_receipt(
+            action="scheduled",
+            report=report,
+            episode_id=episode_id,
+            email_result=email_result,
+        )
         await log_scheduler_job_event(
             job_name="end_of_day_goal_report",
             outcome="succeeded",
@@ -511,7 +668,8 @@ async def run_end_of_day_goal_report() -> None:
                 "email_status": email_result.status,
                 "email_reason": email_result.reason,
                 "email_recipient_hash": email_result.recipient_hash,
-                "report_artifacts": report.get("artifacts"),
+                "report_artifacts": public_report_artifacts(report.get("artifacts")),
+                "report_receipt": public_report_receipt(receipt),
             },
         )
     except Exception as exc:

--- a/backend/tests/test_end_of_day_goal_report.py
+++ b/backend/tests/test_end_of_day_goal_report.py
@@ -160,6 +160,36 @@ async def test_store_report_writes_durable_artifacts(async_db, tmp_path):
     assert artifacts["report_json_sha256"]
 
 
+def test_archive_report_receipt_writes_private_metadata(tmp_path):
+    from src.scheduler.jobs.end_of_day_goal_report import (
+        EmailDeliveryResult,
+        archive_end_of_day_report_receipt,
+    )
+
+    report = {
+        "date": "2026-06-20",
+        "analysis_provider": "deterministic-local",
+        "artifacts": {"report_text_sha256": "abc123"},
+    }
+
+    with patch.object(settings, "report_archive_dir", str(tmp_path / "reports")):
+        receipt = archive_end_of_day_report_receipt(
+            action="manual-preview",
+            report=report,
+            episode_id="episode-1",
+            email_result=EmailDeliveryResult(status="preview_only", reason="manual_preview"),
+        )
+
+    receipt_path = Path(receipt["receipt_path"])
+    payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert payload["artifact_schema"] == "seraph.end_of_day_report_receipt.v1"
+    assert payload["action"] == "manual-preview"
+    assert payload["episode_id"] == "episode-1"
+    assert payload["email"]["status"] == "preview_only"
+    assert stat.S_IMODE(receipt_path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(receipt_path.stat().st_mode) == 0o600
+
+
 @pytest.mark.asyncio
 async def test_email_delivery_requires_allowlisted_recipient_hash():
     from src.scheduler.jobs.end_of_day_goal_report import deliver_report_email
@@ -204,3 +234,68 @@ async def test_email_delivery_sends_only_when_configured_and_preview_disabled():
     smtp.starttls.assert_called_once()
     smtp.login.assert_called_once_with("user", "pass")
     smtp.send_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_manual_report_preview_stores_report_and_receipt(async_db, tmp_path):
+    from src.scheduler.jobs.end_of_day_goal_report import run_manual_end_of_day_goal_report
+
+    with patch.object(settings, "report_archive_dir", str(tmp_path / "reports")), patch(
+        "src.scheduler.jobs.end_of_day_goal_report.build_end_of_day_goal_report",
+        new=AsyncMock(
+            return_value={
+                "date": "2026-06-20",
+                "timezone": "UTC",
+                "body": "Manual preview body",
+                "summary": {"total_observations": 1, "total_tracked_minutes": 5},
+                "goal_alignment": [],
+                "completed_goal_count": 0,
+                "active_goal_count": 1,
+                "analysis_provider": "deterministic-local",
+                "artifact_schema": "seraph.end_of_day_goal_report.v1",
+            }
+        ),
+    ):
+        result = await run_manual_end_of_day_goal_report(send_email=False)
+
+    assert result["action"] == "manual-preview"
+    assert result["email"]["status"] == "preview_only"
+    assert result["report"]["body"] == "Manual preview body"
+    assert result["report"]["artifacts"]["report_text_sha256"]
+    assert result["report"]["artifacts"]["report_json_sha256"]
+    assert result["report"]["artifacts"]["raw_artifact_path_exposed"] is False
+    assert "report_text_path" not in result["report"]["artifacts"]
+    assert "report_json_path" not in result["report"]["artifacts"]
+    assert result["receipt"]["receipt_id"]
+    assert result["receipt"]["receipt_sha256"]
+    assert result["receipt"]["raw_receipt_path_exposed"] is False
+    assert "receipt_path" not in result["receipt"]
+
+
+@pytest.mark.asyncio
+async def test_manual_report_send_respects_preview_required(async_db, tmp_path):
+    from src.scheduler.jobs.end_of_day_goal_report import run_manual_end_of_day_goal_report
+
+    with patch.object(settings, "report_archive_dir", str(tmp_path / "reports")), patch.object(
+        settings, "email_reports_enabled", True
+    ), patch.object(settings, "email_reports_preview_required", True), patch(
+        "src.scheduler.jobs.end_of_day_goal_report.build_end_of_day_goal_report",
+        new=AsyncMock(
+            return_value={
+                "date": "2026-06-20",
+                "timezone": "UTC",
+                "body": "Manual send body",
+                "summary": {"total_observations": 1, "total_tracked_minutes": 5},
+                "goal_alignment": [],
+                "completed_goal_count": 0,
+                "active_goal_count": 1,
+                "analysis_provider": "deterministic-local",
+                "artifact_schema": "seraph.end_of_day_goal_report.v1",
+            }
+        ),
+    ):
+        result = await run_manual_end_of_day_goal_report(send_email=True, preview_acknowledged=False)
+
+    assert result["action"] == "manual-send"
+    assert result["email"]["status"] == "preview_required"
+    assert result["email"]["reason"] == "operator_preview_required"

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -3,7 +3,7 @@
 import json
 import stat
 from datetime import datetime, timezone
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
@@ -142,9 +142,11 @@ async def test_artifact_storage_settings_exposes_safe_operator_posture(client, t
     data = resp.json()
     assert data["screen"]["analysis_enabled"] is True
     assert data["screen"]["provider"] == "codex-local"
-    assert data["screen"]["daemon_connected"] is True
+    assert data["screen"]["daemon_connected"] is False
     assert data["screen"]["artifact_count"] == 0
+    assert data["screen"]["daemon_alive"] is True
     assert data["screen"]["preservation_enabled"] is True
+    assert data["screen"]["budget"]["archive_retention_days"] >= 1
     assert data["screen"]["archive_dir"].endswith("/screen")
     assert data["screen"]["exists"] is True
     assert data["screen"]["writable"] is True
@@ -162,8 +164,10 @@ async def test_artifact_storage_settings_exposes_safe_operator_posture(client, t
     assert data["reports"]["creation_error"] is None
     assert stat.S_IMODE((tmp_path / "reports").stat().st_mode) == 0o700
     assert data["reports"]["analysis_provider"] == "deterministic-local"
+    assert data["reports"]["receipt_count"] == 0
     assert data["email"]["enabled"] is True
     assert data["email"]["smtp_configured"] is True
+    assert data["email"]["sender_configured"] is False
     assert "secret-password" not in str(data)
 
 
@@ -204,12 +208,45 @@ async def test_screen_analysis_settings_persist_and_drive_artifact_storage(clien
         assert data["model"] == "gpt-5.5"
         assert data["preserve_captures"] is True
         assert data["archive_dir"] == str(archive)
+        assert data["max_daily_captures"] == 0
 
         storage = (await client.get("/api/settings/artifact-storage")).json()
         assert storage["screen"]["analysis_enabled"] is True
         assert storage["screen"]["provider"] == "codex-local"
         assert storage["screen"]["archive_dir"] == str(archive)
         assert storage["screen"]["preservation_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_screen_analysis_settings_persist_budget_controls(client, tmp_path):
+    with patch.object(settings, "workspace_dir", str(tmp_path / "workspace")):
+        resp = await client.put(
+            "/api/settings/screen-analysis",
+            json={
+                "min_seconds_between_captures": 45,
+                "max_daily_captures": 200,
+                "archive_retention_days": 180,
+                "archive_max_mb": 1024,
+            },
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["min_seconds_between_captures"] == 45
+    assert data["max_daily_captures"] == 200
+    assert data["archive_retention_days"] == 180
+    assert data["archive_max_mb"] == 1024
+
+
+@pytest.mark.asyncio
+async def test_screen_analysis_settings_reject_negative_budget(client, tmp_path):
+    with patch.object(settings, "workspace_dir", str(tmp_path / "workspace")):
+        resp = await client.put(
+            "/api/settings/screen-analysis",
+            json={"max_daily_captures": -1},
+        )
+
+    assert resp.status_code == 422
 
 
 @pytest.mark.asyncio
@@ -237,3 +274,48 @@ def test_screen_artifact_summary_skips_files_deleted_during_stat(tmp_path, monke
     monkeypatch.setattr(type(image), "stat", flaky_stat)
 
     assert _screen_artifact_summary(tmp_path) == {"artifact_count": 0, "last_artifact_at": None}
+
+
+@pytest.mark.asyncio
+async def test_manual_report_endpoint_returns_safe_preview(client):
+    with patch(
+        "src.scheduler.jobs.end_of_day_goal_report.run_manual_end_of_day_goal_report",
+        new=AsyncMock(
+            return_value={
+                "status": "ok",
+                "action": "manual-preview",
+                "report": {"date": "2026-06-20", "body": "Preview body"},
+                "email": {"status": "preview_only", "reason": "manual_preview", "recipient_hash": None},
+                "receipt": {"receipt_sha256": "abc123", "status": "succeeded"},
+            }
+        ),
+    ) as manual:
+        resp = await client.post("/api/settings/end-of-day-report/manual", json={"send_email": False})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["action"] == "manual-preview"
+    assert data["email"]["status"] == "preview_only"
+    manual.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_test_email_endpoint_returns_safe_status(client):
+    with patch(
+        "src.scheduler.jobs.end_of_day_goal_report.send_end_of_day_report_test_email",
+        new=AsyncMock(
+            return_value={
+                "status": "blocked",
+                "reason": "recipient_not_allowlisted",
+                "recipient_hash": "hash123",
+                "receipt": {"receipt_sha256": "def456", "status": "blocked"},
+            }
+        ),
+    ):
+        resp = await client.post("/api/settings/end-of-day-report/test-email")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "blocked"
+    assert data["recipient_hash"] == "hash123"
+    assert "user@example" not in str(data)

--- a/daemon/seraph_daemon.py
+++ b/daemon/seraph_daemon.py
@@ -83,6 +83,15 @@ def _archive_provider_capture(
     }
 
 
+def _analysis_usage(provider_name: str, *, duration_ms: int | None, success: bool) -> dict[str, object]:
+    return {
+        "provider": provider_name,
+        "duration_ms": duration_ms,
+        "success": success,
+        "cost_posture": "local_no_api_price" if provider_name == "codex-local" else "provider_api_usage",
+    }
+
+
 def _write_private_bytes(path: Path, content: bytes) -> None:
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
@@ -335,6 +344,13 @@ class ScreenAnalysisRuntime:
         self.enabled = False
         self.preserve_captures = False
         self.archive_dir = archive_dir
+        self.min_seconds_between_captures = 0
+        self.max_daily_captures = 0
+        self.archive_retention_days = 365
+        self.archive_max_mb = 0
+        self._last_capture_monotonic = 0.0
+        self._daily_capture_date = datetime.now(timezone.utc).date().isoformat()
+        self._daily_capture_count = 0
 
     async def refresh(self, client: httpx.AsyncClient, url: str, *, force: bool = False) -> None:
         now = time.time()
@@ -349,7 +365,21 @@ class ScreenAnalysisRuntime:
         model = str(payload.get("model") or self._fallback["model"] or "")
         preserve = bool(payload.get("preserve_captures", self._fallback["preserve_captures"]))
         archive_dir = str(payload.get("archive_dir") or self._fallback["archive_dir"])
-        signature = (enabled, provider_name, model, preserve, archive_dir)
+        min_seconds = max(0, int(payload.get("min_seconds_between_captures") or 0))
+        max_daily = max(0, int(payload.get("max_daily_captures") or 0))
+        retention_days = max(1, int(payload.get("archive_retention_days") or 365))
+        archive_max_mb = max(0, int(payload.get("archive_max_mb") or 0))
+        signature = (
+            enabled,
+            provider_name,
+            model,
+            preserve,
+            archive_dir,
+            min_seconds,
+            max_daily,
+            retention_days,
+            archive_max_mb,
+        )
         if signature == self._signature:
             return
 
@@ -359,6 +389,7 @@ class ScreenAnalysisRuntime:
             self.enabled = False
             self.preserve_captures = preserve
             self.archive_dir = archive_dir
+            self._update_budget_settings(min_seconds, max_daily, retention_days, archive_max_mb)
             self._signature = signature
             if old_provider is not None and hasattr(old_provider, "close"):
                 await old_provider.close()
@@ -394,6 +425,7 @@ class ScreenAnalysisRuntime:
             self.enabled = False
             self.preserve_captures = preserve
             self.archive_dir = archive_dir
+            self._update_budget_settings(min_seconds, max_daily, retention_days, archive_max_mb)
             if old_provider is not None and hasattr(old_provider, "close"):
                 await old_provider.close()
             _write_daemon_status(
@@ -414,6 +446,7 @@ class ScreenAnalysisRuntime:
             self.enabled = False
             self.preserve_captures = preserve
             self.archive_dir = archive_dir
+            self._update_budget_settings(min_seconds, max_daily, retention_days, archive_max_mb)
             if old_provider is not None and hasattr(old_provider, "close"):
                 await old_provider.close()
             _write_daemon_status(
@@ -433,6 +466,7 @@ class ScreenAnalysisRuntime:
         self.enabled = True
         self.preserve_captures = preserve
         self.archive_dir = archive_dir
+        self._update_budget_settings(min_seconds, max_daily, retention_days, archive_max_mb)
         self._signature = signature
         self.blocklist = load_blocklist(self._blocklist_file)
         logger.info(
@@ -452,6 +486,52 @@ class ScreenAnalysisRuntime:
             last_error=None,
             last_error_kind=None,
         )
+
+    def _update_budget_settings(
+        self,
+        min_seconds: int,
+        max_daily: int,
+        retention_days: int,
+        archive_max_mb: int,
+    ) -> None:
+        self.min_seconds_between_captures = min_seconds
+        self.max_daily_captures = max_daily
+        self.archive_retention_days = retention_days
+        self.archive_max_mb = archive_max_mb
+
+    def _refresh_daily_counter(self) -> None:
+        today = datetime.now(timezone.utc).date().isoformat()
+        if today != self._daily_capture_date:
+            self._daily_capture_date = today
+            self._daily_capture_count = 0
+
+    def budget_skip_reason(self, *, now: float) -> str | None:
+        self._refresh_daily_counter()
+        if (
+            self.min_seconds_between_captures > 0
+            and self._last_capture_monotonic > 0
+            and now - self._last_capture_monotonic < self.min_seconds_between_captures
+        ):
+            return "min_seconds_between_captures"
+        if self.max_daily_captures > 0 and self._daily_capture_count >= self.max_daily_captures:
+            return "max_daily_captures"
+        return None
+
+    def record_capture(self, *, now: float) -> None:
+        self._refresh_daily_counter()
+        self._last_capture_monotonic = now
+        self._daily_capture_count += 1
+
+    def budget_status(self) -> dict[str, object]:
+        self._refresh_daily_counter()
+        return {
+            "min_seconds_between_captures": self.min_seconds_between_captures,
+            "max_daily_captures": self.max_daily_captures,
+            "daily_capture_count": self._daily_capture_count,
+            "daily_capture_date": self._daily_capture_date,
+            "archive_retention_days": self.archive_retention_days,
+            "archive_max_mb": self.archive_max_mb,
+        }
 
     async def close(self) -> None:
         if self.provider is not None and hasattr(self.provider, "close"):
@@ -574,20 +654,111 @@ async def poll_loop(
                         if verbose:
                             logger.info("Blocked app: %s — skipping screenshot", app_name)
                     else:
-                        try:
-                            from ocr.screenshot import capture_screen_png
+                        budget_skip_reason = screen_runtime.budget_skip_reason(now=time.time())
+                        if budget_skip_reason:
+                            observation["capture_skipped"] = True
+                            observation["capture_skip_reason"] = budget_skip_reason
+                            _write_daemon_status(
+                                state="running",
+                                screen_analysis="capture_budget_skipped",
+                                provider=screen_runtime.provider.name,
+                                capture_ready=False,
+                                active_window=active_window,
+                                frontmost_app=app_name,
+                                window_title=window_title,
+                                last_poll_at=poll_at,
+                                last_error=f"Screen capture skipped by budget: {budget_skip_reason}",
+                                last_error_kind=budget_skip_reason,
+                                capture_budget=screen_runtime.budget_status(),
+                            )
+                            if verbose:
+                                logger.info("Screen capture skipped by budget: %s", budget_skip_reason)
+                        else:
+                            try:
+                                from ocr.screenshot import capture_screen_png
 
-                            png_bytes = await asyncio.to_thread(capture_screen_png)
-                            if not png_bytes:
-                                observation["capture_error"] = (
-                                    "macOS screen capture returned no image. Grant Screen Recording / "
-                                    "Screen & System Audio Recording permission to the terminal/app running Seraph, "
-                                    "then restart the daemon."
-                                )
-                                observation["capture_error_kind"] = "screen_capture_permission"
+                                png_bytes = await asyncio.to_thread(capture_screen_png)
+                                if not png_bytes:
+                                    observation["capture_error"] = (
+                                        "macOS screen capture returned no image. Grant Screen Recording / "
+                                        "Screen & System Audio Recording permission to the terminal/app running Seraph, "
+                                        "then restart the daemon."
+                                    )
+                                    observation["capture_error_kind"] = "screen_capture_permission"
+                                    _write_daemon_status(
+                                        state="running",
+                                        screen_analysis="capture_error",
+                                        provider=screen_runtime.provider.name,
+                                        capture_ready=False,
+                                        active_window=active_window,
+                                        frontmost_app=app_name,
+                                        window_title=window_title,
+                                        last_poll_at=poll_at,
+                                        last_error=observation["capture_error"],
+                                        last_error_kind="screen_capture_permission",
+                                    )
+                                if png_bytes:
+                                    result = await screen_runtime.provider.analyze_screen(png_bytes, app_name)
+                                    if result.success:
+                                        screen_runtime.record_capture(now=time.time())
+                                        analysis = {
+                                            **result.data,
+                                            "analysis_usage": _analysis_usage(
+                                                screen_runtime.provider.name,
+                                                duration_ms=result.duration_ms,
+                                                success=True,
+                                            ),
+                                        }
+                                        observation.update(analysis)
+                                        if screen_runtime.preserve_captures and "capture_artifacts" not in observation:
+                                            observation["capture_artifacts"] = _archive_provider_capture(
+                                                archive_dir=screen_runtime.archive_dir,
+                                                png_bytes=png_bytes,
+                                                app_name=app_name,
+                                                provider_name=screen_runtime.provider.name,
+                                                analysis=analysis,
+                                            )
+                                        if verbose:
+                                            ts = time.strftime("%H:%M:%S")
+                                            logger.info(
+                                                "[%s] analyzed (%dms): %s",
+                                                ts,
+                                                result.duration_ms,
+                                                result.data.get("summary", "")[:80],
+                                            )
+                                        _write_daemon_status(
+                                            state="running",
+                                            screen_analysis="active",
+                                            provider=screen_runtime.provider.name,
+                                            capture_ready=True,
+                                            active_window=active_window,
+                                            frontmost_app=app_name,
+                                            window_title=window_title,
+                                            last_capture_at=datetime.now(timezone.utc).isoformat(),
+                                            last_poll_at=poll_at,
+                                            last_error=None,
+                                            last_error_kind=None,
+                                            capture_budget=screen_runtime.budget_status(),
+                                        )
+                                    else:
+                                        logger.debug("Screen analysis failed: %s", result.error)
+                                        observation["capture_error"] = result.error or "Screen analysis failed."
+                                        observation["capture_error_kind"] = "analysis_error"
+                                        _write_daemon_status(
+                                            state="running",
+                                            screen_analysis="analysis_error",
+                                            provider=screen_runtime.provider.name,
+                                            capture_ready=False,
+                                            last_error=observation["capture_error"],
+                                            last_error_kind="analysis_error",
+                                        )
+                            except Exception:
+                                logger.debug("Screenshot/analysis error", exc_info=True)
+                                observation["capture_error"] = "Screenshot or screen analysis failed unexpectedly."
+                                observation["capture_error_kind"] = "analysis_exception"
                                 _write_daemon_status(
                                     state="running",
-                                    screen_analysis="capture_error",
+                                    screen_analysis="analysis_error",
                                     provider=screen_runtime.provider.name,
                                     capture_ready=False,
                                     active_window=active_window,
@@ -595,69 +766,8 @@ async def poll_loop(
                                     window_title=window_title,
                                     last_poll_at=poll_at,
                                     last_error=observation["capture_error"],
-                                    last_error_kind="screen_capture_permission",
+                                    last_error_kind="analysis_exception",
                                 )
-                            if png_bytes:
-                                result = await screen_runtime.provider.analyze_screen(png_bytes, app_name)
-                                if result.success:
-                                    observation.update(result.data)
-                                    if screen_runtime.preserve_captures and "capture_artifacts" not in observation:
-                                        observation["capture_artifacts"] = _archive_provider_capture(
-                                            archive_dir=screen_runtime.archive_dir,
-                                            png_bytes=png_bytes,
-                                            app_name=app_name,
-                                            provider_name=screen_runtime.provider.name,
-                                            analysis=result.data,
-                                        )
-                                    if verbose:
-                                        ts = time.strftime("%H:%M:%S")
-                                        logger.info(
-                                            "[%s] analyzed (%dms): %s",
-                                            ts,
-                                            result.duration_ms,
-                                            result.data.get("summary", "")[:80],
-                                        )
-                                    _write_daemon_status(
-                                        state="running",
-                                        screen_analysis="active",
-                                        provider=screen_runtime.provider.name,
-                                        capture_ready=True,
-                                        active_window=active_window,
-                                        frontmost_app=app_name,
-                                        window_title=window_title,
-                                        last_capture_at=datetime.now(timezone.utc).isoformat(),
-                                        last_poll_at=poll_at,
-                                        last_error=None,
-                                        last_error_kind=None,
-                                    )
-                                else:
-                                    logger.debug("Screen analysis failed: %s", result.error)
-                                    observation["capture_error"] = result.error or "Screen analysis failed."
-                                    observation["capture_error_kind"] = "analysis_error"
-                                    _write_daemon_status(
-                                        state="running",
-                                        screen_analysis="analysis_error",
-                                        provider=screen_runtime.provider.name,
-                                        capture_ready=False,
-                                        last_error=observation["capture_error"],
-                                        last_error_kind="analysis_error",
-                                    )
-                        except Exception:
-                            logger.debug("Screenshot/analysis error", exc_info=True)
-                            observation["capture_error"] = "Screenshot or screen analysis failed unexpectedly."
-                            observation["capture_error_kind"] = "analysis_exception"
-                            _write_daemon_status(
-                                state="running",
-                                screen_analysis="analysis_error",
-                                provider=screen_runtime.provider.name,
-                                capture_ready=False,
-                                active_window=active_window,
-                                frontmost_app=app_name,
-                                window_title=window_title,
-                                last_poll_at=poll_at,
-                                last_error=observation["capture_error"],
-                                last_error_kind="analysis_exception",
-                            )
 
                 # Post to backend
                 try:
@@ -806,6 +916,34 @@ async def periodic_capture_loop(
                     "app": app_name,
                     "window_title": window_title,
                 }
+                budget_skip_reason = screen_runtime.budget_skip_reason(now=now)
+                if budget_skip_reason:
+                    observation["capture_skipped"] = True
+                    observation["capture_skip_reason"] = budget_skip_reason
+                    _write_daemon_status(
+                        state="running",
+                        screen_analysis="capture_budget_skipped",
+                        provider=screen_runtime.provider.name,
+                        capture_ready=False,
+                        active_window=active_window,
+                        frontmost_app=app_name,
+                        window_title=window_title,
+                        last_poll_at=poll_at,
+                        last_error=f"Screen capture skipped by budget: {budget_skip_reason}",
+                        last_error_kind=budget_skip_reason,
+                        capture_budget=screen_runtime.budget_status(),
+                    )
+                    await client.post(
+                        f"{url}/api/observer/context",
+                        json={
+                            "active_window": active_window,
+                            "observation": observation,
+                            "switch_timestamp": now,
+                        },
+                    )
+                    last_periodic = now
+                    await asyncio.sleep(check_interval)
+                    continue
 
                 try:
                     from ocr.screenshot import capture_screen_png
@@ -828,14 +966,23 @@ async def periodic_capture_loop(
                     if png_bytes:
                         result = await screen_runtime.provider.analyze_screen(png_bytes, app_name)
                         if result.success:
-                            observation.update(result.data)
+                            screen_runtime.record_capture(now=now)
+                            analysis = {
+                                **result.data,
+                                "analysis_usage": _analysis_usage(
+                                    screen_runtime.provider.name,
+                                    duration_ms=result.duration_ms,
+                                    success=True,
+                                ),
+                            }
+                            observation.update(analysis)
                             if screen_runtime.preserve_captures and "capture_artifacts" not in observation:
                                 observation["capture_artifacts"] = _archive_provider_capture(
                                     archive_dir=screen_runtime.archive_dir,
                                     png_bytes=png_bytes,
                                     app_name=app_name,
                                     provider_name=screen_runtime.provider.name,
-                                    analysis=result.data,
+                                    analysis=analysis,
                                 )
                             if verbose:
                                 ts = time.strftime("%H:%M:%S")
@@ -858,6 +1005,7 @@ async def periodic_capture_loop(
                                 last_poll_at=poll_at,
                                 last_error=None,
                                 last_error_kind=None,
+                                capture_budget=screen_runtime.budget_status(),
                             )
                         else:
                             logger.debug("Periodic analysis failed: %s", result.error)

--- a/daemon/tests/test_periodic_capture.py
+++ b/daemon/tests/test_periodic_capture.py
@@ -117,6 +117,10 @@ async def test_screen_analysis_runtime_refreshes_provider_and_archive_from_setti
             "model": "gpt-5.5",
             "preserve_captures": True,
             "archive_dir": str(first_archive),
+            "min_seconds_between_captures": 30,
+            "max_daily_captures": 5,
+            "archive_retention_days": 180,
+            "archive_max_mb": 512,
         }
     )
 
@@ -129,6 +133,10 @@ async def test_screen_analysis_runtime_refreshes_provider_and_archive_from_setti
         assert runtime.provider.name == "codex-local"
         assert runtime.preserve_captures is True
         assert runtime.archive_dir == str(first_archive)
+        assert runtime.min_seconds_between_captures == 30
+        assert runtime.max_daily_captures == 5
+        assert runtime.archive_retention_days == 180
+        assert runtime.archive_max_mb == 512
         assert runtime.blocklist == {"SecretApp"}
 
         second_archive = tmp_path / "second"
@@ -137,10 +145,14 @@ async def test_screen_analysis_runtime_refreshes_provider_and_archive_from_setti
                 "enabled": True,
                 "provider": "apple-vision",
                 "model": "",
-                "preserve_captures": False,
-                "archive_dir": str(second_archive),
-            }
-        )
+            "preserve_captures": False,
+            "archive_dir": str(second_archive),
+            "min_seconds_between_captures": 0,
+            "max_daily_captures": 0,
+            "archive_retention_days": 365,
+            "archive_max_mb": 0,
+        }
+    )
         old_provider = runtime.provider
         await runtime.refresh(second_client, "http://localhost:8004", force=True)
 
@@ -149,6 +161,27 @@ async def test_screen_analysis_runtime_refreshes_provider_and_archive_from_setti
     assert runtime.provider.name == "apple-vision"
     assert runtime.preserve_captures is False
     assert runtime.archive_dir == str(second_archive)
+
+
+def test_screen_analysis_runtime_budget_records_and_skips(tmp_path):
+    runtime = ScreenAnalysisRuntime(
+        enabled=True,
+        provider="codex-local",
+        model=None,
+        preserve_captures=True,
+        archive_dir=str(tmp_path),
+        openrouter_api_key=None,
+        blocklist_file=None,
+    )
+    runtime._update_budget_settings(60, 1, 365, 0)
+
+    assert runtime.budget_skip_reason(now=100.0) is None
+    runtime.record_capture(now=100.0)
+    assert runtime.budget_skip_reason(now=120.0) == "min_seconds_between_captures"
+    assert runtime.budget_skip_reason(now=161.0) == "max_daily_captures"
+    status = runtime.budget_status()
+    assert status["daily_capture_count"] == 1
+    assert status["max_daily_captures"] == 1
 
 
 @pytest.mark.asyncio
@@ -312,6 +345,9 @@ class TestPeriodicCaptureLoop:
             archive_dir=str(tmp_path),
             blocklist=set(),
             refresh=AsyncMock(),
+            budget_skip_reason=MagicMock(return_value=None),
+            record_capture=MagicMock(),
+            budget_status=MagicMock(return_value={}),
         )
 
         async def mock_get(url, **kwargs):
@@ -347,10 +383,69 @@ class TestPeriodicCaptureLoop:
         assert len(posts) == 1
         observation = posts[0]["observation"]
         assert observation["summary"] == "Editing Seraph settings."
+        assert observation["analysis_usage"]["provider"] == "codex-local"
+        assert observation["analysis_usage"]["cost_posture"] == "local_no_api_price"
+        assert observation["analysis_usage"]["duration_ms"] == 12
         assert observation["capture_artifacts"]["provider"] == "codex-local"
         assert Path(observation["capture_artifacts"]["image_path"]).read_bytes() == b"png bytes"
+        analysis_payload = json.loads(Path(observation["capture_artifacts"]["analysis_path"]).read_text(encoding="utf-8"))
+        assert analysis_payload["analysis_usage"]["cost_posture"] == "local_no_api_price"
         assert provider.analyze_screen.await_count == 1
+        screen_runtime.record_capture.assert_called_once()
         assert screen_runtime.refresh.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_detailed_mode_posts_budget_skip_reason(self, tmp_path):
+        posts = []
+        provider = SimpleNamespace(name="codex-local")
+        runtime = ScreenAnalysisRuntime(
+            enabled=True,
+            provider="codex-local",
+            model=None,
+            preserve_captures=True,
+            archive_dir=str(tmp_path),
+            openrouter_api_key=None,
+            blocklist_file=None,
+        )
+        runtime.provider = provider
+        runtime.blocklist = set()
+        runtime._update_budget_settings(0, 0, 365, 0)
+        runtime.budget_skip_reason = MagicMock(return_value="max_daily_captures")
+        runtime.refresh = AsyncMock()
+
+        async def mock_get(url, **kwargs):
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {"mode": "detailed"}
+            return resp
+
+        async def mock_post(url, **kwargs):
+            posts.append(kwargs.get("json", {}))
+            raise asyncio.CancelledError()
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = mock_post
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("seraph_daemon.get_frontmost_app_name", return_value="VS Code"), \
+             patch("seraph_daemon.get_window_title", return_value="settings.py"), \
+             patch("seraph_daemon.get_idle_seconds", return_value=0.0), \
+             patch("ocr.screenshot.capture_screen_png", return_value=b"png bytes"), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+
+            with pytest.raises(asyncio.CancelledError):
+                await periodic_capture_loop(
+                    "http://localhost:8004",
+                    idle_timeout=300,
+                    verbose=False,
+                    screen_runtime=runtime,
+                )
+
+        assert posts[0]["observation"]["capture_skipped"] is True
+        assert posts[0]["observation"]["capture_skip_reason"] == "max_daily_captures"
+        assert not hasattr(provider, "analyze_screen")
 
     @pytest.mark.asyncio
     async def test_skips_when_idle(self):

--- a/docs/implementation/05-guardian-intelligence.md
+++ b/docs/implementation/05-guardian-intelligence.md
@@ -16,7 +16,8 @@
 - [x] hierarchical goals and progress tracking
 - [x] strategist agent with restricted guardian tool set
 - [x] daily briefing, evening review, activity digest, and weekly activity review foundations
-- [x] end-of-day goal report generation now compares local screen-derived activity summaries with active/completed goals, stores the redacted report as an observer memory episode, defaults to deterministic local drafting unless `END_OF_DAY_REPORT_LLM_ENABLED=true`, and can deliver by SMTP only when email is explicitly configured, preview is deliberately disabled, and the recipient is allowlisted
+- [x] end-of-day goal report generation now compares local screen-derived activity summaries with active/completed goals, stores the redacted report as an observer memory episode, defaults to deterministic local drafting unless `END_OF_DAY_REPORT_LLM_ENABLED=true`, and can deliver by SMTP only when email is explicitly configured, preview is deliberately acknowledged/disabled, and the recipient is allowlisted
+- [x] Settings exposes report delivery readiness, manual preview/send/test-email actions, private report receipts, and screen-analysis budget posture so operators can verify the loop without editing env files blindly
 - [x] preserved screen artifacts and end-of-day report artifacts give the learning loop a durable local evidence trail: allowed images, redacted provider output, normalized analysis JSON, report text, and report JSON stay under configured archive roots for future re-analysis
 - [x] observer-driven user-state and attention-budget modeling
 - [x] observer salience, confidence, and interruption-cost scoring that feeds guardian state and proactive policy

--- a/env.dev.example
+++ b/env.dev.example
@@ -58,6 +58,12 @@ CODEX_LOCAL_SANDBOX=workspace-write
 CODEX_LOCAL_APPROVAL_POLICY=never
 CODEX_LOCAL_TIMEOUT_SECONDS=600
 
+# Screen-analysis budgets. 0 means unlimited for caps/size; retention is days.
+SCREEN_ANALYSIS_MIN_SECONDS_BETWEEN_CAPTURES=0
+SCREEN_ANALYSIS_MAX_DAILY_CAPTURES=0
+SCREEN_CAPTURE_ARCHIVE_RETENTION_DAYS=365
+SCREEN_CAPTURE_ARCHIVE_MAX_MB=0
+
 # Local-screen end-of-day report. The report is stored in Seraph memory.
 # Email delivery is off by default and, when enabled, still requires the
 # preview gate to be deliberately disabled plus an allowlisted recipient.

--- a/env.prod.example
+++ b/env.prod.example
@@ -50,6 +50,12 @@ CODEX_LOCAL_SANDBOX=workspace-write
 CODEX_LOCAL_APPROVAL_POLICY=never
 CODEX_LOCAL_TIMEOUT_SECONDS=600
 
+# Screen-analysis budgets. 0 means unlimited for caps/size; retention is days.
+SCREEN_ANALYSIS_MIN_SECONDS_BETWEEN_CAPTURES=0
+SCREEN_ANALYSIS_MAX_DAILY_CAPTURES=0
+SCREEN_CAPTURE_ARCHIVE_RETENTION_DAYS=365
+SCREEN_CAPTURE_ARCHIVE_MAX_MB=0
+
 # Local-screen end-of-day report. The report is stored in Seraph memory.
 # Email delivery is off by default and, when enabled, still requires the
 # preview gate to be deliberately disabled plus an allowlisted recipient.

--- a/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
@@ -30,8 +30,15 @@ function settingsFromScreenAnalysisFixture(screen: {
       capture_mode: screen.capture_mode,
       cadence_seconds: screen.cadence_seconds,
       daemon_connected: screen.daemon_connected,
+      daemon_alive: screen.daemon_connected,
       artifact_count: screen.artifact_count,
       last_artifact_at: screen.last_artifact_at,
+      budget: {
+        min_seconds_between_captures: 0,
+        max_daily_captures: 0,
+        archive_retention_days: 365,
+        archive_max_mb: 0,
+      },
       preservation_enabled: screen.preserve_captures,
       archive_dir: screen.archive_dir,
       archive_dir_source: "screen-analysis-settings",
@@ -65,6 +72,8 @@ function settingsFromScreenAnalysisFixture(screen: {
       writable: true,
       creation_error: null,
       stored_artifacts: ["report_text", "report_json"],
+      receipt_count: 0,
+      last_receipt_at: null,
       control_env: {
         archive_dir: "REPORT_ARCHIVE_DIR",
         enabled: "END_OF_DAY_REPORT_ENABLED",
@@ -77,6 +86,7 @@ function settingsFromScreenAnalysisFixture(screen: {
       smtp_configured: false,
       recipient_configured: false,
       allowlist_configured: false,
+      sender_configured: false,
       control_env: {
         enabled: "EMAIL_REPORTS_ENABLED",
         preview_required: "EMAIL_REPORTS_PREVIEW_REQUIRED",
@@ -185,7 +195,7 @@ describe("ArtifactStoragePanel", () => {
     expect(screen.getByText("deterministic-local")).toBeInTheDocument();
     expect(screen.getByText("Email delivery")).toBeInTheDocument();
     expect(screen.getByText("SMTP")).toBeInTheDocument();
-    expect(screen.getAllByText("Missing")).toHaveLength(2);
+    expect(screen.getAllByText("Missing")).toHaveLength(3);
   });
 
   it("updates capture mode from settings", async () => {
@@ -280,6 +290,68 @@ describe("ArtifactStoragePanel", () => {
     await waitFor(() => expect(screen.getByDisplayValue("detailed / 60s")).toBeInTheDocument());
   });
 
+  it("runs manual report preview and shows safe receipt metadata", async () => {
+    const artifactStorage = settingsFromScreenAnalysisFixture({
+      enabled: true,
+      provider: "codex-local",
+      model: "gpt-5.5",
+      preserve_captures: true,
+      archive_dir: "/tmp/seraph-dev-data/artifacts/screen-captures",
+      capture_mode: "on_switch",
+      cadence_seconds: null,
+      daemon_connected: true,
+      artifact_count: 1,
+      last_artifact_at: null,
+    });
+    artifactStorage.email.enabled = true;
+    artifactStorage.email.smtp_configured = true;
+    artifactStorage.email.recipient_configured = true;
+    artifactStorage.email.allowlist_configured = true;
+    artifactStorage.email.sender_configured = true;
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(artifactStorage))
+      .mockResolvedValueOnce(
+        mockResponse({
+          status: "ok",
+          action: "manual-preview",
+          report: {
+            date: "2026-06-20",
+            analysis_provider: "deterministic-local",
+          },
+          email: {
+            status: "preview_only",
+            reason: "manual_preview",
+            recipient_hash: null,
+          },
+          receipt: {
+            receipt_sha256: "abcdef1234567890",
+            status: "succeeded",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(mockResponse(artifactStorage));
+
+    render(<ArtifactStoragePanel />);
+
+    const sendButton = await screen.findByRole("button", { name: "Send" });
+    expect(sendButton).toBeDisabled();
+    fireEvent.click(await screen.findByRole("button", { name: "Preview" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/settings/end-of-day-report/manual"),
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ send_email: false, preview_acknowledged: false }),
+        }),
+      ),
+    );
+    expect(await screen.findByText(/manual-preview/)).toBeInTheDocument();
+    expect(screen.getByText(/receipt abcdef123456/)).toBeInTheDocument();
+    expect(screen.queryByText(/user@example/)).not.toBeInTheDocument();
+    await waitFor(() => expect(sendButton).not.toBeDisabled());
+  });
+
   it("does not refresh settings after a save resolves on an unmounted panel", async () => {
     const artifactStorage = {
       screen: {
@@ -366,7 +438,7 @@ describe("ArtifactStoragePanel", () => {
     resolveSave(mockResponse({ mode: "detailed" }));
     await Promise.resolve();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).includes("/api/settings/capture-mode"))).toHaveLength(1);
   });
 
   it("explains on_switch mode even when the daemon is capture-ready", async () => {

--- a/frontend/src/components/settings/ArtifactStoragePanel.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.tsx
@@ -9,8 +9,15 @@ interface ArtifactStorageSettings {
     capture_mode: string;
     cadence_seconds: number | null;
     daemon_connected: boolean;
+    daemon_alive: boolean;
     artifact_count: number;
     last_artifact_at: string | null;
+    budget: {
+      min_seconds_between_captures: number;
+      max_daily_captures: number;
+      archive_retention_days: number;
+      archive_max_mb: number;
+    };
     preservation_enabled: boolean;
     archive_dir: string;
     archive_dir_source: string;
@@ -47,6 +54,8 @@ interface ArtifactStorageSettings {
     writable: boolean;
     creation_error: string | null;
     stored_artifacts: string[];
+    receipt_count: number;
+    last_receipt_at: string | null;
     control_env: Record<string, string>;
   };
   email: {
@@ -55,6 +64,7 @@ interface ArtifactStorageSettings {
     smtp_configured: boolean;
     recipient_configured: boolean;
     allowlist_configured: boolean;
+    sender_configured: boolean;
     control_env: Record<string, string>;
   };
 }
@@ -68,8 +78,35 @@ interface ScreenAnalysisSettings {
   capture_mode: string;
   cadence_seconds: number | null;
   daemon_connected: boolean;
+  daemon_alive: boolean;
   artifact_count: number;
   last_artifact_at: string | null;
+  min_seconds_between_captures: number;
+  max_daily_captures: number;
+  archive_retention_days: number;
+  archive_max_mb: number;
+}
+
+interface ReportActionResult {
+  action?: string;
+  status?: string;
+  reason?: string | null;
+  recipient_hash?: string | null;
+  email?: {
+    status?: string;
+    reason?: string | null;
+    recipient_hash?: string | null;
+  };
+  report?: {
+    date?: string;
+    analysis_provider?: string;
+    artifacts?: Record<string, string>;
+  };
+  receipt?: {
+    receipt_sha256?: string;
+    status?: string;
+    reason?: string | null;
+  };
 }
 
 function boolLabel(value: boolean): string {
@@ -155,8 +192,15 @@ function settingsFromScreenAnalysis(screen: ScreenAnalysisSettings): ArtifactSto
       capture_mode: screen.capture_mode,
       cadence_seconds: screen.cadence_seconds,
       daemon_connected: screen.daemon_connected,
+      daemon_alive: screen.daemon_alive ?? screen.daemon_connected,
       artifact_count: screen.artifact_count ?? 0,
       last_artifact_at: screen.last_artifact_at ?? null,
+      budget: {
+        min_seconds_between_captures: screen.min_seconds_between_captures ?? 0,
+        max_daily_captures: screen.max_daily_captures ?? 0,
+        archive_retention_days: screen.archive_retention_days ?? 365,
+        archive_max_mb: screen.archive_max_mb ?? 0,
+      },
       preservation_enabled: screen.preserve_captures,
       archive_dir: screen.archive_dir,
       archive_dir_source: "screen-analysis-settings",
@@ -190,6 +234,8 @@ function settingsFromScreenAnalysis(screen: ScreenAnalysisSettings): ArtifactSto
       writable: false,
       creation_error: "Archive metadata unavailable.",
       stored_artifacts: ["report_text", "report_json"],
+      receipt_count: 0,
+      last_receipt_at: null,
       control_env: {
         archive_dir: "REPORT_ARCHIVE_DIR",
         enabled: "END_OF_DAY_REPORT_ENABLED",
@@ -202,6 +248,7 @@ function settingsFromScreenAnalysis(screen: ScreenAnalysisSettings): ArtifactSto
       smtp_configured: false,
       recipient_configured: false,
       allowlist_configured: false,
+      sender_configured: false,
       control_env: {
         enabled: "EMAIL_REPORTS_ENABLED",
         preview_required: "EMAIL_REPORTS_PREVIEW_REQUIRED",
@@ -242,6 +289,9 @@ export function ArtifactStoragePanel() {
   const [failed, setFailed] = useState(false);
   const [metadataWarning, setMetadataWarning] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [reportAction, setReportAction] = useState<"idle" | "previewing" | "sending" | "testing">("idle");
+  const [reportActionResult, setReportActionResult] = useState<ReportActionResult | null>(null);
+  const [reportActionError, setReportActionError] = useState<string | null>(null);
 
   async function fetchSettings(isCancelled: () => boolean = () => !mountedRef.current) {
     const generation = fetchGenerationRef.current + 1;
@@ -352,6 +402,51 @@ export function ArtifactStoragePanel() {
     }
   };
 
+  const screenBudget = settings?.screen.budget ?? {
+    min_seconds_between_captures: 0,
+    max_daily_captures: 0,
+    archive_retention_days: 365,
+    archive_max_mb: 0,
+  };
+  const previewReadyForSend =
+    reportActionResult?.action === "manual-preview" &&
+    reportActionResult?.status === "ok" &&
+    reportActionResult?.receipt?.status === "succeeded";
+
+  const runReportAction = async (action: "preview" | "send" | "test") => {
+    if (reportAction !== "idle") return;
+    if (action === "send" && !previewReadyForSend) {
+      setReportActionError("Preview the report before sending.");
+      return;
+    }
+    setReportAction(action === "preview" ? "previewing" : action === "send" ? "sending" : "testing");
+    setReportActionError(null);
+    try {
+      const response = await fetch(
+        `${API_URL}${action === "test" ? "/api/settings/end-of-day-report/test-email" : "/api/settings/end-of-day-report/manual"}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+              body: action === "test"
+                ? undefined
+                : JSON.stringify({
+                    send_email: action === "send",
+                    preview_acknowledged: action === "send" && previewReadyForSend,
+                  }),
+            }
+          );
+      if (!response.ok) throw new Error(`Request failed: ${response.status}`);
+      const payload = (await response.json()) as ReportActionResult;
+      if (!mountedRef.current) return;
+      setReportActionResult(payload);
+      await fetchSettings(() => !mountedRef.current);
+    } catch {
+      if (mountedRef.current) setReportActionError("Report action failed.");
+    } finally {
+      if (mountedRef.current) setReportAction("idle");
+    }
+  };
+
   return (
     <div className="px-1">
       <div className="text-[10px] uppercase tracking-wider text-retro-border font-bold mb-2">
@@ -427,8 +522,8 @@ export function ArtifactStoragePanel() {
             </div>
             <ArtifactRow
               label="Daemon"
-              value={settings.screen.daemon_connected ? "linked" : "offline - no new captures"}
-              tone={settings.screen.daemon_connected ? "good" : "warn"}
+              value={settings.screen.daemon_connected ? "linked" : settings.screen.daemon_alive ? "alive, waiting for context post" : "offline - no new captures"}
+              tone={settings.screen.daemon_connected || settings.screen.daemon_alive ? "good" : "warn"}
             />
             <ArtifactRow
               label="Capture"
@@ -467,6 +562,14 @@ export function ArtifactStoragePanel() {
             </div>
             <ArtifactRow label="Screen dir" value={settings.screen.archive_dir} />
             <ArtifactRow
+              label="Budget"
+              value={`min ${screenBudget.min_seconds_between_captures}s · day ${screenBudget.max_daily_captures || "unlimited"}`}
+            />
+            <ArtifactRow
+              label="Retention"
+              value={`${screenBudget.archive_retention_days}d · ${screenBudget.archive_max_mb || "unlimited"} MB`}
+            />
+            <ArtifactRow
               label="Dir state"
               value={dirStateLabel(settings.screen.exists, settings.screen.writable, settings.screen.creation_error)}
               tone={dirStateTone(settings.screen.exists, settings.screen.writable, settings.screen.creation_error)}
@@ -495,6 +598,51 @@ export function ArtifactStoragePanel() {
               />
               <ArtifactRow label="Provider" value={settings.reports.analysis_provider} />
               <ArtifactRow label="Hour" value={`${settings.reports.hour}:00`} />
+              <ArtifactRow
+                label="Receipts"
+                value={`${settings.reports.receipt_count ?? 0} receipts${settings.reports.last_receipt_at ? ` · latest ${settings.reports.last_receipt_at}` : ""}`}
+              />
+              <div className="flex flex-wrap gap-1 pt-1">
+                <button
+                  type="button"
+                  disabled={reportAction !== "idle"}
+                  onClick={() => void runReportAction("preview")}
+                  className="border border-retro-text/20 px-2 py-1 text-[9px] uppercase tracking-wider text-retro-text/70 hover:text-retro-text disabled:opacity-40"
+                >
+                  Preview
+                </button>
+                  <button
+                    type="button"
+                    disabled={reportAction !== "idle" || !settings.email.enabled || !previewReadyForSend}
+                    onClick={() => void runReportAction("send")}
+                    className="border border-retro-text/20 px-2 py-1 text-[9px] uppercase tracking-wider text-retro-text/70 hover:text-retro-text disabled:opacity-40"
+                  >
+                  Send
+                </button>
+                <button
+                  type="button"
+                  disabled={reportAction !== "idle" || !settings.email.enabled}
+                  onClick={() => void runReportAction("test")}
+                  className="border border-retro-text/20 px-2 py-1 text-[9px] uppercase tracking-wider text-retro-text/70 hover:text-retro-text disabled:opacity-40"
+                >
+                  Test
+                </button>
+              </div>
+              {reportActionError && (
+                <div className="text-[9px] text-red-400">{reportActionError}</div>
+              )}
+              {reportActionResult && (
+                <div className="border border-retro-text/10 px-2 py-1 text-[9px] text-retro-text/60">
+                  {(reportActionResult.action ?? reportActionResult.status ?? "report")} ·{" "}
+                  {reportActionResult.email?.status ?? reportActionResult.status ?? "ok"}
+                  {reportActionResult.email?.recipient_hash || reportActionResult.recipient_hash
+                    ? ` · recipient ${reportActionResult.email?.recipient_hash ?? reportActionResult.recipient_hash}`
+                    : ""}
+                  {reportActionResult.receipt?.receipt_sha256
+                    ? ` · receipt ${reportActionResult.receipt.receipt_sha256.slice(0, 12)}`
+                    : ""}
+                </div>
+              )}
             </div>
 
             <div className="border-t border-retro-text/10 pt-2 mt-1">
@@ -514,6 +662,11 @@ export function ArtifactStoragePanel() {
                   label="SMTP"
                   value={settings.email.smtp_configured ? "Configured" : "Missing"}
                   tone={settings.email.smtp_configured ? "good" : "warn"}
+                />
+                <ArtifactRow
+                  label="Sender"
+                  value={settings.email.sender_configured ? "Configured" : "Missing"}
+                  tone={settings.email.sender_configured ? "good" : "warn"}
                 />
                 <ArtifactRow
                   label="Allowlist"


### PR DESCRIPTION
## Summary
- Link: closes #622
- Adds Settings-visible screen capture budget controls/status, daemon liveness separation, and capture usage metadata.
- Adds manual end-of-day report preview, guarded send, and test-email settings actions with private receipts and public-safe receipt/artifact metadata.
- Updates env examples and implementation docs for report/email/capture controls.

## Agent Team / Review
- Lead: scoped and integrated backend/settings/daemon/frontend slice.
- Explorer passes: backend report/email API shape and frontend settings UI shape.
- Critic/Contrarian: Jason reviewed the cumulative intended #622 diff. Initial blockers were raw report artifact path exposure and one-click preview bypass; both were fixed. Fresh critic re-review passed with no blocking findings.

## Validation
- backend/.venv/bin/pytest backend/tests/test_settings_api.py backend/tests/test_end_of_day_goal_report.py -q: 24 passed
- daemon/.venv/bin/pytest daemon/tests/test_periodic_capture.py::test_screen_analysis_runtime_budget_records_and_skips daemon/tests/test_periodic_capture.py::TestPeriodicCaptureLoop::test_detailed_mode_posts_preserved_capture_artifacts daemon/tests/test_periodic_capture.py::TestPeriodicCaptureLoop::test_detailed_mode_posts_budget_skip_reason -q: 3 passed
- npm test -- --run src/components/settings/ArtifactStoragePanel.test.tsx: 9 passed
- python3 -m py_compile backend/src/scheduler/jobs/end_of_day_goal_report.py backend/tests/test_end_of_day_goal_report.py daemon/seraph_daemon.py daemon/tests/test_periodic_capture.py: passed
- git diff --check: passed

## Safety Notes
- API and scheduled audit surfaces expose receipt/artifact ids and hashes only; raw receipt/report artifact paths stay private.
- Send stays disabled in Settings until a successful preview receipt exists in the current panel session.
- Existing unrelated dirty local Codex/operator/cockpit/websocket work was intentionally not staged.