### PR TITLE
Harden screenshot folder public contract

### DIFF
--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, PlainTextResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlmodel import col, select
 
 from config.settings import settings
@@ -52,8 +52,9 @@ class ScreenContextRequest(BaseModel):
 
 
 class ScreenshotFolderScanRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     screenshot_folder: str | None = None
-    artifact_root: str | None = None
     limit: int = 100
 
 
@@ -491,6 +492,16 @@ def _screen_artifact_response(observation: ScreenObservation) -> dict[str, Any] 
     artifacts = _screen_capture_artifacts(observation)
     if artifacts is None:
         return None
+    artifact_links = {
+        "id": artifacts.get("id"),
+        "created_at": artifacts.get("created_at"),
+        "provider": artifacts.get("provider"),
+        "image_url": f"/api/observer/screen-artifacts/{observation.id}/image",
+        "analysis_url": f"/api/observer/screen-artifacts/{observation.id}/analysis",
+    }
+    if artifacts.get("provider") not in {"screenshot_folder", "framekeeper"}:
+        artifact_links["codex_output_url"] = f"/api/observer/screen-artifacts/{observation.id}/codex-output"
+        artifact_links["provider_output_url"] = f"/api/observer/screen-artifacts/{observation.id}/codex-output"
     return {
         "observation_id": observation.id,
         "timestamp": observation.timestamp.isoformat(),
@@ -499,15 +510,7 @@ def _screen_artifact_response(observation: ScreenObservation) -> dict[str, Any] 
         "activity": observation.activity_type,
         "project": observation.project,
         "summary": observation.summary,
-        "artifacts": {
-            "id": artifacts.get("id"),
-            "created_at": artifacts.get("created_at"),
-            "provider": artifacts.get("provider"),
-            "image_url": f"/api/observer/screen-artifacts/{observation.id}/image",
-            "codex_output_url": f"/api/observer/screen-artifacts/{observation.id}/codex-output",
-            "provider_output_url": f"/api/observer/screen-artifacts/{observation.id}/codex-output",
-            "analysis_url": f"/api/observer/screen-artifacts/{observation.id}/analysis",
-        },
+        "artifacts": artifact_links,
     }
 
 
