### PR TITLE
Add screenshot folder image facts to reports

### DIFF
--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -4,7 +4,6 @@ import json
 import logging
 import mimetypes
 import os
-import struct
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -19,6 +18,7 @@ from src.audit.runtime import log_integration_event
 from src.agent.session import session_manager
 from src.db.engine import get_session
 from src.db.models import ScreenObservation
+from src.observer.image_metadata import local_image_metadata
 from src.observer.manager import context_manager
 from src.observer.native_notification_queue import native_notification_queue
 
@@ -642,18 +642,16 @@ def _screenshot_folder_image_analysis(
     artifacts: dict[str, Any],
     observation: ScreenObservation,
 ) -> dict[str, Any]:
-    image_bytes = image_path.stat().st_size
-    dimensions = _image_dimensions(image_path)
-    file_format = image_path.suffix.lower().lstrip(".") or "unknown"
+    metadata = local_image_metadata(image_path)
     return {
         "source": "local_screenshot_folder",
         "analysis_owner": "seraph",
         "image_path": str(image_path),
         "image_sha256": artifacts.get("image_sha256"),
-        "image_bytes": image_bytes,
-        "file_format": "jpeg" if file_format == "jpg" else file_format,
-        "width": dimensions.get("width"),
-        "height": dimensions.get("height"),
+        "image_bytes": metadata.get("image_bytes"),
+        "file_format": metadata.get("file_format"),
+        "width": metadata.get("width"),
+        "height": metadata.get("height"),
         "observation_id": observation.id,
         "observation_summary": observation.summary,
         "report_ready": True,
@@ -662,52 +660,6 @@ def _screenshot_folder_image_analysis(
             "Seraph computed this local image analysis from the configured screenshot directory.",
         ],
     }
-
-
-def _image_dimensions(path: Path) -> dict[str, int | None]:
-    try:
-        with path.open("rb") as handle:
-            header = handle.read(32)
-            if header.startswith(b"\x89PNG\r\n\x1a\n") and len(header) >= 24:
-                width, height = struct.unpack(">II", header[16:24])
-                return {"width": int(width), "height": int(height)}
-            if header.startswith(b"\xff\xd8"):
-                return _jpeg_dimensions(path)
-    except OSError:
-        pass
-    return {"width": None, "height": None}
-
-
-def _jpeg_dimensions(path: Path) -> dict[str, int | None]:
-    try:
-        with path.open("rb") as handle:
-            handle.read(2)
-            while True:
-                marker_prefix = handle.read(1)
-                if marker_prefix == b"":
-                    break
-                if marker_prefix != b"\xff":
-                    continue
-                marker = handle.read(1)
-                while marker == b"\xff":
-                    marker = handle.read(1)
-                if marker in {b"\xc0", b"\xc1", b"\xc2", b"\xc3"}:
-                    segment_length = int.from_bytes(handle.read(2), "big")
-                    if segment_length < 7:
-                        break
-                    handle.read(1)
-                    height = int.from_bytes(handle.read(2), "big")
-                    width = int.from_bytes(handle.read(2), "big")
-                    return {"width": width, "height": height}
-                if marker in {b"\xd8", b"\xd9"}:
-                    continue
-                segment_length = int.from_bytes(handle.read(2), "big")
-                if segment_length < 2:
-                    break
-                handle.seek(segment_length - 2, os.SEEK_CUR)
-    except OSError:
-        pass
-    return {"width": None, "height": None}
 
 
 @router.get("/observer/daemon-status", response_model=DaemonStatusResponse)

