### PR TITLE
Fix local Codex operator routing

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -89,8 +89,9 @@ Receive (streamed):
 | `CODEX_LOCAL_ENABLED` | `true` | Enables the local command-backed Codex operator adapter |
 | `CODEX_LOCAL_COMMAND` | `codex` | Local Codex executable name or path |
 | `CODEX_LOCAL_MODEL` | `gpt-5.5` | Model option passed to `codex exec` |
-| `CODEX_LOCAL_SANDBOX` | `workspace-write` | Sandbox option passed to local `codex exec` |
+| `CODEX_LOCAL_SANDBOX` | `read-only` | Sandbox option passed to local `codex exec` |
 | `CODEX_LOCAL_APPROVAL_POLICY` | `never` | Approval policy option passed to local `codex exec` |
+| `CODEX_LOCAL_ALLOW_WORKSPACE_WRITE` | `false` | Explicit opt-in required before local Codex may use `workspace-write` |
 | `CODEX_LOCAL_TIMEOUT_SECONDS` | `600` | Timeout for local Codex operator invocations |
 | `SCREEN_CAPTURE_ARCHIVE_DIR` | `~/Library/Application Support/Seraph/artifacts/screen-captures` | Durable local archive root for preserved screen capture images, redacted provider output, and normalized JSON served by localhost-only observer artifact endpoints |
 | `SCREEN_ANALYSIS_MIN_SECONDS_BETWEEN_CAPTURES` | `0` | Minimum seconds between screen-analysis captures; `0` disables this throttle |
@@ -179,8 +180,9 @@ RUNTIME_PROFILE_PREFERENCES=chat_agent=codex-openai|openrouter
 CODEX_LOCAL_ENABLED=true
 CODEX_LOCAL_COMMAND=codex
 CODEX_LOCAL_MODEL=gpt-5.5
-CODEX_LOCAL_SANDBOX=workspace-write
+CODEX_LOCAL_SANDBOX=read-only
 CODEX_LOCAL_APPROVAL_POLICY=never
+CODEX_LOCAL_ALLOW_WORKSPACE_WRITE=false
 CODEX_LOCAL_TIMEOUT_SECONDS=600
 
 # Anthropic/Claude-oriented routes.

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -43,8 +43,9 @@ class Settings(BaseSettings):
     codex_local_command: str = "codex"
     codex_local_model: str = "gpt-5.5"
     codex_local_reasoning_effort: str = "low"
-    codex_local_sandbox: str = "workspace-write"
+    codex_local_sandbox: str = "read-only"
     codex_local_approval_policy: str = "never"
+    codex_local_allow_workspace_write: bool = False
     codex_local_timeout_seconds: int = 600
     model_temperature: float = 0.7
     model_max_tokens: int = 4096

--- a/backend/src/agent/session.py
+++ b/backend/src/agent/session.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from time import perf_counter
 
 from sqlalchemy import func, or_, text
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select, col
 
 from config.settings import settings
@@ -181,34 +182,38 @@ class SessionManager:
             return True
 
     async def list_sessions(self) -> list[dict]:
-        async with get_session() as db:
-            # Single query: fetch sessions with their latest message using window function
-            rows = (await db.execute(text(
-                """
-                SELECT
-                    s.id, s.title, s.created_at, s.updated_at,
-                    lm.content AS last_content, lm.role AS last_role
-                FROM sessions s
-                LEFT JOIN (
-                    SELECT session_id, content, role,
-                           ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY created_at DESC) AS rn
-                    FROM messages
-                ) lm ON lm.session_id = s.id AND lm.rn = 1
-                ORDER BY s.updated_at DESC
-                """
-            ))).all()
+        try:
+            async with get_session() as db:
+                # Single query: fetch sessions with their latest message using window function
+                rows = (await db.execute(text(
+                    """
+                    SELECT
+                        s.id, s.title, s.created_at, s.updated_at,
+                        lm.content AS last_content, lm.role AS last_role
+                    FROM sessions s
+                    LEFT JOIN (
+                        SELECT session_id, content, role,
+                               ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY created_at DESC) AS rn
+                        FROM messages
+                    ) lm ON lm.session_id = s.id AND lm.rn = 1
+                    ORDER BY s.updated_at DESC
+                    """
+                ))).all()
 
-            return [
-                {
-                    "id": r.id,
-                    "title": r.title,
-                    "created_at": r.created_at if isinstance(r.created_at, str) else r.created_at.isoformat(),
-                    "updated_at": r.updated_at if isinstance(r.updated_at, str) else r.updated_at.isoformat(),
-                    "last_message": r.last_content[:100] if r.last_content else None,
-                    "last_message_role": r.last_role,
-                }
-                for r in rows
-            ]
+                return [
+                    {
+                        "id": r.id,
+                        "title": r.title,
+                        "created_at": r.created_at if isinstance(r.created_at, str) else r.created_at.isoformat(),
+                        "updated_at": r.updated_at if isinstance(r.updated_at, str) else r.updated_at.isoformat(),
+                        "last_message": r.last_content[:100] if r.last_content else None,
+                        "last_message_role": r.last_role,
+                    }
+                    for r in rows
+                ]
+        except SQLAlchemyError as exc:
+            logger.warning("Session list unavailable; returning empty list: %s", exc)
+            return []
 
     async def get_recent_sessions_summary(
         self,
@@ -218,53 +223,57 @@ class SessionManager:
         snippet_chars: int = 140,
     ) -> str:
         """Summarize recent sessions outside the current thread for guardian state."""
-        async with get_session() as db:
-            stmt = select(Session)
-            if exclude_session_id:
-                stmt = stmt.where(Session.id != exclude_session_id)
-            session_result = await db.execute(stmt)
-            sessions = session_result.scalars().all()
-            if not sessions:
-                return ""
+        try:
+            async with get_session() as db:
+                stmt = select(Session)
+                if exclude_session_id:
+                    stmt = stmt.where(Session.id != exclude_session_id)
+                session_result = await db.execute(stmt)
+                sessions = session_result.scalars().all()
+                if not sessions:
+                    return ""
 