@@ -607,7 +610,7 @@ async def scan_screenshot_folder(body: ScreenshotFolderScanRequest, request: Req
     from src.observer.screenshot_folder_source import ScreenshotFolderImageError, scan_screenshot_folder
 
     _require_local_artifact_request(request)
-    root = _screenshot_folder_path(body.screenshot_folder or body.artifact_root)
+    root = _screenshot_folder_path(body.screenshot_folder)
     try:
         result = await scan_screenshot_folder(root, limit=body.limit)
     except ScreenshotFolderImageError as exc:

--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -8,7 +8,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlmodel import select
 
 from config.settings import settings
@@ -31,14 +31,14 @@ class CaptureModeRequest(BaseModel):
 
 
 class ScreenAnalysisSettingsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     enabled: bool | None = None
     provider: str | None = None
     model: str | None = None
     preserve_captures: bool | None = None
     archive_dir: str | None = None
     screenshot_folder: str | None = None
-    framekeeper_screenshot_folder: str | None = None
-    framekeeper_artifact_root: str | None = None
     min_seconds_between_captures: int | None = None
     max_daily_captures: int | None = None
     archive_retention_days: int | None = None
@@ -267,6 +267,22 @@ def _write_screen_analysis_settings(payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
     path.chmod(0o600)
+
+
+def _normalize_screenshot_folder_for_save(configured_root: str) -> str:
+    candidate = Path(configured_root).expanduser()
+    if str(candidate) and not candidate.is_absolute():
+        raise HTTPException(status_code=422, detail="screenshot_folder must be an absolute path")
+    if ".." in candidate.parts:
+        raise HTTPException(status_code=422, detail="screenshot_folder must not contain '..' path traversal components")
+    normalized = candidate.resolve()
+    from src.observer.screenshot_folder_source import ScreenshotFolderImageError, validate_screenshot_folder_root
+
+    try:
+        validate_screenshot_folder_root(normalized)
+    except ScreenshotFolderImageError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return str(normalized)
 
 
 def _screen_artifact_summary(archive_dir: Path) -> dict[str, object]:
@@ -503,18 +519,10 @@ async def set_screen_analysis_settings(body: ScreenAnalysisSettingsRequest):
         ):
             raise HTTPException(status_code=422, detail="Screen archive directory must be private and writable")
         payload["archive_dir"] = str(archive_dir)
-    configured_screenshot_folder = body.screenshot_folder
-    if configured_screenshot_folder is None:
-        configured_screenshot_folder = (
-            body.framekeeper_screenshot_folder
-            if body.framekeeper_screenshot_folder is not None
-            else body.framekeeper_artifact_root
-        )
-    if configured_screenshot_folder is not None:
-        configured_root = configured_screenshot_folder.strip()
+    if body.screenshot_folder is not None:
+        configured_root = body.screenshot_folder.strip()
         if configured_root:
-            normalized_root = str(Path(configured_root).expanduser().resolve())
-            payload["screenshot_folder"] = normalized_root
+            payload["screenshot_folder"] = _normalize_screenshot_folder_for_save(configured_root)
             payload.pop("framekeeper_screenshot_folder", None)
             payload.pop("framekeeper_artifact_root", None)
         else:

--- a/backend/tests/test_observer_screen_artifacts.py
+++ b/backend/tests/test_observer_screen_artifacts.py
@@ -196,6 +196,10 @@ async def test_screenshot_folder_scan_persists_observation_and_serves_image(asyn
     assert list_resp.status_code == 200
     item = list_resp.json()["items"][0]
     assert item["artifacts"]["provider"] == "screenshot_folder"
+    assert item["artifacts"]["image_url"].endswith(f"/{observation.id}/image")
+    assert item["artifacts"]["analysis_url"].endswith(f"/{observation.id}/analysis")
+    assert "codex_output_url" not in item["artifacts"]
+    assert "provider_output_url" not in item["artifacts"]
 
     image_resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/image")
     assert image_resp.status_code == 200
@@ -303,6 +307,19 @@ async def test_screenshot_folder_scan_rejects_broad_workspace_root(client, tmp_p
 
     assert resp.status_code == 400
     assert "dedicated image directory" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_screenshot_folder_scan_rejects_legacy_artifact_root_request_key(client, tmp_path):
+    root = tmp_path / "screenshots"
+    root.mkdir()
+
+    resp = await client.post(
+        "/api/observer/screenshot-folder/scan",
+        json={"artifact_root": str(root), "limit": 10},
+    )
+
+    assert resp.status_code == 422
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -176,7 +176,10 @@ async def test_artifact_storage_prefers_seraph_screen_archive_env(client, tmp_pa
     preferred = tmp_path / "seraph-screen"
     fallback = tmp_path / "fallback-screen"
     monkeypatch.setenv("SERAPH_SCREEN_CAPTURE_ARCHIVE_DIR", str(preferred))
-    with patch.object(settings, "screen_capture_archive_dir", str(fallback)):
+    with (
+        patch.object(settings, "workspace_dir", str(tmp_path / "workspace")),
+        patch.object(settings, "screen_capture_archive_dir", str(fallback)),
+    ):
         resp = await client.get("/api/settings/artifact-storage")
 
     assert resp.status_code == 200
@@ -279,7 +282,7 @@ async def test_screen_analysis_settings_persist_and_drive_artifact_storage(clien
 
 
 @pytest.mark.asyncio
-async def test_screen_analysis_settings_accept_legacy_framekeeper_artifact_root(client, tmp_path):
+async def test_screen_analysis_settings_reject_public_legacy_framekeeper_artifact_root(client, tmp_path):
     with patch.object(settings, "workspace_dir", str(tmp_path / "workspace")):
         framekeeper_root = tmp_path / "legacy-framekeeper"
         resp = await client.put(
@@ -287,11 +290,68 @@ async def test_screen_analysis_settings_accept_legacy_framekeeper_artifact_root(
             json={"framekeeper_artifact_root": str(framekeeper_root)},
         )
 
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["screenshot_folder"] == str(framekeeper_root)
-        assert "framekeeper_screenshot_folder" not in data
-        assert "framekeeper_artifact_root" not in data
+        assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_screen_analysis_settings_reject_public_legacy_framekeeper_screenshot_folder(client, tmp_path):
+    with patch.object(settings, "workspace_dir", str(tmp_path / "workspace")):
+        framekeeper_root = tmp_path / "legacy-framekeeper"
+        resp = await client.put(
+            "/api/settings/screen-analysis",
+            json={"framekeeper_screenshot_folder": str(framekeeper_root)},
+        )
+
+        assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_screen_analysis_settings_migrates_legacy_local_file_without_exposing_keys(client, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    screenshot_root = tmp_path / "legacy-screenshots"
+    (workspace / "screen-analysis-settings.json").write_text(
+        json.dumps({"framekeeper_artifact_root": str(screenshot_root)}),
+        encoding="utf-8",
+    )
+
+    with patch.object(settings, "workspace_dir", str(workspace)):
+        resp = await client.get("/api/settings/screen-analysis")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["screenshot_folder"] == str(screenshot_root)
+    assert "framekeeper_screenshot_folder" not in data
+    assert "framekeeper_artifact_root" not in data
+
+
+@pytest.mark.asyncio
+async def test_screen_analysis_settings_reject_relative_screenshot_folder(client, tmp_path):
+    with patch.object(settings, "workspace_dir", str(tmp_path / "workspace")):
+        resp = await client.put(
+            "/api/settings/screen-analysis",
+            json={"screenshot_folder": "relative/screenshots"},
+        )
+
+        assert resp.status_code == 422
+        assert "absolute path" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_screen_analysis_settings_reject_broad_screenshot_folder(client, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    with (
+        patch.object(settings, "workspace_dir", str(workspace)),
+        patch("src.observer.screenshot_folder_source.settings.workspace_dir", str(workspace)),
+    ):
+        resp = await client.put(
+            "/api/settings/screen-analysis",
+            json={"screenshot_folder": str(workspace)},
+        )
+
+        assert resp.status_code == 422
+        assert "dedicated image directory" in resp.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -38,11 +38,11 @@ Seraph resolves the screenshot folder in this order:
 
 1. `SERAPH_SCREENSHOT_FOLDER`
 2. Seraph settings key `screenshot_folder`
-3. Legacy Seraph settings keys `framekeeper_screenshot_folder` or `framekeeper_artifact_root`
-4. Legacy env fallbacks `SERAPH_FRAMEKEEPER_SCREENSHOT_FOLDER` or `SERAPH_FRAMEKEEPER_ARTIFACT_ROOT`
-5. Seraph workspace default `artifacts/screenshot-folder`
+3. Seraph workspace default `artifacts/screenshot-folder`
 
 The default is a generic Seraph-owned workspace folder so unconfigured Seraph never assumes a specific screenshot producer. To consume Framekeeper output, configure Seraph with Framekeeper's screenshot folder explicitly.
+
+Older local settings may still be migrated internally, but new API requests and docs should use only `screenshot_folder`. `artifact_root` and producer-specific key names are not part of the current public contract.
 
 ## Folder Scan
 
@@ -62,6 +62,8 @@ Optional JSON body:
 ```
 
 If `screenshot_folder` is omitted, Seraph uses the configured folder. For each new image, Seraph computes SHA-256, stores a duplicate marker in observation details, persists a `ScreenObservation`, and leaves analysis and report generation inside Seraph.
+
+The request model is intentionally strict: legacy `artifact_root` or producer-specific fields are rejected instead of being treated as screenshot-folder aliases.
 
 The artifact analysis endpoint returns Seraph-owned local image analysis, including source, hash, byte size, file format, dimensions when detectable, observation id, and report readiness. This analysis is computed from the image file in Seraph.
 


### PR DESCRIPTION
## Summary
- reject public legacy screenshot-folder aliases and require the current screenshot_folder API key
- validate saved screenshot folders as absolute, non-traversing, dedicated image directories
- hide nonexistent provider-output links for screenshot-folder observations and update the implementation doc

## Boundary
Seraph consumes ordinary screenshot image files from a configured folder. Framekeeper or any other producer only writes screenshots there. There is no manifest, sidecar, handshake, or service connection in this path.

## Verification
- PYTHONPYCACHEPREFIX=/tmp/seraph-pycache python3 -m py_compile backend/src/api/settings.py backend/src/api/observer.py backend/src/observer/screenshot_folder_source.py
- git diff --check
- cd backend && UV_CACHE_DIR=/tmp/seraph-uv-cache uv run pytest tests/test_settings_api.py tests/test_observer_screen_artifacts.py tests/test_screenshot_folder_ingest_job.py tests/test_end_of_day_goal_report.py -q (48 passed)

## Review
- Explorer pass: Nash audited the Seraph and Framekeeper boundary and identified the public legacy aliases/provider-output links as the next gap.
- Critic pass: Hilbert reviewed the final diff against develop and reported no blocking findings. Residual note about dedicated framekeeper_screenshot_folder rejection coverage was addressed with an explicit test before this PR.