--- a/backend/src/observer/image_metadata.py
+++ b/backend/src/observer/image_metadata.py
@@ -1,0 +1,93 @@
+"""Local image metadata helpers for Seraph-owned screenshot analysis."""
+
+from __future__ import annotations
+
+import os
+import struct
+from pathlib import Path
+from typing import Any
+
+
+def local_image_metadata(path: Path) -> dict[str, Any]:
+    """Return local image facts derived from the image file itself."""
+    image_bytes = path.stat().st_size
+    dimensions = image_dimensions(path)
+    file_format = path.suffix.lower().lstrip(".") or "unknown"
+    if file_format == "jpg":
+        file_format = "jpeg"
+    return {
+        "image_bytes": image_bytes,
+        "file_format": file_format,
+        "width": dimensions.get("width"),
+        "height": dimensions.get("height"),
+    }
+
+
+def image_dimensions(path: Path) -> dict[str, int | None]:
+    try:
+        with path.open("rb") as handle:
+            header = handle.read(32)
+            if header.startswith(b"\x89PNG\r\n\x1a\n") and len(header) >= 24:
+                width, height = struct.unpack(">II", header[16:24])
+                return {"width": int(width), "height": int(height)}
+            if header.startswith(b"\xff\xd8"):
+                return _jpeg_dimensions(path)
+    except OSError:
+        pass
+    return {"width": None, "height": None}
+
+
+def _jpeg_dimensions(path: Path) -> dict[str, int | None]:
+    try:
+        with path.open("rb") as handle:
+            handle.read(2)
+            while True:
+                marker_prefix = handle.read(1)
+                if marker_prefix == b"":
+                    break
+                if marker_prefix != b"\xff":
+                    continue
+                marker = handle.read(1)
+                while marker == b"\xff":
+                    marker = handle.read(1)
+                if marker in {b"\xc0", b"\xc1", b"\xc2", b"\xc3"}:
+                    segment_length = int.from_bytes(handle.read(2), "big")
+                    if segment_length < 7:
+                        break
+                    handle.read(1)
+                    height = int.from_bytes(handle.read(2), "big")
+                    width = int.from_bytes(handle.read(2), "big")
+                    return {"width": width, "height": height}
+                if marker in {b"\xd8", b"\xd9"}:
+                    continue
+                segment_length = int.from_bytes(handle.read(2), "big")
+                if segment_length < 2:
+                    break
+                handle.seek(segment_length - 2, os.SEEK_CUR)
+    except OSError:
+        pass
+    return {"width": None, "height": None}
+
+
+def image_metadata_label(metadata: dict[str, Any]) -> str:
+    """Format image facts for observation summaries and reports."""
+    parts: list[str] = []
+    file_format = str(metadata.get("file_format") or "").strip()
+    if file_format:
+        parts.append(file_format)
+    width = metadata.get("width")
+    height = metadata.get("height")
+    if isinstance(width, int) and isinstance(height, int) and width > 0 and height > 0:
+        parts.append(f"{width}x{height}")
+    image_bytes = metadata.get("image_bytes")
+    if isinstance(image_bytes, int) and image_bytes >= 0:
+        parts.append(_format_bytes(image_bytes))
+    return ", ".join(parts)
+
+
+def _format_bytes(value: int) -> str:
+    if value < 1024:
+        return f"{value} B"
+    if value < 1024 * 1024:
+        return f"{value / 1024:.1f} KB"
+    return f"{value / (1024 * 1024):.1f} MB"

--- a/backend/src/observer/screenshot_folder_source.py
+++ b/backend/src/observer/screenshot_folder_source.py
@@ -15,6 +15,7 @@ from config.settings import settings
 from src.audit.runtime import log_integration_event
 from src.db.engine import get_session
 from src.db.models import ScreenObservation
+from src.observer.image_metadata import image_metadata_label, local_image_metadata
 from src.observer.screen_repository import screen_observation_repo
 
 
@@ -161,6 +162,7 @@ async def _image_to_observation(image_path: Path, root: Path) -> dict[str, objec
         return None
 
     stat = resolved.stat()
+    metadata = local_image_metadata(resolved)
     captured_at = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
     capture_id = image_sha256[:16]
     details = [
@@ -176,17 +178,22 @@ async def _image_to_observation(image_path: Path, root: Path) -> dict[str, objec
                 "image_path": str(resolved),
                 "image_sha256": image_sha256,
                 "image_bytes": stat.st_size,
+                "file_format": metadata.get("file_format"),
+                "width": metadata.get("width"),
+                "height": metadata.get("height"),
             },
             sort_keys=True,
             separators=(",", ":"),
         ),
     ]
