### PR TITLE
Refresh public docs for v2026.4.11

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,13 +43,13 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 ## Installation
 
 ```bash
-yarn
+npm ci
 ```
 
 ## Local Development
 
 ```bash
-yarn start
+npm run start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -57,23 +57,30 @@ This command starts a local development server and opens up a browser window. Mo
 ## Build
 
 ```bash
-yarn build
+npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
 ## Deployment
 
-Using SSH:
+The public docs site deploys through GitHub Pages Actions, not the legacy
+`gh-pages` branch flow.
+
+Normal docs changes still land through a PR to `develop`. The public site is
+published when `develop` is explicitly promoted to `main` with `docs/**`
+changes. The workflow is `.github/workflows/deploy-docs.yml` and runs:
 
 ```bash
-USE_SSH=true yarn deploy
+cd docs
+npm ci
+npm run build
 ```
 
-Not using SSH:
+The generated artifact in `docs/build` is uploaded with
+`actions/upload-pages-artifact` and deployed with `actions/deploy-pages` to the
+`github-pages` environment at `https://docs.seraph.quest`.
 
-```bash
-GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+Do not use direct `docusaurus deploy` or `gh-pages` branch publication for this
+repo. If a docs-only publication is needed outside the normal `develop` to
+`main` promotion, use the workflow dispatch on `Deploy Docs`.

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -20,6 +20,7 @@ Use these for current truth:
 
 - `docs/implementation/00-master-roadmap.md`
 - `docs/implementation/STATUS.md`
+- `docs/implementation/12-current-app-guide.md`
 - `docs/research/00-synthesis.md`
 
-Use this archive only when you need historical context or to recover an older design decision from git history.
+Use this archive only when you need historical context or to recover an older design decision from git history. Many pages in this route intentionally preserve older wording and may contradict the current cockpit-first app.

--- a/docs/implementation/00-master-roadmap.md
+++ b/docs/implementation/00-master-roadmap.md
@@ -43,6 +43,8 @@ When these docs are updated on an open feature branch, they describe the intende
 ## Current Status
 
 Read this roadmap together with [Development Status](./STATUS.md).
+For a shorter reader-facing overview of the current app, start with
+[Current App Guide](./12-current-app-guide.md).
 For the implementation-side mirrors of the evidence, benchmark, superiority, world-class strategy, and agent parity goal layers, also read [08. Docs Contract](./08-docs-contract.md), [09. Benchmark Status](./09-benchmark-status.md), [10. Superiority Delivery](./10-superiority-delivery.md), [11. World-Class Strategy Delivery](./11-world-class-strategy-delivery.md), and [16. Agent Parity Execution Roadmap](./16-agent-parity-execution-roadmap.md).
 
 ## M1 Capability Contract

--- a/docs/implementation/12-current-app-guide.md
+++ b/docs/implementation/12-current-app-guide.md
@@ -1,0 +1,146 @@
+---
+slug: /current-app
+title: Current App Guide
+---
+
+# Current App Guide
+
+This is the short reader-facing guide to Seraph as it exists in the current
+`v2026.4.11` era. For exhaustive shipped-state detail, use
+[Development Status](./STATUS.md). For target shape and comparative evidence,
+use the [research tree](/research).
+
+Seraph is a cockpit-first AI guardian workspace. It remembers, watches, and
+acts through a browser cockpit, a FastAPI runtime, a local observer daemon,
+workflow and tool execution, approval gates, audit trails, memory, settings,
+and governed extension surfaces. The old village and editor direction is
+archive-only and is not the active app contract.
+
+## First Run
+
+Use the managed local lifecycle script for local development:
+
+```bash
+./manage.sh -e dev local up
+```
+
+The managed dev stack starts the local backend and frontend, prints their
+ports, and keeps local paths consistent with the app settings. Use
+`./manage.sh -e dev local status` to check backend, frontend, and daemon state.
+Use `./manage.sh -e dev local down` before restarting the stack.
+
+The browser cockpit normally runs on `http://127.0.0.1:3001`, and the backend
+API normally runs on `http://127.0.0.1:8004` in the managed dev environment.
+
+## The Cockpit
+
+The cockpit is the primary interface. It is not a landing page and not a
+marketing shell. It is an operator workspace for active work:
+
+- conversation and live response state
+- guardian state, restraint reasons, and user-model evidence
+- workflow runs, branch families, recovery controls, and artifact handoff
+- approvals, audit activity, and the Activity Ledger
+- capability discovery, starter packs, runbooks, and extension governance
+- continuity, reach health, native notification state, and desktop presence
+- settings for runtime policy, daemon/screen analysis, artifact storage, and
+  connector or MCP posture
+
+The cockpit is dense by design. It should tell the operator what Seraph is
+doing, why it is doing it, what is blocked, what can be recovered, and which
+actions require approval.
+
+## Actions And Workflows
+
+Seraph can route work through native tools, workflows, skills, MCP surfaces,
+starter packs, runbooks, and managed extension contributions. Important
+execution paths are approval-aware and audit-visible.
+
+Current workflow surfaces include run history, step records, checkpoint truth,
+branch/resume controls, artifact lineage, source-run follow-through, recovery
+drafts, and workflow-family comparison. These controls are intended to make
+longer work inspectable and recoverable, not to claim crash-proof production
+workflow orchestration.
+
+## Runtime And Providers
+
+Seraph uses a provider-neutral runtime layer for remote LLM/provider routing
+and a separate local Codex operator adapter for command-backed local Codex
+execution. Provider profiles decide who thinks. Tool policy, MCP policy,
+approval policy, and execution boundaries decide what the agent may do.
+
+Supported configuration families include OpenRouter, OpenAI-compatible routes,
+remote OpenAI API routes, Anthropic/Claude-oriented routes, local Ollama, and
+the separate `codex-local` command-backed operator path. Missing credentials
+or missing local commands should fail closed with operator-visible state.
+
+## Screen Awareness And Reports
+
+The local observer daemon can capture screen context and route screen analysis
+through local Apple Vision, local Codex CLI parsing, or explicitly configured
+cloud OCR. Screen capture and analysis artifacts can be preserved locally when
+enabled in settings, so future better models can re-analyze the same evidence.
+
+End-of-day report infrastructure is part of the local guardian direction:
+screen-derived summaries, goals, activity, and analysis records can be stored
+locally and used for configured report delivery. Email delivery remains a
+configuration-sensitive integration surface; local previews and stored reports
+are the safer default while mail settings are being validated.
+
+## Memory And Guardian State
+
+Seraph has canonical local memory plus guarded external memory-provider
+augmentation. External providers can add evidence and recall, but they do not
+replace canonical guardian memory. Stale, conflicting, privacy-limited, or
+low-confidence provider evidence should be visible as such.
+
+Guardian state exposes intent, confidence, restraint, judgment risks, user-model
+evidence, and next-step guidance. The goal is useful restraint and grounded
+follow-through, not unbounded autonomy.
+
+## Presence And Reach
+
+Seraph currently centers on the browser cockpit plus a macOS observer/desktop
+presence path. The app surfaces browser WebSocket state, daemon state, screen
+analysis settings, native notification continuity, route health, and degraded
+reach reasons.
+
+Broader mobile, messaging, always-available reach, voice, and media claims stay
+bounded. Some receipts and canaries exist, but the public docs should not
+claim OpenClaw-class reach, full voice/media parity, always-available mobile
+operation, or production-ready broad channel coverage unless the claim ledger
+permits exact wording.
+
+## Extensions And Source Adapters
+
+Seraph's extension platform packages skills, workflows, runbooks, starter
+packs, MCP definitions, browser providers, messaging connectors, observer
+sources, channel adapters, node adapters, canvas outputs, and workflow runtimes
+under governed manifests.
+
+The current app includes extension lifecycle APIs, an extension studio,
+catalog/marketplace flow composition, diagnostics, compatibility metadata,
+rollback/quarantine/re-entry concepts, and source-adapter contracts for
+provider-neutral evidence and bounded authenticated source actions.
+
+## Proof And Boundaries
+
+Seraph has many deterministic benchmark, proof, and receipt surfaces, but those
+are claim boundaries, not blanket product claims. The public docs should keep
+these distinctions clear:
+
+- bounded proof is not production readiness
+- provider configurability is not provider parity
+- deterministic or recorded-live receipts are not broad outcome superiority
+- local Codex command execution is not an OpenAI API dependency
+- full parity, security superiority, solved operator control, safe autonomous
+  computer use, and broad reference-system exceedance remain blocked unless
+  the claim ledger permits exact wording
+
+## Where Truth Lives
+
+- `docs/implementation/` is shipped-state and delivery truth.
+- `docs/research/` is product thesis, target shape, and evidence logic.
+- GitHub issues, Project items, and PRs are the live execution layer.
+- `/legacy` is historical archive material and may contradict the current app.
+

