### PR TITLE
Remove Framekeeper-specific screenshot folder coupling

### DIFF
--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -462,8 +462,8 @@ def _artifact_path(raw_path: str | None, *, allowed_roots: list[Path]) -> Path:
 
 def _artifact_allowed_roots(artifacts: dict[str, Any]) -> list[Path]:
     roots = [_screen_artifact_root()]
-    if artifacts.get("provider") in {"screenshot_folder", "framekeeper"}:
-        configured_root = str(artifacts.get("screenshot_folder") or artifacts.get("artifact_root") or "").strip()
+    if artifacts.get("provider") == "screenshot_folder":
+        configured_root = str(artifacts.get("screenshot_folder") or "").strip()
         if configured_root:
             roots.append(Path(configured_root).expanduser().resolve())
     return roots
@@ -484,7 +484,11 @@ def _screen_capture_artifacts(observation: ScreenObservation) -> dict[str, Any] 
                 payload = json.loads(item.removeprefix("capture_artifacts:"))
             except json.JSONDecodeError:
                 return None
-            return payload if isinstance(payload, dict) else None
+            if not isinstance(payload, dict):
+                return None
+            if str(payload.get("provider") or "").strip() == "framekeeper":
+                return None
+            return payload
     return None
 
 
@@ -499,7 +503,7 @@ def _screen_artifact_response(observation: ScreenObservation) -> dict[str, Any] 
         "image_url": f"/api/observer/screen-artifacts/{observation.id}/image",
         "analysis_url": f"/api/observer/screen-artifacts/{observation.id}/analysis",
     }
