### PR TITLE
Show screenshot analysis pipeline status

### DIFF
--- a/backend/src/api/settings.py
+++ b/backend/src/api/settings.py
@@ -9,12 +9,14 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict
-from sqlmodel import select
+from sqlalchemy import func
+from sqlmodel import col, select
 
 from config.settings import settings
 from src.db.engine import get_session as get_db
-from src.db.models import UserProfile
+from src.db.models import MemoryEpisode, ScreenObservation, UserProfile
 from src.observer.manager import context_manager
+from src.observer.screenshot_semantic_analysis import semantic_analysis_status_from_details
 from src.observer.user_state import InterruptionMode
 from src.tools.policy import MCP_POLICY_MODES, TOOL_POLICY_MODES
 
@@ -70,6 +72,7 @@ _VALID_MCP_POLICY_MODES = set(MCP_POLICY_MODES)
 _VALID_APPROVAL_MODES = {"off", "high_risk"}
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _SCREENSHOT_FOLDER_ENV = "SERAPH_SCREENSHOT_FOLDER"
+_SCREENSHOT_DIGEST_TOOL_NAME = "screenshot_observation_digest"
 
 
 def _env_enabled(name: str, default: bool = False) -> bool:
@@ -329,6 +332,107 @@ def _screenshot_folder_summary(root: Path) -> dict[str, object]:
     }
 
 
