### PR TITLE
Wire local VLM screenshot analysis

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -110,6 +110,11 @@ class Settings(BaseSettings):
     screenshot_folder_ingest_enabled: bool = True
     screenshot_folder_ingest_interval_min: int = 5
     screenshot_folder_ingest_limit: int = 100
+    screen_analysis_provider: str = ""  # local-vlm enables semantic screenshot analysis
+    local_vlm_base_url: str = ""
+    local_vlm_model: str = ""
+    local_vlm_api_key: str = ""
+    local_vlm_timeout_seconds: int = 120
     report_archive_dir: str = ""
     end_of_day_report_enabled: bool = True
     end_of_day_report_hour: int = 21

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -110,6 +110,10 @@ class Settings(BaseSettings):
     screenshot_folder_ingest_enabled: bool = True
     screenshot_folder_ingest_interval_min: int = 5
     screenshot_folder_ingest_limit: int = 100
+    screenshot_observation_digest_enabled: bool = True
+    screenshot_observation_digest_interval_min: int = 15
+    screenshot_observation_digest_window_min: int = 30
+    screenshot_observation_digest_max_chars: int = 6000
     screen_analysis_provider: str = ""  # local-vlm enables semantic screenshot analysis
     local_vlm_base_url: str = ""
     local_vlm_model: str = ""

--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -493,6 +493,16 @@ def _screen_capture_artifacts(observation: ScreenObservation) -> dict[str, Any] 
     return None
 
 
+def _screen_observation_details(observation: ScreenObservation) -> list[Any]:
+    if not observation.details_json:
+        return []
+    try:
+        details = json.loads(observation.details_json)
+    except json.JSONDecodeError:
+        return []
+    return details if isinstance(details, list) else []
+
+
 def _screen_artifact_response(observation: ScreenObservation) -> dict[str, Any] | None:
     artifacts = _screen_capture_artifacts(observation)
     if artifacts is None:
@@ -647,10 +657,20 @@ def _screenshot_folder_image_analysis(
     artifacts: dict[str, Any],
     observation: ScreenObservation,
 ) -> dict[str, Any]:
+    from src.observer.screenshot_semantic_analysis import (
+        semantic_analysis_error_from_details,
+        semantic_analysis_from_details,
+    )
+
     metadata = local_image_metadata(image_path)
