### PR TITLE
Clean up current app guide EOF

### DIFF
--- a/docs/implementation/12-current-app-guide.md
+++ b/docs/implementation/12-current-app-guide.md
@@ -143,4 +143,3 @@ these distinctions clear:
 - `docs/research/` is product thesis, target shape, and evidence logic.
 - GitHub issues, Project items, and PRs are the live execution layer.
 - `/legacy` is historical archive material and may contradict the current app.
-


### PR DESCRIPTION
Follow-up to #631.

## Summary

- Removes the extra blank line at EOF in `docs/implementation/12-current-app-guide.md`.
- Keeps the publication diff clean for `git diff --check origin/main..HEAD`.

## Validation

- `git diff --check origin/main..HEAD`
- Docs build/typecheck passed before this whitespace-only cleanup:
  - `cd docs && npm run build`
  - `cd docs && npm run typecheck`

## Review

Independent critic review requested for the one-line cleanup before merge.

