### PR TITLE
Keep screenshot folder producer generic

### DIFF
--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -486,7 +486,8 @@ def _screen_capture_artifacts(observation: ScreenObservation) -> dict[str, Any] 
                 return None
             if not isinstance(payload, dict):
                 return None
-            if str(payload.get("provider") or "").strip() == "framekeeper":
+            provider = str(payload.get("provider") or "").strip()
+            if provider and provider != "screenshot_folder":
                 return None
             return payload
     return None

--- a/backend/src/scheduler/jobs/end_of_day_goal_report.py
+++ b/backend/src/scheduler/jobs/end_of_day_goal_report.py
@@ -331,7 +331,7 @@ def _observation_source(observation: ScreenObservation) -> str:
                         continue
                     if isinstance(artifacts, dict):
                         provider = str(artifacts.get("provider") or artifacts.get("source") or "").strip()
-                        if provider and provider != "framekeeper":
+                        if provider == "screenshot_folder":
                             return provider
     if observation.app_name == "Screenshot Folder":
         return "screenshot_folder"

--- a/backend/tests/test_end_of_day_goal_report.py
+++ b/backend/tests/test_end_of_day_goal_report.py
@@ -91,7 +91,7 @@ async def test_build_report_counts_screenshot_folder_observation_source(async_db
             {
                 "provider": "screenshot_folder",
                 "source": "local_image_directory",
-                "image_path": "/tmp/framekeeper/capture.png",
+                "image_path": "/tmp/screenshot-recorder/capture.png",
                 "image_sha256": "abc123",
                 "image_bytes": 67,
                 "file_format": "png",
@@ -128,11 +128,11 @@ async def test_build_report_counts_screenshot_folder_observation_source(async_db
     assert "- screenshot_folder: 1 observation, 0m" in report["body"]
     assert "Screenshot samples:" in report["body"]
     assert "- capture.png (png, 1x1, 67 B)" in report["body"]
-    assert "/tmp/framekeeper" not in report["body"]
+    assert "/tmp/screenshot-recorder" not in report["body"]
 
 
 @pytest.mark.asyncio
-async def test_build_report_does_not_treat_framekeeper_as_source(async_db):
+async def test_build_report_does_not_treat_named_external_provider_as_source(async_db):
     from src.db.models import ScreenObservation
     from src.scheduler.jobs.end_of_day_goal_report import build_end_of_day_goal_report
 
@@ -140,7 +140,7 @@ async def test_build_report_does_not_treat_framekeeper_as_source(async_db):
         "capture_artifacts:"
         + json.dumps(
             {
-                "provider": "framekeeper",
+                "provider": "external_recorder",
                 "image_path": "/tmp/screenshots/capture.png",
                 "image_bytes": 67,
                 "file_format": "png",
@@ -152,10 +152,10 @@ async def test_build_report_does_not_treat_framekeeper_as_source(async_db):
         db.add(
             ScreenObservation(
                 timestamp=datetime(2026, 6, 20, 12, 0, tzinfo=timezone.utc),
-                app_name="Framekeeper",
+                app_name="External Recorder",
                 window_title="capture.png",
                 activity_type="screen",
-                summary="Legacy producer-specific observation.",
+                summary="Producer-specific observation.",
                 details_json=json.dumps(details),
             )
         )
@@ -166,9 +166,9 @@ async def test_build_report_does_not_treat_framekeeper_as_source(async_db):
         report = await build_end_of_day_goal_report(date(2026, 6, 20))
 
     assert report["summary"]["source_observations"] == {"observer_daemon": 1}
-    assert "framekeeper" not in report["summary"]["source_observations"]
+    assert "external_recorder" not in report["summary"]["source_observations"]
     assert report["summary"]["screenshot_samples"] == []
-    assert "framekeeper" not in report["body"].lower()
+    assert "external recorder" not in report["body"].lower()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_observer_screen_artifacts.py
+++ b/backend/tests/test_observer_screen_artifacts.py
@@ -121,23 +121,23 @@ async def test_screen_artifact_endpoints_are_localhost_only(app, async_db, tmp_p
 
 
 @pytest.mark.asyncio
-async def test_screen_artifacts_ignore_legacy_framekeeper_provider(async_db, client, tmp_path, monkeypatch):
+async def test_screen_artifacts_ignore_named_external_provider(async_db, client, tmp_path, monkeypatch):
     monkeypatch.setattr("src.api.observer.settings.screen_capture_archive_dir", str(tmp_path))
     image_path = tmp_path / "capture.png"
     image_path.write_bytes(b"png bytes")
     artifacts = {
-        "id": "legacy-framekeeper-artifact",
-        "provider": "framekeeper",
+        "id": "external-recorder-artifact",
+        "provider": "external_recorder",
         "screenshot_folder": str(tmp_path),
         "image_path": str(image_path),
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
     async with async_db() as db:
         observation = ScreenObservation(
-            app_name="Framekeeper",
+            app_name="External Recorder",
             window_title="capture.png",
             activity_type="screen",
-            summary="Legacy producer-specific artifact",
+            summary="Producer-specific artifact",
             details_json=json.dumps(["capture_artifacts:" + json.dumps(artifacts)]),
         )
         db.add(observation)

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -7,7 +7,7 @@ title: Screenshot Folder Source
 
 Seraph does not connect to a screenshot app or service. It can scan a local directory that contains ordinary screenshot image files.
 
-Framekeeper is one possible producer for that directory, but Seraph does not call Framekeeper, read Framekeeper metadata, require manifests, or expect any service handshake. The contract is just `.png`, `.jpg`, and `.jpeg` files in a configured folder.
+The producing app is intentionally anonymous to Seraph. Seraph does not call a recorder, read recorder metadata, require manifests, or expect any service handshake. The contract is just `.png`, `.jpg`, and `.jpeg` files in a configured folder.
 
 ## Boundary
 
@@ -40,7 +40,7 @@ Seraph resolves the screenshot folder in this order:
 2. Seraph settings key `screenshot_folder`
 3. Seraph workspace default `artifacts/screenshot-folder`
 
-The default is a generic Seraph-owned workspace folder so unconfigured Seraph never assumes a specific screenshot producer. To consume Framekeeper output, configure Seraph with Framekeeper's screenshot folder explicitly.
+The default is a generic Seraph-owned workspace folder so unconfigured Seraph never assumes a specific screenshot producer. To consume screenshots from another app, configure Seraph with that app's screenshot folder explicitly.
 
 Seraph does not migrate or resolve producer-specific screenshot keys. API requests, stored settings, and environment configuration use only `screenshot_folder` or `SERAPH_SCREENSHOT_FOLDER`. `artifact_root` and producer-specific key names are not part of the current contract.
 
@@ -67,7 +67,7 @@ The request model is intentionally strict: legacy `artifact_root` or producer-sp
 
 The artifact analysis endpoint returns Seraph-owned local image analysis, including source, hash, byte size, file format, dimensions when detectable, observation id, and report readiness. This analysis is computed from the image file in Seraph.
 
-End-of-day reports consume screenshot-folder `ScreenObservation` rows through the same report builder as other screen observations. Seraph records the observation source as `screenshot_folder` from its own stored capture-artifact details and includes report-safe screenshot samples using filenames, format, dimensions, and size. Reports do not rely on Framekeeper manifests, sidecars, or service metadata.
+End-of-day reports consume screenshot-folder `ScreenObservation` rows through the same report builder as other screen observations. Seraph records the observation source as `screenshot_folder` from its own stored capture-artifact details and includes report-safe screenshot samples using filenames, format, dimensions, and size. Reports do not rely on recorder manifests, sidecars, or service metadata.
 
 Configure a narrow, trusted screenshot directory. Seraph rejects obvious broad roots such as the filesystem root, home folder, Desktop, Downloads, and Seraph workspace root.
 


### PR DESCRIPTION
## Summary
- remove the remaining Framekeeper-specific artifact/report special cases from Seraph's screenshot-folder path
- allow screen artifacts only for legacy Seraph no-provider records or Seraph's own provider=screenshot_folder records
- rename negative tests to generic external recorder/provider language
- update the screenshot-folder implementation note so producers are anonymous folder writers, not connected services

Refs natgurlain/framekeeper#1

## Verification
- PYTHONPYCACHEPREFIX=/tmp/seraph-pycache python3 -m py_compile backend/src/api/observer.py backend/src/scheduler/jobs/end_of_day_goal_report.py backend/src/observer/screenshot_folder_source.py
- git diff --check
- cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_observer_screen_artifacts.py tests/test_end_of_day_goal_report.py tests/test_screenshot_folder_ingest_job.py -q

## Review
- Independent Critic/Contrarian subagent: no findings
- Critic confirmed the diff removes Framekeeper-specific coupling and keeps only legacy no-provider Seraph archive artifacts plus provider=screenshot_folder