+    details = _screen_observation_details(observation)
+    semantic_analysis = semantic_analysis_from_details(details)
+    semantic_error = semantic_analysis_error_from_details(details)
+    semantic_status = "ready" if semantic_analysis else "failed" if semantic_error else "not_configured"
     return {
         "source": "local_screenshot_folder",
         "analysis_owner": "seraph",
+        "semantic_status": semantic_status,
         "image_path": str(image_path),
         "image_sha256": artifacts.get("image_sha256"),
         "image_bytes": metadata.get("image_bytes"),
@@ -659,6 +679,8 @@ def _screenshot_folder_image_analysis(
         "height": metadata.get("height"),
         "observation_id": observation.id,
         "observation_summary": observation.summary,
+        "semantic_analysis": semantic_analysis,
+        "semantic_error": semantic_error,
         "report_ready": True,
         "notes": [
             "The screenshot folder source produced only the image file.",

--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -58,6 +58,12 @@ class ScreenshotFolderScanRequest(BaseModel):
     limit: int = 100
 
 
+class ScreenshotReanalysisRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    reanalysis_reason: str
+
+
 class NativeNotificationResponse(BaseModel):
     id: str
     intervention_id: str | None = None
@@ -619,6 +625,62 @@ async def get_screen_artifact_analysis(observation_id: str, request: Request) ->
     return payload if isinstance(payload, dict) else {"value": payload}
 
 
+@router.post("/observer/screen-artifacts/{observation_id}/reanalyze")
+async def reanalyze_screen_artifact(
+    observation_id: str,
+    body: ScreenshotReanalysisRequest,
+    request: Request,
+) -> dict[str, Any]:
+    """Explicitly re-run Seraph semantic analysis for one local screenshot artifact."""
+    from src.observer.screenshot_semantic_analysis import (
+        ScreenshotSemanticAnalysisError,
+        analyze_screenshot_image,
+        replace_semantic_analysis_details,
+        validate_reanalysis_reason,
+    )
+
+    _require_local_artifact_request(request)
+    try:
+        reanalysis_reason = validate_reanalysis_reason(body.reanalysis_reason)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    observation = await _screen_artifact_observation(observation_id)
+    artifacts = _screen_capture_artifacts(observation) or {}
+    if artifacts.get("provider") != "screenshot_folder":
+        raise HTTPException(status_code=400, detail="Only screenshot-folder artifacts can be reanalyzed here")
+    image_path = _artifact_path(
+        str(artifacts.get("image_path") or ""),
+        allowed_roots=_artifact_allowed_roots(artifacts),
+    )
+
+    analysis = None
+    error_reason = None
+    try:
+        analysis = await analyze_screenshot_image(image_path, artifacts)
+        if analysis is None:
+            error_reason = "provider not configured"
+    except ScreenshotSemanticAnalysisError as exc:
+        error_reason = str(exc)
+
+    details = replace_semantic_analysis_details(
+        _screen_observation_details(observation),
+        analysis=analysis,
+        error_reason=error_reason,
+        reanalysis_reason=reanalysis_reason,
+    )
+    observation.details_json = json.dumps(details)
+    async with get_session() as db:
+        db.add(observation)
+
+    return {
+        "observation_id": observation.id,
+        "image_sha256": artifacts.get("image_sha256"),
+        "reanalysis_reason": reanalysis_reason,
+        "analysis": _screenshot_folder_image_analysis(image_path, artifacts, observation),
+    }
+
+
 @router.post("/observer/screenshot-folder/scan")
 async def scan_screenshot_folder(body: ScreenshotFolderScanRequest, request: Request) -> dict[str, Any]:
     """Scan a local screenshot folder as a Seraph image source."""
@@ -658,19 +720,30 @@ def _screenshot_folder_image_analysis(
     observation: ScreenObservation,
 ) -> dict[str, Any]:
     from src.observer.screenshot_semantic_analysis import (
+        semantic_analysis_needs_reanalysis,
         semantic_analysis_error_from_details,
         semantic_analysis_from_details,
+        semantic_analysis_status_from_details,
     )
 
     metadata = local_image_metadata(image_path)
     details = _screen_observation_details(observation)
     semantic_analysis = semantic_analysis_from_details(details)
     semantic_error = semantic_analysis_error_from_details(details)
-    semantic_status = "ready" if semantic_analysis else "failed" if semantic_error else "not_configured"
+    persisted_status = semantic_analysis_status_from_details(details) or {}
+    if semantic_analysis_needs_reanalysis(details):
+        semantic_status = "needs_reanalysis"
+    elif semantic_analysis:
+        semantic_status = "succeeded"
+    elif semantic_error:
+        semantic_status = "failed"
+    else:
+        semantic_status = str(persisted_status.get("status") or "pending")
     return {
         "source": "local_screenshot_folder",
         "analysis_owner": "seraph",
         "semantic_status": semantic_status,
+        "semantic_status_detail": persisted_status or None,
         "image_path": str(image_path),
         "image_sha256": artifacts.get("image_sha256"),
         "image_bytes": metadata.get("image_bytes"),

--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -9,12 +9,14 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict
-from sqlmodel import select
+from sqlalchemy import func
+from sqlmodel import col, select
 
 from config.settings import settings
 from src.db.engine import get_session as get_db
-from src.db.models import UserProfile
+from src.db.models import MemoryEpisode, ScreenObservation, UserProfile
 from src.observer.manager import context_manager
+from src.observer.screenshot_semantic_analysis import semantic_analysis_status_from_details
 from src.observer.user_state import InterruptionMode
 from src.tools.policy import MCP_POLICY_MODES, TOOL_POLICY_MODES
 
@@ -70,6 +72,7 @@ _VALID_MCP_POLICY_MODES = set(MCP_POLICY_MODES)
 _VALID_APPROVAL_MODES = {"off", "high_risk"}
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _SCREENSHOT_FOLDER_ENV = "SERAPH_SCREENSHOT_FOLDER"
+_SCREENSHOT_DIGEST_TOOL_NAME = "screenshot_observation_digest"
 
 
 def _env_enabled(name: str, default: bool = False) -> bool:
@@ -329,6 +332,107 @@ def _screenshot_folder_summary(root: Path) -> dict[str, object]:
     }
 
 
+def _screen_observation_details(details_json: str | None) -> list[object]:
+    try:
+        payload = json.loads(details_json or "[]")
+    except json.JSONDecodeError:
+        return []
+    return payload if isinstance(payload, list) else []
+
+
+def _utc_iso(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _is_screenshot_folder_observation(observation: ScreenObservation) -> bool:
+    if observation.app_name == "Screenshot Folder":
+        return True
+    for item in _screen_observation_details(observation.details_json):
+        if not (isinstance(item, str) and item.startswith("capture_artifacts:")):
+            continue
+        try:
+            artifacts = json.loads(item.removeprefix("capture_artifacts:"))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(artifacts, dict) and artifacts.get("provider") == "screenshot_folder":
+            return True
+    return False
+
+
+async def _screenshot_folder_pipeline_summary() -> dict[str, object]:
+    status_counts: dict[str, int] = {
+        "pending": 0,
+        "succeeded": 0,
+        "failed": 0,
+        "needs_reanalysis": 0,
+        "unknown": 0,
+    }
+    latest_observation_at: str | None = None
+    latest_analyzed_at: str | None = None
+    latest_failure: str | None = None
+    async with get_db() as db:
+        observation_result = await db.execute(
+            select(ScreenObservation)
+            .where(col(ScreenObservation.blocked) == False)  # noqa: E712
+            .where(
+                (
+                    col(ScreenObservation.app_name) == "Screenshot Folder"
+                )
+                | col(ScreenObservation.details_json).contains('"provider":"screenshot_folder"')
+                | col(ScreenObservation.details_json).contains('"provider": "screenshot_folder"')
+            )
+            .order_by(col(ScreenObservation.timestamp).desc())
+            .limit(500)
+        )
+        observations = list(observation_result.scalars().all())
+        digest_result = await db.execute(
+            select(MemoryEpisode)
+            .where(col(MemoryEpisode.source_tool_name) == _SCREENSHOT_DIGEST_TOOL_NAME)
+            .order_by(col(MemoryEpisode.observed_at).desc())
+            .limit(1)
+        )
+        latest_digest = digest_result.scalar_one_or_none()
+        digest_count_result = await db.execute(
+            select(func.count())
+            .select_from(MemoryEpisode)
+            .where(col(MemoryEpisode.source_tool_name) == _SCREENSHOT_DIGEST_TOOL_NAME)
+        )
+        digest_count = int(digest_count_result.scalar_one() or 0)
+
+    for observation in observations:
+        if not _is_screenshot_folder_observation(observation):
+            continue
+        if latest_observation_at is None:
+            latest_observation_at = _utc_iso(observation.timestamp)
+        details = _screen_observation_details(observation.details_json)
+        status = semantic_analysis_status_from_details(details) or {}
+        status_name = str(status.get("status") or "unknown")
+        if status_name not in status_counts:
+            status_name = "unknown"
+        status_counts[status_name] += 1
+        recorded_at = status.get("recorded_at")
+        if isinstance(recorded_at, str) and status_name == "succeeded" and latest_analyzed_at is None:
+            latest_analyzed_at = recorded_at
+        if status_name == "failed" and latest_failure is None:
+            latest_failure = str(status.get("reason") or "analysis failed")
+
+    return {
+        "observation_count": sum(status_counts.values()),
+        "analysis_status": status_counts,
+        "analysis_backlog": status_counts["pending"] + status_counts["needs_reanalysis"],
+        "analysis_failures": status_counts["failed"],
+        "latest_observation_at": latest_observation_at,
+        "latest_analyzed_at": latest_analyzed_at,
+        "latest_failure": latest_failure,
+        "digest_count": digest_count,
+        "latest_digest_at": _utc_iso(latest_digest.observed_at) if latest_digest is not None else None,
+    }
+
+
 def _report_receipt_summary(report_dir: Path) -> dict[str, object]:
     receipts_dir = report_dir / "receipts"
     if not receipts_dir.exists():
@@ -529,6 +633,7 @@ async def get_artifact_storage_settings():
     report_receipts = _report_receipt_summary(report_archive_dir)
     screenshot_folder, screenshot_folder_source = _screenshot_folder()
     screenshot_source = _screenshot_folder_summary(screenshot_folder)
+    screenshot_pipeline = await _screenshot_folder_pipeline_summary()
     screen_analysis = await get_screen_analysis_settings()
     screen_archive_dir = Path(str(screen_analysis["archive_dir"]))
     screen_dir_status = _archive_dir_status(screen_archive_dir)
@@ -574,6 +679,12 @@ async def get_artifact_storage_settings():
             "exists": screenshot_source["exists"],
             "readable": screenshot_source["readable"],
             "stored_artifacts": ["image"],
+            "analysis": {
+                "provider": settings.screen_analysis_provider or "not_configured",
+                "model": settings.local_vlm_model or "",
+                "base_url_configured": bool(settings.local_vlm_base_url.strip()),
+                **screenshot_pipeline,
+            },
             "auto_ingest_enabled": settings.screenshot_folder_ingest_enabled,
             "auto_ingest_interval_min": settings.screenshot_folder_ingest_interval_min,
             "auto_ingest_limit": settings.screenshot_folder_ingest_limit,

--- a/backend/src/observer/screenshot_folder_source.py
+++ b/backend/src/observer/screenshot_folder_source.py
@@ -17,6 +17,12 @@ from src.db.engine import get_session
 from src.db.models import ScreenObservation
 from src.observer.image_metadata import image_metadata_label, local_image_metadata
 from src.observer.screen_repository import screen_observation_repo
+from src.observer.screenshot_semantic_analysis import (
+    ScreenshotSemanticAnalysisError,
+    analyze_screenshot_image,
+    screenshot_analysis_detail,
+    screenshot_analysis_error_detail,
+)
 
 
 class ScreenshotFolderImageError(ValueError):
@@ -102,7 +108,8 @@ def validate_screenshot_folder_root(root: Path) -> None:
     dangerous_roots = _dangerous_scan_roots()
     if root in dangerous_roots:
         raise ScreenshotFolderImageError(
-            "Screenshot folder must be a dedicated image directory, not a broad home, desktop, downloads, workspace, or filesystem root"
+            "Screenshot folder must be a dedicated image directory, not a broad home, "
+            "desktop, downloads, workspace, or filesystem root"
         )
 
 
@@ -153,27 +160,30 @@ async def _image_to_observation(image_path: Path, root: Path) -> dict[str, objec
     metadata = local_image_metadata(resolved)
     captured_at = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
     capture_id = image_sha256[:16]
+    artifacts = {
+        "id": capture_id,
+        "provider": SCREENSHOT_FOLDER_PROVIDER,
+        "source": "local_image_directory",
+        "created_at": captured_at.isoformat(),
+        "screenshot_folder": str(root),
+        "image_path": str(resolved),
+        "image_sha256": image_sha256,
+        "image_bytes": stat.st_size,
+        "file_format": metadata.get("file_format"),
+        "width": metadata.get("width"),
+        "height": metadata.get("height"),
+    }
     details = [
         f"{SCREENSHOT_FOLDER_HASH_PREFIX}:{image_sha256}",
-        "capture_artifacts:"
-        + json.dumps(
-            {
-                "id": capture_id,
-                "provider": SCREENSHOT_FOLDER_PROVIDER,
-                "source": "local_image_directory",
-                "created_at": captured_at.isoformat(),
-                "screenshot_folder": str(root),
-                "image_path": str(resolved),
-                "image_sha256": image_sha256,
-                "image_bytes": stat.st_size,
-                "file_format": metadata.get("file_format"),
-                "width": metadata.get("width"),
-                "height": metadata.get("height"),
-            },
-            sort_keys=True,
-            separators=(",", ":"),
-        ),
+        "capture_artifacts:" + json.dumps(artifacts, sort_keys=True, separators=(",", ":")),
     ]
+    try:
+        analysis = await analyze_screenshot_image(resolved, artifacts)
+    except ScreenshotSemanticAnalysisError as exc:
+        details.append(screenshot_analysis_error_detail(str(exc)))
+    else:
+        if analysis is not None:
+            details.append(screenshot_analysis_detail(analysis))
     metadata_label = image_metadata_label(metadata)
     summary_suffix = f" ({metadata_label})" if metadata_label else ""
     return {

--- a/backend/src/observer/screenshot_folder_source.py
+++ b/backend/src/observer/screenshot_folder_source.py
@@ -22,6 +22,7 @@ from src.observer.screenshot_semantic_analysis import (
     analyze_screenshot_image,
     screenshot_analysis_detail,
     screenshot_analysis_error_detail,
+    screenshot_analysis_status_detail,
 )
 
 
@@ -181,9 +182,13 @@ async def _image_to_observation(image_path: Path, root: Path) -> dict[str, objec
         analysis = await analyze_screenshot_image(resolved, artifacts)
     except ScreenshotSemanticAnalysisError as exc:
         details.append(screenshot_analysis_error_detail(str(exc)))
+        details.append(screenshot_analysis_status_detail("failed", reason=str(exc)))
     else:
         if analysis is not None:
             details.append(screenshot_analysis_detail(analysis))
+            details.append(screenshot_analysis_status_detail("succeeded"))
+        else:
+            details.append(screenshot_analysis_status_detail("pending", reason="provider not configured"))
     metadata_label = image_metadata_label(metadata)
     summary_suffix = f" ({metadata_label})" if metadata_label else ""
     return {

--- a/backend/src/observer/screenshot_semantic_analysis.py
+++ b/backend/src/observer/screenshot_semantic_analysis.py
@@ -1,0 +1,142 @@
+"""Provider-backed semantic analysis for local screenshot images."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from config.settings import settings
+from src.observer.screenshot_analysis_contract import (
+    ScreenshotAnalysis,
+    ScreenshotAnalysisContractError,
+    parse_screenshot_analysis_output,
+    screenshot_analysis_prompt,
+)
+
+logger = logging.getLogger(__name__)
+
+SCREENSHOT_ANALYSIS_DETAIL_PREFIX = "screenshot_analysis:"
+SCREENSHOT_ANALYSIS_ERROR_DETAIL_PREFIX = "screenshot_analysis_error:"
+
+
+class ScreenshotSemanticAnalysisError(RuntimeError):
+    """Raised when the configured semantic screenshot analyzer fails."""
+
+
+def screenshot_semantic_analysis_enabled() -> bool:
+    """Return true when Seraph should call the local VLM screenshot analyzer."""
+    return settings.screen_analysis_provider.strip().lower() == "local-vlm" and bool(
+        settings.local_vlm_base_url.strip()
+    )
+
+
+async def analyze_screenshot_image(image_path: Path, artifacts: dict[str, Any]) -> ScreenshotAnalysis | None:
+    """Analyze one screenshot image through the configured Seraph VLM provider."""
+    if not screenshot_semantic_analysis_enabled():
+        return None
+    return await _analyze_with_local_vlm(image_path, artifacts)
+
+
+def screenshot_analysis_detail(analysis: ScreenshotAnalysis) -> str:
+    """Serialize a validated screenshot analysis for ScreenObservation details."""
+    payload = analysis.model_dump(mode="json")
+    return SCREENSHOT_ANALYSIS_DETAIL_PREFIX + json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def screenshot_analysis_error_detail(reason: str) -> str:
+    """Serialize a bounded analyzer failure for ScreenObservation details."""
+    bounded_reason = " ".join(str(reason or "unknown").strip().split())[:240] or "unknown"
+    return SCREENSHOT_ANALYSIS_ERROR_DETAIL_PREFIX + json.dumps(
+        {"provider": settings.screen_analysis_provider or "unknown", "reason": bounded_reason},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def semantic_analysis_from_details(details: list[Any]) -> dict[str, Any] | None:
+    """Extract the persisted semantic analysis payload from observation details."""
+    for item in details:
+        if not isinstance(item, str) or not item.startswith(SCREENSHOT_ANALYSIS_DETAIL_PREFIX):
+            continue
+        try:
+            payload = json.loads(item.removeprefix(SCREENSHOT_ANALYSIS_DETAIL_PREFIX))
+        except json.JSONDecodeError:
+            return None
+        if isinstance(payload, dict):
+            return payload
+    return None
+
+
+def semantic_analysis_error_from_details(details: list[Any]) -> dict[str, Any] | None:
+    """Extract the persisted semantic analysis failure payload from observation details."""
+    for item in details:
+        if not isinstance(item, str) or not item.startswith(SCREENSHOT_ANALYSIS_ERROR_DETAIL_PREFIX):
+            continue
+        try:
+            payload = json.loads(item.removeprefix(SCREENSHOT_ANALYSIS_ERROR_DETAIL_PREFIX))
+        except json.JSONDecodeError:
+            return None
+        if isinstance(payload, dict):
+            return payload
+    return None
+
+
+async def _analyze_with_local_vlm(image_path: Path, artifacts: dict[str, Any]) -> ScreenshotAnalysis:
+    metadata = {
+        "captured_at": artifacts.get("created_at"),
+        "source": "screenshot_folder",
+        "filename": image_path.name,
+        "image_sha256": artifacts.get("image_sha256"),
+        "file_format": artifacts.get("file_format"),
+        "width": artifacts.get("width"),
+        "height": artifacts.get("height"),
+    }
+    prompt = screenshot_analysis_prompt(metadata)
+    endpoint = settings.local_vlm_base_url.rstrip("/") + "/v1/analyze-file"
+    data = {"prompt": prompt}
+    if settings.local_vlm_model.strip():
+        data["model"] = settings.local_vlm_model.strip()
+    headers = {}
+    if settings.local_vlm_api_key.strip():
+        headers["Authorization"] = f"Bearer {settings.local_vlm_api_key.strip()}"
+
+    try:
+        async with httpx.AsyncClient(timeout=max(settings.local_vlm_timeout_seconds, 1)) as client:
+            with image_path.open("rb") as image_file:
+                response = await client.post(
+                    endpoint,
+                    data=data,
+                    files={"file": (image_path.name, image_file, _image_media_type(image_path))},
+                    headers=headers,
+                )
+        response.raise_for_status()
+        payload = response.json()
+        return parse_screenshot_analysis_output(_provider_analysis_payload(payload))
+    except (OSError, httpx.HTTPError, ValueError, ScreenshotAnalysisContractError) as exc:
+        logger.warning("screenshot semantic analysis failed for %s: %s", image_path, exc)
+        raise ScreenshotSemanticAnalysisError(str(exc)) from exc
+
+
+def _provider_analysis_payload(payload: Any) -> str | dict[str, Any]:
+    if isinstance(payload, dict):
+        for key in ("analysis", "output", "result", "content", "text"):
+            value = payload.get(key)
+            if isinstance(value, (str, dict)):
+                return value
+        return payload
+    if isinstance(payload, str):
+        return payload
+    raise ScreenshotAnalysisContractError("local VLM response must be JSON text or object")
+
+
+def _image_media_type(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".png":
+        return "image/png"
+    if suffix in {".jpg", ".jpeg"}:
+        return "image/jpeg"
+    return "application/octet-stream"

--- a/backend/src/observer/screenshot_semantic_analysis.py
+++ b/backend/src/observer/screenshot_semantic_analysis.py
@@ -6,6 +6,7 @@ import json
 import logging
 from pathlib import Path
 from typing import Any
+from datetime import datetime, timezone
 
 import httpx
 
@@ -13,6 +14,8 @@ from config.settings import settings
 from src.observer.screenshot_analysis_contract import (
     ScreenshotAnalysis,
     ScreenshotAnalysisContractError,
+    SCREENSHOT_ANALYSIS_PROMPT_VERSION,
+    SCREENSHOT_ANALYSIS_SCHEMA_VERSION,
     parse_screenshot_analysis_output,
     screenshot_analysis_prompt,
 )
@@ -21,6 +24,13 @@ logger = logging.getLogger(__name__)
 
 SCREENSHOT_ANALYSIS_DETAIL_PREFIX = "screenshot_analysis:"
 SCREENSHOT_ANALYSIS_ERROR_DETAIL_PREFIX = "screenshot_analysis_error:"
+SCREENSHOT_ANALYSIS_STATUS_DETAIL_PREFIX = "screenshot_analysis_status:"
+REANALYSIS_REASONS = {
+    "prompt_version_changed",
+    "model_version_changed",
+    "provider_failure_retry",
+    "manual_operator_request",
+}
 
 
 class ScreenshotSemanticAnalysisError(RuntimeError):
@@ -47,11 +57,32 @@ def screenshot_analysis_detail(analysis: ScreenshotAnalysis) -> str:
     return SCREENSHOT_ANALYSIS_DETAIL_PREFIX + json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
 
+def screenshot_analysis_status_detail(
+    status: str,
+    *,
+    reason: str | None = None,
+    reanalysis_reason: str | None = None,
+) -> str:
+    """Serialize semantic analysis status for idempotency and reanalysis decisions."""
+    payload = {
+        "status": status,
+        "provider": settings.screen_analysis_provider or "not_configured",
+        "model": settings.local_vlm_model or None,
+        "schema_version": SCREENSHOT_ANALYSIS_SCHEMA_VERSION,
+        "prompt_version": SCREENSHOT_ANALYSIS_PROMPT_VERSION,
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if reason:
+        payload["reason"] = _bounded_reason(reason)
+    if reanalysis_reason:
+        payload["reanalysis_reason"] = reanalysis_reason
+    return SCREENSHOT_ANALYSIS_STATUS_DETAIL_PREFIX + json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
 def screenshot_analysis_error_detail(reason: str) -> str:
     """Serialize a bounded analyzer failure for ScreenObservation details."""
-    bounded_reason = " ".join(str(reason or "unknown").strip().split())[:240] or "unknown"
     return SCREENSHOT_ANALYSIS_ERROR_DETAIL_PREFIX + json.dumps(
-        {"provider": settings.screen_analysis_provider or "unknown", "reason": bounded_reason},
+        {"provider": settings.screen_analysis_provider or "unknown", "reason": _bounded_reason(reason)},
         sort_keys=True,
         separators=(",", ":"),
     )
@@ -83,6 +114,81 @@ def semantic_analysis_error_from_details(details: list[Any]) -> dict[str, Any] |
         if isinstance(payload, dict):
             return payload
     return None
+
+
+def semantic_analysis_status_from_details(details: list[Any]) -> dict[str, Any] | None:
+    """Extract the latest semantic analysis status payload from observation details."""
+    latest: dict[str, Any] | None = None
+    for item in details:
+        if not isinstance(item, str) or not item.startswith(SCREENSHOT_ANALYSIS_STATUS_DETAIL_PREFIX):
+            continue
+        try:
+            payload = json.loads(item.removeprefix(SCREENSHOT_ANALYSIS_STATUS_DETAIL_PREFIX))
+        except json.JSONDecodeError:
+            return None
+        if isinstance(payload, dict):
+            latest = payload
+    return latest
+
+
+def semantic_analysis_needs_reanalysis(details: list[Any]) -> bool:
+    """Return true when stored analysis exists but belongs to an old prompt or model contract."""
+    analysis = semantic_analysis_from_details(details)
+    status = semantic_analysis_status_from_details(details)
+    if analysis is None or status is None:
+        return False
+    return (
+        analysis.get("prompt_version") != SCREENSHOT_ANALYSIS_PROMPT_VERSION
+        or analysis.get("schema_version") != SCREENSHOT_ANALYSIS_SCHEMA_VERSION
+        or status.get("model") != (settings.local_vlm_model or None)
+    )
+
+
+def validate_reanalysis_reason(reason: str) -> str:
+    """Validate the explicit operator reason required before reanalysis."""
+    normalized = str(reason or "").strip()
+    if normalized not in REANALYSIS_REASONS:
+        allowed = ", ".join(sorted(REANALYSIS_REASONS))
+        raise ValueError(f"reanalysis_reason must be one of: {allowed}")
+    return normalized
+
+
+def replace_semantic_analysis_details(
+    details: list[Any],
+    *,
+    analysis: ScreenshotAnalysis | None,
+    error_reason: str | None,
+    reanalysis_reason: str,
+) -> list[str]:
+    """Replace existing semantic analysis details while preserving capture metadata."""
+    next_details = [
+        item
+        for item in details
+        if not (
+            isinstance(item, str)
+            and (
+                item.startswith(SCREENSHOT_ANALYSIS_DETAIL_PREFIX)
+                or item.startswith(SCREENSHOT_ANALYSIS_ERROR_DETAIL_PREFIX)
+                or item.startswith(SCREENSHOT_ANALYSIS_STATUS_DETAIL_PREFIX)
+            )
+        )
+    ]
+    if analysis is not None:
+        next_details.append(screenshot_analysis_detail(analysis))
+        next_details.append(
+            screenshot_analysis_status_detail("succeeded", reanalysis_reason=reanalysis_reason)
+        )
+    else:
+        reason = error_reason or "unknown"
+        next_details.append(screenshot_analysis_error_detail(reason))
+        next_details.append(
+            screenshot_analysis_status_detail(
+                "failed",
+                reason=reason,
+                reanalysis_reason=reanalysis_reason,
+            )
+        )
+    return [str(item) for item in next_details if isinstance(item, str)]
 
 
 async def _analyze_with_local_vlm(image_path: Path, artifacts: dict[str, Any]) -> ScreenshotAnalysis:
@@ -140,3 +246,7 @@ def _image_media_type(path: Path) -> str:
     if suffix in {".jpg", ".jpeg"}:
         return "image/jpeg"
     return "application/octet-stream"
+
+
+def _bounded_reason(reason: str) -> str:
+    return " ".join(str(reason or "unknown").strip().split())[:240] or "unknown"

--- a/backend/src/scheduler/engine.py
+++ b/backend/src/scheduler/engine.py
@@ -80,6 +80,7 @@ def init_scheduler() -> AsyncIOScheduler | None:
     from src.scheduler.jobs.activity_digest import run_activity_digest
     from src.scheduler.jobs.end_of_day_goal_report import run_end_of_day_goal_report
     from src.scheduler.jobs.screenshot_folder_ingest import run_screenshot_folder_ingest
+    from src.scheduler.jobs.screenshot_observation_digest import run_screenshot_observation_digest
     from src.scheduler.jobs.weekly_activity_review import run_weekly_activity_review
     from src.scheduler.jobs.screen_cleanup import run_screen_cleanup
 
@@ -161,6 +162,14 @@ def init_scheduler() -> AsyncIOScheduler | None:
             ),
             "id": "screenshot_folder_ingest",
             "name": "Screenshot folder image ingest",
+        },
+        {
+            "func": _async_job_wrapper(run_screenshot_observation_digest, loop),
+            "trigger": IntervalTrigger(
+                minutes=_settings_int("screenshot_observation_digest_interval_min", 15, minimum=1, maximum=1440)
+            ),
+            "id": "screenshot_observation_digest",
+            "name": "Screenshot observation digest",
         },
         {
             "func": _async_job_wrapper(run_screen_cleanup, loop),

--- a/backend/src/scheduler/jobs/end_of_day_goal_report.py
+++ b/backend/src/scheduler/jobs/end_of_day_goal_report.py
@@ -19,7 +19,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from config.settings import settings
 from src.audit.runtime import log_integration_event, log_scheduler_job_event
-from src.db.models import GoalStatus, MemoryEpisodeType, ScreenObservation
+from src.db.models import GoalStatus, MemoryEpisode, MemoryEpisodeType, ScreenObservation
 from src.llm_runtime import completion_with_fallback
 from src.observer.image_metadata import image_metadata_label
 
@@ -45,6 +45,9 @@ Use only the redacted structured inputs. Do not invent screen details.
 - Screenshot samples:
 {screenshot_samples}
 
+## Screenshot Observation Digests
+{screenshot_digests}
+
 ## Goals
 Active goals:
 {active_goals}
@@ -52,12 +55,12 @@ Active goals:
 Completed today:
 {completed_goals}
 
-## Alignment Hints
+## Critical Goal Comparison
 {alignment_hints}
 
 Write:
 1. A short summary of what the day was mostly about.
-2. A "Goals vs day" section that says what aligned, what drifted, and what is unclear.
+2. A "Goals vs day" section that critically says what aligned, what drifted, what was blocked, what is unclear, and whether the user pushed the needle.
 3. 3 practical tips for tomorrow.
 
 Keep it useful and concise. No private raw screen text, no copied secrets, no long logs."""
@@ -67,6 +70,9 @@ _SECRET_PATTERNS = (
     re.compile(r"\b(sk-[A-Za-z0-9_-]{12,})\b"),
     re.compile(r"\b([A-Za-z0-9_./+=-]{24,})\b"),
 )
+
+_SCREENSHOT_DIGEST_TOOL_NAME = "screenshot_observation_digest"
+_SCREENSHOT_DIGEST_SCHEMA_VERSION = "seraph.screenshot_observation_digest.v1"
 
 
 @dataclass(frozen=True)
@@ -316,6 +322,56 @@ async def _screen_summary_for_local_day(report_day: date, tz: ZoneInfo) -> dict[
     }
 
 
+async def _screenshot_digests_for_local_day(report_day: date, tz: ZoneInfo) -> dict[str, Any]:
+    local_start = datetime.combine(report_day, time.min, tzinfo=tz)
+    local_end = datetime.combine(report_day, time.max, tzinfo=tz)
+    start_utc = local_start.astimezone(timezone.utc)
+    end_utc = local_end.astimezone(timezone.utc)
+
+    from sqlmodel import col, select
+    from src.db.engine import get_session
+
+    async with get_session() as db:
+        result = await db.execute(
+            select(MemoryEpisode)
+            .where(col(MemoryEpisode.source_tool_name) == _SCREENSHOT_DIGEST_TOOL_NAME)
+            .where(col(MemoryEpisode.observed_at) >= start_utc)
+            .where(col(MemoryEpisode.observed_at) <= end_utc)
+            .order_by(col(MemoryEpisode.observed_at))
+        )
+        episodes = list(result.scalars().all())
+
+    digests: list[dict[str, Any]] = []
+    observation_ids: list[str] = []
+    text_chunks: list[str] = []
+    for episode in episodes:
+        metadata = _episode_metadata(episode)
+        if metadata.get("artifact_schema") != _SCREENSHOT_DIGEST_SCHEMA_VERSION:
+            continue
+        ids = [str(item) for item in metadata.get("observation_ids", []) if item]
+        observation_ids.extend(ids)
+        content = _redact_report_body(episode.content, limit=1400)
+        digests.append(
+            {
+                "episode_id": episode.id,
+                "window_start": metadata.get("window_start"),
+                "window_end": metadata.get("window_end"),
+                "observation_count": int(metadata.get("observation_count") or len(ids)),
+                "observation_ids": ids,
+                "content": content,
+            }
+        )
+        if content:
+            text_chunks.append(content)
+
+    return {
+        "count": len(digests),
+        "observation_ids": _unique_strings(observation_ids)[:100],
+        "digests": digests[:16],
+        "redacted_text": "\n\n".join(text_chunks)[:8000],
+    }
+
+
 def _observation_source(observation: ScreenObservation) -> str:
     if observation.details_json:
         try:
@@ -395,32 +451,92 @@ def _tokens(value: str) -> set[str]:
     }
 
 
-def _goal_alignment(summary: dict[str, Any], active_goals: list[Any]) -> list[dict[str, Any]]:
+def _goal_alignment(
+    summary: dict[str, Any],
+    active_goals: list[Any],
+    screenshot_digests: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    screenshot_digests = screenshot_digests or {}
+    digest_text = str(screenshot_digests.get("redacted_text") or "")
     context_text = " ".join(
         [
             " ".join(summary.get("by_project", {}).keys()),
             " ".join(summary.get("by_activity", {}).keys()),
             " ".join(summary.get("by_app", {}).keys()),
             " ".join(summary.get("redacted_samples", [])),
+            digest_text,
         ]
     )
     context_tokens = _tokens(context_text)
+    digest_tokens = _tokens(digest_text)
+    blocked_signals = _digest_section_values(digest_text, "Blockers")
+    drift_signals = _digest_section_values(digest_text, "Drift")
     results: list[dict[str, Any]] = []
     for goal in active_goals:
         goal_text = " ".join(
             item for item in [goal.title, goal.description or "", goal.domain] if item
         )
-        overlap = sorted(_tokens(goal_text) & context_tokens)
+        goal_tokens = _tokens(goal_text)
+        overlap = sorted(goal_tokens & context_tokens)
+        digest_overlap = sorted(goal_tokens & digest_tokens)
+        status = "unclear"
+        needle_movement = "unclear"
+        evidence: list[str] = []
+        matching_blockers = [
+            signal for signal in blocked_signals if goal_tokens & _tokens(signal)
+        ]
+        matching_drift = [
+            signal for signal in drift_signals if goal_tokens & _tokens(signal)
+        ]
+        if digest_overlap or overlap:
+            status = "aligned"
+            needle_movement = "pushed"
+        if matching_drift and digest_overlap:
+            status = "drifted"
+            needle_movement = "drifted"
+            evidence.extend(matching_drift[:3])
+        if matching_blockers and digest_overlap:
+            status = "blocked"
+            needle_movement = "blocked"
+            evidence.extend(matching_blockers[:3])
+        if not evidence and digest_overlap:
+            evidence.extend(_digest_section_values(digest_text, "Progression")[:3])
         results.append(
             {
                 "goal_id": goal.id,
                 "title": _redact_text(goal.title, limit=120),
                 "domain": goal.domain,
-                "status": "aligned" if overlap else "unclear",
+                "status": status,
+                "needle_movement": needle_movement,
                 "evidence_tokens": overlap[:6],
+                "digest_evidence_tokens": digest_overlap[:6],
+                "evidence": _unique_strings(evidence)[:5],
+                "source_observation_ids": screenshot_digests.get("observation_ids", [])[:20]
+                if digest_overlap
+                else [],
             }
         )
     return results
+
+
+def _digest_section_values(text: str, heading: str) -> list[str]:
+    if not text:
+        return []
+    lines = text.splitlines()
+    values: list[str] = []
+    in_section = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == f"{heading}:":
+            in_section = True
+            continue
+        if in_section and stripped.endswith(":") and not stripped.startswith("- "):
+            break
+        if in_section and stripped.startswith("- "):
+            value = stripped[2:].strip()
+            if value and value.lower() != "none":
+                values.append(_redact_text(value, limit=180))
+    return _unique_strings([value for value in values if value])
 
 
 def _format_seconds_map(values: dict[str, int], *, empty: str) -> str:
@@ -461,6 +577,24 @@ def _format_samples(samples: list[str], *, empty: str) -> str:
     return "\n".join(f"- {_redact_text(sample, limit=160)}" for sample in samples[:8])
 
 
+def _format_screenshot_digests(screenshot_digests: dict[str, Any] | None) -> str:
+    if not screenshot_digests or not screenshot_digests.get("digests"):
+        return "- No rolling screenshot observation digests available"
+    lines = []
+    for digest in screenshot_digests.get("digests", [])[:8]:
+        window = " to ".join(
+            str(item)
+            for item in [digest.get("window_start"), digest.get("window_end")]
+            if item
+        )
+        prefix = f"- Window {window}" if window else "- Window"
+        lines.append(f"{prefix}: {digest.get('observation_count', 0)} observations")
+        content = _redact_report_body(str(digest.get("content") or ""), limit=700)
+        if content:
+            lines.extend(f"  {line}" for line in content.splitlines()[:12])
+    return "\n".join(lines)
+
+
 def _format_goals(goals: list[Any]) -> str:
     if not goals:
         return "- None"
@@ -475,15 +609,41 @@ def _format_alignment(alignment: list[dict[str, Any]]) -> str:
         return "- No active goals to compare."
     lines = []
     for item in alignment[:12]:
-        evidence = ", ".join(item["evidence_tokens"]) or "no clear screen-observation match"
-        lines.append(f"- {item['title']}: {item['status']} ({evidence})")
+        tokens = ", ".join(item.get("digest_evidence_tokens") or item.get("evidence_tokens") or [])
+        evidence = "; ".join(item.get("evidence") or [])
+        evidence_text = evidence or tokens or "no clear screen-observation match"
+        lines.append(
+            f"- {item['title']}: {item['status']}, needle={item.get('needle_movement', 'unclear')} "
+            f"({evidence_text})"
+        )
     return "\n".join(lines)
+
+
+def _episode_metadata(episode: MemoryEpisode) -> dict[str, Any]:
+    try:
+        payload = json.loads(episode.metadata_json or "{}")
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _unique_strings(values: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for value in values:
+        text = _redact_text(str(value), limit=240)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
 
 
 def _deterministic_report_body(
     *,
     report_day: date,
     summary: dict[str, Any],
+    screenshot_digests: dict[str, Any],
     alignment: list[dict[str, Any]],
     completed_goals: list[Any],
 ) -> str:
@@ -498,9 +658,14 @@ def _deterministic_report_body(
         summary.get("screenshot_samples", []),
         empty="- No screenshot-folder images analyzed",
     )
+    digest_summary = _format_screenshot_digests(screenshot_digests)
     aligned = [item for item in alignment if item["status"] == "aligned"]
-    unclear = [item for item in alignment if item["status"] != "aligned"]
+    blocked = [item for item in alignment if item["status"] == "blocked"]
+    drifted = [item for item in alignment if item["status"] == "drifted"]
+    unclear = [item for item in alignment if item["status"] == "unclear"]
+    pushed = [item for item in alignment if item.get("needle_movement") == "pushed"]
     completed = _format_goals(completed_goals)
+    comparison = _format_alignment(alignment)
 
     tips = [
         "Start tomorrow by naming the one goal the first focus block should serve.",
@@ -531,11 +696,20 @@ def _deterministic_report_body(
             "Screenshot samples:",
             screenshot_samples,
             "",
+            "Screenshot observation digests:",
+            digest_summary,
+            "",
             "Goals vs day:",
             f"- Aligned goals: {len(aligned)}",
+            f"- Pushed-the-needle goals: {len(pushed)}",
+            f"- Blocked goals: {len(blocked)}",
+            f"- Drifted goals: {len(drifted)}",
             f"- Unclear goals: {len(unclear)}",
             f"- Completed today: {len(completed_goals)}",
             completed,
+            "",
+            "Critical comparison:",
+            comparison,
             "",
             "Useful tips for tomorrow:",
             *(f"- {tip}" for tip in tips),
@@ -546,12 +720,13 @@ def _deterministic_report_body(
 async def build_end_of_day_goal_report(report_day: date | None = None) -> dict[str, Any]:
     tz = _safe_timezone()
     target_day = report_day or datetime.now(tz).date()
-    summary, goal_results = await asyncio.gather(
+    summary, screenshot_digests, goal_results = await asyncio.gather(
         _screen_summary_for_local_day(target_day, tz),
+        _screenshot_digests_for_local_day(target_day, tz),
         _goals_for_report(target_day),
     )
     active_goals, completed_goals = goal_results
-    alignment = _goal_alignment(summary, active_goals)
+    alignment = _goal_alignment(summary, active_goals, screenshot_digests)
 
     if settings.end_of_day_report_llm_enabled:
         prompt = _REPORT_PROMPT.format(
@@ -569,6 +744,7 @@ async def build_end_of_day_goal_report(report_day: date | None = None) -> dict[s
                 summary.get("screenshot_samples", []),
                 empty="- No screenshot-folder images analyzed",
             ),
+            screenshot_digests=_format_screenshot_digests(screenshot_digests),
             active_goals=_format_goals(active_goals),
             completed_goals=_format_goals(completed_goals),
             alignment_hints=_format_alignment(alignment),
@@ -587,6 +763,7 @@ async def build_end_of_day_goal_report(report_day: date | None = None) -> dict[s
             _deterministic_report_body(
                 report_day=target_day,
                 summary=summary,
+                screenshot_digests=screenshot_digests,
                 alignment=alignment,
                 completed_goals=completed_goals,
             ),
@@ -600,6 +777,7 @@ async def build_end_of_day_goal_report(report_day: date | None = None) -> dict[s
         "timezone": str(tz),
         "body": body,
         "summary": summary,
+        "screenshot_digests": screenshot_digests,
         "goal_alignment": alignment,
         "completed_goal_count": len(completed_goals),
         "active_goal_count": len(active_goals),
@@ -625,6 +803,10 @@ async def store_end_of_day_goal_report(report: dict[str, Any]) -> str:
             "date": report["date"],
             "timezone": report["timezone"],
             "screen_observation_count": report["summary"].get("total_observations", 0),
+            "screenshot_digest_count": (report.get("screenshot_digests") or {}).get("count", 0),
+            "screenshot_digest_observation_ids": (report.get("screenshot_digests") or {}).get(
+                "observation_ids", []
+            ),
             "total_tracked_minutes": report["summary"].get("total_tracked_minutes", 0),
             "active_goal_count": report["active_goal_count"],
             "completed_goal_count": report["completed_goal_count"],

--- a/backend/src/scheduler/jobs/screenshot_observation_digest.py
+++ b/backend/src/scheduler/jobs/screenshot_observation_digest.py
@@ -1,0 +1,360 @@
+"""Rolling privacy-safe digest windows for screenshot-folder observations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import or_
+from sqlmodel import col, select
+
+from config.settings import settings
+from src.audit.runtime import log_scheduler_job_event
+from src.db.engine import get_session
+from src.db.models import MemoryEpisode, MemoryEpisodeType, ScreenObservation
+from src.observer.screenshot_semantic_analysis import (
+    semantic_analysis_error_from_details,
+    semantic_analysis_from_details,
+    semantic_analysis_status_from_details,
+)
+from src.scheduler.jobs.end_of_day_goal_report import _redact_text
+
+logger = logging.getLogger(__name__)
+
+SCREENSHOT_DIGEST_SCHEMA_VERSION = "seraph.screenshot_observation_digest.v1"
+SCREENSHOT_DIGEST_TOOL_NAME = "screenshot_observation_digest"
+
+
+@dataclass(frozen=True)
+class ScreenshotDigestResult:
+    status: str
+    window_start: datetime
+    window_end: datetime
+    observation_count: int
+    episode_id: str | None = None
+    digest_key: str | None = None
+
+
+async def run_screenshot_observation_digest() -> None:
+    """Scheduler entrypoint for the current rolling screenshot digest window."""
+    if not settings.screenshot_observation_digest_enabled:
+        await log_scheduler_job_event(
+            job_name=SCREENSHOT_DIGEST_TOOL_NAME,
+            outcome="skipped",
+            details={"reason": "disabled"},
+        )
+        return
+    try:
+        result = await build_current_screenshot_observation_digest()
+        await log_scheduler_job_event(
+            job_name=SCREENSHOT_DIGEST_TOOL_NAME,
+            outcome="succeeded",
+            details={
+                "status": result.status,
+                "window_start": result.window_start.isoformat(),
+                "window_end": result.window_end.isoformat(),
+                "observation_count": result.observation_count,
+                "episode_id": result.episode_id,
+                "digest_key": result.digest_key,
+            },
+        )
+    except Exception as exc:
+        await log_scheduler_job_event(
+            job_name=SCREENSHOT_DIGEST_TOOL_NAME,
+            outcome="failed",
+            details={"error": exc.__class__.__name__},
+        )
+        logger.exception("screenshot observation digest failed")
+
+
+async def build_current_screenshot_observation_digest(
+    *,
+    now: datetime | None = None,
+) -> ScreenshotDigestResult:
+    """Build or update the current rolling digest window."""
+    window_end = _floor_window(now or datetime.now(timezone.utc), _window_minutes())
+    window_start = window_end - timedelta(minutes=_window_minutes())
+    return await build_screenshot_observation_digest(window_start=window_start, window_end=window_end)
+
+
+async def build_screenshot_observation_digest(
+    *,
+    window_start: datetime,
+    window_end: datetime,
+) -> ScreenshotDigestResult:
+    """Build or update one screenshot digest window."""
+    start = _ensure_utc(window_start)
+    end = _ensure_utc(window_end)
+    observations = await _screenshot_observations(start, end)
+    digest_key = _digest_key(start, end)
+    if not observations:
+        return ScreenshotDigestResult(
+            status="empty",
+            window_start=start,
+            window_end=end,
+            observation_count=0,
+            digest_key=digest_key,
+        )
+
+    payload = _digest_payload(start, end, observations, digest_key=digest_key)
+    content = _digest_content(payload)
+    payload_digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+
+    async with get_session() as db:
+        existing = await _existing_digest_episode(db, digest_key)
+        metadata = {
+            "kind": SCREENSHOT_DIGEST_TOOL_NAME,
+            "artifact_schema": SCREENSHOT_DIGEST_SCHEMA_VERSION,
+            "digest_key": digest_key,
+            "payload_sha256": payload_digest,
+            "window_start": start.isoformat(),
+            "window_end": end.isoformat(),
+            "observation_ids": payload["observation_ids"],
+            "observation_count": payload["observation_count"],
+            "content_char_count": len(content),
+        }
+        if existing is not None:
+            existing_metadata = _metadata(existing)
+            if existing_metadata.get("payload_sha256") == payload_digest:
+                return ScreenshotDigestResult(
+                    status="unchanged",
+                    window_start=start,
+                    window_end=end,
+                    observation_count=len(observations),
+                    episode_id=existing.id,
+                    digest_key=digest_key,
+                )
+            existing.summary = _digest_summary(payload)
+            existing.content = content
+            existing.metadata_json = json.dumps(metadata, sort_keys=True)
+            existing.observed_at = end
+            db.add(existing)
+            return ScreenshotDigestResult(
+                status="updated",
+                window_start=start,
+                window_end=end,
+                observation_count=len(observations),
+                episode_id=existing.id,
+                digest_key=digest_key,
+            )
+
+        episode = MemoryEpisode(
+            episode_type=MemoryEpisodeType.observer,
+            summary=_digest_summary(payload),
+            content=content,
+            source_tool_name=SCREENSHOT_DIGEST_TOOL_NAME,
+            salience=0.55,
+            confidence=0.75,
+            metadata_json=json.dumps(metadata, sort_keys=True),
+            observed_at=end,
+        )
+        db.add(episode)
+        await db.flush()
+        episode_id = episode.id
+
+    return ScreenshotDigestResult(
+        status="created",
+        window_start=start,
+        window_end=end,
+        observation_count=len(observations),
+        episode_id=episode_id,
+        digest_key=digest_key,
+    )
+
+
+async def _screenshot_observations(start: datetime, end: datetime) -> list[ScreenObservation]:
+    async with get_session() as db:
+        result = await db.execute(
+            select(ScreenObservation)
+            .where(col(ScreenObservation.timestamp) >= start)
+            .where(col(ScreenObservation.timestamp) < end)
+            .where(col(ScreenObservation.blocked) == False)  # noqa: E712
+            .where(
+                or_(
+                    col(ScreenObservation.app_name) == "Screenshot Folder",
+                    col(ScreenObservation.details_json).contains('"provider":"screenshot_folder"'),
+                    col(ScreenObservation.details_json).contains('"provider": "screenshot_folder"'),
+                )
+            )
+            .order_by(col(ScreenObservation.timestamp))
+        )
+        return list(result.scalars().all())
+
+
+def _digest_payload(
+    start: datetime,
+    end: datetime,
+    observations: list[ScreenObservation],
+    *,
+    digest_key: str,
+) -> dict[str, Any]:
+    activities: Counter[str] = Counter()
+    projects: Counter[str] = Counter()
+    statuses: Counter[str] = Counter()
+    apps: Counter[str] = Counter()
+    summaries: list[str] = []
+    snippets: list[str] = []
+    blockers: list[str] = []
+    drift: list[str] = []
+    confidence_values: list[float] = []
+
+    for obs in observations:
+        details = _details(obs)
+        analysis = semantic_analysis_from_details(details) or {}
+        status = semantic_analysis_status_from_details(details) or {}
+        error = semantic_analysis_error_from_details(details) or {}
+        activity = str(analysis.get("activity_type") or obs.activity_type or "unknown")
+        project = str(analysis.get("project") or obs.project or "unknown")
+        activities[activity] += 1
+        projects[project] += 1
+        apps[obs.app_name or "unknown"] += 1
+        statuses[str(status.get("status") or ("failed" if error else "pending"))] += 1
+        summary = _redact_text(str(analysis.get("summary") or obs.summary or ""), limit=180)
+        if summary and summary not in summaries:
+            summaries.append(summary)
+        for text in analysis.get("key_visible_text") or []:
+            snippet = _redact_text(str(text), limit=120)
+            if snippet and snippet not in snippets:
+                snippets.append(snippet)
+        alignment = analysis.get("goal_alignment") if isinstance(analysis.get("goal_alignment"), dict) else {}
+        alignment_status = str(alignment.get("status") or "")
+        if alignment_status == "blocked":
+            blockers.extend(_redacted_list(alignment.get("evidence"), limit=120))
+        if alignment_status == "drifted":
+            drift.extend(_redacted_list(alignment.get("evidence"), limit=120))
+        confidence = analysis.get("confidence")
+        if isinstance(confidence, (int, float)):
+            confidence_values.append(float(confidence))
+
+    return {
+        "artifact_schema": SCREENSHOT_DIGEST_SCHEMA_VERSION,
+        "digest_key": digest_key,
+        "window_start": start.isoformat(),
+        "window_end": end.isoformat(),
+        "observation_count": len(observations),
+        "observation_ids": [obs.id for obs in observations],
+        "activity_mix": dict(activities.most_common(8)),
+        "project_mix": dict(projects.most_common(8)),
+        "app_mix": dict(apps.most_common(8)),
+        "analysis_status": dict(statuses.most_common()),
+        "average_confidence": round(sum(confidence_values) / len(confidence_values), 3)
+        if confidence_values
+        else None,
+        "progression": summaries[:12],
+        "privacy_safe_snippets": snippets[:12],
+        "blockers": _unique(blockers)[:8],
+        "drift": _unique(drift)[:8],
+    }
+
+
+def _digest_content(payload: dict[str, Any]) -> str:
+    blockers = [f"- {item}" for item in payload["blockers"]] or ["- None"]
+    drift = [f"- {item}" for item in payload["drift"]] or ["- None"]
+    snippets = [f"- {item}" for item in payload["privacy_safe_snippets"]] or ["- None"]
+    lines = [
+        f"Screenshot digest {payload['window_start']} to {payload['window_end']}",
+        f"Observations: {payload['observation_count']}",
+        f"Analysis status: {payload['analysis_status']}",
+        f"Activity mix: {payload['activity_mix']}",
+        f"Project mix: {payload['project_mix']}",
+        f"Average confidence: {payload['average_confidence']}",
+        "",
+        "Progression:",
+        *[f"- {item}" for item in payload["progression"]],
+        "",
+        "Privacy-safe snippets:",
+        *snippets,
+        "",
+        "Evidence observation IDs:",
+        *[f"- {item}" for item in payload["observation_ids"]],
+        "",
+        "Blockers:",
+        *blockers,
+        "",
+        "Drift:",
+        *drift,
+    ]
+    content = "\n".join(lines)
+    return content[: max(settings.screenshot_observation_digest_max_chars, 500)]
+
+
+def _digest_summary(payload: dict[str, Any]) -> str:
+    project = next(iter(payload["project_mix"]), "unknown")
+    return (
+        f"Screenshot digest {payload['window_start']} to {payload['window_end']}: "
+        f"{payload['observation_count']} observations, main project {project}"
+    )
+
+
+async def _existing_digest_episode(db: Any, digest_key: str) -> MemoryEpisode | None:
+    result = await db.execute(
+        select(MemoryEpisode)
+        .where(col(MemoryEpisode.source_tool_name) == SCREENSHOT_DIGEST_TOOL_NAME)
+        .where(col(MemoryEpisode.metadata_json).contains(f'"digest_key": "{digest_key}"'))
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+def _digest_key(start: datetime, end: datetime) -> str:
+    raw = "|".join([SCREENSHOT_DIGEST_SCHEMA_VERSION, start.isoformat(), end.isoformat()])
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+def _floor_window(value: datetime, minutes: int) -> datetime:
+    timestamp = _ensure_utc(value)
+    minute = (timestamp.minute // minutes) * minutes
+    return timestamp.replace(minute=minute, second=0, microsecond=0)
+
+
+def _window_minutes() -> int:
+    raw = settings.screenshot_observation_digest_window_min
+    if not isinstance(raw, int) or raw < 1 or raw > 240:
+        return 30
+    return raw
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _details(observation: ScreenObservation) -> list[Any]:
+    try:
+        payload = json.loads(observation.details_json or "[]")
+    except json.JSONDecodeError:
+        return []
+    return payload if isinstance(payload, list) else []
+
+
+def _metadata(episode: MemoryEpisode) -> dict[str, Any]:
+    try:
+        payload = json.loads(episode.metadata_json or "{}")
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _redacted_list(values: Any, *, limit: int) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    return [_redact_text(str(value), limit=limit) for value in values if _redact_text(str(value), limit=limit)]
+
+
+def _unique(values: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -33,6 +33,7 @@ _PATCH_TARGETS = [
     "src.api.settings.get_db",  # aliased: `import get_session as get_db`
     "src.api.observer.get_session",
     "src.scheduler.jobs.memory_consolidation.get_session",
+    "src.scheduler.jobs.screenshot_observation_digest.get_session",
     "src.scheduler.scheduled_jobs.get_session",
     "src.observer.insight_queue.get_session",
     "src.observer.screenshot_folder_source.get_session",

--- a/backend/tests/test_end_of_day_goal_report.py
+++ b/backend/tests/test_end_of_day_goal_report.py
@@ -132,6 +132,133 @@ async def test_build_report_counts_screenshot_folder_observation_source(async_db
 
 
 @pytest.mark.asyncio
+async def test_build_report_uses_screenshot_digests_for_needle_movement(async_db):
+    from src.db.models import Goal, MemoryEpisode, MemoryEpisodeType
+    from src.scheduler.jobs.end_of_day_goal_report import build_end_of_day_goal_report
+
+    async with async_db() as db:
+        db.add(
+            Goal(
+                id="goal-digest",
+                path="/",
+                level="daily",
+                title="Ship Seraph screenshot digest report",
+                domain="productivity",
+                status="active",
+                sort_order=0,
+            )
+        )
+        db.add(
+            MemoryEpisode(
+                episode_type=MemoryEpisodeType.observer,
+                source_tool_name="screenshot_observation_digest",
+                summary="Screenshot digest window",
+                content="\n".join(
+                    [
+                        "Screenshot digest 2026-06-20T10:00:00+00:00 to 2026-06-20T10:30:00+00:00",
+                        "Observations: 2",
+                        "Progression:",
+                        "- Seraph screenshot digest report implementation was visible.",
+                        "Evidence observation IDs:",
+                        "- obs-a",
+                        "- obs-b",
+                        "Blockers:",
+                        "- Billing migration is blocked by an unrelated provider.",
+                        "Drift:",
+                        "- None",
+                    ]
+                ),
+                metadata_json=json.dumps(
+                    {
+                        "artifact_schema": "seraph.screenshot_observation_digest.v1",
+                        "window_start": "2026-06-20T10:00:00+00:00",
+                        "window_end": "2026-06-20T10:30:00+00:00",
+                        "observation_count": 2,
+                        "observation_ids": ["obs-a", "obs-b"],
+                    },
+                    sort_keys=True,
+                ),
+                observed_at=datetime(2026, 6, 20, 10, 30, tzinfo=timezone.utc),
+            )
+        )
+
+    with patch.object(settings, "user_timezone", "UTC"), patch.object(
+        settings, "end_of_day_report_llm_enabled", False
+    ):
+        report = await build_end_of_day_goal_report(date(2026, 6, 20))
+
+    assert report["screenshot_digests"]["count"] == 1
+    assert report["goal_alignment"][0]["status"] == "aligned"
+    assert report["goal_alignment"][0]["needle_movement"] == "pushed"
+    assert report["goal_alignment"][0]["source_observation_ids"] == ["obs-a", "obs-b"]
+    assert "Screenshot observation digests:" in report["body"]
+    assert "- Pushed-the-needle goals: 1" in report["body"]
+    assert "needle=pushed" in report["body"]
+
+
+@pytest.mark.asyncio
+async def test_build_report_marks_digest_goal_blocked(async_db):
+    from src.db.models import Goal, MemoryEpisode, MemoryEpisodeType
+    from src.scheduler.jobs.end_of_day_goal_report import build_end_of_day_goal_report
+
+    async with async_db() as db:
+        db.add(
+            Goal(
+                id="goal-blocked",
+                path="/",
+                level="daily",
+                title="Finish Seraph screenshot reports",
+                domain="productivity",
+                status="active",
+                sort_order=0,
+            )
+        )
+        db.add(
+            MemoryEpisode(
+                episode_type=MemoryEpisodeType.observer,
+                source_tool_name="screenshot_observation_digest",
+                summary="Screenshot digest window",
+                content="\n".join(
+                    [
+                        "Screenshot digest 2026-06-20T11:00:00+00:00 to 2026-06-20T11:30:00+00:00",
+                        "Observations: 1",
+                        "Progression:",
+                        "- Seraph screenshot reports were being tested.",
+                        "Evidence observation IDs:",
+                        "- obs-c",
+                        "Blockers:",
+                        "- Seraph screenshot reports are blocked by local VLM provider failure.",
+                        "Drift:",
+                        "- None",
+                    ]
+                ),
+                metadata_json=json.dumps(
+                    {
+                        "artifact_schema": "seraph.screenshot_observation_digest.v1",
+                        "window_start": "2026-06-20T11:00:00+00:00",
+                        "window_end": "2026-06-20T11:30:00+00:00",
+                        "observation_count": 1,
+                        "observation_ids": ["obs-c"],
+                    },
+                    sort_keys=True,
+                ),
+                observed_at=datetime(2026, 6, 20, 11, 30, tzinfo=timezone.utc),
+            )
+        )
+
+    with patch.object(settings, "user_timezone", "UTC"), patch.object(
+        settings, "end_of_day_report_llm_enabled", False
+    ):
+        report = await build_end_of_day_goal_report(date(2026, 6, 20))
+
+    assert report["goal_alignment"][0]["status"] == "blocked"
+    assert report["goal_alignment"][0]["needle_movement"] == "blocked"
+    assert "local VLM provider failure" in report["goal_alignment"][0]["evidence"][0]
+    assert "- Blocked goals: 1" in report["body"]
+    assert "needle=blocked" in report["body"]
+
+
+@pytest.mark.asyncio
 async def test_build_report_does_not_treat_named_external_provider_as_source(async_db):
     from src.db.models import ScreenObservation
     from src.scheduler.jobs.end_of_day_goal_report import build_end_of_day_goal_report

--- a/backend/tests/test_observer_screen_artifacts.py
+++ b/backend/tests/test_observer_screen_artifacts.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -246,6 +247,8 @@ async def test_screenshot_folder_scan_persists_observation_and_serves_image(asyn
     assert analysis["provider"] == "screenshot_folder"
     assert analysis["analysis"]["analysis_owner"] == "seraph"
     assert analysis["analysis"]["source"] == "local_screenshot_folder"
+    assert analysis["analysis"]["semantic_status"] == "pending"
+    assert analysis["analysis"]["semantic_status_detail"]["status"] == "pending"
     assert analysis["analysis"]["image_sha256"] == image_sha256
     assert analysis["analysis"]["image_bytes"] == len(image.read_bytes())
     assert analysis["analysis"]["file_format"] == "png"
@@ -255,6 +258,35 @@ async def test_screenshot_folder_scan_persists_observation_and_serves_image(asyn
     output_resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/codex-output")
     assert output_resp.status_code == 200
     assert "screenshot folder source only provided the image file" in output_resp.text
+
+
+@pytest.mark.asyncio
+async def test_screenshot_folder_scan_uses_file_mtime_as_observation_timestamp(async_db, client, tmp_path):
+    root = tmp_path / "screenshots"
+    image = _write_screenshot(root, name="capture-time.png")
+    captured_at = datetime(2026, 6, 30, 12, 34, 56, tzinfo=timezone.utc)
+    os.utime(image, (captured_at.timestamp(), captured_at.timestamp()))
+
+    resp = await client.post(
+        "/api/observer/screenshot-folder/scan",
+        json={"screenshot_folder": str(root), "limit": 10},
+    )
+
+    assert resp.status_code == 200
+    async with async_db() as db:
+        result = await db.execute(select(ScreenObservation))
+        observation = result.scalar_one()
+
+    timestamp = observation.timestamp
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    assert timestamp == captured_at
+    artifacts = [
+        json.loads(item.removeprefix("capture_artifacts:"))
+        for item in json.loads(observation.details_json or "[]")
+        if isinstance(item, str) and item.startswith("capture_artifacts:")
+    ][0]
+    assert artifacts["created_at"] == captured_at.isoformat()
 
 
 @pytest.mark.asyncio
@@ -325,7 +357,8 @@ async def test_screenshot_folder_scan_persists_local_vlm_semantic_analysis(
     analysis_resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/analysis")
     assert analysis_resp.status_code == 200
     analysis = analysis_resp.json()["analysis"]
-    assert analysis["semantic_status"] == "ready"
+    assert analysis["semantic_status"] == "succeeded"
+    assert analysis["semantic_status_detail"]["status"] == "succeeded"
     assert analysis["semantic_analysis"]["project"] == "seraph"
     assert analysis["semantic_analysis"]["activity_type"] == "coding"
     assert analysis["semantic_analysis"]["goal_alignment"]["status"] == "aligned"
@@ -381,8 +414,193 @@ async def test_screenshot_folder_scan_keeps_metadata_when_local_vlm_fails(
     assert analysis_resp.status_code == 200
     analysis = analysis_resp.json()["analysis"]
     assert analysis["semantic_status"] == "failed"
+    assert analysis["semantic_status_detail"]["status"] == "failed"
     assert analysis["semantic_error"]["reason"] == "provider unavailable"
     assert analysis["semantic_analysis"] is None
+
+
+@pytest.mark.asyncio
+async def test_screenshot_folder_reanalysis_requires_explicit_allowed_reason(async_db, client, tmp_path):
+    root = tmp_path / "screenshots"
+    _write_screenshot(root, name="capture-invalid-reason.png")
+
+    scan = await client.post(
+        "/api/observer/screenshot-folder/scan",
+        json={"screenshot_folder": str(root), "limit": 10},
+    )
+    assert scan.status_code == 200
+    async with async_db() as db:
+        result = await db.execute(select(ScreenObservation))
+        observation = result.scalar_one()
+
+    resp = await client.post(
+        f"/api/observer/screen-artifacts/{observation.id}/reanalyze",
+        json={"reanalysis_reason": "because I feel like it"},
+    )
+
+    assert resp.status_code == 422
+    assert "prompt_version_changed" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_screenshot_folder_reanalysis_replaces_failed_status_without_duplicate_observation(
+    async_db, client, tmp_path, monkeypatch
+):
+    from src.observer.screenshot_semantic_analysis import ScreenshotSemanticAnalysisError
+
+    root = tmp_path / "screenshots"
+    _write_screenshot(root, name="capture-retry.png")
+    calls = {"count": 0}
+
+    async def analyzer(image_path, artifacts):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise ScreenshotSemanticAnalysisError("provider unavailable")
+        return ScreenshotAnalysis.model_validate(
+            {
+                "schema_version": "seraph.screenshot_analysis.v1",
+                "prompt_version": "seraph.screenshot_analysis.prompt.v1",
+                "summary": "The user recovered screenshot analysis.",
+                "detailed_observations": ["The screenshot analysis retry succeeded."],
+                "activity_type": "reviewing",
+                "project": "seraph",
+                "applications": ["editor"],
+                "visible_artifacts": ["capture-retry.png"],
+                "key_visible_text": ["reanalyze"],
+                "user_intent": "Retry semantic screenshot analysis.",
+                "goal_alignment": {
+                    "status": "aligned",
+                    "goal_refs": ["screenshot intelligence loop"],
+                    "evidence": ["The reanalysis endpoint is being exercised."],
+                    "needle_movement": "pushed",
+                },
+                "confidence": 0.8,
+                "sensitive_content_seen": False,
+                "privacy_notes": [],
+                "report_tags": ["retry"],
+            }
+        )
+
+    monkeypatch.setattr(
+        "src.observer.screenshot_folder_source.analyze_screenshot_image",
+        analyzer,
+    )
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.analyze_screenshot_image", analyzer)
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.screen_analysis_provider", "local-vlm")
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.local_vlm_base_url", "http://gpu:8088")
+
+    scan = await client.post(
+        "/api/observer/screenshot-folder/scan",
+        json={"screenshot_folder": str(root), "limit": 10},
+    )
+    assert scan.status_code == 200
+    async with async_db() as db:
+        result = await db.execute(select(ScreenObservation))
+        observation = result.scalar_one()
+
+    retry = await client.post(
+        f"/api/observer/screen-artifacts/{observation.id}/reanalyze",
+        json={"reanalysis_reason": "provider_failure_retry"},
+    )
+
+    assert retry.status_code == 200
+    analysis = retry.json()["analysis"]
+    assert analysis["semantic_status"] == "succeeded"
+    assert analysis["semantic_status_detail"]["reanalysis_reason"] == "provider_failure_retry"
+    assert analysis["semantic_analysis"]["summary"] == "The user recovered screenshot analysis."
+    async with async_db() as db:
+        result = await db.execute(select(ScreenObservation))
+        observations = list(result.scalars().all())
+    assert len(observations) == 1
+
+
+@pytest.mark.asyncio
+async def test_screenshot_folder_analysis_marks_old_prompt_version_for_reanalysis(
+    async_db, client, tmp_path
+):
+    root = tmp_path / "screenshots"
+    image = _write_screenshot(root, name="capture-old-version.png")
+    image_sha256 = hashlib.sha256(image.read_bytes()).hexdigest()
+    artifacts = {
+        "id": image_sha256[:16],
+        "provider": "screenshot_folder",
+        "source": "local_image_directory",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "screenshot_folder": str(root.resolve()),
+        "image_path": str(image.resolve()),
+        "image_sha256": image_sha256,
+        "image_bytes": len(image.read_bytes()),
+        "file_format": "png",
+        "width": None,
+        "height": None,
+    }
+    async with async_db() as db:
+        db.add(
+            ScreenObservation(
+                app_name="Screenshot Folder",
+                window_title=image.name,
+                activity_type="screen",
+                summary="Old analysis.",
+                details_json=json.dumps(
+                    [
+                        f"screenshot_folder_image_sha256:{image_sha256}",
+                        "capture_artifacts:" + json.dumps(artifacts, sort_keys=True, separators=(",", ":")),
+                        "screenshot_analysis:"
+                        + json.dumps(
+                            {
+                                "schema_version": "seraph.screenshot_analysis.v1",
+                                "prompt_version": "old.prompt",
+                                "summary": "Old prompt analysis.",
+                                "detailed_observations": [],
+                                "activity_type": "unknown",
+                                "project": None,
+                                "applications": [],
+                                "visible_artifacts": [],
+                                "key_visible_text": [],
+                                "user_intent": "unknown",
+                                "goal_alignment": {
+                                    "status": "unknown",
+                                    "goal_refs": [],
+                                    "evidence": [],
+                                    "needle_movement": "unknown",
+                                },
+                                "confidence": 0.1,
+                                "sensitive_content_seen": False,
+                                "privacy_notes": [],
+                                "report_tags": [],
+                            },
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ),
+                        "screenshot_analysis_status:"
+                        + json.dumps(
+                            {
+                                "status": "succeeded",
+                                "provider": "local-vlm",
+                                "model": None,
+                                "schema_version": "seraph.screenshot_analysis.v1",
+                                "prompt_version": "old.prompt",
+                                "recorded_at": datetime.now(timezone.utc).isoformat(),
+                            },
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ),
+                    ]
+                ),
+                timestamp=datetime.now(timezone.utc),
+            )
+        )
+
+    analysis_resp = await client.get(f"/api/observer/screen-artifacts/{artifacts['id']}/analysis")
+    assert analysis_resp.status_code == 404
+    async with async_db() as db:
+        result = await db.execute(select(ScreenObservation))
+        observation = result.scalar_one()
+
+    analysis_resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/analysis")
+    assert analysis_resp.status_code == 200
+    analysis = analysis_resp.json()["analysis"]
+    assert analysis["semantic_status"] == "needs_reanalysis"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_observer_screen_artifacts.py
+++ b/backend/tests/test_observer_screen_artifacts.py
@@ -10,6 +10,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlmodel import select
 
 from src.db.models import ScreenObservation
+from src.observer.screenshot_analysis_contract import ScreenshotAnalysis
 
 
 @pytest.mark.asyncio
@@ -254,6 +255,134 @@ async def test_screenshot_folder_scan_persists_observation_and_serves_image(asyn
     output_resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/codex-output")
     assert output_resp.status_code == 200
     assert "screenshot folder source only provided the image file" in output_resp.text
+
+
+@pytest.mark.asyncio
+async def test_screenshot_folder_scan_persists_local_vlm_semantic_analysis(
+    async_db, client, tmp_path, monkeypatch
+):
+    root = tmp_path / "screenshots"
+    image = _write_screenshot(root, name="capture-semantic.png", data=_sample_png())
+    image_sha256 = hashlib.sha256(image.read_bytes()).hexdigest()
+    calls = []
+
+    async def fake_analyze_screenshot_image(image_path, artifacts):
+        calls.append((image_path, artifacts))
+        return ScreenshotAnalysis.model_validate(
+            {
+                "schema_version": "seraph.screenshot_analysis.v1",
+                "prompt_version": "seraph.screenshot_analysis.prompt.v1",
+                "summary": "The user is implementing screenshot ingestion in Seraph.",
+                "detailed_observations": ["A code editor and tests are visible."],
+                "activity_type": "coding",
+                "project": "seraph",
+                "applications": ["editor"],
+                "visible_artifacts": ["test_observer_screen_artifacts.py"],
+                "key_visible_text": ["screenshot-folder/scan"],
+                "user_intent": "Wire screenshot folder images into analysis.",
+                "goal_alignment": {
+                    "status": "aligned",
+                    "goal_refs": ["screenshot intelligence loop"],
+                    "evidence": ["The visible file concerns screenshot ingestion."],
+                    "needle_movement": "pushed",
+                },
+                "confidence": 0.86,
+                "sensitive_content_seen": False,
+                "privacy_notes": [],
+                "report_tags": ["screenshots", "seraph"],
+            }
+        )
+
+    monkeypatch.setattr(
+        "src.observer.screenshot_folder_source.analyze_screenshot_image",
+        fake_analyze_screenshot_image,
+    )
+
+    resp = await client.post(
+        "/api/observer/screenshot-folder/scan",
+        json={"screenshot_folder": str(root), "limit": 10},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["ingested"] == 1
+    assert calls
+    assert calls[0][0] == image.resolve()
+    assert calls[0][1]["image_sha256"] == image_sha256
+
+    async with async_db() as db:
+        result = await db.execute(select(ScreenObservation))
+        observation = result.scalar_one()
+
+    stored_details = json.loads(observation.details_json or "[]")
+    semantic_details = [
+        json.loads(item.removeprefix("screenshot_analysis:"))
+        for item in stored_details
+        if isinstance(item, str) and item.startswith("screenshot_analysis:")
+    ]
+    assert semantic_details[0]["summary"] == "The user is implementing screenshot ingestion in Seraph."
+    assert semantic_details[0]["goal_alignment"]["needle_movement"] == "pushed"
+
+    analysis_resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/analysis")
+    assert analysis_resp.status_code == 200
+    analysis = analysis_resp.json()["analysis"]
+    assert analysis["semantic_status"] == "ready"
+    assert analysis["semantic_analysis"]["project"] == "seraph"
+    assert analysis["semantic_analysis"]["activity_type"] == "coding"
+    assert analysis["semantic_analysis"]["goal_alignment"]["status"] == "aligned"
+    assert analysis["semantic_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_screenshot_folder_scan_keeps_metadata_when_local_vlm_fails(
+    async_db, client, tmp_path, monkeypatch
+):
+    from src.observer.screenshot_semantic_analysis import ScreenshotSemanticAnalysisError
+
+    root = tmp_path / "screenshots"
+    _write_screenshot(root, name="capture-failure.png")
+
+    async def failing_analyze_screenshot_image(_image_path, _artifacts):
+        raise ScreenshotSemanticAnalysisError("provider unavailable")
+
+    monkeypatch.setattr(
+        "src.observer.screenshot_folder_source.analyze_screenshot_image",
+        failing_analyze_screenshot_image,
+    )
+
+    first = await client.post(
+        "/api/observer/screenshot-folder/scan",
+        json={"screenshot_folder": str(root), "limit": 10},
+    )
+    second = await client.post(
+        "/api/observer/screenshot-folder/scan",
+        json={"screenshot_folder": str(root), "limit": 10},
+    )
+
+    assert first.status_code == 200
+    assert first.json()["ingested"] == 1
+    assert first.json()["rejected"] == []
+    assert second.status_code == 200
+    assert second.json()["ingested"] == 0
+    assert second.json()["skipped_duplicates"] == 1
+
+    async with async_db() as db:
+        result = await db.execute(select(ScreenObservation))
+        observation = result.scalar_one()
+
+    stored_details = json.loads(observation.details_json or "[]")
+    error_details = [
+        json.loads(item.removeprefix("screenshot_analysis_error:"))
+        for item in stored_details
+        if isinstance(item, str) and item.startswith("screenshot_analysis_error:")
+    ]
+    assert error_details[0]["reason"] == "provider unavailable"
+
+    analysis_resp = await client.get(f"/api/observer/screen-artifacts/{observation.id}/analysis")
+    assert analysis_resp.status_code == 200
+    analysis = analysis_resp.json()["analysis"]
+    assert analysis["semantic_status"] == "failed"
+    assert analysis["semantic_error"]["reason"] == "provider unavailable"
+    assert analysis["semantic_analysis"] is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_screenshot_intelligence_loop.py
+++ b/backend/tests/test_screenshot_intelligence_loop.py
@@ -1,0 +1,158 @@
+"""Full-loop tests for screenshot-folder intelligence and reports."""
+
+from __future__ import annotations
+
+import os
+import hashlib
+import json
+from datetime import date, datetime, timezone
+
+import pytest
+
+from config.settings import settings
+
+
+@pytest.mark.asyncio
+async def test_screenshot_folder_analysis_digest_report_and_status_loop(
+    async_db,
+    client,
+    tmp_path,
+    monkeypatch,
+):
+    from src.db.models import Goal, MemoryEpisode, ScreenObservation
+    from src.observer.screenshot_analysis_contract import parse_screenshot_analysis_output
+    from src.observer.screenshot_folder_source import scan_screenshot_folder
+    from src.scheduler.jobs.end_of_day_goal_report import build_end_of_day_goal_report
+    from src.scheduler.jobs.screenshot_observation_digest import build_screenshot_observation_digest
+    from sqlmodel import select
+
+    screenshot_root = tmp_path / "screenshots"
+    screenshot_root.mkdir()
+    image_bytes = b"fake png bytes"
+    image_sha256 = hashlib.sha256(image_bytes).hexdigest()
+    image = screenshot_root / "seraph-loop.png"
+    duplicate_image = screenshot_root / "seraph-loop-copy.png"
+    image.write_bytes(image_bytes)
+    duplicate_image.write_bytes(image_bytes)
+    captured_at = datetime(2026, 6, 30, 10, 5, tzinfo=timezone.utc)
+    os.utime(image, (captured_at.timestamp(), captured_at.timestamp()))
+    os.utime(duplicate_image, (captured_at.timestamp(), captured_at.timestamp()))
+    analysis = parse_screenshot_analysis_output(
+        {
+            "schema_version": "seraph.screenshot_analysis.v1",
+            "prompt_version": "seraph.screenshot_analysis.prompt.v1",
+            "summary": "The user is implementing Seraph screenshot intelligence loop tests.",
+            "detailed_observations": [
+                "A test covers screenshot ingestion, digest creation, and reporting."
+            ],
+            "activity_type": "coding",
+            "project": "seraph",
+            "applications": ["editor"],
+            "visible_artifacts": ["test_screenshot_intelligence_loop.py"],
+            "key_visible_text": ["screenshot intelligence loop"],
+            "user_intent": "Verify the complete Seraph screenshot analysis path.",
+            "goal_alignment": {
+                "status": "aligned",
+                "goal_refs": ["Seraph screenshot intelligence loop"],
+                "evidence": ["The visible work is the screenshot loop test."],
+                "needle_movement": "pushed",
+            },
+            "confidence": 0.9,
+            "sensitive_content_seen": False,
+            "privacy_notes": [],
+            "report_tags": ["screenshots", "daily-report"],
+        }
+    )
+
+    analyzer_calls = []
+
+    async def fake_analyze_screenshot_image(_image_path, _artifacts):
+        analyzer_calls.append((_image_path, dict(_artifacts)))
+        return analysis
+
+    monkeypatch.setattr(
+        "src.observer.screenshot_folder_source.analyze_screenshot_image",
+        fake_analyze_screenshot_image,
+    )
+    monkeypatch.setenv("SERAPH_SCREENSHOT_FOLDER", str(screenshot_root))
+    monkeypatch.setattr("src.api.settings.settings.screen_analysis_provider", "local-vlm")
+    monkeypatch.setattr("src.api.settings.settings.local_vlm_base_url", "http://gpu:8088")
+    monkeypatch.setattr("src.api.settings.settings.local_vlm_model", "gemma-test")
+    async with async_db() as db:
+        db.add(
+            Goal(
+                id="goal-loop",
+                path="/",
+                level="daily",
+                title="Ship Seraph screenshot intelligence loop",
+                domain="productivity",
+                status="active",
+                sort_order=0,
+            )
+        )
+
+    scan_result = await scan_screenshot_folder(screenshot_root, limit=10)
+    duplicate_scan_result = await scan_screenshot_folder(screenshot_root, limit=10)
+    digest_result = await build_screenshot_observation_digest(
+        window_start=datetime(2026, 6, 30, 10, 0, tzinfo=timezone.utc),
+        window_end=datetime(2026, 6, 30, 10, 30, tzinfo=timezone.utc),
+    )
+    with monkeypatch.context() as report_patch:
+        report_patch.setattr(settings, "user_timezone", "UTC")
+        report_patch.setattr(settings, "end_of_day_report_llm_enabled", False)
+        report = await build_end_of_day_goal_report(date(2026, 6, 30))
+
+    status = (await client.get("/api/settings/artifact-storage")).json()
+    async with async_db() as db:
+        observations = list((await db.execute(select(ScreenObservation))).scalars().all())
+        episodes = list((await db.execute(select(MemoryEpisode))).scalars().all())
+
+    assert scan_result.ingested == 1
+    assert scan_result.skipped_duplicates == 1
+    assert duplicate_scan_result.ingested == 0
+    assert duplicate_scan_result.skipped_duplicates == 2
+    assert len(analyzer_calls) == 1
+    analyzed_path, analyzed_artifacts = analyzer_calls[0]
+    assert analyzed_path in {image.resolve(), duplicate_image.resolve()}
+    assert analyzed_artifacts["provider"] == "screenshot_folder"
+    assert analyzed_artifacts["source"] == "local_image_directory"
+    assert analyzed_artifacts["created_at"] == captured_at.isoformat()
+    assert analyzed_artifacts["image_sha256"] == image_sha256
+    assert "manifest" not in analyzed_artifacts
+    assert "service" not in analyzed_artifacts
+    assert len(observations) == 1
+    assert observations[0].timestamp.replace(tzinfo=timezone.utc) == captured_at
+    details = json.loads(observations[0].details_json or "[]")
+    assert f"screenshot_folder_image_sha256:{image_sha256}" in details
+    assert any(str(item).startswith("capture_artifacts:") for item in details)
+    assert any(str(item).startswith("screenshot_analysis:") for item in details)
+    assert any(str(item).startswith("screenshot_analysis_status:") for item in details)
+    assert digest_result.status == "created"
+    assert digest_result.observation_count == 1
+    digest_episode = next(
+        episode for episode in episodes if episode.source_tool_name == "screenshot_observation_digest"
+    )
+    digest_metadata = json.loads(digest_episode.metadata_json or "{}")
+    assert digest_metadata["observation_ids"] == [observations[0].id]
+    assert digest_metadata["observation_count"] == 1
+    assert "Evidence observation IDs:" in digest_episode.content
+    assert observations[0].id in digest_episode.content
+    assert "screenshot intelligence loop" in digest_episode.content
+    assert str(image.resolve()) not in digest_episode.content
+    assert image_sha256 not in digest_episode.content
+    assert report["screenshot_digests"]["count"] == 1
+    assert report["screenshot_digests"]["observation_ids"] == ["[redacted]"]
+    assert observations[0].id not in report["screenshot_digests"]["redacted_text"]
+    assert "[redacted]" in report["screenshot_digests"]["redacted_text"]
+    assert "screenshot intelligence loop" in report["screenshot_digests"]["redacted_text"]
+    assert str(image.resolve()) not in report["screenshot_digests"]["redacted_text"]
+    assert image_sha256 not in report["screenshot_digests"]["redacted_text"]
+    assert report["goal_alignment"][0]["status"] == "aligned"
+    assert report["goal_alignment"][0]["needle_movement"] == "pushed"
+    assert report["goal_alignment"][0]["source_observation_ids"] == ["[redacted]"]
+    assert "- Pushed-the-needle goals: 1" in report["body"]
+    assert status["screenshot_folder"]["analysis"]["observation_count"] == 1
+    assert status["screenshot_folder"]["analysis"]["analysis_status"]["succeeded"] == 1
+    assert status["screenshot_folder"]["analysis"]["analysis_failures"] == 0
+    assert status["screenshot_folder"]["analysis"]["analysis_backlog"] == 0
+    assert status["screenshot_folder"]["analysis"]["digest_count"] == 1

--- a/backend/tests/test_screenshot_observation_digest.py
+++ b/backend/tests/test_screenshot_observation_digest.py
@@ -1,0 +1,227 @@
+"""Tests for rolling screenshot observation digests."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+from sqlmodel import select
+
+import src.db.models  # noqa: F401
+from src.db.models import MemoryEpisode, ScreenObservation
+
+
+@pytest.mark.asyncio
+async def test_screenshot_digest_groups_window_and_links_evidence(async_db):
+    from src.scheduler.jobs.screenshot_observation_digest import build_screenshot_observation_digest
+
+    start = datetime(2026, 6, 30, 9, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 6, 30, 9, 30, tzinfo=timezone.utc)
+    async with async_db() as db:
+        db.add(
+            _observation(
+                timestamp=datetime(2026, 6, 30, 9, 5, tzinfo=timezone.utc),
+                image_sha256="hash-one",
+                summary="Working on Seraph screenshot digest with api_key=super-secret-token",
+                analysis={
+                    "summary": "Implemented rolling screenshot digest.",
+                    "activity_type": "coding",
+                    "project": "seraph",
+                    "key_visible_text": ["digest job", "api_key=super-secret-token"],
+                    "confidence": 0.8,
+                    "goal_alignment": {
+                        "status": "aligned",
+                        "evidence": ["Digest code is visible."],
+                        "needle_movement": "pushed",
+                    },
+                },
+            )
+        )
+        db.add(
+            _observation(
+                timestamp=datetime(2026, 6, 30, 9, 20, tzinfo=timezone.utc),
+                image_sha256="hash-two",
+                summary="Reviewing blocked provider retry",
+                analysis={
+                    "summary": "Reviewed failed provider retry.",
+                    "activity_type": "reviewing",
+                    "project": "seraph",
+                    "key_visible_text": ["provider retry"],
+                    "confidence": 0.6,
+                    "goal_alignment": {
+                        "status": "blocked",
+                        "evidence": ["Provider unavailable."],
+                        "needle_movement": "blocked",
+                    },
+                },
+            )
+        )
+        db.add(
+            _observation(
+                timestamp=datetime(2026, 6, 30, 9, 45, tzinfo=timezone.utc),
+                image_sha256="hash-outside",
+                summary="Outside the digest window",
+            )
+        )
+
+    result = await build_screenshot_observation_digest(window_start=start, window_end=end)
+
+    assert result.status == "created"
+    assert result.observation_count == 2
+    async with async_db() as db:
+        episodes = list((await db.execute(select(MemoryEpisode))).scalars().all())
+    assert len(episodes) == 1
+    episode = episodes[0]
+    metadata = json.loads(episode.metadata_json or "{}")
+    assert metadata["kind"] == "screenshot_observation_digest"
+    assert metadata["observation_count"] == 2
+    assert len(metadata["observation_ids"]) == 2
+    assert "hash-one" not in episode.content
+    assert "api_key=super-secret-token" not in episode.content
+    assert "[redacted]" in episode.content
+    assert "Provider unavailable." in episode.content
+
+
+@pytest.mark.asyncio
+async def test_screenshot_digest_is_idempotent_and_updates_when_window_changes(async_db):
+    from src.scheduler.jobs.screenshot_observation_digest import build_screenshot_observation_digest
+
+    start = datetime(2026, 6, 30, 10, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 6, 30, 10, 30, tzinfo=timezone.utc)
+    async with async_db() as db:
+        db.add(
+            _observation(
+                timestamp=datetime(2026, 6, 30, 10, 5, tzinfo=timezone.utc),
+                image_sha256="hash-a",
+                summary="First digest observation",
+            )
+        )
+
+    created = await build_screenshot_observation_digest(window_start=start, window_end=end)
+    unchanged = await build_screenshot_observation_digest(window_start=start, window_end=end)
+    async with async_db() as db:
+        db.add(
+            _observation(
+                timestamp=datetime(2026, 6, 30, 10, 15, tzinfo=timezone.utc),
+                image_sha256="hash-b",
+                summary="Second digest observation",
+            )
+        )
+    updated = await build_screenshot_observation_digest(window_start=start, window_end=end)
+
+    assert created.status == "created"
+    assert unchanged.status == "unchanged"
+    assert updated.status == "updated"
+    assert created.episode_id == unchanged.episode_id == updated.episode_id
+    async with async_db() as db:
+        episodes = list((await db.execute(select(MemoryEpisode))).scalars().all())
+    assert len(episodes) == 1
+    metadata = json.loads(episodes[0].metadata_json or "{}")
+    assert metadata["observation_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_screenshot_digest_respects_content_size_limit(async_db, monkeypatch):
+    from src.scheduler.jobs.screenshot_observation_digest import build_screenshot_observation_digest
+
+    start = datetime(2026, 6, 30, 11, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 6, 30, 11, 30, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        "src.scheduler.jobs.screenshot_observation_digest.settings.screenshot_observation_digest_max_chars",
+        500,
+    )
+    async with async_db() as db:
+        for index in range(12):
+            db.add(
+                _observation(
+                    timestamp=datetime(2026, 6, 30, 11, index, tzinfo=timezone.utc),
+                    image_sha256=f"hash-{index}",
+                    summary=f"Long digest observation {index} " + ("useful context " * 20),
+                )
+            )
+
+    result = await build_screenshot_observation_digest(window_start=start, window_end=end)
+
+    assert result.status == "created"
+    async with async_db() as db:
+        episode = (await db.execute(select(MemoryEpisode))).scalar_one()
+    assert len(episode.content) <= 500
+
+
+def _observation(
+    *,
+    timestamp: datetime,
+    image_sha256: str,
+    summary: str,
+    analysis: dict | None = None,
+) -> ScreenObservation:
+    analysis_payload = {
+        "schema_version": "seraph.screenshot_analysis.v1",
+        "prompt_version": "seraph.screenshot_analysis.prompt.v1",
+        "summary": summary,
+        "detailed_observations": [],
+        "activity_type": "coding",
+        "project": "seraph",
+        "applications": ["editor"],
+        "visible_artifacts": [],
+        "key_visible_text": [],
+        "user_intent": "unknown",
+        "goal_alignment": {
+            "status": "unknown",
+            "goal_refs": [],
+            "evidence": [],
+            "needle_movement": "unknown",
+        },
+        "confidence": 0.5,
+        "sensitive_content_seen": False,
+        "privacy_notes": [],
+        "report_tags": [],
+    }
+    if analysis:
+        analysis_payload.update(analysis)
+    details = [
+        f"screenshot_folder_image_sha256:{image_sha256}",
+        "capture_artifacts:"
+        + json.dumps(
+            {
+                "id": image_sha256[:16],
+                "provider": "screenshot_folder",
+                "source": "local_image_directory",
+                "created_at": timestamp.isoformat(),
+                "screenshot_folder": "/tmp/screenshots",
+                "image_path": f"/tmp/screenshots/{image_sha256}.png",
+                "image_sha256": image_sha256,
+                "image_bytes": 10,
+                "file_format": "png",
+                "width": 1,
+                "height": 1,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        "screenshot_analysis:" + json.dumps(analysis_payload, sort_keys=True, separators=(",", ":")),
+        "screenshot_analysis_status:"
+        + json.dumps(
+            {
+                "status": "succeeded",
+                "provider": "local-vlm",
+                "model": "gemma",
+                "schema_version": "seraph.screenshot_analysis.v1",
+                "prompt_version": "seraph.screenshot_analysis.prompt.v1",
+                "recorded_at": timestamp.isoformat(),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    ]
+    return ScreenObservation(
+        timestamp=timestamp,
+        app_name="Screenshot Folder",
+        window_title=f"{image_sha256}.png",
+        activity_type="screen",
+        project=None,
+        summary=summary,
+        details_json=json.dumps(details),
+        blocked=False,
+    )

--- a/backend/tests/test_screenshot_semantic_analysis.py
+++ b/backend/tests/test_screenshot_semantic_analysis.py
@@ -1,0 +1,107 @@
+"""Tests for provider-backed semantic screenshot analysis."""
+
+from __future__ import annotations
+
+from src.observer.screenshot_semantic_analysis import analyze_screenshot_image
+
+
+async def test_local_vlm_analyzer_posts_prompt_file_and_validates_response(tmp_path, monkeypatch):
+    image = tmp_path / "capture.png"
+    image.write_bytes(b"png bytes")
+    calls = []
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "analysis": {
+                    "schema_version": "seraph.screenshot_analysis.v1",
+                    "prompt_version": "seraph.screenshot_analysis.prompt.v1",
+                    "summary": "The user is reviewing a screenshot analysis flow.",
+                    "detailed_observations": ["A Seraph test file is visible."],
+                    "activity_type": "reviewing",
+                    "project": "seraph",
+                    "applications": ["editor"],
+                    "visible_artifacts": ["test_screenshot_semantic_analysis.py"],
+                    "key_visible_text": ["local-vlm"],
+                    "user_intent": "Verify local VLM request wiring.",
+                    "goal_alignment": {
+                        "status": "aligned",
+                        "goal_refs": ["screenshot intelligence loop"],
+                        "evidence": ["The screenshot analyzer test is being edited."],
+                        "needle_movement": "pushed",
+                    },
+                    "confidence": 0.91,
+                    "sensitive_content_seen": False,
+                    "privacy_notes": [],
+                    "report_tags": ["vlm", "screenshots"],
+                }
+            }
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def post(self, endpoint, *, data, files, headers):
+            file_name, image_file, media_type = files["file"]
+            calls.append(
+                {
+                    "endpoint": endpoint,
+                    "data": data,
+                    "file_name": file_name,
+                    "file_bytes": image_file.read(),
+                    "media_type": media_type,
+                    "headers": headers,
+                    "timeout": self.timeout,
+                }
+            )
+            return FakeResponse()
+
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.screen_analysis_provider", "local-vlm")
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.local_vlm_base_url", "http://gpu:8088")
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.local_vlm_model", "gemma-4-test")
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.local_vlm_api_key", "secret-token")
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.local_vlm_timeout_seconds", 9)
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.httpx.AsyncClient", FakeAsyncClient)
+
+    analysis = await analyze_screenshot_image(
+        image,
+        {
+            "created_at": "2026-06-30T10:00:00+00:00",
+            "image_sha256": "abc123",
+            "file_format": "png",
+            "width": 1,
+            "height": 1,
+        },
+    )
+
+    assert analysis is not None
+    assert analysis.project == "seraph"
+    assert analysis.goal_alignment.needle_movement == "pushed"
+    assert calls[0]["endpoint"] == "http://gpu:8088/v1/analyze-file"
+    assert calls[0]["data"]["model"] == "gemma-4-test"
+    assert "seraph.screenshot_analysis.v1" in calls[0]["data"]["prompt"]
+    assert calls[0]["file_name"] == "capture.png"
+    assert calls[0]["file_bytes"] == b"png bytes"
+    assert calls[0]["media_type"] == "image/png"
+    assert calls[0]["headers"] == {"Authorization": "Bearer secret-token"}
+    assert calls[0]["timeout"] == 9
+
+
+async def test_local_vlm_analyzer_is_disabled_without_provider(tmp_path, monkeypatch):
+    image = tmp_path / "capture.png"
+    image.write_bytes(b"png bytes")
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.screen_analysis_provider", "")
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.local_vlm_base_url", "http://gpu:8088")
+
+    analysis = await analyze_screenshot_image(image, {})
+
+    assert analysis is None

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -190,11 +190,58 @@ async def test_artifact_storage_prefers_seraph_screen_archive_env(client, tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_artifact_storage_exposes_screenshot_folder_status(client, tmp_path, monkeypatch):
+async def test_artifact_storage_exposes_screenshot_folder_status(client, async_db, tmp_path, monkeypatch):
+    from src.db.models import MemoryEpisode, MemoryEpisodeType, ScreenObservation
+
     screenshot_root = tmp_path / "screenshots"
     screenshot_root.mkdir()
     (screenshot_root / "capture-1.png").write_bytes(b"png bytes")
     monkeypatch.setenv("SERAPH_SCREENSHOT_FOLDER", str(screenshot_root))
+    observed_at = datetime(2026, 6, 30, 9, 5, tzinfo=timezone.utc)
+    async with async_db() as db:
+        db.add(
+            ScreenObservation(
+                timestamp=observed_at,
+                app_name="Screenshot Folder",
+                window_title="capture-1.png",
+                activity_type="screen",
+                summary="Screenshot image ingested.",
+                details_json=json.dumps(
+                    [
+                        "capture_artifacts:"
+                        + json.dumps(
+                            {
+                                "provider": "screenshot_folder",
+                                "image_path": str(screenshot_root / "capture-1.png"),
+                            },
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ),
+                        "screenshot_analysis_status:"
+                        + json.dumps(
+                            {
+                                "status": "failed",
+                                "provider": "local-vlm",
+                                "model": "gemma",
+                                "reason": "provider unavailable",
+                                "recorded_at": observed_at.isoformat(),
+                            },
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ),
+                    ]
+                ),
+            )
+        )
+        db.add(
+            MemoryEpisode(
+                episode_type=MemoryEpisodeType.observer,
+                source_tool_name="screenshot_observation_digest",
+                summary="Screenshot digest",
+                content="Screenshot digest",
+                observed_at=datetime(2026, 6, 30, 9, 30, tzinfo=timezone.utc),
+            )
+        )
 
     resp = await client.get("/api/settings/artifact-storage")
 
@@ -207,6 +254,13 @@ async def test_artifact_storage_exposes_screenshot_folder_status(client, tmp_pat
     assert data["screenshot_folder"]["status"] == "ready"
     assert data["screenshot_folder"]["image_count"] == 1
     assert data["screenshot_folder"]["stored_artifacts"] == ["image"]
+    assert data["screenshot_folder"]["analysis"]["observation_count"] == 1
+    assert data["screenshot_folder"]["analysis"]["analysis_failures"] == 1
+    assert data["screenshot_folder"]["analysis"]["analysis_backlog"] == 0
+    assert data["screenshot_folder"]["analysis"]["analysis_status"]["failed"] == 1
+    assert data["screenshot_folder"]["analysis"]["latest_failure"] == "provider unavailable"
+    assert data["screenshot_folder"]["analysis"]["digest_count"] == 1
+    assert data["screenshot_folder"]["analysis"]["latest_digest_at"] == "2026-06-30T09:30:00+00:00"
     assert data["screenshot_folder"]["auto_ingest_enabled"] is True
     assert data["screenshot_folder"]["auto_ingest_interval_min"] == settings.screenshot_folder_ingest_interval_min
     assert data["screenshot_folder"]["auto_ingest_limit"] == settings.screenshot_folder_ingest_limit

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -98,7 +98,7 @@ The semantic analysis schema captures:
 
 The VLM prompt requires the model to treat screenshot content as untrusted and return only the JSON shape defined by the contract. The parser rejects non-JSON output, unknown fields, invalid enum values, and out-of-range confidence values. It also redacts sensitive-looking strings before the analysis can become a durable observation.
 
-This contract is the boundary for the next implementation slice. The current folder scan still persists metadata observations; the follow-up analyzer will call a configured VLM, validate the output with this contract, and persist the semantic analysis without requiring any direct connection to the screenshot producer.
+This contract is the boundary between local image ingestion and screenshot understanding. The folder scan calls the configured Seraph-side analyzer when one is available, validates the output with this contract, and persists the semantic analysis without requiring any direct connection to the screenshot producer.
 
 End-of-day reports consume screenshot-folder `ScreenObservation` rows through the same report builder as other screen observations. Seraph records the observation source as `screenshot_folder` from its own stored capture-artifact details and includes report-safe screenshot samples using filenames, format, dimensions, and size. Reports do not rely on recorder manifests, sidecars, or service metadata.
 
@@ -121,6 +121,8 @@ The Seraph settings UI describes this as a local screenshot folder, not as Serap
 The settings panel saves `screenshot_folder` through `/api/settings/screen-analysis`. The manual scan action calls Seraph's local `/api/observer/screenshot-folder/scan` endpoint. Seraph can also run its own `screenshot_folder_ingest` scheduler job, controlled by `SCREENSHOT_FOLDER_INGEST_ENABLED`, `SCREENSHOT_FOLDER_INGEST_INTERVAL_MIN`, and `SCREENSHOT_FOLDER_INGEST_LIMIT`.
 
 Both paths only read local image files from the configured folder. They do not start, connect to, or query any screenshot producer.
+
+The artifact-storage settings API also exposes Seraph-owned screenshot analysis status for the configured folder: observation count, analyzer status mix, backlog, failures, latest observation/analyzed timestamps, digest count, and latest digest timestamp. The UI shows these fields beside the local folder path and scan controls so the operator can see whether screenshots are being analyzed and rolled into report-ready digest windows.
 
 ## Remote VLM Analysis Target
 
@@ -199,7 +201,40 @@ SERAPH_LOCAL_VLM_BASE_URL=http://GPU_SERVER_IP:8088
 SERAPH_LOCAL_VLM_MODEL=unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_M
 ```
 
-When configured, screenshot-folder ingestion posts the screenshot image plus Seraph's strict analysis prompt to `/v1/analyze-file`, validates the returned JSON against `seraph.screenshot_analysis.v1`, and stores the privacy-safe semantic payload inside the Seraph `ScreenObservation`. If the provider is not configured or fails, ingestion still stores the screenshot metadata observation and records a bounded analyzer status instead of retrying the same image as a new screenshot.
+When configured, screenshot-folder ingestion posts the screenshot image plus Seraph's strict analysis prompt to `/v1/analyze-file`, validates the returned JSON against `seraph.screenshot_analysis.v1`, and stores the privacy-safe semantic payload inside the Seraph `ScreenObservation`.
+If the provider is not configured or fails, ingestion still stores the screenshot metadata observation and records a bounded analyzer status instead of retrying the same image as a new screenshot.
+
+Each screenshot observation carries Seraph-owned analysis status details:
+
+- `pending` when the screenshot was ingested but no semantic provider was configured
+- `succeeded` when a validated semantic analysis payload was stored
+- `failed` when the provider call or schema validation failed
+- `needs_reanalysis` when a stored semantic payload was produced by an older prompt, schema, or configured model
+
+Duplicate screenshot files are still suppressed by image SHA-256, so the same image cannot accidentally create a second semantic observation.
+Reanalysis is explicit and local-only through `POST /api/observer/screen-artifacts/{observation_id}/reanalyze`; callers must provide one of `prompt_version_changed`, `model_version_changed`, `provider_failure_retry`, or `manual_operator_request`.
+Reanalysis replaces the semantic analysis/status details on the existing observation and preserves the original screenshot hash and file mtime-derived capture timestamp.
+
+## Rolling Observation Digests
+
+Seraph condenses analyzed screenshot-folder observations into rolling memory episodes before daily report generation. The scheduler job is `screenshot_observation_digest`.
+
+Default settings:
+
+- `SCREENSHOT_OBSERVATION_DIGEST_ENABLED=true`
+- `SCREENSHOT_OBSERVATION_DIGEST_INTERVAL_MIN=15`
+- `SCREENSHOT_OBSERVATION_DIGEST_WINDOW_MIN=30`
+- `SCREENSHOT_OBSERVATION_DIGEST_MAX_CHARS=6000`
+
+Each digest stores a `MemoryEpisode` with source tool `screenshot_observation_digest` and schema `seraph.screenshot_observation_digest.v1`. Digest metadata includes the digest key, window start/end, source screenshot observation ids, observation count, content character count, and payload SHA-256.
+
+The digest is intentionally text-only and privacy-bounded. It never embeds raw screenshots, image hashes, full visible text, or provider transcripts. It includes compact redacted progression notes, activity/project/app mixes, analysis status counts, confidence, blocker evidence, drift evidence, and the source observation ids needed for traceability.
+
+Digest writes are idempotent per window and schema. If a window has not changed, Seraph keeps the existing episode. If new observations appear in the same window, Seraph updates the same episode instead of creating duplicates.
+
+End-of-day reports consume these rolling digest episodes as the day-level screenshot evidence layer. The report builder passes redacted digest text into the optional LLM prompt and into the deterministic local fallback. Goal comparison uses the digest evidence to classify each active goal as aligned, blocked, drifted, or unclear, and records whether the day pushed the needle, got blocked, drifted, or remained unclear.
+
+The final report stores digest count and source screenshot observation ids in report metadata for traceability. It still does not copy raw screenshots, image hashes, long visible text, or provider transcripts into the report.
 
 Current model notes:
 
@@ -216,6 +251,24 @@ Sources checked June 30, 2026:
 - [seraph-quest/vlm-screenshot-server](https://github.com/seraph-quest/vlm-screenshot-server)
 
 ## Verification
+
+Full screenshot intelligence loop receipt:
+
+- local screenshot image file is scanned from the configured folder
+- Seraph computes its own hash and mtime-derived capture timestamp
+- Seraph runs semantic analysis through its own analyzer boundary
+- duplicate image ingestion remains hash-based
+- rolling digest stores redacted text and source observation ids
+- end-of-day report consumes digest text and compares against active goals
+- settings status shows observation, analyzer, backlog, failure, and digest counts
+- no screenshot producer service, manifest, or sidecar is required
+
+Focused receipt command:
+
+```bash
+cd /Users/bigcube/Desktop/repos/seraph/backend
+UV_CACHE_DIR=/tmp/seraph-uv-cache uv run pytest tests/test_screenshot_intelligence_loop.py
+```
 
 This branch verifies the image-source path with:
 

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -191,7 +191,7 @@ curl -F "file=@/path/to/screenshot.png" \
   http://GPU_SERVER_IP:8088/v1/analyze-file
 ```
 
-Seraph-side first-class `local-vlm` wiring is still a follow-up implementation item. The intended future settings shape is:
+Seraph-side first-class `local-vlm` wiring is available behind explicit settings:
 
 ```env
 SERAPH_SCREEN_ANALYSIS_PROVIDER=local-vlm
@@ -199,7 +199,7 @@ SERAPH_LOCAL_VLM_BASE_URL=http://GPU_SERVER_IP:8088
 SERAPH_LOCAL_VLM_MODEL=unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_M
 ```
 
-Until that provider exists, this section is an operator target and integration contract, not a claim that current Seraph releases can call the wrapper automatically.
+When configured, screenshot-folder ingestion posts the screenshot image plus Seraph's strict analysis prompt to `/v1/analyze-file`, validates the returned JSON against `seraph.screenshot_analysis.v1`, and stores the privacy-safe semantic payload inside the Seraph `ScreenObservation`. If the provider is not configured or fails, ingestion still stores the screenshot metadata observation and records a bounded analyzer status instead of retrying the same image as a new screenshot.
 
 Current model notes:
 

--- a/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
@@ -74,6 +74,20 @@ function settingsFromScreenAnalysisFixture(screen: {
       exists: false,
       readable: false,
       stored_artifacts: ["image"],
+      analysis: {
+        provider: "metadata unavailable",
+        model: "",
+        base_url_configured: false,
+        observation_count: 0,
+        analysis_status: {},
+        analysis_backlog: 0,
+        analysis_failures: 0,
+        latest_observation_at: null,
+        latest_analyzed_at: null,
+        latest_failure: null,
+        digest_count: 0,
+        latest_digest_at: null,
+      },
       auto_ingest_enabled: true,
       auto_ingest_interval_min: 5,
       auto_ingest_limit: 100,
@@ -181,6 +195,26 @@ describe("ArtifactStoragePanel", () => {
           exists: true,
           readable: true,
           stored_artifacts: ["image"],
+          analysis: {
+            provider: "local-vlm",
+            model: "gemma-4-26b",
+            base_url_configured: true,
+            observation_count: 12,
+            analysis_status: {
+              succeeded: 9,
+              failed: 1,
+              pending: 2,
+              needs_reanalysis: 0,
+              unknown: 0,
+            },
+            analysis_backlog: 2,
+            analysis_failures: 1,
+            latest_observation_at: "2026-06-20T18:41:00Z",
+            latest_analyzed_at: "2026-06-20T18:42:00Z",
+            latest_failure: "provider unavailable",
+            digest_count: 3,
+            latest_digest_at: "2026-06-20T18:30:00Z",
+          },
           auto_ingest_enabled: true,
           auto_ingest_interval_min: 5,
           auto_ingest_limit: 100,
@@ -236,6 +270,10 @@ describe("ArtifactStoragePanel", () => {
     expect(screen.getByText(/2 images/)).toBeInTheDocument();
     expect(screen.getByText("every 5m · up to 100 images")).toBeInTheDocument();
     expect(screen.getByText("local image files only")).toBeInTheDocument();
+    expect(screen.getByText("local-vlm · gemma-4-26b")).toBeInTheDocument();
+    expect(screen.getByText("12 observations · 2 backlog · 1 failed")).toBeInTheDocument();
+    expect(screen.getByText("3 windows · latest 2026-06-20T18:30:00Z")).toBeInTheDocument();
+    expect(screen.getByText("provider unavailable")).toBeInTheDocument();
     expect(screen.queryByText("/api/observer/screenshot-folder/scan")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Scan folder" })).toBeInTheDocument();
     expect(screen.getByDisplayValue("codex-local")).toBeInTheDocument();

--- a/frontend/src/components/settings/ArtifactStoragePanel.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.tsx
@@ -55,6 +55,20 @@ interface ArtifactStorageSettings {
     exists: boolean;
     readable: boolean;
     stored_artifacts: string[];
+    analysis?: {
+      provider: string;
+      model: string;
+      base_url_configured: boolean;
+      observation_count: number;
+      analysis_status: Record<string, number>;
+      analysis_backlog: number;
+      analysis_failures: number;
+      latest_observation_at: string | null;
+      latest_analyzed_at: string | null;
+      latest_failure: string | null;
+      digest_count: number;
+      latest_digest_at: string | null;
+    };
     auto_ingest_enabled: boolean;
     auto_ingest_interval_min: number;
     auto_ingest_limit: number;
@@ -178,6 +192,15 @@ function screenshotFolderStateTone(settings: NonNullable<ArtifactStorageSettings
   return settings.image_count > 0 ? "good" : "normal";
 }
 
+function screenshotAnalysisTone(
+  analysis: NonNullable<ArtifactStorageSettings["screenshot_folder"]>["analysis"],
+): "normal" | "good" | "warn" {
+  if (!analysis) return "normal";
+  if (analysis.analysis_failures > 0) return "warn";
+  if (analysis.analysis_backlog > 0) return "normal";
+  return analysis.observation_count > 0 ? "good" : "normal";
+}
+
 function isArtifactStorageSettings(value: unknown): value is ArtifactStorageSettings {
   if (typeof value !== "object" || value === null) return false;
   const candidate = value as Partial<ArtifactStorageSettings>;
@@ -270,6 +293,20 @@ function settingsFromScreenAnalysis(screen: ScreenAnalysisSettings): ArtifactSto
       exists: false,
       readable: false,
       stored_artifacts: ["image"],
+      analysis: {
+        provider: "metadata unavailable",
+        model: "",
+        base_url_configured: false,
+        observation_count: 0,
+        analysis_status: {},
+        analysis_backlog: 0,
+        analysis_failures: 0,
+        latest_observation_at: null,
+        latest_analyzed_at: null,
+        latest_failure: null,
+        digest_count: 0,
+        latest_digest_at: null,
+      },
       auto_ingest_enabled: true,
       auto_ingest_interval_min: 5,
       auto_ingest_limit: 100,
@@ -649,6 +686,44 @@ export function ArtifactStoragePanel() {
                   tone={screenshotFolderSource.auto_ingest_enabled ? "good" : "normal"}
                 />
                 <ArtifactRow label="Reads" value="local image files only" tone="good" />
+                {screenshotFolderSource.analysis && (
+                  <>
+                    <ArtifactRow
+                      label="Analyzer"
+                      value={
+                        screenshotFolderSource.analysis.provider === "not_configured"
+                          ? "not configured"
+                          : `${screenshotFolderSource.analysis.provider}${screenshotFolderSource.analysis.model ? ` · ${screenshotFolderSource.analysis.model}` : ""}`
+                      }
+                      tone={screenshotFolderSource.analysis.provider === "not_configured" ? "warn" : "good"}
+                    />
+                    <ArtifactRow
+                      label="Analyzed"
+                      value={
+                        `${screenshotFolderSource.analysis.observation_count} observations · ` +
+                        `${screenshotFolderSource.analysis.analysis_backlog} backlog · ` +
+                        `${screenshotFolderSource.analysis.analysis_failures} failed`
+                      }
+                      tone={screenshotAnalysisTone(screenshotFolderSource.analysis)}
+                    />
+                    <ArtifactRow
+                      label="Latest"
+                      value={screenshotFolderSource.analysis.latest_analyzed_at ?? screenshotFolderSource.analysis.latest_observation_at ?? "none"}
+                      tone={screenshotFolderSource.analysis.latest_analyzed_at ? "good" : "normal"}
+                    />
+                    <ArtifactRow
+                      label="Digest"
+                      value={
+                        `${screenshotFolderSource.analysis.digest_count} windows` +
+                        (screenshotFolderSource.analysis.latest_digest_at ? ` · latest ${screenshotFolderSource.analysis.latest_digest_at}` : "")
+                      }
+                      tone={screenshotFolderSource.analysis.digest_count > 0 ? "good" : "normal"}
+                    />
+                    {screenshotFolderSource.analysis.latest_failure && (
+                      <ArtifactRow label="Failure" value={screenshotFolderSource.analysis.latest_failure} tone="warn" />
+                    )}
+                  </>
+                )}
                 <ArtifactRow label="Inspect" value={`${screenshotFolderSource.inspection_endpoint} (${screenshotFolderSource.inspection_visibility.replace(/_/g, " ")})`} />
                 <div className="flex flex-wrap items-center gap-2 pt-1">
                   <button


### PR DESCRIPTION
## Summary
- add explicit `local-vlm` screenshot analysis settings for Seraph-owned semantic analysis
- call the configured local VLM wrapper during screenshot-folder ingestion and validate output with `seraph.screenshot_analysis.v1`
- persist semantic analysis or bounded analyzer failure status in `ScreenObservation.details_json`
- expose semantic status, semantic payload, and analyzer failure through the existing screen artifact analysis endpoint
- update screenshot-folder implementation docs now that first-class local VLM wiring exists

## Scope
This keeps the producer contract unchanged: screenshot producers only write image files. Seraph scans images, dedupes by image hash, owns semantic analysis, and stores observations/reports.

Closes #654
Part of #647
Stacked on #655

## Validation
- `uv run pytest tests/test_screenshot_semantic_analysis.py tests/test_screenshot_analysis_contract.py tests/test_observer_screen_artifacts.py tests/test_screenshot_folder_ingest_job.py`
- `python3 -m py_compile backend/src/observer/screenshot_semantic_analysis.py backend/src/observer/screenshot_folder_source.py backend/src/api/observer.py backend/config/settings.py`
- `git diff --check`

## Team Lead / Review
- Lead pass scoped this as T2 only: provider-backed analysis during folder ingestion, no report rewrite or schema migration.
- Critic/Contrarian pass checked producer decoupling, privacy boundary, duplicate behavior, provider failure handling, and missing test seams.
- Finding accepted and fixed: added `tests/test_screenshot_semantic_analysis.py` to prove the local VLM client posts prompt/model/file payloads and validates wrapper responses.
- Residual risk deferred to T3: explicit reanalysis controls for already-ingested screenshots after a provider outage.