-    if artifacts.get("provider") not in {"screenshot_folder", "framekeeper"}:
+    if artifacts.get("provider") != "screenshot_folder":
         artifact_links["codex_output_url"] = f"/api/observer/screen-artifacts/{observation.id}/codex-output"
         artifact_links["provider_output_url"] = f"/api/observer/screen-artifacts/{observation.id}/codex-output"
     return {
@@ -566,7 +570,7 @@ async def get_screen_artifact_codex_output(observation_id: str, request: Request
     _require_local_artifact_request(request)
     observation = await _screen_artifact_observation(observation_id)
     artifacts = _screen_capture_artifacts(observation) or {}
-    if artifacts.get("provider") in {"screenshot_folder", "framekeeper"} and not (
+    if artifacts.get("provider") == "screenshot_folder" and not (
         artifacts.get("codex_output_path") or artifacts.get("provider_output_path")
     ):
         return PlainTextResponse(
@@ -585,7 +589,7 @@ async def get_screen_artifact_analysis(observation_id: str, request: Request) ->
     _require_local_artifact_request(request)
     observation = await _screen_artifact_observation(observation_id)
     artifacts = _screen_capture_artifacts(observation) or {}
-    if artifacts.get("provider") in {"screenshot_folder", "framekeeper"} and not artifacts.get("analysis_path"):
+    if artifacts.get("provider") == "screenshot_folder" and not artifacts.get("analysis_path"):
         image_path = _artifact_path(
             str(artifacts.get("image_path") or ""),
             allowed_roots=_artifact_allowed_roots(artifacts),

--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -70,8 +70,6 @@ _VALID_MCP_POLICY_MODES = set(MCP_POLICY_MODES)
 _VALID_APPROVAL_MODES = {"off", "high_risk"}
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _SCREENSHOT_FOLDER_ENV = "SERAPH_SCREENSHOT_FOLDER"
-_LEGACY_FRAMEKEEPER_SCREENSHOT_FOLDER_ENV = "SERAPH_FRAMEKEEPER_SCREENSHOT_FOLDER"
-_LEGACY_FRAMEKEEPER_ARTIFACT_ROOT_ENV = "SERAPH_FRAMEKEEPER_ARTIFACT_ROOT"
 
 
 def _env_enabled(name: str, default: bool = False) -> bool:
@@ -99,18 +97,9 @@ def _screenshot_folder() -> tuple[Path, str]:
     if configured:
         return Path(configured).expanduser().resolve(), _SCREENSHOT_FOLDER_ENV
     payload = _read_screen_analysis_settings()
-    settings_configured = str(
-        payload.get("screenshot_folder")
-        or payload.get("framekeeper_screenshot_folder")
-        or payload.get("framekeeper_artifact_root")
-        or ""
-    ).strip()
+    settings_configured = str(payload.get("screenshot_folder") or "").strip()
     if settings_configured:
         return Path(settings_configured).expanduser().resolve(), "screen-analysis-settings"
-    for env_name in (_LEGACY_FRAMEKEEPER_SCREENSHOT_FOLDER_ENV, _LEGACY_FRAMEKEEPER_ARTIFACT_ROOT_ENV):
-        configured = os.environ.get(env_name, "").strip()
-        if configured:
-            return Path(configured).expanduser().resolve(), env_name
     return Path(settings.workspace_dir).expanduser().resolve() / "artifacts" / "screenshot-folder", "default"
 
 
@@ -218,8 +207,6 @@ def _read_screen_analysis_settings() -> dict[str, object]:
                 "archive_retention_days",
                 "archive_max_mb",
                 "screenshot_folder",
-                "framekeeper_screenshot_folder",
-                "framekeeper_artifact_root",
             ):
                 if key in loaded:
                     payload[key] = loaded[key]
@@ -231,21 +218,12 @@ def _read_screen_analysis_settings() -> dict[str, object]:
     payload["preserve_captures"] = bool(payload.get("preserve_captures"))
     payload["model"] = str(payload.get("model") or "")
     payload["archive_dir"] = str(Path(str(payload.get("archive_dir") or "")).expanduser().resolve())
-    screenshot_folder = str(
-        payload.get("screenshot_folder")
-        or payload.get("framekeeper_screenshot_folder")
-        or payload.get("framekeeper_artifact_root")
-        or ""
-    ).strip()
+    screenshot_folder = str(payload.get("screenshot_folder") or "").strip()
     if screenshot_folder:
         normalized_folder = str(Path(screenshot_folder).expanduser().resolve())
         payload["screenshot_folder"] = normalized_folder
-        payload.pop("framekeeper_screenshot_folder", None)
-        payload.pop("framekeeper_artifact_root", None)
     else:
         payload.pop("screenshot_folder", None)
-        payload.pop("framekeeper_screenshot_folder", None)
-        payload.pop("framekeeper_artifact_root", None)
     for key in (
         "min_seconds_between_captures",
         "max_daily_captures",
@@ -523,12 +501,8 @@ async def set_screen_analysis_settings(body: ScreenAnalysisSettingsRequest):
         configured_root = body.screenshot_folder.strip()
         if configured_root:
             payload["screenshot_folder"] = _normalize_screenshot_folder_for_save(configured_root)
-            payload.pop("framekeeper_screenshot_folder", None)
-            payload.pop("framekeeper_artifact_root", None)
         else:
             payload.pop("screenshot_folder", None)
-            payload.pop("framekeeper_screenshot_folder", None)
-            payload.pop("framekeeper_artifact_root", None)
     for field_name in (
         "min_seconds_between_captures",
         "max_daily_captures",

--- a/backend/src/observer/screenshot_folder_source.py
+++ b/backend/src/observer/screenshot_folder_source.py
@@ -34,10 +34,7 @@ class ScreenshotFolderScanResult:
 SUPPORTED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg"}
 SCREENSHOT_FOLDER_PROVIDER = "screenshot_folder"
 SCREENSHOT_FOLDER_HASH_PREFIX = "screenshot_folder_image_sha256"
-LEGACY_FRAMEKEEPER_HASH_PREFIX = "framekeeper_image_sha256"
 SCREENSHOT_FOLDER_ENV = "SERAPH_SCREENSHOT_FOLDER"
-LEGACY_FRAMEKEEPER_SCREENSHOT_FOLDER_ENV = "SERAPH_FRAMEKEEPER_SCREENSHOT_FOLDER"
-LEGACY_FRAMEKEEPER_ARTIFACT_ROOT_ENV = "SERAPH_FRAMEKEEPER_ARTIFACT_ROOT"
 
 
 def resolve_screenshot_folder(configured: str | None = None) -> Path:
@@ -54,18 +51,9 @@ def resolve_screenshot_folder(configured: str | None = None) -> Path:
         except (OSError, json.JSONDecodeError):
             payload = {}
         if isinstance(payload, dict):
-            settings_root = str(
-                payload.get("screenshot_folder")
-                or payload.get("framekeeper_screenshot_folder")
-                or payload.get("framekeeper_artifact_root")
-                or ""
-            ).strip()
+            settings_root = str(payload.get("screenshot_folder") or "").strip()
             if settings_root:
                 return Path(settings_root).expanduser().resolve()
-    for legacy_env in (LEGACY_FRAMEKEEPER_SCREENSHOT_FOLDER_ENV, LEGACY_FRAMEKEEPER_ARTIFACT_ROOT_ENV):
-        env_root = os.environ.get(legacy_env, "").strip()
-        if env_root:
-            return Path(env_root).expanduser().resolve()
     return Path(settings.workspace_dir).expanduser().resolve() / "artifacts" / "screenshot-folder"
 
 
@@ -201,19 +189,15 @@ async def _image_to_observation(image_path: Path, root: Path) -> dict[str, objec
 
 
 async def _image_already_ingested(image_sha256: str) -> bool:
-    markers = [
-        f"{SCREENSHOT_FOLDER_HASH_PREFIX}:{image_sha256}",
-        f"{LEGACY_FRAMEKEEPER_HASH_PREFIX}:{image_sha256}",
-    ]
+    marker = f"{SCREENSHOT_FOLDER_HASH_PREFIX}:{image_sha256}"
     async with get_session() as db:
-        for marker in markers:
-            result = await db.execute(
-                select(ScreenObservation)
-                .where(col(ScreenObservation.details_json).contains(marker))
-                .limit(1)
-            )
-            if result.scalar_one_or_none() is not None:
-                return True
+        result = await db.execute(
+            select(ScreenObservation)
+            .where(col(ScreenObservation.details_json).contains(marker))
+            .limit(1)
+        )
+        if result.scalar_one_or_none() is not None:
+            return True
     return False
 
 

--- a/backend/src/scheduler/jobs/end_of_day_goal_report.py
+++ b/backend/src/scheduler/jobs/end_of_day_goal_report.py
@@ -331,12 +331,10 @@ def _observation_source(observation: ScreenObservation) -> str:
                         continue
                     if isinstance(artifacts, dict):
                         provider = str(artifacts.get("provider") or artifacts.get("source") or "").strip()
-                        if provider:
+                        if provider and provider != "framekeeper":
                             return provider
     if observation.app_name == "Screenshot Folder":
         return "screenshot_folder"
-    if observation.app_name == "Framekeeper":
-        return "framekeeper"
     return "observer_daemon"
 
 
@@ -359,7 +357,7 @@ def _screenshot_image_sample(observation: ScreenObservation) -> str | None:
         if not isinstance(artifacts, dict):
             continue
         provider = str(artifacts.get("provider") or artifacts.get("source") or "").strip()
-        if provider not in {"screenshot_folder", "framekeeper"}:
+        if provider != "screenshot_folder":
             continue
         image_name = Path(str(artifacts.get("image_path") or observation.window_title or "screenshot")).name
         metadata_label = image_metadata_label(

--- a/backend/tests/test_end_of_day_goal_report.py
+++ b/backend/tests/test_end_of_day_goal_report.py
@@ -132,6 +132,46 @@ async def test_build_report_counts_screenshot_folder_observation_source(async_db
 
 
 @pytest.mark.asyncio
+async def test_build_report_does_not_treat_framekeeper_as_source(async_db):
+    from src.db.models import ScreenObservation
+    from src.scheduler.jobs.end_of_day_goal_report import build_end_of_day_goal_report
+
+    details = [
+        "capture_artifacts:"
+        + json.dumps(
+            {
+                "provider": "framekeeper",
+                "image_path": "/tmp/screenshots/capture.png",
+                "image_bytes": 67,
+                "file_format": "png",
+            },
+            sort_keys=True,
+        )
+    ]
+    async with async_db() as db:
+        db.add(
+            ScreenObservation(
+                timestamp=datetime(2026, 6, 20, 12, 0, tzinfo=timezone.utc),
+                app_name="Framekeeper",
+                window_title="capture.png",
+                activity_type="screen",
+                summary="Legacy producer-specific observation.",
+                details_json=json.dumps(details),
+            )
+        )
+
+    with patch.object(settings, "user_timezone", "UTC"), patch.object(
+        settings, "end_of_day_report_llm_enabled", False
+    ):
+        report = await build_end_of_day_goal_report(date(2026, 6, 20))
+
+    assert report["summary"]["source_observations"] == {"observer_daemon": 1}
+    assert "framekeeper" not in report["summary"]["source_observations"]
+    assert report["summary"]["screenshot_samples"] == []
+    assert "framekeeper" not in report["body"].lower()
+
+
+@pytest.mark.asyncio
 async def test_run_report_stores_episode_and_keeps_email_preview_only(async_db):
     from src.db.models import MemoryEpisode
     from sqlmodel import select

--- a/backend/tests/test_observer_screen_artifacts.py
+++ b/backend/tests/test_observer_screen_artifacts.py
@@ -121,6 +121,36 @@ async def test_screen_artifact_endpoints_are_localhost_only(app, async_db, tmp_p
 
 
 @pytest.mark.asyncio
+async def test_screen_artifacts_ignore_legacy_framekeeper_provider(async_db, client, tmp_path, monkeypatch):
+    monkeypatch.setattr("src.api.observer.settings.screen_capture_archive_dir", str(tmp_path))
+    image_path = tmp_path / "capture.png"
+    image_path.write_bytes(b"png bytes")
+    artifacts = {
+        "id": "legacy-framekeeper-artifact",
+        "provider": "framekeeper",
+        "screenshot_folder": str(tmp_path),
+        "image_path": str(image_path),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    async with async_db() as db:
+        observation = ScreenObservation(
+            app_name="Framekeeper",
+            window_title="capture.png",
+            activity_type="screen",
+            summary="Legacy producer-specific artifact",
+            details_json=json.dumps(["capture_artifacts:" + json.dumps(artifacts)]),
+        )
+        db.add(observation)
+
+    list_resp = await client.get("/api/observer/screen-artifacts")
+    assert list_resp.status_code == 200
+    assert list_resp.json()["items"] == []
+
+    image_resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/image")
+    assert image_resp.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_screen_artifact_root_prefers_seraph_archive_env(tmp_path, monkeypatch):
     from src.api.observer import _screen_artifact_root
 

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -222,8 +222,6 @@ async def test_artifact_storage_exposes_screenshot_folder_status(client, tmp_pat
 async def test_artifact_storage_defaults_to_seraph_owned_screenshot_folder(client, tmp_path, monkeypatch):
     workspace = tmp_path / "workspace"
     monkeypatch.delenv("SERAPH_SCREENSHOT_FOLDER", raising=False)
-    monkeypatch.delenv("SERAPH_FRAMEKEEPER_SCREENSHOT_FOLDER", raising=False)
-    monkeypatch.delenv("SERAPH_FRAMEKEEPER_ARTIFACT_ROOT", raising=False)
     with patch.object(settings, "workspace_dir", str(workspace)):
         resp = await client.get("/api/settings/artifact-storage")
 
@@ -306,7 +304,7 @@ async def test_screen_analysis_settings_reject_public_legacy_framekeeper_screens
 
 
 @pytest.mark.asyncio
-async def test_screen_analysis_settings_migrates_legacy_local_file_without_exposing_keys(client, tmp_path):
+async def test_screen_analysis_settings_ignores_legacy_framekeeper_local_file_keys(client, tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     screenshot_root = tmp_path / "legacy-screenshots"
@@ -320,9 +318,26 @@ async def test_screen_analysis_settings_migrates_legacy_local_file_without_expos
 
     assert resp.status_code == 200
     data = resp.json()
-    assert data["screenshot_folder"] == str(screenshot_root)
+    assert "screenshot_folder" not in data
     assert "framekeeper_screenshot_folder" not in data
     assert "framekeeper_artifact_root" not in data
+
+
+@pytest.mark.asyncio
+async def test_artifact_storage_ignores_legacy_framekeeper_env_keys(client, tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    legacy_root = tmp_path / "legacy-screenshots"
+    monkeypatch.delenv("SERAPH_SCREENSHOT_FOLDER", raising=False)
+    monkeypatch.setenv("SERAPH_FRAMEKEEPER_SCREENSHOT_FOLDER", str(legacy_root))
+    monkeypatch.setenv("SERAPH_FRAMEKEEPER_ARTIFACT_ROOT", str(legacy_root))
+
+    with patch.object(settings, "workspace_dir", str(workspace)):
+        resp = await client.get("/api/settings/artifact-storage")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["screenshot_folder"]["path"] == str(workspace / "artifacts" / "screenshot-folder")
+    assert data["screenshot_folder"]["path_source"] == "default"
 
 
 @pytest.mark.asyncio

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -42,7 +42,7 @@ Seraph resolves the screenshot folder in this order:
 
 The default is a generic Seraph-owned workspace folder so unconfigured Seraph never assumes a specific screenshot producer. To consume Framekeeper output, configure Seraph with Framekeeper's screenshot folder explicitly.
 
-Older local settings may still be migrated internally, but new API requests and docs should use only `screenshot_folder`. `artifact_root` and producer-specific key names are not part of the current public contract.
+Seraph does not migrate or resolve producer-specific screenshot keys. API requests, stored settings, and environment configuration use only `screenshot_folder` or `SERAPH_SCREENSHOT_FOLDER`. `artifact_root` and producer-specific key names are not part of the current contract.
 
 ## Folder Scan
 


### PR DESCRIPTION
## Summary
- remove Framekeeper-named env/config fallback resolution from the screenshot-folder source
- stop treating provider=framekeeper as a screenshot-folder artifact/report source
- update implementation docs and regression tests so Seraph only uses generic screenshot_folder / SERAPH_SCREENSHOT_FOLDER configuration

## Validation
- PYTHONPYCACHEPREFIX=/tmp/seraph-pycache python3 -m py_compile backend/src/observer/screenshot_folder_source.py backend/src/api/observer.py backend/src/api/settings.py backend/src/scheduler/jobs/end_of_day_goal_report.py
- git diff --check
- UV_CACHE_DIR=/tmp/seraph-uv-cache uv run pytest tests/test_observer_screen_artifacts.py tests/test_settings_api.py::test_artifact_storage_exposes_screenshot_folder_status tests/test_settings_api.py::test_artifact_storage_defaults_to_seraph_owned_screenshot_folder tests/test_settings_api.py::test_screen_analysis_settings_persist_and_drive_artifact_storage tests/test_settings_api.py::test_screen_analysis_settings_reject_public_legacy_framekeeper_artifact_root tests/test_settings_api.py::test_screen_analysis_settings_reject_public_legacy_framekeeper_screenshot_folder tests/test_settings_api.py::test_screen_analysis_settings_ignores_legacy_framekeeper_local_file_keys tests/test_settings_api.py::test_artifact_storage_ignores_legacy_framekeeper_env_keys tests/test_screenshot_folder_ingest_job.py tests/test_end_of_day_goal_report.py::test_build_report_counts_screenshot_folder_observation_source tests/test_end_of_day_goal_report.py::test_build_report_does_not_treat_framekeeper_as_source -q
- UV_CACHE_DIR=/tmp/seraph-uv-cache uv run pytest tests/test_settings_api.py tests/test_observer_screen_artifacts.py tests/test_screenshot_folder_ingest_job.py tests/test_end_of_day_goal_report.py -q

## Review
- Lead critic pass checked for remaining runtime coupling and accepted the intentional compatibility break: Framekeeper-named Seraph settings/env keys are no longer resolved. Independent subagent review was not available in this tool surface for this PR, so this is recorded as a limitation rather than a substitute approval.