--- a/docs/implementation/16-agent-parity-execution-roadmap.md
+++ b/docs/implementation/16-agent-parity-execution-roadmap.md
@@ -77,7 +77,7 @@ June 18, 2026 correction: the next parity train is feature-first. The BV-EF proo
 ## Paired Research
 
 - full goal document: [20. Seraph Agent Parity And Exceedance Goals](/research/seraph-agent-parity-and-exceedance-goals)
-- execution prompt: [17. Full Production Parity Goal Prompt](/implementation/full-production-parity-goal-prompt)
+- execution prompt: [17. Full Production Parity Goal Prompt](./17-full-production-parity-goal-prompt.md)
 - competitor truth and source discipline: [18. Agent Competition Truth Table](/research/agent-competition-truth-table)
 - claim gate: [19. Strategy Claim Ledger](/research/strategy-claim-ledger)
 - world-class strategy: [17. Seraph World-Class Strategy](/research/seraph-world-class-strategy)

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -7,6 +7,10 @@ title: Seraph Development Status
 
 Seraph is an AI guardian that remembers, watches, and acts. This page is the fastest answer to what is real on `develop` right now.
 
+For a shorter reader-facing overview of the current app, start with
+[Current App Guide](./12-current-app-guide.md). This status page remains the
+dense shipped-state record.
+
 ## Legend
 
 - `[x]` shipped on `develop`