+    metadata_label = image_metadata_label(metadata)
+    summary_suffix = f" ({metadata_label})" if metadata_label else ""
     return {
         "app_name": "Screenshot Folder",
         "window_title": resolved.name,
         "activity_type": "screen",
         "project": None,
-        "summary": f"Screenshot image added from folder: {resolved.name}.",
+        "summary": f"Screenshot image added from folder: {resolved.name}{summary_suffix}.",
         "details": details,
         "blocked": False,
         "timestamp": captured_at,

--- a/backend/src/scheduler/jobs/end_of_day_goal_report.py
+++ b/backend/src/scheduler/jobs/end_of_day_goal_report.py
@@ -21,6 +21,7 @@ from config.settings import settings
 from src.audit.runtime import log_integration_event, log_scheduler_job_event
 from src.db.models import GoalStatus, MemoryEpisodeType, ScreenObservation
 from src.llm_runtime import completion_with_fallback
+from src.observer.image_metadata import image_metadata_label
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,8 @@ Use only the redacted structured inputs. Do not invent screen details.
 {project_breakdown}
 - Source mix:
 {source_breakdown}
+- Screenshot samples:
+{screenshot_samples}
 
 ## Goals
 Active goals:
@@ -275,6 +278,7 @@ async def _screen_summary_for_local_day(report_day: date, tz: ZoneInfo) -> dict[
     by_source: dict[str, int] = {}
     source_observations: dict[str, int] = {}
     details: list[str] = []
+    screenshot_samples: list[str] = []
     total_seconds = 0
     for obs in observations:
         duration = obs.duration_s or 0
@@ -290,6 +294,9 @@ async def _screen_summary_for_local_day(report_day: date, tz: ZoneInfo) -> dict[
             redacted = _redact_text(obs.summary, limit=160)
             if redacted and redacted not in details:
                 details.append(redacted)
+        screenshot_sample = _screenshot_image_sample(obs)
+        if screenshot_sample and screenshot_sample not in screenshot_samples:
+            screenshot_samples.append(screenshot_sample)
 
     return {
         "date": report_day.isoformat(),
@@ -305,6 +312,7 @@ async def _screen_summary_for_local_day(report_day: date, tz: ZoneInfo) -> dict[
             sorted(source_observations.items(), key=lambda item: (-item[1], item[0]))
         ),
         "redacted_samples": details[:8],
+        "screenshot_samples": screenshot_samples[:8],
     }
 
 
@@ -330,6 +338,41 @@ def _observation_source(observation: ScreenObservation) -> str:
     if observation.app_name == "Framekeeper":
         return "framekeeper"
     return "observer_daemon"
+
+
+def _screenshot_image_sample(observation: ScreenObservation) -> str | None:
+    if not observation.details_json:
+        return None
+    try:
+        details = json.loads(observation.details_json)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(details, list):
+        return None
+    for item in details:
+        if not (isinstance(item, str) and item.startswith("capture_artifacts:")):
+            continue
+        try:
+            artifacts = json.loads(item.removeprefix("capture_artifacts:"))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(artifacts, dict):
+            continue
+        provider = str(artifacts.get("provider") or artifacts.get("source") or "").strip()
+        if provider not in {"screenshot_folder", "framekeeper"}:
+            continue
+        image_name = Path(str(artifacts.get("image_path") or observation.window_title or "screenshot")).name
+        metadata_label = image_metadata_label(
+            {
+                "file_format": artifacts.get("file_format"),
+                "width": artifacts.get("width"),
+                "height": artifacts.get("height"),
+                "image_bytes": artifacts.get("image_bytes"),
+            }
+        )
+        label = f"{image_name} ({metadata_label})" if metadata_label else image_name
+        return _redact_text(label, limit=160)
+    return None
 
 
 async def _goals_for_report(report_day: date) -> tuple[list[Any], list[Any]]:
@@ -414,6 +457,12 @@ def _format_source_mix(
     return "\n".join(lines)
 
 
+def _format_samples(samples: list[str], *, empty: str) -> str:
+    if not samples:
+        return empty
+    return "\n".join(f"- {_redact_text(sample, limit=160)}" for sample in samples[:8])
+
+
 def _format_goals(goals: list[Any]) -> str:
     if not goals:
         return "- None"
@@ -447,6 +496,10 @@ def _deterministic_report_body(
         summary.get("source_observations", {}),
         empty="- No observation sources detected",
     )
+    screenshot_samples = _format_samples(
+        summary.get("screenshot_samples", []),
+        empty="- No screenshot-folder images analyzed",
+    )
     aligned = [item for item in alignment if item["status"] == "aligned"]
     unclear = [item for item in alignment if item["status"] != "aligned"]
     completed = _format_goals(completed_goals)
@@ -476,6 +529,9 @@ def _deterministic_report_body(
             "",
             "Source mix:",
             sources,
+            "",
+            "Screenshot samples:",
+            screenshot_samples,
             "",
             "Goals vs day:",
             f"- Aligned goals: {len(aligned)}",
@@ -510,6 +566,10 @@ async def build_end_of_day_goal_report(report_day: date | None = None) -> dict[s
                 summary.get("by_source", {}),
                 summary.get("source_observations", {}),
                 empty="- No observation sources detected",
+            ),
+            screenshot_samples=_format_samples(
+                summary.get("screenshot_samples", []),
+                empty="- No screenshot-folder images analyzed",
             ),
             active_goals=_format_goals(active_goals),
             completed_goals=_format_goals(completed_goals),

--- a/backend/tests/test_end_of_day_goal_report.py
+++ b/backend/tests/test_end_of_day_goal_report.py
@@ -93,6 +93,10 @@ async def test_build_report_counts_screenshot_folder_observation_source(async_db
                 "source": "local_image_directory",
                 "image_path": "/tmp/framekeeper/capture.png",
                 "image_sha256": "abc123",
+                "image_bytes": 67,
+                "file_format": "png",
+                "width": 1,
+                "height": 1,
             },
             sort_keys=True,
         )
@@ -119,8 +123,12 @@ async def test_build_report_counts_screenshot_folder_observation_source(async_db
     assert report["summary"]["total_observations"] == 1
     assert report["summary"]["by_source"] == {"screenshot_folder": 0}
     assert report["summary"]["source_observations"] == {"screenshot_folder": 1}
+    assert report["summary"]["screenshot_samples"] == ["capture.png (png, 1x1, 67 B)"]
     assert "Source mix:" in report["body"]
     assert "- screenshot_folder: 1 observation, 0m" in report["body"]
+    assert "Screenshot samples:" in report["body"]
+    assert "- capture.png (png, 1x1, 67 B)" in report["body"]
+    assert "/tmp/framekeeper" not in report["body"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_observer_screen_artifacts.py
+++ b/backend/tests/test_observer_screen_artifacts.py
@@ -174,7 +174,7 @@ async def test_screenshot_folder_scan_persists_observation_and_serves_image(asyn
         observation = result.scalar_one()
 
     assert observation.app_name == "Screenshot Folder"
-    assert observation.summary == "Screenshot image added from folder: capture-valid.png."
+    assert observation.summary == "Screenshot image added from folder: capture-valid.png (png, 9 B)."
     stored_details = json.loads(observation.details_json or "[]")
     image_sha256 = hashlib.sha256(image.read_bytes()).hexdigest()
     assert f"screenshot_folder_image_sha256:{image_sha256}" in stored_details
@@ -189,6 +189,10 @@ async def test_screenshot_folder_scan_persists_observation_and_serves_image(asyn
     assert "artifact_root" not in artifact_details
     assert artifact_details["image_path"] == str(image.resolve())
     assert artifact_details["image_sha256"] == image_sha256
+    assert artifact_details["file_format"] == "png"
+    assert artifact_details["image_bytes"] == len(image.read_bytes())
+    assert artifact_details["width"] is None
+    assert artifact_details["height"] is None
     assert "analysis_path" not in artifact_details
     assert "provider_output_path" not in artifact_details
 
@@ -213,6 +217,7 @@ async def test_screenshot_folder_scan_persists_observation_and_serves_image(asyn
     assert analysis["analysis"]["source"] == "local_screenshot_folder"
     assert analysis["analysis"]["image_sha256"] == image_sha256
     assert analysis["analysis"]["image_bytes"] == len(image.read_bytes())
+    assert analysis["analysis"]["file_format"] == "png"
     assert analysis["analysis"]["report_ready"] is True
     assert analysis["image_sha256"] == image_sha256
 
@@ -344,6 +349,16 @@ async def test_screenshot_folder_image_analysis_extracts_png_dimensions(async_db
     assert analysis["width"] == 1
     assert analysis["height"] == 1
     assert analysis["image_path"] == str(image.resolve())
+    stored_details = json.loads(observation.details_json or "[]")
+    artifact_details = [
+        json.loads(item.removeprefix("capture_artifacts:"))
+        for item in stored_details
+        if isinstance(item, str) and item.startswith("capture_artifacts:")
+    ][0]
+    assert artifact_details["file_format"] == "png"
+    assert artifact_details["width"] == 1
+    assert artifact_details["height"] == 1
+    assert observation.summary == "Screenshot image added from folder: capture-real.png (png, 1x1, 67 B)."
 
 
 @pytest.mark.asyncio

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -61,13 +61,13 @@ Optional JSON body:
 }
 ```
 
-If `screenshot_folder` is omitted, Seraph uses the configured folder. For each new image, Seraph computes SHA-256, stores a duplicate marker in observation details, persists a `ScreenObservation`, and leaves analysis and report generation inside Seraph.
+If `screenshot_folder` is omitted, Seraph uses the configured folder. For each new image, Seraph computes SHA-256 plus local image facts such as byte size, file format, and dimensions when detectable. Seraph stores those Seraph-owned facts in observation details, persists a `ScreenObservation`, and leaves analysis and report generation inside Seraph.
 
 The request model is intentionally strict: legacy `artifact_root` or producer-specific fields are rejected instead of being treated as screenshot-folder aliases.
 
 The artifact analysis endpoint returns Seraph-owned local image analysis, including source, hash, byte size, file format, dimensions when detectable, observation id, and report readiness. This analysis is computed from the image file in Seraph.
 
-End-of-day reports consume screenshot-folder `ScreenObservation` rows through the same report builder as other screen observations. Seraph records the observation source as `screenshot_folder` from its own stored capture-artifact details.
+End-of-day reports consume screenshot-folder `ScreenObservation` rows through the same report builder as other screen observations. Seraph records the observation source as `screenshot_folder` from its own stored capture-artifact details and includes report-safe screenshot samples using filenames, format, dimensions, and size. Reports do not rely on Framekeeper manifests, sidecars, or service metadata.
 
 Configure a narrow, trusted screenshot directory. Seraph rejects obvious broad roots such as the filesystem root, home folder, Desktop, Downloads, and Seraph workspace root.
 


### PR DESCRIPTION
## Summary
- add a Seraph-owned local image metadata helper for screenshot-folder images
- persist image format, byte size, and dimensions when detectable in screenshot-folder observation details
- include report-safe screenshot samples in end-of-day reports without exposing raw image paths
- update the screenshot-folder source doc to describe local image facts and report samples

## Boundary
Framekeeper or any other producer still only writes ordinary screenshot image files. Seraph reads those images from the configured folder and computes its own local facts. This PR does not add manifests, sidecars, service handshakes, or producer-supplied analysis data.

## Verification
- PYTHONPYCACHEPREFIX=/tmp/seraph-pycache python3 -m py_compile backend/src/observer/image_metadata.py backend/src/observer/screenshot_folder_source.py backend/src/api/observer.py backend/src/scheduler/jobs/end_of_day_goal_report.py
- git diff --check
- cd backend && UV_CACHE_DIR=/tmp/seraph-uv-cache uv run pytest tests/test_observer_screen_artifacts.py tests/test_end_of_day_goal_report.py tests/test_screenshot_folder_ingest_job.py -q (26 passed)
- cd backend && UV_CACHE_DIR=/tmp/seraph-uv-cache uv run pytest tests/test_settings_api.py tests/test_observer_screen_artifacts.py tests/test_screenshot_folder_ingest_job.py tests/test_end_of_day_goal_report.py -q (48 passed)

## Review
- Lead critic pass: checked the diff for privacy and boundary regressions. Report samples use basename plus Seraph-computed image facts; tests assert raw paths are not present in report bodies. No manifest, sidecar, or service connection dependency was added.
- Limitation: independent subagent review was not spawned because the available multi-agent tool instructions restrict spawning unless explicitly requested.