-            recency_stmt = (
-                select(Message.session_id, func.max(Message.created_at))
-                .where(Message.role.in_(["user", "assistant"]))  # type: ignore[attr-defined]
-                .group_by(Message.session_id)
-            )
-            if exclude_session_id:
-                recency_stmt = recency_stmt.where(Message.session_id != exclude_session_id)
-            recency_rows = await db.execute(recency_stmt)
-            conversation_recency = {
-                session_id: latest_at
-                for session_id, latest_at in recency_rows.all()
-            }
-            sessions = sorted(
-                sessions,
-                key=lambda session: conversation_recency.get(session.id) or session.created_at,
-                reverse=True,
-            )[:limit_sessions]
-
-            lines: list[str] = []
-            for session in sessions:
-                msg_result = await db.execute(
-                    select(Message)
-                    .where(Message.session_id == session.id)
+                recency_stmt = (
+                    select(Message.session_id, func.max(Message.created_at))
                     .where(Message.role.in_(["user", "assistant"]))  # type: ignore[attr-defined]
-                    .order_by(col(Message.created_at).desc())
-                    .limit(1)
+                    .group_by(Message.session_id)
                 )
-                latest = msg_result.scalars().first()
-                title = session.title or "Untitled session"
-                if latest and latest.content:
-                    snippet = latest.content.replace("\n", " ").strip()
-                    if len(snippet) > snippet_chars:
-                        snippet = snippet[:snippet_chars] + "..."
-                    lines.append(f"- {title}: {latest.role} said \"{snippet}\"")
-                else:
-                    lines.append(f"- {title}: no user-facing messages yet")
+                if exclude_session_id:
+                    recency_stmt = recency_stmt.where(Message.session_id != exclude_session_id)
+                recency_rows = await db.execute(recency_stmt)
+                conversation_recency = {
+                    session_id: latest_at
+                    for session_id, latest_at in recency_rows.all()
+                }
+                sessions = sorted(
+                    sessions,
+                    key=lambda session: conversation_recency.get(session.id) or session.created_at,
+                    reverse=True,
+                )[:limit_sessions]
 
-            return "\n".join(lines)
+                lines: list[str] = []
+                for session in sessions:
+                    msg_result = await db.execute(
+                        select(Message)
+                        .where(Message.session_id == session.id)
+                        .where(Message.role.in_(["user", "assistant"]))  # type: ignore[attr-defined]
+                        .order_by(col(Message.created_at).desc())
+                        .limit(1)
+                    )
+                    latest = msg_result.scalars().first()
+                    title = session.title or "Untitled session"
+                    if latest and latest.content:
+                        snippet = latest.content.replace("\n", " ").strip()
+                        if len(snippet) > snippet_chars:
+                            snippet = snippet[:snippet_chars] + "..."
+                        lines.append(f"- {title}: {latest.role} said \"{snippet}\"")
+                    else:
+                        lines.append(f"- {title}: no user-facing messages yet")
+
+                return "\n".join(lines)
+        except SQLAlchemyError as exc:
+            logger.warning("Recent sessions summary unavailable; returning empty summary: %s", exc)
+            return ""
 
     async def _conversation_recency_map(
         self,

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -19,6 +19,13 @@ from src.audit.repository import audit_repository
 from src.api.profile import get_or_create_profile, mark_onboarding_complete
 from src.guardian.state import build_guardian_state
 from src.models.schemas import ChatRequest, ChatResponse
+from src.operators.local_codex import (
+    LocalCodexConfigurationError,
+    is_local_codex_model,
+    local_codex_chat_sandbox,
+    local_codex_chat_timeout_seconds,
+    run_local_codex,
+)
 from src.tools.policy import get_current_tool_policy_mode
 from src.vault.redaction import redact_secrets_in_text
 from src.llm_runtime import (
@@ -42,6 +49,74 @@ async def chat(request: ChatRequest):
 
     # Check onboarding status
     profile = await get_or_create_profile()
+    if is_local_codex_model(settings.default_model):
+        started_at = perf_counter()
+        timeout_seconds = local_codex_chat_timeout_seconds()
+        try:
+            result = await run_local_codex(
+                request.message,
+                session_id=session.id,
+                timeout_seconds=timeout_seconds,
+                sandbox=local_codex_chat_sandbox(),
+            )
+            output = (result.get("stdout") or "").strip()
+            stderr = (result.get("stderr") or "").strip()
+            if result.get("timed_out"):
+                raise asyncio.TimeoutError
+            if not result.get("ok"):
+                raise LocalCodexConfigurationError(stderr or "Local Codex returned a non-zero exit code.")
+            response_text = await redact_secrets_in_text(
+                output or stderr or "Local Codex completed without output."
+            )
+        except asyncio.TimeoutError:
+            safe_detail = await redact_secrets_in_text(f"Local Codex timed out after {timeout_seconds}s.")
+            await log_agent_run_event(
+                session_id=session.id,
+                transport="rest",
+                is_onboarding=not profile.onboarding_completed,
+                outcome="timed_out",
+                policy_mode=get_current_tool_policy_mode(),
+                details={
+                    "duration_ms": int((perf_counter() - started_at) * 1000),
+                    "message_length": len(request.message),
+                    "timeout_seconds": timeout_seconds,
+                    "runtime": "codex-local",
+                },
+            )
+            raise HTTPException(status_code=504, detail=safe_detail)
+        except LocalCodexConfigurationError as exc:
+            safe_detail = await redact_secrets_in_text(f"Local Codex unavailable: {exc}")
+            await log_agent_run_event(
+                session_id=session.id,
+                transport="rest",
+                is_onboarding=not profile.onboarding_completed,
+                outcome="failed",
+                policy_mode=get_current_tool_policy_mode(),
+                details={
+                    "duration_ms": int((perf_counter() - started_at) * 1000),
+                    "message_length": len(request.message),
+                    "error": safe_detail,
+                    "runtime": "codex-local",
+                },
+            )
+            raise HTTPException(status_code=503, detail=safe_detail)
+
+        await session_manager.add_message(session.id, "assistant", response_text)
+        await log_agent_run_event(
+            session_id=session.id,
+            transport="rest",
+            is_onboarding=not profile.onboarding_completed,
+            outcome="succeeded",
+            policy_mode=get_current_tool_policy_mode(),
+            details={
+                "duration_ms": int((perf_counter() - started_at) * 1000),
+                "message_length": len(request.message),
+                "response_length": len(response_text),
+                "runtime": "codex-local",
+            },
+        )
+        return ChatResponse(response=response_text, session_id=session.id)
+
     if not profile.onboarding_completed:
         agent = create_onboarding_agent(request.message)
     else:

--- a/backend/src/api/operator.py
+++ b/backend/src/api/operator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta, timezone
+import logging
 import re
 from typing import Any
 
@@ -15,6 +16,7 @@ from src.agent.session import session_manager
 from src.app import _runtime_model_label, _runtime_provider_label
 from src.llm_runtime import provider_profile_statuses, resolve_runtime_profile
 from src.operators.local_codex import (
+    is_local_codex_model,
     LocalCodexConfigurationError,
     local_codex_status,
     local_operator_statuses,
@@ -153,6 +155,7 @@ from src.workflows.post_dx_live_durable_orchestration import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 class MemoryOperatorControlRequest(BaseModel):
@@ -693,11 +696,13 @@ def _build_operator_continuity_graph(
         for item in sessions
         if isinstance(item, dict) and isinstance(item.get("id"), str)
     }
+    raw_snapshot_threads = continuity_snapshot.get("threads") if isinstance(continuity_snapshot, dict) else []
+    snapshot_thread_items = raw_snapshot_threads if isinstance(raw_snapshot_threads, list) else []
     snapshot_threads = {
         _continuity_graph_session_key(
             item.get("thread_id") if isinstance(item, dict) else None
         ): item
-        for item in (continuity_snapshot.get("threads") if isinstance(continuity_snapshot, dict) else [])
+        for item in snapshot_thread_items
         if isinstance(item, dict)
     }
     nodes: dict[str, dict[str, Any]] = {}
@@ -1238,7 +1243,7 @@ def _continuity_operator_items(
 
 def _runtime_status_payload() -> dict[str, Any]:
     model = settings.default_model.strip()
-    active_profile = resolve_runtime_profile(runtime_path="chat_agent")
+    active_profile = "codex-local" if is_local_codex_model(model) else resolve_runtime_profile(runtime_path="chat_agent")
     return {
         "version": "2026.4.10",
         "build_id": "SERAPH_PRIME_v2026.4.10",
@@ -1248,7 +1253,7 @@ def _runtime_status_payload() -> dict[str, Any]:
         "api_base": settings.llm_api_base.strip(),
         "active_profile": active_profile,
         "provider_profiles": provider_profile_statuses(),
-        "local_operators": local_operator_statuses(),
+        "local_operators": local_operator_statuses(probe=False),
         "timezone": settings.user_timezone,
         "llm_logging_enabled": settings.llm_log_enabled,
     }
@@ -4856,7 +4861,7 @@ async def get_operator_continuity_graph(
     session_id: str | None = Query(default=None),
     limit_sessions: int = Query(default=6, ge=1, le=20),
 ):
-    sessions, workflow_runs, pending_approvals, notifications, queued_insights, recent_interventions, continuity_snapshot = await asyncio.gather(
+    results = await asyncio.gather(
         session_manager.list_sessions(),
         _list_workflow_runs(limit=max(limit_sessions * 8, 60), session_id=session_id),
         approval_repository.list_pending(session_id=session_id, limit=max(limit_sessions * 4, 40)),
@@ -4864,7 +4869,29 @@ async def get_operator_continuity_graph(
         insight_queue.peek_all(),
         guardian_feedback_repository.list_recent(limit=max(limit_sessions * 8, 60), session_id=session_id),
         build_observer_continuity_snapshot(),
+        return_exceptions=True,
     )
+    (
+        sessions,
+        workflow_runs,
+        pending_approvals,
+        notifications,
+        queued_insights,
+        recent_interventions,
+        continuity_snapshot,
+    ) = results
+    source_names = (
+        "sessions",
+        "workflow_runs",
+        "pending_approvals",
+        "notifications",
+        "queued_insights",
+        "recent_interventions",
+        "continuity_snapshot",
+    )
+    for name, result in zip(source_names, results, strict=True):
+        if isinstance(result, Exception):
+            logger.warning("Operator continuity graph degraded: %s source failed: %s", name, result)
     return _build_operator_continuity_graph(
         sessions if isinstance(sessions, list) else [],
         workflow_runs if isinstance(workflow_runs, list) else [],

--- a/backend/src/api/ws.py
+++ b/backend/src/api/ws.py
@@ -22,6 +22,13 @@ from src.audit.repository import audit_repository
 from src.api.profile import get_or_create_profile, mark_onboarding_complete, reset_onboarding
 from src.guardian.state import build_guardian_state
 from src.models.schemas import WSMessage, WSResponse
+from src.operators.local_codex import (
+    LocalCodexConfigurationError,
+    is_local_codex_model,
+    local_codex_chat_sandbox,
+    local_codex_chat_timeout_seconds,
+    run_local_codex,
+)
 from src.scheduler.connection_manager import ws_manager
 from src.tools.policy import get_current_tool_policy_mode
 from src.vault.redaction import redact_secrets_in_text
@@ -153,6 +160,98 @@ async def websocket_chat(websocket: WebSocket):
                 context_manager.update_last_interaction()
             except Exception:
                 pass
+
+            if is_local_codex_model(settings.default_model):
+                started_at = perf_counter()
+                timeout_seconds = local_codex_chat_timeout_seconds()
+                try:
+                    result = await run_local_codex(
+                        ws_msg.message,
+                        session_id=session.id,
+                        timeout_seconds=timeout_seconds,
+                        sandbox=local_codex_chat_sandbox(),
+                    )
+                    output = (result.get("stdout") or "").strip()
+                    stderr = (result.get("stderr") or "").strip()
+                    if result.get("timed_out"):
+                        raise asyncio.TimeoutError
+                    if not result.get("ok"):
+                        raise LocalCodexConfigurationError(stderr or "Local Codex returned a non-zero exit code.")
+                    final_result = await redact_secrets_in_text(
+                        output or stderr or "Local Codex completed without output."
+                    )
+                except asyncio.TimeoutError:
+                    safe_error = await redact_secrets_in_text(f"Local Codex timed out after {timeout_seconds}s.")
+                    await log_agent_run_event(
+                        session_id=session.id,
+                        transport="websocket",
+                        is_onboarding=False,
+                        outcome="timed_out",
+                        policy_mode=get_current_tool_policy_mode(),
+                        details={
+                            "duration_ms": int((perf_counter() - started_at) * 1000),
+                            "message_length": len(ws_msg.message),
+                            "timeout_seconds": timeout_seconds,
+                            "runtime": "codex-local",
+                        },
+                    )
+                    await websocket.send_text(
+                        WSResponse(
+                            type="error",
+                            content=safe_error,
+                            session_id=session.id,
+                            seq=_next_seq(),
+                        ).model_dump_json()
+                    )
+                    continue
+                except LocalCodexConfigurationError as exc:
+                    safe_error = await redact_secrets_in_text(f"Local Codex unavailable: {exc}")
+                    await log_agent_run_event(
+                        session_id=session.id,
+                        transport="websocket",
+                        is_onboarding=False,
+                        outcome="failed",
+                        policy_mode=get_current_tool_policy_mode(),
+                        details={
+                            "duration_ms": int((perf_counter() - started_at) * 1000),
+                            "message_length": len(ws_msg.message),
+                            "error": safe_error,
+                            "runtime": "codex-local",
+                        },
+                    )
+                    await websocket.send_text(
+                        WSResponse(
+                            type="error",
+                            content=safe_error,
+                            session_id=session.id,
+                            seq=_next_seq(),
+                        ).model_dump_json()
+                    )
+                    continue
+
+                await session_manager.add_message(session.id, "assistant", final_result)
+                await log_agent_run_event(
+                    session_id=session.id,
+                    transport="websocket",
+                    is_onboarding=False,
+                    outcome="succeeded",
+                    policy_mode=get_current_tool_policy_mode(),
+                    details={
+                        "duration_ms": int((perf_counter() - started_at) * 1000),
+                        "message_length": len(ws_msg.message),
+                        "response_length": len(final_result),
+                        "runtime": "codex-local",
+                    },
+                )
+                await websocket.send_text(
+                    WSResponse(
+                        type="final",
+                        content=final_result,
+                        session_id=session.id,
+                        seq=_next_seq(),
+                    ).model_dump_json()
+                )
+                continue
 
             agent, is_onboarding, specialist_names = await _build_agent(session.id, ws_msg.message)
 

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -14,7 +14,7 @@ from src.extensions.registry import default_manifest_roots_for_workspace
 from src.llm_logger import init_llm_logging
 from src.llm_runtime import provider_profile_statuses, resolve_runtime_profile
 from src.memory.soul import ensure_soul_exists
-from src.operators.local_codex import local_operator_statuses
+from src.operators.local_codex import is_local_codex_model, local_operator_statuses
 from src.runbooks.manager import runbook_manager
 from src.scheduler.engine import init_scheduler, shutdown_scheduler, sync_scheduled_jobs
 from src.skills.manager import skill_manager
@@ -30,6 +30,8 @@ _LOCAL_DEV_ORIGIN_REGEX = r"https?://(localhost|127\.0\.0\.1)(:\d+)?$"
 def _runtime_provider_label() -> str:
     model = settings.default_model.strip()
     api_base = settings.llm_api_base.strip()
+    if is_local_codex_model(model):
+        return "codex-local"
     if model.startswith("openrouter/") or "openrouter" in api_base:
         return "openrouter"
     if model.startswith("ollama/") or settings.local_model.strip().startswith("ollama/"):
@@ -47,6 +49,8 @@ def _runtime_model_label(model: str) -> str:
     normalized = model.strip()
     if not normalized:
         return "unknown"
+    if is_local_codex_model(normalized):
+        return settings.codex_local_model.strip() or "codex"
     return normalized.split("/")[-1]
 
 @asynccontextmanager
@@ -153,7 +157,7 @@ def create_app() -> FastAPI:
     @app.get("/api/runtime/status")
     async def runtime_status():
         model = settings.default_model.strip()
-        active_profile = resolve_runtime_profile(runtime_path="chat_agent")
+        active_profile = "codex-local" if is_local_codex_model(model) else resolve_runtime_profile(runtime_path="chat_agent")
         return {
             "version": app.version,
             "build_id": f"SERAPH_PRIME_v{app.version}",
@@ -163,7 +167,7 @@ def create_app() -> FastAPI:
             "api_base": settings.llm_api_base.strip(),
             "active_profile": active_profile,
             "provider_profiles": provider_profile_statuses(),
-            "local_operators": local_operator_statuses(),
+            "local_operators": local_operator_statuses(probe=False),
             "timezone": settings.user_timezone,
             "llm_logging_enabled": settings.llm_log_enabled,
         }

--- a/backend/src/llm_runtime.py
+++ b/backend/src/llm_runtime.py
@@ -13,14 +13,17 @@ import os
 from fnmatch import fnmatchcase
 from threading import Lock
 from time import monotonic
+from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
 
 from smolagents import LiteLLMModel as BaseLiteLLMModel
+from smolagents.models import ChatMessage, MessageRole
 
 from config.settings import settings
 from src.approval.runtime import get_current_session_id
 from src.audit.repository import audit_repository
+from src.operators.local_codex import is_local_codex_model, local_codex_chat_timeout_seconds, run_local_codex
 
 logger = logging.getLogger(__name__)
 _runtime_request_lock = Lock()
@@ -1038,6 +1041,77 @@ def build_completion_kwargs(
     if api_base:
         kwargs["api_base"] = api_base
     return kwargs
+
+
+def _message_value(message: Any, key: str, default: Any = None) -> Any:
+    if isinstance(message, dict):
+        return message.get(key, default)
+    return getattr(message, key, default)
+
+
+def _messages_to_local_operator_prompt(messages: list[Any]) -> str:
+    parts: list[str] = []
+    for message in messages:
+        role = str(_message_value(message, "role", "user") or "user").strip() or "user"
+        content = str(_message_value(message, "content", "") or "").strip()
+        if content:
+            parts.append(f"{role}: {content}")
+    return "\n\n".join(parts).strip()
+
+
+def _local_operator_completion_response(content: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=content),
+            )
+        ],
+    )
+
+
+def _trim_after_stop_sequences(content: str, stop_sequences: list[str] | None) -> str:
+    if not stop_sequences:
+        return content
+    earliest_stop = len(content)
+    for stop_sequence in stop_sequences:
+        if not stop_sequence:
+            continue
+        stop_index = content.find(stop_sequence)
+        if stop_index >= 0:
+            earliest_stop = min(earliest_stop, stop_index)
+    return content[:earliest_stop]
+
+
+def _local_operator_chat_message(
+    content: str,
+    *,
+    raw: Any | None = None,
+    stop_sequences: list[str] | None = None,
+) -> ChatMessage:
+    return ChatMessage(
+        role=MessageRole.ASSISTANT,
+        content=_trim_after_stop_sequences(content, stop_sequences),
+        raw=raw,
+    )
+
+
+def _run_local_codex_completion(prompt: str, *, session_id: str | None) -> dict[str, Any]:
+    async def _run() -> dict[str, Any]:
+        return await run_local_codex(
+            prompt,
+            timeout_seconds=local_codex_chat_timeout_seconds(),
+            session_id=session_id,
+        )
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(_run())
+
+    return {
+        "ok": False,
+        "stderr": "Local Codex completion is unavailable from synchronous code inside an active event loop.",
+    }
 
 
 def has_fallback_model(*, runtime_path: str | None = None) -> bool:
@@ -2449,13 +2523,32 @@ class FallbackLiteLLMModel(BaseLiteLLMModel):
             try:
                 if is_primary:
                     primary_attempted = True
-                    response = super().generate(
-                        messages,
-                        stop_sequences=stop_sequences,
-                        response_format=response_format,
-                        tools_to_call_from=tools_to_call_from,
-                        **kwargs,
-                    )
+                    if is_local_codex_model(primary_model):
+                        local_result = _run_local_codex_completion(
+                            _messages_to_local_operator_prompt(messages),
+                            session_id=get_current_session_id(),
+                        )
+                        if not local_result.get("ok", False):
+                            raise RuntimeError(
+                                str(
+                                    local_result.get("stderr")
+                                    or local_result.get("stdout")
+                                    or "Local Codex operator failed."
+                                ).strip()
+                            )
+                        response = _local_operator_chat_message(
+                            str(local_result.get("stdout") or "").strip(),
+                            raw=local_result,
+                            stop_sequences=stop_sequences,
+                        )
+                    else:
+                        response = super().generate(
+                            messages,
+                            stop_sequences=stop_sequences,
+                            response_format=response_format,
+                            tools_to_call_from=tools_to_call_from,
+                            **kwargs,
+                        )
                     _mark_target_succeeded(
                         model_id=primary_model,
                         api_base=self.api_base,
@@ -2480,13 +2573,32 @@ class FallbackLiteLLMModel(BaseLiteLLMModel):
 
                 fallback_model = target["model"]
                 attempted_fallback_models.append(fallback_model.model_id)
-                response = fallback_model.generate(
-                    messages,
-                    stop_sequences=stop_sequences,
-                    response_format=response_format,
-                    tools_to_call_from=tools_to_call_from,
-                    **kwargs,
-                )
+                if is_local_codex_model(fallback_model.model_id):
+                    local_result = _run_local_codex_completion(
+                        _messages_to_local_operator_prompt(messages),
+                        session_id=get_current_session_id(),
+                    )
+                    if not local_result.get("ok", False):
+                        raise RuntimeError(
+                            str(
+                                local_result.get("stderr")
+                                or local_result.get("stdout")
+                                or "Local Codex operator failed."
+                            ).strip()
+                        )
+                    response = _local_operator_chat_message(
+                        str(local_result.get("stdout") or "").strip(),
+                        raw=local_result,
+                        stop_sequences=stop_sequences,
+                    )
+                else:
+                    response = fallback_model.generate(
+                        messages,
+                        stop_sequences=stop_sequences,
+                        response_format=response_format,
+                        tools_to_call_from=tools_to_call_from,
+                        **kwargs,
+                    )
                 _mark_target_succeeded(
                     model_id=fallback_model.model_id,
                     api_base=fallback_model.api_base,
@@ -2694,7 +2806,23 @@ def completion_with_fallback_sync(
             try:
                 if is_primary:
                     primary_attempted = True
-                    response = litellm.completion(**primary_kwargs)
+                    if is_local_codex_model(primary_model):
+                        local_prompt = _messages_to_local_operator_prompt(messages)
+                        if not local_prompt:
+                            raise ValueError("Local Codex completion requires at least one non-empty message")
+                        local_result = _run_local_codex_completion(
+                            local_prompt,
+                            session_id=get_current_session_id(),
+                        )
+                        if not local_result.get("ok"):
+                            if local_result.get("timed_out"):
+                                raise TimeoutError("Local Codex completion timed out")
+                            raise RuntimeError(
+                                (local_result.get("stderr") or local_result.get("stdout") or "Local Codex completion failed").strip()
+                            )
+                        response = _local_operator_completion_response(str(local_result.get("stdout") or "").strip())
+                    else:
+                        response = litellm.completion(**primary_kwargs)
                     _mark_target_succeeded(
                         model_id=primary_model,
                         api_base=primary_kwargs.get("api_base"),

--- a/backend/src/memory/control.py
+++ b/backend/src/memory/control.py
@@ -5,6 +5,8 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from src.audit.repository import audit_repository
 from src.db.models import Memory, MemoryEdgeType, MemoryKind, MemoryStatus
 from src.memory.decay import apply_memory_decay_policies, summarize_memory_reconciliation_state
@@ -709,20 +711,35 @@ async def get_memory_live_controls_snapshot(
     bounded_limit = min(max(int(limit or 8), 1), 50)
     provider_inventory = _apply_provider_quarantine_overlay(list_memory_provider_inventory())
     fetch_limit = bounded_limit if not owner_session_id else min(bounded_limit * 10, 200)
-    active = _scope_memories_to_owner(
-        await memory_repository.list_memories(status=MemoryStatus.active, limit=fetch_limit),
-        owner_session_id,
-    )[:bounded_limit]
-    superseded = _scope_memories_to_owner(
-        await memory_repository.list_memories(status=MemoryStatus.superseded, limit=fetch_limit),
-        owner_session_id,
-    )[:bounded_limit]
-    archived = _scope_memories_to_owner(
-        await memory_repository.list_memories(status=MemoryStatus.archived, limit=fetch_limit),
-        owner_session_id,
-    )[:bounded_limit]
-    receipts = await list_memory_audit_receipts(limit=bounded_limit)
-    reconciliation = await summarize_memory_reconciliation_state(limit=min(bounded_limit, 10))
+    try:
+        active = _scope_memories_to_owner(
+            await memory_repository.list_memories(status=MemoryStatus.active, limit=fetch_limit),
+            owner_session_id,
+        )[:bounded_limit]
+        superseded = _scope_memories_to_owner(
+            await memory_repository.list_memories(status=MemoryStatus.superseded, limit=fetch_limit),
+            owner_session_id,
+        )[:bounded_limit]
+        archived = _scope_memories_to_owner(
+            await memory_repository.list_memories(status=MemoryStatus.archived, limit=fetch_limit),
+            owner_session_id,
+        )[:bounded_limit]
+        receipts = await list_memory_audit_receipts(limit=bounded_limit)
+        reconciliation = await summarize_memory_reconciliation_state(limit=min(bounded_limit, 10))
+        operator_status = "guardian_memory_live_controls_visible"
+    except SQLAlchemyError:
+        active = []
+        superseded = []
+        archived = []
+        receipts = {"events": []}
+        reconciliation = {
+            "summary": {
+                "status": "unavailable",
+                "reason": "memory database unavailable",
+            },
+            "items": [],
+        }
+        operator_status = "guardian_memory_live_controls_degraded"
 
     active_candidates = [_candidate_payload(memory, candidate_type="memory_candidate") for memory in active]
     review_candidates = [
@@ -750,7 +767,7 @@ async def get_memory_live_controls_snapshot(
     )
     snapshot = {
         "summary": {
-            "operator_status": "guardian_memory_live_controls_visible",
+            "operator_status": operator_status,
             "provider_count": provider_inventory.get("summary", {}).get("provider_count", 0),
             "quarantined_provider_count": provider_inventory.get("summary", {}).get("quarantined_count", 0),
             "active_memory_candidate_count": len(active),

--- a/backend/src/operators/local_codex.py
+++ b/backend/src/operators/local_codex.py
@@ -9,14 +9,20 @@ import os
 from pathlib import Path
 import re
 import shutil
+import signal
 import subprocess
+import tempfile
+from contextlib import suppress
+from time import monotonic
 from typing import Any
 
 from config.settings import REPO_ROOT, settings
 from src.audit.repository import audit_repository
 
 _OUTPUT_LIMIT = 24_000
-_STATUS_TIMEOUT_SECONDS = 5
+_STATUS_TIMEOUT_SECONDS = 1
+_STATUS_CACHE_TTL_SECONDS = 10
+_CHAT_TIMEOUT_SECONDS = 30
 _ENV_ALLOWLIST = {
     "PATH",
     "HOME",
@@ -29,11 +35,14 @@ _ENV_ALLOWLIST = {
 }
 _APPROVAL_POLICIES = {"untrusted", "on-request", "never"}
 _SANDBOX_MODES = {"read-only", "workspace-write"}
+_REASONING_EFFORTS = {"minimal", "low", "medium", "high", "xhigh"}
 _SECRET_ENV_MARKERS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL", "AUTH")
 _SECRET_PATTERNS = (
     re.compile(r"(?i)\b(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*[^\s,;]+"),
     re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+"),
 )
+_LOCAL_CODEX_MODEL_IDS = {"codex", "codex-local", "local-codex"}
+_status_cache: tuple[tuple[Any, ...], float, dict[str, Any]] | None = None
 
 
 class LocalCodexConfigurationError(RuntimeError):
@@ -45,6 +54,7 @@ class LocalCodexCommand:
     argv: list[str]
     cwd: Path
     timeout_seconds: int
+    output_path: Path | None = None
 
     @property
     def display(self) -> str:
@@ -53,6 +63,12 @@ class LocalCodexCommand:
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def is_local_codex_model(model: str | None = None) -> bool:
+    """Return whether a configured model id means the local Codex operator."""
+    normalized = (model if model is not None else settings.default_model).strip().lower()
+    return normalized in _LOCAL_CODEX_MODEL_IDS or normalized.startswith("codex-local/")
 
 
 def _display_arg(value: str) -> str:
@@ -91,6 +107,15 @@ def _workspace_root(raw_cwd: str | None = None) -> Path:
 def _timeout_seconds(raw_timeout: int | None = None) -> int:
     timeout = raw_timeout if raw_timeout is not None else settings.codex_local_timeout_seconds
     return min(max(int(timeout or 1), 1), 3600)
+
+
+def local_codex_chat_timeout_seconds() -> int:
+    """Bound interactive chat turns so the cockpit never spins for minutes."""
+    return min(
+        _timeout_seconds(settings.codex_local_timeout_seconds),
+        _timeout_seconds(settings.agent_chat_timeout),
+        _CHAT_TIMEOUT_SECONDS,
+    )
 
 
 def _codex_env() -> dict[str, str]:
@@ -138,9 +163,13 @@ def _redact_output(value: str) -> str:
 
 
 def _normalize_sandbox(value: str | None = None) -> str:
-    sandbox = (value if value is not None else settings.codex_local_sandbox).strip() or "workspace-write"
+    sandbox = (value if value is not None else settings.codex_local_sandbox).strip() or "read-only"
     if sandbox not in _SANDBOX_MODES:
         raise LocalCodexConfigurationError("Local Codex sandbox mode must be read-only or workspace-write.")
+    if sandbox == "workspace-write" and not settings.codex_local_allow_workspace_write:
+        raise LocalCodexConfigurationError(
+            "Local Codex workspace-write sandbox requires CODEX_LOCAL_ALLOW_WORKSPACE_WRITE=true."
+        )
     return sandbox
 
 
@@ -151,8 +180,20 @@ def _normalize_approval_policy(value: str | None = None) -> str:
     return policy
 
 
+def local_codex_chat_sandbox() -> str:
+    """Return the safe sandbox used for user-facing chat turns."""
+    return "read-only"
+
+
 def _normalize_model(value: str | None = None) -> str:
     return (value if value is not None else settings.codex_local_model).strip()
+
+
+def _normalize_reasoning_effort(value: str | None = None) -> str:
+    effort = (value if value is not None else settings.codex_local_reasoning_effort).strip() or "low"
+    if effort not in _REASONING_EFFORTS:
+        raise LocalCodexConfigurationError("Local Codex reasoning effort is not allowed.")
+    return effort
 
 
 def local_codex_command(
@@ -177,19 +218,44 @@ def local_codex_command(
         str(workspace),
         "--sandbox",
         _normalize_sandbox(sandbox),
+        "--ephemeral",
+        "--ignore-rules",
+        "--ignore-user-config",
+        "--color",
+        "never",
     ]
     selected_model = _normalize_model(model)
     if selected_model:
         argv.extend(["--model", selected_model])
+    argv.extend(["-c", f'model_reasoning_effort="{_normalize_reasoning_effort()}"'])
+    output_fd, output_name = tempfile.mkstemp(prefix="seraph-codex-last-", suffix=".txt")
+    os.close(output_fd)
+    output_path = Path(output_name)
+    argv.extend(["--output-last-message", str(output_path)])
     argv.append(prompt)
     return LocalCodexCommand(
         argv=argv,
         cwd=workspace,
         timeout_seconds=_timeout_seconds(timeout_seconds),
+        output_path=output_path,
     )
 
 
-def local_codex_status() -> dict[str, Any]:
+def _status_cache_key() -> tuple[Any, ...]:
+    return (
+        settings.codex_local_enabled,
+        settings.codex_local_command,
+        settings.codex_local_model,
+        settings.codex_local_reasoning_effort,
+        settings.codex_local_sandbox,
+        settings.codex_local_approval_policy,
+        settings.codex_local_allow_workspace_write,
+        settings.codex_local_timeout_seconds,
+    )
+
+
+def local_codex_configured_status() -> dict[str, Any]:
+    """Return local Codex configuration without running the Codex command."""
     command = ""
     try:
         command = _safe_command_name()
@@ -202,11 +268,15 @@ def local_codex_status() -> dict[str, Any]:
             "operator_kind": "local_command",
             "enabled": settings.codex_local_enabled,
             "ready": False,
+            "readiness_probe": "not_run",
             "unavailable_reason": str(exc),
             "command": command or None,
             "model": settings.codex_local_model,
+            "reasoning_effort": settings.codex_local_reasoning_effort,
             "sandbox": settings.codex_local_sandbox,
             "approval_policy": settings.codex_local_approval_policy,
+            "workspace_write_allowed": settings.codex_local_allow_workspace_write,
+            "requires_api_key": False,
         }
 
     payload: dict[str, Any] = {
@@ -216,17 +286,81 @@ def local_codex_status() -> dict[str, Any]:
         "command": command,
         "command_path": resolved_command,
         "model": settings.codex_local_model,
+        "reasoning_effort": settings.codex_local_reasoning_effort,
         "sandbox": configured_sandbox,
         "approval_policy": configured_approval_policy,
+        "workspace_write_allowed": settings.codex_local_allow_workspace_write,
+        "timeout_seconds": settings.codex_local_timeout_seconds,
+        "workspace_root": str(REPO_ROOT),
+        "requires_api_key": False,
+        "readiness_probe": "not_run",
+    }
+    if not settings.codex_local_enabled:
+        payload.update({"ready": False, "unavailable_reason": "local Codex operator is disabled"})
+    elif not resolved_command:
+        payload.update({"ready": False, "unavailable_reason": "codex command was not found on PATH"})
+    else:
+        payload.update({"ready": None, "unavailable_reason": None})
+    return payload
+
+
+def local_codex_status(*, force_refresh: bool = False) -> dict[str, Any]:
+    global _status_cache
+    cache_key = _status_cache_key()
+    now = monotonic()
+    if (
+        not force_refresh
+        and _status_cache is not None
+        and _status_cache[0] == cache_key
+        and now - _status_cache[1] <= _STATUS_CACHE_TTL_SECONDS
+    ):
+        return dict(_status_cache[2])
+
+    command = ""
+    try:
+        command = _safe_command_name()
+        configured_sandbox = _normalize_sandbox()
+        configured_approval_policy = _normalize_approval_policy()
+        resolved_command = shutil.which(command)
+    except LocalCodexConfigurationError as exc:
+        payload = {
+            "id": "codex-local",
+            "operator_kind": "local_command",
+            "enabled": settings.codex_local_enabled,
+            "ready": False,
+            "unavailable_reason": str(exc),
+            "command": command or None,
+            "model": settings.codex_local_model,
+            "reasoning_effort": settings.codex_local_reasoning_effort,
+            "sandbox": settings.codex_local_sandbox,
+            "approval_policy": settings.codex_local_approval_policy,
+            "workspace_write_allowed": settings.codex_local_allow_workspace_write,
+        }
+        _status_cache = (cache_key, now, dict(payload))
+        return payload
+
+    payload: dict[str, Any] = {
+        "id": "codex-local",
+        "operator_kind": "local_command",
+        "enabled": settings.codex_local_enabled,
+        "command": command,
+        "command_path": resolved_command,
+        "model": settings.codex_local_model,
+        "reasoning_effort": settings.codex_local_reasoning_effort,
+        "sandbox": configured_sandbox,
+        "approval_policy": configured_approval_policy,
+        "workspace_write_allowed": settings.codex_local_allow_workspace_write,
         "timeout_seconds": settings.codex_local_timeout_seconds,
         "workspace_root": str(REPO_ROOT),
         "requires_api_key": False,
     }
     if not settings.codex_local_enabled:
         payload.update({"ready": False, "unavailable_reason": "local Codex operator is disabled"})
+        _status_cache = (cache_key, now, dict(payload))
         return payload
     if not resolved_command:
         payload.update({"ready": False, "unavailable_reason": "codex command was not found on PATH"})
+        _status_cache = (cache_key, now, dict(payload))
         return payload
 
     try:
@@ -241,9 +375,11 @@ def local_codex_status() -> dict[str, Any]:
         )
     except subprocess.TimeoutExpired:
         payload.update({"ready": False, "unavailable_reason": "codex --version timed out"})
+        _status_cache = (cache_key, now, dict(payload))
         return payload
     except OSError as exc:
         payload.update({"ready": False, "unavailable_reason": str(exc)})
+        _status_cache = (cache_key, now, dict(payload))
         return payload
 
     version_text = (result.stdout or result.stderr or "").strip()
@@ -254,11 +390,12 @@ def local_codex_status() -> dict[str, Any]:
     })
     if result.returncode != 0:
         payload["unavailable_reason"] = "codex --version failed"
+    _status_cache = (cache_key, now, dict(payload))
     return payload
 
 
-def local_operator_statuses() -> list[dict[str, Any]]:
-    return [local_codex_status()]
+def local_operator_statuses(*, probe: bool = True) -> list[dict[str, Any]]:
+    return [local_codex_status() if probe else local_codex_configured_status()]
 
 
 async def run_local_codex(
@@ -271,7 +408,7 @@ async def run_local_codex(
     timeout_seconds: int | None = None,
     session_id: str | None = None,
 ) -> dict[str, Any]:
-    status = local_codex_status()
+    status = local_codex_configured_status()
     prompt_hash = _sha256_text(prompt)
     audit_base = {
         "operator_id": "codex-local",
@@ -281,7 +418,7 @@ async def run_local_codex(
         "model": model or settings.codex_local_model,
         "workspace_root": str(REPO_ROOT),
     }
-    if not status.get("ready"):
+    if status.get("ready") is False:
         await audit_repository.log_event(
             event_type="local_operator_unavailable",
             summary="Local Codex operator unavailable",
@@ -387,13 +524,65 @@ async def run_local_codex(
 async def _run_codex_subprocess(command: LocalCodexCommand) -> subprocess.CompletedProcess[str]:
     import asyncio
 
-    return await asyncio.to_thread(
-        subprocess.run,
-        command.argv,
+    process = await asyncio.create_subprocess_exec(
+        *command.argv,
         cwd=str(command.cwd),
-        capture_output=True,
-        text=True,
-        shell=False,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
         env=_codex_env(),
-        timeout=command.timeout_seconds,
+        start_new_session=True,
     )
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            process.communicate(input=b""),
+            timeout=command.timeout_seconds,
+        )
+    except asyncio.TimeoutError as exc:
+        await asyncio.shield(_terminate_process_group(process))
+        _cleanup_output_path(command.output_path)
+        raise subprocess.TimeoutExpired(command.argv, command.timeout_seconds) from exc
+    except asyncio.CancelledError:
+        await asyncio.shield(_terminate_process_group(process))
+        _cleanup_output_path(command.output_path)
+        raise
+    output_text = _read_output_path(command.output_path)
+    _cleanup_output_path(command.output_path)
+
+    return subprocess.CompletedProcess(
+        command.argv,
+        process.returncode,
+        output_text or stdout_bytes.decode("utf-8", errors="replace"),
+        stderr_bytes.decode("utf-8", errors="replace"),
+    )
+
+
+async def _terminate_process_group(process: Any) -> None:
+    import asyncio
+
+    pid = int(process.pid)
+    with suppress(ProcessLookupError):
+        os.killpg(pid, signal.SIGTERM)
+    try:
+        await asyncio.wait_for(process.wait(), timeout=2)
+        return
+    except asyncio.TimeoutError:
+        pass
+    with suppress(ProcessLookupError):
+        os.killpg(pid, signal.SIGKILL)
+    with suppress(Exception):
+        await asyncio.wait_for(process.wait(), timeout=2)
+
+
+def _read_output_path(output_path: Path | None) -> str:
+    if output_path is None or not output_path.exists():
+        return ""
+    with suppress(OSError, UnicodeDecodeError):
+        return output_path.read_text(encoding="utf-8").strip()
+    return ""
+
+
+def _cleanup_output_path(output_path: Path | None) -> None:
+    if output_path is not None:
+        with suppress(OSError):
+            output_path.unlink()

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 
 from config.settings import settings
 
@@ -34,6 +35,19 @@ async def test_runtime_status_exposes_release_and_model(client):
     assert any(item["id"] == "openrouter" for item in payload["provider_profiles"])
     assert any(item["id"] == "codex-local" for item in payload["local_operators"])
     assert all("api_key" not in item for item in payload["provider_profiles"])
+
+
+@pytest.mark.asyncio
+async def test_runtime_status_reports_local_codex_when_selected(client):
+    with patch.object(settings, "default_model", "codex-local"), patch.object(settings, "codex_local_model", "gpt-5.5"):
+        response = await client.get("/api/runtime/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["provider"] == "codex-local"
+    assert payload["model"] == "codex-local"
+    assert payload["model_label"] == "gpt-5.5"
+    assert payload["active_profile"] == "codex-local"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_llm_runtime.py
+++ b/backend/tests/test_llm_runtime.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1159,6 +1159,94 @@ def test_completion_with_fallback_sync_uses_local_profile_for_runtime_path(async
     assert events[0]["details"]["runtime_path"] == "session_consolidation"
     assert events[0]["details"]["runtime_profile"] == "local"
     assert events[0]["details"]["primary_model"] == "ollama/llama3.2"
+
+
+def test_completion_with_fallback_sync_routes_codex_local_to_local_operator(async_db):
+    with (
+        patch.object(settings, "default_model", "codex-local"),
+        patch.object(settings, "runtime_profile_preferences", ""),
+        patch.object(settings, "runtime_model_overrides", ""),
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", ""),
+        patch("src.llm_runtime.run_local_codex", new=AsyncMock(return_value={"ok": True, "stdout": "Local title"})) as mock_codex,
+        patch("litellm.completion") as mock_completion,
+    ):
+        result = completion_with_fallback_sync(
+            messages=[{"role": "user", "content": "Name this session"}],
+            temperature=0.3,
+            max_tokens=64,
+            runtime_path="session_title_generation",
+        )
+
+    assert result.choices[0].message.content == "Local title"
+    mock_completion.assert_not_called()
+    mock_codex.assert_awaited_once()
+    assert "user: Name this session" in mock_codex.await_args.args[0]
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=10)
+        return [e for e in events if e["event_type"] == "llm_primary_success"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["details"]["runtime_path"] == "session_title_generation"
+    assert events[0]["details"]["primary_model"] == "codex-local"
+
+
+async def test_completion_with_fallback_sync_fails_fast_for_codex_local_inside_running_loop(async_db):
+    with (
+        patch.object(settings, "default_model", "codex-local"),
+        patch.object(settings, "runtime_profile_preferences", ""),
+        patch.object(settings, "runtime_model_overrides", ""),
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", ""),
+        patch("src.llm_runtime.run_local_codex", new=AsyncMock(return_value={"ok": True, "stdout": "Loop title"})) as mock_codex,
+        patch("litellm.completion") as mock_completion,
+    ):
+        with pytest.raises(RuntimeError, match="active event loop"):
+            completion_with_fallback_sync(
+                messages=[{"role": "user", "content": "Name this session"}],
+                temperature=0.3,
+                max_tokens=64,
+                runtime_path="session_title_generation",
+            )
+
+    mock_completion.assert_not_called()
+    mock_codex.assert_not_awaited()
+
+
+def test_fallback_litellm_model_generate_routes_codex_local_to_local_operator(async_db):
+    with (
+        patch.object(settings, "runtime_profile_preferences", ""),
+        patch.object(settings, "runtime_model_overrides", ""),
+        patch.object(settings, "fallback_model", ""),
+        patch.object(settings, "fallback_models", ""),
+        patch(
+            "src.llm_runtime.run_local_codex",
+            new=AsyncMock(return_value={"ok": True, "stdout": "Agent reply<stop>ignored"}),
+        ) as mock_codex,
+        patch("litellm.completion") as mock_completion,
+    ):
+        model = FallbackLiteLLMModel(model_id="codex-local")
+        result = model.generate(
+            [{"role": "user", "content": "Say hello"}],
+            stop_sequences=["<stop>"],
+        )
+
+    assert result.role == "assistant"
+    assert result.content == "Agent reply"
+    mock_completion.assert_not_called()
+    mock_codex.assert_awaited_once()
+    assert "user: Say hello" in mock_codex.await_args.args[0]
+
+    async def _fetch():
+        events = await audit_repository.list_events(limit=10)
+        return [e for e in events if e["event_type"] == "llm_primary_success"]
+
+    events = asyncio.run(_fetch())
+    assert events
+    assert events[0]["details"]["runtime_path"] == "agent_generate"
+    assert events[0]["details"]["primary_model"] == "codex-local"
 
 
 def test_completion_with_fallback_sync_uses_runtime_model_override(async_db):

--- a/backend/tests/test_local_codex_operator.py
+++ b/backend/tests/test_local_codex_operator.py
@@ -7,7 +7,9 @@ from config.settings import REPO_ROOT, settings
 from src.audit.repository import audit_repository
 from src.operators.local_codex import (
     LocalCodexConfigurationError,
+    _codex_env,
     _truncate_output,
+    local_codex_chat_timeout_seconds,
     local_codex_command,
     local_codex_status,
     run_local_codex,
@@ -20,11 +22,12 @@ def test_local_codex_command_uses_local_exec_contract():
         patch.object(settings, "codex_local_model", "gpt-5.5"),
         patch.object(settings, "codex_local_sandbox", "workspace-write"),
         patch.object(settings, "codex_local_approval_policy", "never"),
+        patch.object(settings, "codex_local_allow_workspace_write", True),
         patch.object(settings, "codex_local_timeout_seconds", 42),
     ):
         command = local_codex_command("fix the thing")
 
-    assert command.argv == [
+    assert command.argv[:15] == [
         "codex",
         "--ask-for-approval",
         "never",
@@ -33,12 +36,34 @@ def test_local_codex_command_uses_local_exec_contract():
         str(REPO_ROOT),
         "--sandbox",
         "workspace-write",
+        "--ephemeral",
+        "--ignore-rules",
+        "--ignore-user-config",
+        "--color",
+        "never",
         "--model",
         "gpt-5.5",
-        "fix the thing",
     ]
+    assert command.argv[15:18] == [
+        "-c",
+        'model_reasoning_effort="low"',
+        "--output-last-message",
+    ]
+    assert command.argv[-1] == "fix the thing"
+    assert command.output_path is not None
+    assert command.output_path.name.startswith("seraph-codex-last-")
+    assert command.output_path.suffix == ".txt"
+    command.output_path.unlink(missing_ok=True)
     assert command.cwd == REPO_ROOT
     assert command.timeout_seconds == 42
+
+
+def test_local_codex_chat_timeout_caps_interactive_turns():
+    with (
+        patch.object(settings, "agent_chat_timeout", 120),
+        patch.object(settings, "codex_local_timeout_seconds", 600),
+    ):
+        assert local_codex_chat_timeout_seconds() == 30
 
 
 @pytest.mark.parametrize("approval_policy", ["bogus", "always"])
@@ -89,6 +114,14 @@ def test_local_codex_status_fails_closed_when_sandbox_config_is_unsafe():
     assert status["unavailable_reason"] == "Local Codex sandbox mode must be read-only or workspace-write."
 
 
+def test_local_codex_command_rejects_workspace_write_without_explicit_opt_in():
+    with (
+        patch.object(settings, "codex_local_allow_workspace_write", False),
+        pytest.raises(LocalCodexConfigurationError, match="CODEX_LOCAL_ALLOW_WORKSPACE_WRITE=true"),
+    ):
+        local_codex_command("do it", sandbox="workspace-write")
+
+
 def test_local_codex_status_reports_version_without_api_key_requirement():
     completed = subprocess.CompletedProcess(["codex", "--version"], 0, stdout="codex 1.2.3\n", stderr="")
     with (
@@ -119,13 +152,7 @@ async def test_run_local_codex_audits_without_prompt_or_raw_output(async_db):
     with (
         patch.object(settings, "openai_api_key", secret_value),
         patch("src.operators.local_codex.shutil.which", return_value="/usr/local/bin/codex"),
-        patch(
-            "src.operators.local_codex.subprocess.run",
-            side_effect=[
-                subprocess.CompletedProcess(["codex", "--version"], 0, stdout="codex 1.2.3\n", stderr=""),
-                completed,
-            ],
-        ),
+        patch("src.operators.local_codex._run_codex_subprocess", AsyncMock(return_value=completed)),
     ):
         result = await run_local_codex("private task prompt")
 
@@ -156,23 +183,24 @@ async def test_run_local_codex_subprocess_env_strips_provider_api_keys(monkeypat
     completed = subprocess.CompletedProcess(["codex", "exec"], 0, stdout="ok", stderr="")
     with (
         patch("src.operators.local_codex.shutil.which", return_value="/usr/local/bin/codex"),
-        patch(
-            "src.operators.local_codex.subprocess.run",
-            side_effect=[
-                subprocess.CompletedProcess(["codex", "--version"], 0, stdout="codex 1.2.3\n", stderr=""),
-                completed,
-            ],
-        ) as mock_run,
+        patch("src.operators.local_codex._run_codex_subprocess", AsyncMock(return_value=completed)) as mock_exec,
     ):
         result = await run_local_codex("inspect local state")
 
     assert result["ok"] is True
-    exec_env = mock_run.call_args_list[1].kwargs["env"]
+    exec_command = mock_exec.await_args.args[0]
+    exec_env = _codex_env()
     assert "OPENAI_API_KEY" not in exec_env
     assert "OPENROUTER_API_KEY" not in exec_env
     assert "ANTHROPIC_API_KEY" not in exec_env
     assert "LLM_API_KEY" not in exec_env
     assert exec_env["SERAPH_LOCAL_OPERATOR"] == "codex-local"
+    assert exec_command.display == (
+        f"codex --ask-for-approval never exec -C {REPO_ROOT} "
+        "--sandbox read-only --ephemeral --ignore-rules --ignore-user-config "
+        '--color never --model gpt-5.5 -c model_reasoning_effort="low" '
+    ) + f"--output-last-message {exec_command.output_path} 'inspect local state'"
+    exec_command.output_path.unlink(missing_ok=True)
 
 
 def test_local_codex_output_redaction_covers_env_configured_and_pattern_secrets(monkeypatch):
@@ -200,6 +228,44 @@ async def test_runtime_status_exposes_local_operator_separately_from_provider_pr
     assert "local_operators" in payload
     assert any(item["id"] == "codex-local" for item in payload["local_operators"])
     assert all(item["id"] != "codex-local" for item in payload["provider_profiles"])
+
+
+@pytest.mark.asyncio
+async def test_rest_chat_uses_local_codex_when_selected(client):
+    with (
+        patch.object(settings, "default_model", "codex-local"),
+        patch(
+            "src.api.chat.run_local_codex",
+            AsyncMock(return_value={
+                "ok": True,
+                "stdout": "hello from local codex",
+                "stderr": "",
+            }),
+        ) as mock_run,
+    ):
+        response = await client.post("/api/chat", json={"message": "hello"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["response"] == "hello from local codex"
+    assert payload["session_id"]
+    mock_run.assert_awaited_once()
+    assert mock_run.await_args.kwargs["session_id"] == payload["session_id"]
+    assert mock_run.await_args.kwargs["timeout_seconds"] == 30
+    assert mock_run.await_args.kwargs["sandbox"] == "read-only"
+
+
+@pytest.mark.asyncio
+async def test_rest_chat_local_codex_times_out_instead_of_hanging(client):
+    with (
+        patch.object(settings, "default_model", "codex-local"),
+        patch("src.api.chat.local_codex_chat_timeout_seconds", return_value=1),
+        patch("src.api.chat.run_local_codex", AsyncMock(return_value={"ok": False, "timed_out": True})),
+    ):
+        response = await client.post("/api/chat", json={"message": "hello"})
+
+    assert response.status_code == 504
+    assert response.json()["detail"] == "Local Codex timed out after 1s."
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_operator_api.py
+++ b/backend/tests/test_operator_api.py
@@ -10326,6 +10326,31 @@ async def test_operator_continuity_graph_links_sessions_workflows_artifacts_and_
 
 
 @pytest.mark.asyncio
+async def test_operator_continuity_graph_degrades_when_sources_or_snapshot_threads_fail(client):
+    with (
+        patch("src.api.operator.session_manager.list_sessions", AsyncMock(side_effect=RuntimeError("sessions missing"))),
+        patch("src.api.operator._list_workflow_runs", AsyncMock(return_value=[])),
+        patch("src.api.operator.approval_repository.list_pending", AsyncMock(return_value=[])),
+        patch("src.api.operator.native_notification_queue.list", AsyncMock(return_value=[])),
+        patch("src.api.operator.insight_queue.peek_all", AsyncMock(return_value=[])),
+        patch("src.api.operator.guardian_feedback_repository.list_recent", AsyncMock(return_value=[])),
+        patch(
+            "src.api.operator.build_observer_continuity_snapshot",
+            AsyncMock(return_value={"summary": {"continuity_health": "attention"}, "threads": None}),
+        ),
+    ):
+        resp = await client.get("/api/operator/continuity-graph", params={"limit_sessions": 4})
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["summary"]["continuity_health"] == "attention"
+    assert payload["summary"]["tracked_sessions"] == 0
+    assert payload["sessions"] == []
+    assert payload["nodes"] == []
+    assert payload["edges"] == []
+
+
+@pytest.mark.asyncio
 async def test_operator_engineering_memory_applies_window_and_reports_total_bundle_counts(client):
     now = datetime.now(timezone.utc)
     fresh_pr_started_at = (now - timedelta(hours=2)).isoformat().replace("+00:00", "Z")

--- a/env.dev.example
+++ b/env.dev.example
@@ -54,8 +54,9 @@ SANDBOX_URL=http://sandbox-dev:8060
 CODEX_LOCAL_ENABLED=true
 CODEX_LOCAL_COMMAND=codex
 CODEX_LOCAL_MODEL=gpt-5.5
-CODEX_LOCAL_SANDBOX=workspace-write
+CODEX_LOCAL_SANDBOX=read-only
 CODEX_LOCAL_APPROVAL_POLICY=never
+CODEX_LOCAL_ALLOW_WORKSPACE_WRITE=false
 CODEX_LOCAL_TIMEOUT_SECONDS=600
 
 # Screen-analysis budgets. 0 means unlimited for caps/size; retention is days.

--- a/env.prod.example
+++ b/env.prod.example
@@ -46,8 +46,9 @@ SANDBOX_URL=http://sandbox:8060
 CODEX_LOCAL_ENABLED=true
 CODEX_LOCAL_COMMAND=codex
 CODEX_LOCAL_MODEL=gpt-5.5
-CODEX_LOCAL_SANDBOX=workspace-write
+CODEX_LOCAL_SANDBOX=read-only
 CODEX_LOCAL_APPROVAL_POLICY=never
+CODEX_LOCAL_ALLOW_WORKSPACE_WRITE=false
 CODEX_LOCAL_TIMEOUT_SECONDS=600
 
 # Screen-analysis budgets. 0 means unlimited for caps/size; retention is days.

--- a/frontend/src/components/cockpit/CockpitView.test.tsx
+++ b/frontend/src/components/cockpit/CockpitView.test.tsx
@@ -319,6 +319,18 @@ describe("CockpitView", () => {
     );
   });
 
+  it("does not claim runtime linked when runtime status exists but websocket is disconnected", async () => {
+    useChatStore.setState({ connectionStatus: "disconnected" });
+    mockCockpitBaselineFetch(fetchMock, {});
+
+    render(<CockpitView onSend={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText("DIRECT FALLBACK · BALANCED TOOLS · HIGH_RISK APPROVAL")).toBeInTheDocument());
+    expect(screen.getAllByText("disconnected").length).toBeGreaterThan(0);
+    expect(screen.queryByText("LIVE LINK · BALANCED TOOLS · HIGH_RISK APPROVAL")).not.toBeInTheDocument();
+    expect(screen.queryByText("runtime linked")).not.toBeInTheDocument();
+  });
+
   it("does not queue stale workflow fallback drafts when live recovery control is refused", async () => {
     fetchMock.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);

--- a/frontend/src/components/cockpit/CockpitView.tsx
+++ b/frontend/src/components/cockpit/CockpitView.tsx
@@ -7,7 +7,7 @@ import { useChatStore } from "../../stores/chatStore";
 import { useQuestStore } from "../../stores/questStore";
 import { useCockpitLayoutStore } from "../../stores/cockpitLayoutStore";
 import { PANEL_MIN_SIZES, usePanelLayoutStore } from "../../stores/panelLayoutStore";
-import type { ChatMessage, GoalInfo } from "../../types";
+import type { ChatMessage, ConnectionStatus, GoalInfo } from "../../types";
 import {
   buildWorkflowDraft,
   workflowAcceptsArtifact,
@@ -6778,9 +6778,11 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
   }, [focusPane, pendingApprovals, pendingLifecycleApprovalId]);
 
   const refreshCockpit = useCallback(async (isCancelled: () => boolean = () => false) => {
-    const fetchJson = async (url: string) => {
+    const fetchJson = async (url: string, timeoutMs = 5000) => {
+      const controller = new AbortController();
+      const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
       try {
-        const response = await fetch(url);
+        const response = await fetch(url, { signal: controller.signal });
         if (isCancelled() || !response.ok) {
           return { ok: false, payload: null };
         }
@@ -6791,6 +6793,8 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
         return { ok: true, payload };
       } catch {
         return { ok: false, payload: null };
+      } finally {
+        window.clearTimeout(timeout);
       }
     };
 
@@ -6855,7 +6859,6 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
     ]);
 
     if (isCancelled()) return;
-
     if (runtimeStatusResult.ok && runtimeStatusResult.payload && typeof runtimeStatusResult.payload === "object") {
       setRuntimeStatus(runtimeStatusResult.payload as RuntimeStatus);
     }
@@ -8006,7 +8009,15 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
     () => starterPacks.filter((pack) => pack.availability === "ready"),
     [starterPacks],
   );
-  const connectionLabel = connectionStatus === "connected" ? "live" : connectionStatus;
+  const runtimeAvailable = runtimeStatus !== null;
+  const effectiveConnectionStatus: ConnectionStatus = connectionStatus === "connected"
+    ? "connected"
+    : connectionStatus === "connecting" || connectionStatus === "error"
+      ? "disconnected"
+      : connectionStatus;
+  const connectionLabel = effectiveConnectionStatus === "connected"
+    ? "live"
+    : effectiveConnectionStatus;
   const runtimeProviderLabel = (runtimeStatus?.provider ?? "unknown").replace(/[_.-]+/g, " ").toUpperCase();
   const runtimeModelLabel = (runtimeStatus?.model_label ?? runtimeStatus?.model ?? "unknown")
     .replace(/^openrouter\//, "")
@@ -8084,7 +8095,14 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
     : null;
   const workspaceTelemetryLeft = `${runtimeProviderLabel} · ${runtimeModelLabel}`;
   const workspaceTelemetryCenter = `${activeLayout.label.toUpperCase()} WORKSPACE · 16PX GRID SNAP · ${runtimeBuildLabel}`;
-  const workspaceTelemetryRight = `${connectionLabel.toUpperCase()} LINK · ${toolPolicyMode.toUpperCase()} TOOLS · ${approvalMode.toUpperCase()} APPROVAL`;
+  const workspaceTelemetryRight = effectiveConnectionStatus === "connected"
+    ? `${connectionLabel.toUpperCase()} LINK · ${toolPolicyMode.toUpperCase()} TOOLS · ${approvalMode.toUpperCase()} APPROVAL`
+    : `DIRECT FALLBACK · ${toolPolicyMode.toUpperCase()} TOOLS · ${approvalMode.toUpperCase()} APPROVAL`;
+  const desktopPresenceLabel = daemonPresence?.connected
+    ? "desktop live"
+    : runtimeAvailable
+      ? "desktop optional"
+      : "desktop offline";
   const submitDisabled = isAgentBusy || !composer.trim();
   const operatorRunbooks = useMemo(
     () => runbooks,
@@ -8106,7 +8124,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
   );
   const seraphPresenceSnapshot = useMemo(
     () => ({
-      connectionStatus,
+      connectionStatus: effectiveConnectionStatus,
       animationState: agentVisual.animationState,
       isAgentBusy,
       pendingApprovalCount: pendingApprovals.length,
@@ -8130,7 +8148,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
     [
       agentVisual.animationState,
       ambientState,
-      connectionStatus,
+      effectiveConnectionStatus,
       continuitySummary?.actionable_thread_count,
       continuitySummary?.attention_family_count,
       continuitySummary?.attention_presence_surface_count,
@@ -12958,11 +12976,9 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
 
         <div className="cockpit-topbar-right">
           <div className="cockpit-pill-row">
-            <span className={`cockpit-pill cockpit-pill--${connectionStatus}`}>{connectionLabel}</span>
+            <span className={`cockpit-pill cockpit-pill--${effectiveConnectionStatus}`}>{connectionLabel}</span>
             <span className="cockpit-pill">{ambientState.replace("_", " ")}</span>
-            <span className="cockpit-pill">
-              desktop {daemonPresence?.connected ? "live" : "offline"}
-            </span>
+            <span className="cockpit-pill">{desktopPresenceLabel}</span>
             {daemonPresence && (
               <button
                 type="button"
@@ -14300,7 +14316,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
               <CockpitWorkspaceWindow
                 panelId="presence_pane"
                 title="Seraph presence"
-                meta={connectionStatus === "connected" ? "runtime linked" : connectionLabel}
+                meta={effectiveConnectionStatus === "connected" ? "live link" : "direct fallback"}
                 hint={COCKPIT_WINDOW_HINTS.presence}
                 showHint={false}
                 minWidth={368}
@@ -18669,7 +18685,7 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
             value={composer}
             onChange={(event) => setComposer(event.target.value)}
             placeholder={
-              connectionStatus === "connected"
+              effectiveConnectionStatus === "connected"
                 ? "Ask Seraph, redirect a workflow, or steer the guardian."
                 : "WebSocket offline. Message will fall back to direct chat."
             }

--- a/frontend/src/components/cockpit/SeraphPresencePane.tsx
+++ b/frontend/src/components/cockpit/SeraphPresencePane.tsx
@@ -93,7 +93,9 @@ export function SeraphPresencePane({ snapshot, isSelected = false }: SeraphPrese
       {
         label: "Context",
         value: contextLabel(snapshot),
-        hint: (snapshot.dataQuality ?? "runtime linked").replace(/_/g, " "),
+        hint: (snapshot.dataQuality ?? (
+          snapshot.connectionStatus === "connected" ? "live link" : "direct fallback"
+        )).replace(/_/g, " "),
       },
       {
         label: "Queue",

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -1,5 +1,27 @@
-export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8004";
-export const WS_URL = import.meta.env.VITE_WS_URL || "ws://localhost:8004/ws/chat";
+const localWsUrl = () => {
+  if (typeof window === "undefined") {
+    return "ws://localhost:8004/ws/chat";
+  }
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  if (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") {
+    return `ws://${window.location.hostname}:8004/ws/chat`;
+  }
+  return `${protocol}//${window.location.host}/ws/chat`;
+};
+
+const configuredApiUrl = import.meta.env.VITE_API_URL;
+const localApiUrl = () => {
+  if (typeof window === "undefined") {
+    return "http://localhost:8004";
+  }
+  if (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") {
+    return `http://${window.location.hostname}:8004`;
+  }
+  return "";
+};
+
+export const API_URL = configuredApiUrl === "/api" ? "" : configuredApiUrl || localApiUrl();
+export const WS_URL = import.meta.env.VITE_WS_URL || localWsUrl();
 
 export const WALK_DURATION_MS = 800;
 export const SPEECH_DISPLAY_MS = 3000;

--- a/frontend/src/hooks/useWebSocket.test.ts
+++ b/frontend/src/hooks/useWebSocket.test.ts
@@ -9,12 +9,17 @@ import { describe, it, expect, vi } from "vitest";
 // We test the constants and behavior rather than the hook directly
 // since hooks require a React rendering context.
 import { WS_RECONNECT_DELAY_MS } from "../config/constants";
-import { buildClarificationMessage, resolveClarificationSessionId } from "./useWebSocket";
+import { WS_RESPONSE_TIMEOUT_MS, buildClarificationMessage, resolveClarificationSessionId } from "./useWebSocket";
 
 describe("WS reconnection constants", () => {
   it("has a sensible initial reconnect delay", () => {
     expect(WS_RECONNECT_DELAY_MS).toBeGreaterThan(0);
     expect(WS_RECONNECT_DELAY_MS).toBeLessThanOrEqual(10_000);
+  });
+
+  it("allows normal backend agent turns to finish before resetting the socket", () => {
+    expect(WS_RESPONSE_TIMEOUT_MS).toBeGreaterThanOrEqual(120_000);
+    expect(WS_RESPONSE_TIMEOUT_MS).toBeLessThanOrEqual(130_000);
   });
 });
 

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -2,15 +2,16 @@ import { useEffect, useRef, useCallback } from "react";
 import { API_URL, WS_URL, WS_RECONNECT_DELAY_MS, WS_PING_INTERVAL_MS } from "../config/constants";
 import { useChatStore } from "../stores/chatStore";
 import { detectToolFromStep } from "../lib/toolParser";
-import { useAgentAnimation } from "./useAgentAnimation";
+import { getIdleState, getThinkingState } from "../lib/animationStateMachine";
 import { appEventBus } from "../lib/appEventBus";
-import type { WSResponse, ChatMessage } from "../types";
+import type { AmbientState, ChatMessage, ConnectionStatus, SessionContinuityState, WSResponse } from "../types";
 
 function makeId(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
 }
 
 const WS_BACKOFF_MAX_MS = 30_000;
+export const WS_RESPONSE_TIMEOUT_MS = 130_000;
 
 type ClarificationPayload = {
   content?: string;
@@ -47,20 +48,55 @@ export function useWebSocket() {
   const wsRef = useRef<WebSocket | null>(null);
   const pingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const connectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const responseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const backoffRef = useRef(WS_RECONNECT_DELAY_MS);
   const pendingResumeRef = useRef<{ sessionId: string | null; message: string } | null>(null);
 
-  const {
-    addMessage,
-    setSessionId,
-    setConnectionStatus,
-    setAgentBusy,
-    setAmbientState,
-    setChatPanelOpen,
-    markSessionContinuity,
-  } = useChatStore();
+  const addMessage = useCallback((message: ChatMessage) => {
+    useChatStore.getState().addMessage(message);
+  }, []);
+  const setSessionId = useCallback((sessionId: string) => {
+    useChatStore.getState().setSessionId(sessionId);
+  }, []);
+  const setConnectionStatus = useCallback((status: ConnectionStatus) => {
+    useChatStore.getState().setConnectionStatus(status);
+  }, []);
+  const setAgentBusy = useCallback((busy: boolean) => {
+    useChatStore.getState().setAgentBusy(busy);
+  }, []);
+  const setAmbientState = useCallback((state: AmbientState) => {
+    useChatStore.getState().setAmbientState(state);
+  }, []);
+  const setChatPanelOpen = useCallback((open: boolean) => {
+    useChatStore.getState().setChatPanelOpen(open);
+  }, []);
+  const markSessionContinuity = useCallback((sessionId: string, state: SessionContinuityState) => {
+    useChatStore.getState().markSessionContinuity(sessionId, state);
+  }, []);
 
-  const { onToolDetected, onFinalAnswer, onThinking } = useAgentAnimation();
+  const onThinking = useCallback(() => {
+    const thinking = getThinkingState();
+    useChatStore.getState().setAgentVisual({
+      animationState: "thinking",
+      positionX: thinking.positionX,
+      speechText: null,
+    });
+  }, []);
+  const onToolDetected = useCallback((_toolName: string, stepContent?: string) => {
+    useChatStore.getState().setAgentVisual({
+      animationState: "casting",
+      speechText: stepContent ?? null,
+    });
+  }, []);
+  const onFinalAnswer = useCallback((answer: string) => {
+    const idle = getIdleState();
+    useChatStore.getState().setAgentVisual({
+      animationState: "speaking",
+      positionX: idle.positionX,
+      speechText: answer.length > 80 ? answer.slice(0, 80) + "..." : answer,
+    });
+  }, []);
 
   const onToolDetectedRef = useRef(onToolDetected);
   const onFinalAnswerRef = useRef(onFinalAnswer);
@@ -82,6 +118,13 @@ export function useWebSocket() {
     timestamp: Date.now(),
     sessionId: useChatStore.getState().sessionId,
   }), []);
+
+  const clearResponseTimeout = useCallback(() => {
+    if (responseTimeoutRef.current) {
+      clearTimeout(responseTimeoutRef.current);
+      responseTimeoutRef.current = null;
+    }
+  }, []);
 
   const sendSocketMessage = useCallback(
     (
@@ -107,15 +150,32 @@ export function useWebSocket() {
             session_id: sessionId,
           })
         );
+        clearResponseTimeout();
+        responseTimeoutRef.current = setTimeout(() => {
+          if (wsRef.current?.readyState === WebSocket.OPEN) {
+            wsRef.current.close();
+          }
+          setAgentBusy(false);
+          setConnectionStatus("disconnected");
+          addMessage(buildErrorMessage(
+            "Seraph did not return a response in time. The live link was reset; send again to use the direct chat fallback."
+          ));
+        }, WS_RESPONSE_TIMEOUT_MS);
         return true;
       } catch {
+        clearResponseTimeout();
         setAgentBusy(false);
         addMessage(buildErrorMessage("Message delivery failed."));
         return false;
       }
     },
-    [addMessage, buildErrorMessage, buildUserMessage, setAgentBusy, onThinking]
+    [addMessage, buildErrorMessage, buildUserMessage, clearResponseTimeout, setAgentBusy, setConnectionStatus, onThinking]
   );
+  const sendSocketMessageRef = useRef(sendSocketMessage);
+
+  useEffect(() => {
+    sendSocketMessageRef.current = sendSocketMessage;
+  }, [sendSocketMessage]);
 
   const sendRestMessage = useCallback(async (message: string, sessionId: string | null) => {
     setAgentBusy(true);
@@ -210,10 +270,27 @@ export function useWebSocket() {
     setConnectionStatus("connecting");
     const ws = new WebSocket(WS_URL);
     wsRef.current = ws;
+    if (connectTimeoutRef.current) {
+      clearTimeout(connectTimeoutRef.current);
+    }
+    connectTimeoutRef.current = setTimeout(() => {
+      if (wsRef.current === ws) {
+        setConnectionStatus(ws.readyState === WebSocket.OPEN ? "connected" : "disconnected");
+      }
+    }, Math.max(WS_RECONNECT_DELAY_MS - 500, 1000));
 
     ws.onopen = () => {
+      wsRef.current = ws;
+      if (connectTimeoutRef.current) {
+        clearTimeout(connectTimeoutRef.current);
+        connectTimeoutRef.current = null;
+      }
       setConnectionStatus("connected");
       backoffRef.current = WS_RECONNECT_DELAY_MS; // reset on successful connect
+      if (reconnectRef.current) {
+        clearTimeout(reconnectRef.current);
+        reconnectRef.current = null;
+      }
       useChatStore.getState().fetchProfile();
       useChatStore.getState().fetchToolRegistry();
 
@@ -222,7 +299,7 @@ export function useWebSocket() {
       if (pendingResumeRef.current) {
         const pending = pendingResumeRef.current;
         pendingResumeRef.current = null;
-        sendSocketMessage(pending.message, pending.sessionId, false, "resume_message");
+        sendSocketMessageRef.current(pending.message, pending.sessionId, false, "resume_message");
       }
 
       pingRef.current = setInterval(() => {
@@ -233,6 +310,8 @@ export function useWebSocket() {
     };
 
     ws.onmessage = (event) => {
+      if (wsRef.current !== ws) return;
+      setConnectionStatus("connected");
       try {
         const data: WSResponse = JSON.parse(event.data);
 
@@ -266,6 +345,7 @@ export function useWebSocket() {
           };
           addMessage(stepMsg);
         } else if (data.type === "final") {
+          clearResponseTimeout();
           setAgentBusy(false);
           onFinalAnswerRef.current(data.content);
 
@@ -291,6 +371,7 @@ export function useWebSocket() {
             }
           });
         } else if (data.type === "error") {
+          clearResponseTimeout();
           setAgentBusy(false);
 
           const errorMsg: ChatMessage = {
@@ -302,6 +383,7 @@ export function useWebSocket() {
           };
           addMessage(errorMsg);
         } else if (data.type === "approval_required") {
+          clearResponseTimeout();
           setAgentBusy(false);
 
           const approvalMsg: ChatMessage = {
@@ -317,6 +399,7 @@ export function useWebSocket() {
           };
           addMessage(approvalMsg);
         } else if (data.type === "clarification_required") {
+          clearResponseTimeout();
           setAgentBusy(false);
 
           addMessage(buildClarificationMessage(data, data.session_id));
@@ -353,19 +436,38 @@ export function useWebSocket() {
     };
 
     ws.onclose = () => {
+      if (wsRef.current !== ws) return;
+      clearResponseTimeout();
       setAgentBusy(false);
+      if (connectTimeoutRef.current) {
+        clearTimeout(connectTimeoutRef.current);
+        connectTimeoutRef.current = null;
+      }
+      if (useChatStore.getState().connectionStatus === "connecting") {
+        setConnectionStatus("disconnected");
+      }
       setConnectionStatus("disconnected");
+      wsRef.current = null;
       if (pingRef.current) clearInterval(pingRef.current);
       reconnectRef.current = setTimeout(connect, backoffRef.current);
       backoffRef.current = Math.min(backoffRef.current * 2, WS_BACKOFF_MAX_MS);
     };
 
     ws.onerror = () => {
+      if (wsRef.current !== ws) return;
+      clearResponseTimeout();
       setAgentBusy(false);
+      if (connectTimeoutRef.current) {
+        clearTimeout(connectTimeoutRef.current);
+        connectTimeoutRef.current = null;
+      }
+      if (useChatStore.getState().connectionStatus === "connecting") {
+        setConnectionStatus("error");
+      }
       setConnectionStatus("error");
       ws.close();
     };
-  }, [addMessage, markSessionContinuity, setSessionId, setConnectionStatus, setAgentBusy, setAmbientState, setChatPanelOpen]);
+  }, [addMessage, clearResponseTimeout, markSessionContinuity, setSessionId, setConnectionStatus, setAgentBusy, setAmbientState, setChatPanelOpen]);
 
   const skipOnboarding = useCallback(() => {
     if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
@@ -376,6 +478,9 @@ export function useWebSocket() {
   const sendMessage = useCallback(
     async (message: string) => {
       const sessionId = useChatStore.getState().sessionId;
+      if (useChatStore.getState().connectionStatus !== "connected") {
+        return sendRestMessage(message, sessionId);
+      }
       if (sendSocketMessage(message, sessionId, true)) {
         return true;
       }
@@ -389,7 +494,7 @@ export function useWebSocket() {
     const handleApprovalResume = (payload: { sessionId?: string | null; message?: string }) => {
       if (!payload?.message) return;
       const fallbackSessionId = useChatStore.getState().sessionId;
-      const ok = sendSocketMessage(
+      const ok = sendSocketMessageRef.current(
         payload.message,
         payload.sessionId ?? fallbackSessionId,
         false,
@@ -409,9 +514,13 @@ export function useWebSocket() {
       appEventBus.off("approval-resume", handleApprovalResume);
       if (pingRef.current) clearInterval(pingRef.current);
       if (reconnectRef.current) clearTimeout(reconnectRef.current);
-      wsRef.current?.close();
+      if (connectTimeoutRef.current) clearTimeout(connectTimeoutRef.current);
+      clearResponseTimeout();
+      const ws = wsRef.current;
+      wsRef.current = null;
+      ws?.close();
     };
-  }, [connect, sendSocketMessage]);
+  }, [connect]);
 
   return { sendMessage, skipOnboarding };
 }


### PR DESCRIPTION
Closes #617

## Summary
- route codex-local chat and WebSocket turns through the local Codex CLI with fail-closed status, audit redaction, and bounded interactive timeouts
- make local Codex read-only by default; workspace-write now requires explicit CODEX_LOCAL_ALLOW_WORKSPACE_WRITE=true and is not used by chat
- prevent runtime-status probes from falsely driving the cockpit connected/linking labels, preserve direct chat fallback, and keep frontend dev defaults pointed at the local backend
- keep sync LLM runtime from blocking an active event loop on local Codex; it fails fast so fallbacks can proceed

## Team / Review
- Lead coordinated the batch and verification.
- Critic pass 1 found blockers around workspace-write permissions, timeout cleanup, sync event-loop blocking, false linked UI state, and stale env docs.
- Fixes were applied, then Critic pass 2 reported no material blockers.

## Validation
- backend/.venv/bin/pytest backend/tests/test_local_codex_operator.py backend/tests/test_llm_runtime.py backend/tests/test_app.py::test_runtime_status_exposes_release_and_model backend/tests/test_app.py::test_runtime_status_reports_local_codex_when_selected -q (109 passed)
- npm test -- --run src/hooks/useWebSocket.test.ts src/components/cockpit/CockpitView.test.tsx (82 passed)

## Critic Disposition
- P1 sync runtime event-loop block: accepted and fixed by fail-fast behavior inside an active loop.
- P1 stale env examples: accepted and fixed in dev/prod examples.
- P2 missing UI regression: accepted and covered in CockpitView tests.