@@ -20,6 +24,7 @@ High-risk strategic wording in this status page remains governed by [19. Strateg
 ## Current Snapshot
 
 - [x] Seraph is usable today as a real guardian workspace with a browser cockpit, memory, screen awareness, proactive behavior, and a real action layer.
+- [x] Public docs target the `v2026.4.11` app era; the published GitHub Pages site updates only after a `main` push touches `docs/**` and the Pages workflow succeeds.
 - [x] The live truth surface is now `docs/research/` plus `docs/implementation/`, while the GitHub Project, issues, and PRs carry active execution state.
 - [x] Trust Boundaries, Execution Plane, and Runtime Reliability have strong foundations on `develop`.
 - [x] The target product shape is now a power-user guardian workspace, not a village-first shell.

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "start": "docusaurus start --port 3333",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
-    "deploy": "docusaurus deploy",
+    "deploy": "echo \"Direct Docusaurus deploy is unsupported here. Merge to develop, promote develop to main, or dispatch Deploy Docs.\" && exit 1",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",

--- a/docs/sidebars.implementation.ts
+++ b/docs/sidebars.implementation.ts
@@ -8,6 +8,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'master-roadmap',
         'STATUS',
+        'current-app-guide',
       ],
     },
     {

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -3,15 +3,22 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   legacySidebar: [
     'intro',
-    'setup',
     {
       type: 'category',
-      label: 'Overview',
+      label: 'Historical Setup',
+      collapsed: true,
+      items: ['setup'],
+    },
+    {
+      type: 'category',
+      label: 'Archived Overview',
+      collapsed: true,
       items: ['overview/status-report', 'overview/roadmap'],
     },
     {
       type: 'category',
-      label: 'Plan',
+      label: 'Archived Plan',
+      collapsed: true,
       items: [
         'plan/trust-boundaries',
         'plan/execution-plane',
@@ -24,6 +31,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Archived Phases',
+      collapsed: true,
       items: [
         'development/phase-1-persistent-identity',
         'development/phase-2-capable-executor',
@@ -35,14 +43,16 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
-      label: 'Integrations',
+      label: 'Historical Integrations',
+      collapsed: true,
       items: [
         'integrations/things3-mcp',
       ],
     },
     {
       type: 'category',
-      label: 'Extensions',
+      label: 'Historical Extensions',
+      collapsed: true,
       items: [
         'extensions/overview',
         'extensions/create-a-capability-pack',
@@ -54,7 +64,8 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
-      label: 'Contributing',
+      label: 'Historical Contributing',
+      collapsed: true,
       items: [
         'contributing/git-workflow',
         'development/testing',
@@ -62,7 +73,8 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
-      label: 'Architecture',
+      label: 'Historical Architecture',
+      collapsed: true,
       items: [
         'architecture/tauri-analysis',
         'architecture/recursive-delegation-research',


### PR DESCRIPTION
Closes #630.

## Summary

- Adds a reader-facing Current App Guide for the `v2026.4.11` Seraph app era.
- Wires the guide into the implementation docs sidebar and links it from the roadmap/status surfaces.
- Marks the legacy docs route more clearly as historical archive material.
- Updates docs build/deploy instructions from stale `yarn`/direct Docusaurus deploy guidance to the repo's npm + GitHub Pages Actions flow.
- Fixes a pre-existing broken implementation-doc link caught by the Docusaurus build.

## Publication path

This PR targets `develop` first. The public GitHub Pages site is published only after the docs changes are explicitly promoted from `develop` to `main` or the Deploy Docs workflow is dispatched.

## Team / review

- Lead: docs/deploy integration and validation.
- Deployment explorer: confirmed Docusaurus app, Pages workflow, and current stale deployment state.
- Docs drift explorer: identified the current-app guide, archive warnings, and deploy-doc updates as the highest-impact refresh.
- Independent Critic/Contrarian: Laplace reviewed the committed cumulative diff after fixes and reported no material blockers.

Non-blocking critic note: one cleanup-level EOF blank-line nit in the new guide; no correctness, navigation, or publication impact.

## Validation

- `git diff --check`
- `cd docs && npm run build`
- `cd docs && npm run typecheck`

