### PR TITLE
Test screenshot folder symlink rejection

### DIFF
--- a/backend/tests/test_observer_screen_artifacts.py
+++ b/backend/tests/test_observer_screen_artifacts.py
@@ -260,6 +260,36 @@ async def test_screenshot_folder_scan_ignores_temporary_write_files(async_db, cl
 
 
 @pytest.mark.asyncio
+async def test_screenshot_folder_scan_rejects_symlink_escape(async_db, client, tmp_path):
+    root = tmp_path / "screenshots"
+    root.mkdir()
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(b"outside screenshot")
+    link = root / "linked-outside.png"
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available on this filesystem")
+
+    resp = await client.post(
+        "/api/observer/screenshot-folder/scan",
+        json={"screenshot_folder": str(root), "limit": 10},
+    )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["scanned"] == 1
+    assert payload["ingested"] == 0
+    assert payload["skipped_duplicates"] == 0
+    assert payload["rejected"] == [
+        {"image_path": str(outside.resolve()), "reason": "image is outside screenshot folder root"}
+    ]
+    async with async_db() as db:
+        result = await db.execute(select(ScreenObservation))
+        assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
 async def test_screenshot_folder_scan_rejects_broad_workspace_root(client, tmp_path, monkeypatch):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -275,7 +305,6 @@ async def test_screenshot_folder_scan_rejects_broad_workspace_root(client, tmp_p
     assert "dedicated image directory" in resp.json()["detail"]
 
 
-@pytest.mark.asyncio
 @pytest.mark.asyncio
 async def test_screenshot_folder_image_analysis_extracts_png_dimensions(async_db, client, tmp_path):
     root = tmp_path / "screenshots"


### PR DESCRIPTION
## Summary
- add screenshot-folder scan coverage for symlinks that resolve outside the configured folder
- assert the scan rejects the outside image and persists no ScreenObservation
- remove a duplicate pytest asyncio marker in the same test file

## Boundary
Seraph consumes a configured local folder of ordinary screenshot image files. This PR does not add manifests, sidecars, service callbacks, app-to-app handshakes, or Framekeeper-specific runtime behavior.

## Verification
- cd backend && UV_CACHE_DIR=/tmp/seraph-uv-cache uv run pytest tests/test_observer_screen_artifacts.py tests/test_screenshot_folder_ingest_job.py -q
- git diff --check
- GitHub Actions Tests attempt 2: frontend-tests passed; backend-tests shards 1-10 passed

## Review
- Independent Critic/Contrarian found no blocking or non-blocking findings
- Reviewer confirmed the symlink escape assertion proves no observation is persisted and no manifest/sidecar/service-connection assumptions were introduced