+def _screen_observation_details(details_json: str | None) -> list[object]:
+    try:
+        payload = json.loads(details_json or "[]")
+    except json.JSONDecodeError:
+        return []
+    return payload if isinstance(payload, list) else []
+
+
+def _utc_iso(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _is_screenshot_folder_observation(observation: ScreenObservation) -> bool:
+    if observation.app_name == "Screenshot Folder":
+        return True
+    for item in _screen_observation_details(observation.details_json):
+        if not (isinstance(item, str) and item.startswith("capture_artifacts:")):
+            continue
+        try:
+            artifacts = json.loads(item.removeprefix("capture_artifacts:"))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(artifacts, dict) and artifacts.get("provider") == "screenshot_folder":
+            return True
+    return False
+
+
+async def _screenshot_folder_pipeline_summary() -> dict[str, object]:
+    status_counts: dict[str, int] = {
+        "pending": 0,
+        "succeeded": 0,
+        "failed": 0,
+        "needs_reanalysis": 0,
+        "unknown": 0,
+    }
+    latest_observation_at: str | None = None
+    latest_analyzed_at: str | None = None
+    latest_failure: str | None = None
+    async with get_db() as db:
+        observation_result = await db.execute(
+            select(ScreenObservation)
+            .where(col(ScreenObservation.blocked) == False)  # noqa: E712
+            .where(
+                (
+                    col(ScreenObservation.app_name) == "Screenshot Folder"
+                )
+                | col(ScreenObservation.details_json).contains('"provider":"screenshot_folder"')
+                | col(ScreenObservation.details_json).contains('"provider": "screenshot_folder"')
+            )
+            .order_by(col(ScreenObservation.timestamp).desc())
+            .limit(500)
+        )
+        observations = list(observation_result.scalars().all())
+        digest_result = await db.execute(
+            select(MemoryEpisode)
+            .where(col(MemoryEpisode.source_tool_name) == _SCREENSHOT_DIGEST_TOOL_NAME)
+            .order_by(col(MemoryEpisode.observed_at).desc())
+            .limit(1)
+        )
+        latest_digest = digest_result.scalar_one_or_none()
+        digest_count_result = await db.execute(
+            select(func.count())
+            .select_from(MemoryEpisode)
+            .where(col(MemoryEpisode.source_tool_name) == _SCREENSHOT_DIGEST_TOOL_NAME)
+        )
+        digest_count = int(digest_count_result.scalar_one() or 0)
+
+    for observation in observations:
+        if not _is_screenshot_folder_observation(observation):
+            continue
+        if latest_observation_at is None:
+            latest_observation_at = _utc_iso(observation.timestamp)
+        details = _screen_observation_details(observation.details_json)
+        status = semantic_analysis_status_from_details(details) or {}
+        status_name = str(status.get("status") or "unknown")
+        if status_name not in status_counts:
+            status_name = "unknown"
+        status_counts[status_name] += 1
+        recorded_at = status.get("recorded_at")
+        if isinstance(recorded_at, str) and status_name == "succeeded" and latest_analyzed_at is None:
+            latest_analyzed_at = recorded_at
+        if status_name == "failed" and latest_failure is None:
+            latest_failure = str(status.get("reason") or "analysis failed")
+
+    return {
+        "observation_count": sum(status_counts.values()),
+        "analysis_status": status_counts,
+        "analysis_backlog": status_counts["pending"] + status_counts["needs_reanalysis"],
+        "analysis_failures": status_counts["failed"],
+        "latest_observation_at": latest_observation_at,
+        "latest_analyzed_at": latest_analyzed_at,
+        "latest_failure": latest_failure,
+        "digest_count": digest_count,
+        "latest_digest_at": _utc_iso(latest_digest.observed_at) if latest_digest is not None else None,
+    }
+
+
 def _report_receipt_summary(report_dir: Path) -> dict[str, object]:
     receipts_dir = report_dir / "receipts"
     if not receipts_dir.exists():
@@ -529,6 +633,7 @@ async def get_artifact_storage_settings():
     report_receipts = _report_receipt_summary(report_archive_dir)
     screenshot_folder, screenshot_folder_source = _screenshot_folder()
     screenshot_source = _screenshot_folder_summary(screenshot_folder)
+    screenshot_pipeline = await _screenshot_folder_pipeline_summary()
     screen_analysis = await get_screen_analysis_settings()
     screen_archive_dir = Path(str(screen_analysis["archive_dir"]))
     screen_dir_status = _archive_dir_status(screen_archive_dir)
@@ -574,6 +679,12 @@ async def get_artifact_storage_settings():
             "exists": screenshot_source["exists"],
             "readable": screenshot_source["readable"],
             "stored_artifacts": ["image"],
+            "analysis": {
+                "provider": settings.screen_analysis_provider or "not_configured",
+                "model": settings.local_vlm_model or "",
+                "base_url_configured": bool(settings.local_vlm_base_url.strip()),
+                **screenshot_pipeline,
+            },
             "auto_ingest_enabled": settings.screenshot_folder_ingest_enabled,
             "auto_ingest_interval_min": settings.screenshot_folder_ingest_interval_min,
             "auto_ingest_limit": settings.screenshot_folder_ingest_limit,

--- a/backend/tests/test_screenshot_intelligence_loop.py
+++ b/backend/tests/test_screenshot_intelligence_loop.py
@@ -1,0 +1,158 @@
+"""Full-loop tests for screenshot-folder intelligence and reports."""
+
+from __future__ import annotations
+
+import os
+import hashlib
+import json
+from datetime import date, datetime, timezone
+
+import pytest
+
+from config.settings import settings
+
+
+@pytest.mark.asyncio
+async def test_screenshot_folder_analysis_digest_report_and_status_loop(
+    async_db,
+    client,
+    tmp_path,
+    monkeypatch,
+):
+    from src.db.models import Goal, MemoryEpisode, ScreenObservation
+    from src.observer.screenshot_analysis_contract import parse_screenshot_analysis_output
+    from src.observer.screenshot_folder_source import scan_screenshot_folder
+    from src.scheduler.jobs.end_of_day_goal_report import build_end_of_day_goal_report
+    from src.scheduler.jobs.screenshot_observation_digest import build_screenshot_observation_digest
+    from sqlmodel import select
+
+    screenshot_root = tmp_path / "screenshots"
+    screenshot_root.mkdir()
+    image_bytes = b"fake png bytes"
+    image_sha256 = hashlib.sha256(image_bytes).hexdigest()
+    image = screenshot_root / "seraph-loop.png"
+    duplicate_image = screenshot_root / "seraph-loop-copy.png"
+    image.write_bytes(image_bytes)
+    duplicate_image.write_bytes(image_bytes)
+    captured_at = datetime(2026, 6, 30, 10, 5, tzinfo=timezone.utc)
+    os.utime(image, (captured_at.timestamp(), captured_at.timestamp()))
+    os.utime(duplicate_image, (captured_at.timestamp(), captured_at.timestamp()))
+    analysis = parse_screenshot_analysis_output(
+        {
+            "schema_version": "seraph.screenshot_analysis.v1",
+            "prompt_version": "seraph.screenshot_analysis.prompt.v1",
+            "summary": "The user is implementing Seraph screenshot intelligence loop tests.",
+            "detailed_observations": [
+                "A test covers screenshot ingestion, digest creation, and reporting."
+            ],
+            "activity_type": "coding",
+            "project": "seraph",
+            "applications": ["editor"],
+            "visible_artifacts": ["test_screenshot_intelligence_loop.py"],
+            "key_visible_text": ["screenshot intelligence loop"],
+            "user_intent": "Verify the complete Seraph screenshot analysis path.",
+            "goal_alignment": {
+                "status": "aligned",
+                "goal_refs": ["Seraph screenshot intelligence loop"],
+                "evidence": ["The visible work is the screenshot loop test."],
+                "needle_movement": "pushed",
+            },
+            "confidence": 0.9,
+            "sensitive_content_seen": False,
+            "privacy_notes": [],
+            "report_tags": ["screenshots", "daily-report"],
+        }
+    )
+
+    analyzer_calls = []
+
+    async def fake_analyze_screenshot_image(_image_path, _artifacts):
+        analyzer_calls.append((_image_path, dict(_artifacts)))
+        return analysis
+
+    monkeypatch.setattr(
+        "src.observer.screenshot_folder_source.analyze_screenshot_image",
+        fake_analyze_screenshot_image,
+    )
+    monkeypatch.setenv("SERAPH_SCREENSHOT_FOLDER", str(screenshot_root))
+    monkeypatch.setattr("src.api.settings.settings.screen_analysis_provider", "local-vlm")
+    monkeypatch.setattr("src.api.settings.settings.local_vlm_base_url", "http://gpu:8088")
+    monkeypatch.setattr("src.api.settings.settings.local_vlm_model", "gemma-test")
+    async with async_db() as db:
+        db.add(
+            Goal(
+                id="goal-loop",
+                path="/",
+                level="daily",
+                title="Ship Seraph screenshot intelligence loop",
+                domain="productivity",
+                status="active",
+                sort_order=0,
+            )
+        )
+
+    scan_result = await scan_screenshot_folder(screenshot_root, limit=10)
+    duplicate_scan_result = await scan_screenshot_folder(screenshot_root, limit=10)
+    digest_result = await build_screenshot_observation_digest(
+        window_start=datetime(2026, 6, 30, 10, 0, tzinfo=timezone.utc),
+        window_end=datetime(2026, 6, 30, 10, 30, tzinfo=timezone.utc),
+    )
+    with monkeypatch.context() as report_patch:
+        report_patch.setattr(settings, "user_timezone", "UTC")
+        report_patch.setattr(settings, "end_of_day_report_llm_enabled", False)
+        report = await build_end_of_day_goal_report(date(2026, 6, 30))
+
+    status = (await client.get("/api/settings/artifact-storage")).json()
+    async with async_db() as db:
+        observations = list((await db.execute(select(ScreenObservation))).scalars().all())
+        episodes = list((await db.execute(select(MemoryEpisode))).scalars().all())
+
+    assert scan_result.ingested == 1
+    assert scan_result.skipped_duplicates == 1
+    assert duplicate_scan_result.ingested == 0
+    assert duplicate_scan_result.skipped_duplicates == 2
+    assert len(analyzer_calls) == 1
+    analyzed_path, analyzed_artifacts = analyzer_calls[0]
+    assert analyzed_path in {image.resolve(), duplicate_image.resolve()}
+    assert analyzed_artifacts["provider"] == "screenshot_folder"
+    assert analyzed_artifacts["source"] == "local_image_directory"
+    assert analyzed_artifacts["created_at"] == captured_at.isoformat()
+    assert analyzed_artifacts["image_sha256"] == image_sha256
+    assert "manifest" not in analyzed_artifacts
+    assert "service" not in analyzed_artifacts
+    assert len(observations) == 1
+    assert observations[0].timestamp.replace(tzinfo=timezone.utc) == captured_at
+    details = json.loads(observations[0].details_json or "[]")
+    assert f"screenshot_folder_image_sha256:{image_sha256}" in details
+    assert any(str(item).startswith("capture_artifacts:") for item in details)
+    assert any(str(item).startswith("screenshot_analysis:") for item in details)
+    assert any(str(item).startswith("screenshot_analysis_status:") for item in details)
+    assert digest_result.status == "created"
+    assert digest_result.observation_count == 1
+    digest_episode = next(
+        episode for episode in episodes if episode.source_tool_name == "screenshot_observation_digest"
+    )
+    digest_metadata = json.loads(digest_episode.metadata_json or "{}")
+    assert digest_metadata["observation_ids"] == [observations[0].id]
+    assert digest_metadata["observation_count"] == 1
+    assert "Evidence observation IDs:" in digest_episode.content
+    assert observations[0].id in digest_episode.content
+    assert "screenshot intelligence loop" in digest_episode.content
+    assert str(image.resolve()) not in digest_episode.content
+    assert image_sha256 not in digest_episode.content
+    assert report["screenshot_digests"]["count"] == 1
+    assert report["screenshot_digests"]["observation_ids"] == ["[redacted]"]
+    assert observations[0].id not in report["screenshot_digests"]["redacted_text"]
+    assert "[redacted]" in report["screenshot_digests"]["redacted_text"]
+    assert "screenshot intelligence loop" in report["screenshot_digests"]["redacted_text"]
+    assert str(image.resolve()) not in report["screenshot_digests"]["redacted_text"]
+    assert image_sha256 not in report["screenshot_digests"]["redacted_text"]
+    assert report["goal_alignment"][0]["status"] == "aligned"
+    assert report["goal_alignment"][0]["needle_movement"] == "pushed"
+    assert report["goal_alignment"][0]["source_observation_ids"] == ["[redacted]"]
+    assert "- Pushed-the-needle goals: 1" in report["body"]
+    assert status["screenshot_folder"]["analysis"]["observation_count"] == 1
+    assert status["screenshot_folder"]["analysis"]["analysis_status"]["succeeded"] == 1
+    assert status["screenshot_folder"]["analysis"]["analysis_failures"] == 0
+    assert status["screenshot_folder"]["analysis"]["analysis_backlog"] == 0
+    assert status["screenshot_folder"]["analysis"]["digest_count"] == 1

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -190,11 +190,58 @@ async def test_artifact_storage_prefers_seraph_screen_archive_env(client, tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_artifact_storage_exposes_screenshot_folder_status(client, tmp_path, monkeypatch):
+async def test_artifact_storage_exposes_screenshot_folder_status(client, async_db, tmp_path, monkeypatch):
+    from src.db.models import MemoryEpisode, MemoryEpisodeType, ScreenObservation
+
     screenshot_root = tmp_path / "screenshots"
     screenshot_root.mkdir()
     (screenshot_root / "capture-1.png").write_bytes(b"png bytes")
     monkeypatch.setenv("SERAPH_SCREENSHOT_FOLDER", str(screenshot_root))
+    observed_at = datetime(2026, 6, 30, 9, 5, tzinfo=timezone.utc)
+    async with async_db() as db:
+        db.add(
+            ScreenObservation(
+                timestamp=observed_at,
+                app_name="Screenshot Folder",
+                window_title="capture-1.png",
+                activity_type="screen",
+                summary="Screenshot image ingested.",
+                details_json=json.dumps(
+                    [
+                        "capture_artifacts:"
+                        + json.dumps(
+                            {
+                                "provider": "screenshot_folder",
+                                "image_path": str(screenshot_root / "capture-1.png"),
+                            },
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ),
+                        "screenshot_analysis_status:"
+                        + json.dumps(
+                            {
+                                "status": "failed",
+                                "provider": "local-vlm",
+                                "model": "gemma",
+                                "reason": "provider unavailable",
+                                "recorded_at": observed_at.isoformat(),
+                            },
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ),
+                    ]
+                ),
+            )
+        )
+        db.add(
+            MemoryEpisode(
+                episode_type=MemoryEpisodeType.observer,
+                source_tool_name="screenshot_observation_digest",
+                summary="Screenshot digest",
+                content="Screenshot digest",
+                observed_at=datetime(2026, 6, 30, 9, 30, tzinfo=timezone.utc),
+            )
+        )
 
     resp = await client.get("/api/settings/artifact-storage")
 
@@ -207,6 +254,13 @@ async def test_artifact_storage_exposes_screenshot_folder_status(client, tmp_pat
     assert data["screenshot_folder"]["status"] == "ready"
     assert data["screenshot_folder"]["image_count"] == 1
     assert data["screenshot_folder"]["stored_artifacts"] == ["image"]
+    assert data["screenshot_folder"]["analysis"]["observation_count"] == 1
+    assert data["screenshot_folder"]["analysis"]["analysis_failures"] == 1
+    assert data["screenshot_folder"]["analysis"]["analysis_backlog"] == 0
+    assert data["screenshot_folder"]["analysis"]["analysis_status"]["failed"] == 1
+    assert data["screenshot_folder"]["analysis"]["latest_failure"] == "provider unavailable"
+    assert data["screenshot_folder"]["analysis"]["digest_count"] == 1
+    assert data["screenshot_folder"]["analysis"]["latest_digest_at"] == "2026-06-30T09:30:00+00:00"
     assert data["screenshot_folder"]["auto_ingest_enabled"] is True
     assert data["screenshot_folder"]["auto_ingest_interval_min"] == settings.screenshot_folder_ingest_interval_min
     assert data["screenshot_folder"]["auto_ingest_limit"] == settings.screenshot_folder_ingest_limit

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -122,6 +122,8 @@ The settings panel saves `screenshot_folder` through `/api/settings/screen-analy
 
 Both paths only read local image files from the configured folder. They do not start, connect to, or query any screenshot producer.
 
+The artifact-storage settings API also exposes Seraph-owned screenshot analysis status for the configured folder: observation count, analyzer status mix, backlog, failures, latest observation/analyzed timestamps, digest count, and latest digest timestamp. The UI shows these fields beside the local folder path and scan controls so the operator can see whether screenshots are being analyzed and rolled into report-ready digest windows.
+
 ## Remote VLM Analysis Target
 
 Seraph can keep screenshot production separate from analysis while still using a GPU on another machine. The target shape is:

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -98,7 +98,7 @@ The semantic analysis schema captures:
 
 The VLM prompt requires the model to treat screenshot content as untrusted and return only the JSON shape defined by the contract. The parser rejects non-JSON output, unknown fields, invalid enum values, and out-of-range confidence values. It also redacts sensitive-looking strings before the analysis can become a durable observation.
 
-This contract is the boundary for the next implementation slice. The current folder scan still persists metadata observations; the follow-up analyzer will call a configured VLM, validate the output with this contract, and persist the semantic analysis without requiring any direct connection to the screenshot producer.
+This contract is the boundary between local image ingestion and screenshot understanding. The folder scan calls the configured Seraph-side analyzer when one is available, validates the output with this contract, and persists the semantic analysis without requiring any direct connection to the screenshot producer.
 
 End-of-day reports consume screenshot-folder `ScreenObservation` rows through the same report builder as other screen observations. Seraph records the observation source as `screenshot_folder` from its own stored capture-artifact details and includes report-safe screenshot samples using filenames, format, dimensions, and size. Reports do not rely on recorder manifests, sidecars, or service metadata.
 
@@ -251,6 +251,24 @@ Sources checked June 30, 2026:
 - [seraph-quest/vlm-screenshot-server](https://github.com/seraph-quest/vlm-screenshot-server)
 
 ## Verification
+
+Full screenshot intelligence loop receipt:
+
+- local screenshot image file is scanned from the configured folder
+- Seraph computes its own hash and mtime-derived capture timestamp
+- Seraph runs semantic analysis through its own analyzer boundary
+- duplicate image ingestion remains hash-based
+- rolling digest stores redacted text and source observation ids
+- end-of-day report consumes digest text and compares against active goals
+- settings status shows observation, analyzer, backlog, failure, and digest counts
+- no screenshot producer service, manifest, or sidecar is required
+
+Focused receipt command:
+
+```bash
+cd /Users/bigcube/Desktop/repos/seraph/backend
+UV_CACHE_DIR=/tmp/seraph-uv-cache uv run pytest tests/test_screenshot_intelligence_loop.py
+```
 
 This branch verifies the image-source path with:
 

--- a/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
@@ -74,6 +74,20 @@ function settingsFromScreenAnalysisFixture(screen: {
       exists: false,
       readable: false,
       stored_artifacts: ["image"],
+      analysis: {
+        provider: "metadata unavailable",
+        model: "",
+        base_url_configured: false,
+        observation_count: 0,
+        analysis_status: {},
+        analysis_backlog: 0,
+        analysis_failures: 0,
+        latest_observation_at: null,
+        latest_analyzed_at: null,
+        latest_failure: null,
+        digest_count: 0,
+        latest_digest_at: null,
+      },
       auto_ingest_enabled: true,
       auto_ingest_interval_min: 5,
       auto_ingest_limit: 100,
@@ -181,6 +195,26 @@ describe("ArtifactStoragePanel", () => {
           exists: true,
           readable: true,
           stored_artifacts: ["image"],
+          analysis: {
+            provider: "local-vlm",
+            model: "gemma-4-26b",
+            base_url_configured: true,
+            observation_count: 12,
+            analysis_status: {
+              succeeded: 9,
+              failed: 1,
+              pending: 2,
+              needs_reanalysis: 0,
+              unknown: 0,
+            },
+            analysis_backlog: 2,
+            analysis_failures: 1,
+            latest_observation_at: "2026-06-20T18:41:00Z",
+            latest_analyzed_at: "2026-06-20T18:42:00Z",
+            latest_failure: "provider unavailable",
+            digest_count: 3,
+            latest_digest_at: "2026-06-20T18:30:00Z",
+          },
           auto_ingest_enabled: true,
           auto_ingest_interval_min: 5,
           auto_ingest_limit: 100,
@@ -236,6 +270,10 @@ describe("ArtifactStoragePanel", () => {
     expect(screen.getByText(/2 images/)).toBeInTheDocument();
     expect(screen.getByText("every 5m · up to 100 images")).toBeInTheDocument();
     expect(screen.getByText("local image files only")).toBeInTheDocument();
+    expect(screen.getByText("local-vlm · gemma-4-26b")).toBeInTheDocument();
+    expect(screen.getByText("12 observations · 2 backlog · 1 failed")).toBeInTheDocument();
+    expect(screen.getByText("3 windows · latest 2026-06-20T18:30:00Z")).toBeInTheDocument();
+    expect(screen.getByText("provider unavailable")).toBeInTheDocument();
     expect(screen.queryByText("/api/observer/screenshot-folder/scan")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Scan folder" })).toBeInTheDocument();
     expect(screen.getByDisplayValue("codex-local")).toBeInTheDocument();

--- a/frontend/src/components/settings/ArtifactStoragePanel.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.tsx
@@ -55,6 +55,20 @@ interface ArtifactStorageSettings {
     exists: boolean;
     readable: boolean;
     stored_artifacts: string[];
+    analysis?: {
+      provider: string;
+      model: string;
+      base_url_configured: boolean;
+      observation_count: number;
+      analysis_status: Record<string, number>;
+      analysis_backlog: number;
+      analysis_failures: number;
+      latest_observation_at: string | null;
+      latest_analyzed_at: string | null;
+      latest_failure: string | null;
+      digest_count: number;
+      latest_digest_at: string | null;
+    };
     auto_ingest_enabled: boolean;
     auto_ingest_interval_min: number;
     auto_ingest_limit: number;
@@ -178,6 +192,15 @@ function screenshotFolderStateTone(settings: NonNullable<ArtifactStorageSettings
   return settings.image_count > 0 ? "good" : "normal";
 }
 
+function screenshotAnalysisTone(
+  analysis: NonNullable<ArtifactStorageSettings["screenshot_folder"]>["analysis"],
+): "normal" | "good" | "warn" {
+  if (!analysis) return "normal";
+  if (analysis.analysis_failures > 0) return "warn";
+  if (analysis.analysis_backlog > 0) return "normal";
+  return analysis.observation_count > 0 ? "good" : "normal";
+}
+
 function isArtifactStorageSettings(value: unknown): value is ArtifactStorageSettings {
   if (typeof value !== "object" || value === null) return false;
   const candidate = value as Partial<ArtifactStorageSettings>;
@@ -270,6 +293,20 @@ function settingsFromScreenAnalysis(screen: ScreenAnalysisSettings): ArtifactSto
       exists: false,
       readable: false,
       stored_artifacts: ["image"],
+      analysis: {
+        provider: "metadata unavailable",
+        model: "",
+        base_url_configured: false,
+        observation_count: 0,
+        analysis_status: {},
+        analysis_backlog: 0,
+        analysis_failures: 0,
+        latest_observation_at: null,
+        latest_analyzed_at: null,
+        latest_failure: null,
+        digest_count: 0,
+        latest_digest_at: null,
+      },
       auto_ingest_enabled: true,
       auto_ingest_interval_min: 5,
       auto_ingest_limit: 100,
@@ -649,6 +686,44 @@ export function ArtifactStoragePanel() {
                   tone={screenshotFolderSource.auto_ingest_enabled ? "good" : "normal"}
                 />
                 <ArtifactRow label="Reads" value="local image files only" tone="good" />
+                {screenshotFolderSource.analysis && (
+                  <>
+                    <ArtifactRow
+                      label="Analyzer"
+                      value={
+                        screenshotFolderSource.analysis.provider === "not_configured"
+                          ? "not configured"
+                          : `${screenshotFolderSource.analysis.provider}${screenshotFolderSource.analysis.model ? ` · ${screenshotFolderSource.analysis.model}` : ""}`
+                      }
+                      tone={screenshotFolderSource.analysis.provider === "not_configured" ? "warn" : "good"}
+                    />
+                    <ArtifactRow
+                      label="Analyzed"
+                      value={
+                        `${screenshotFolderSource.analysis.observation_count} observations · ` +
+                        `${screenshotFolderSource.analysis.analysis_backlog} backlog · ` +
+                        `${screenshotFolderSource.analysis.analysis_failures} failed`
+                      }
+                      tone={screenshotAnalysisTone(screenshotFolderSource.analysis)}
+                    />
+                    <ArtifactRow
+                      label="Latest"
+                      value={screenshotFolderSource.analysis.latest_analyzed_at ?? screenshotFolderSource.analysis.latest_observation_at ?? "none"}
+                      tone={screenshotFolderSource.analysis.latest_analyzed_at ? "good" : "normal"}
+                    />
+                    <ArtifactRow
+                      label="Digest"
+                      value={
+                        `${screenshotFolderSource.analysis.digest_count} windows` +
+                        (screenshotFolderSource.analysis.latest_digest_at ? ` · latest ${screenshotFolderSource.analysis.latest_digest_at}` : "")
+                      }
+                      tone={screenshotFolderSource.analysis.digest_count > 0 ? "good" : "normal"}
+                    />
+                    {screenshotFolderSource.analysis.latest_failure && (
+                      <ArtifactRow label="Failure" value={screenshotFolderSource.analysis.latest_failure} tone="warn" />
+                    )}
+                  </>
+                )}
                 <ArtifactRow label="Inspect" value={`${screenshotFolderSource.inspection_endpoint} (${screenshotFolderSource.inspection_visibility.replace(/_/g, " ")})`} />
                 <div className="flex flex-wrap items-center gap-2 pt-1">
                   <button


### PR DESCRIPTION
## Summary

Implements T6 from #647 by exposing screenshot-folder analysis pipeline status in settings and rendering it in the settings UI.

Closes #650
Part of #647
Stacked on #659

## Changes

- Adds Seraph-owned screenshot pipeline status to `/api/settings/artifact-storage`.
- Shows observation counts, analyzer status mix, backlog, failures, latest observation/analyzed timestamps, digest count, and latest digest timestamp.
- Adds screenshot-folder analyzer/backlog/digest rows to `ArtifactStoragePanel`.
- Keeps the settings surface focused on local image folder scanning and Seraph analysis/report readiness.
- Documents the shipped status surface.

## Validation

- `uv run pytest -q tests/test_settings_api.py::test_artifact_storage_exposes_screenshot_folder_status`
- `npm run test -- ArtifactStoragePanel.test.tsx`
- `npm run build`
- `python3 -m py_compile backend/src/api/settings.py`
- `git diff --check`
- `git diff --cached --check`

## Team Lead / Critic

Lead pass verified branch rules, stack base, staged scope, and validation.

Critic/Contrarian pass checked producer boundary, privacy, DB query cost, and UI copy. One finding was accepted and fixed: digest count now uses a database count query instead of loading all digest episodes.
