### PR TITLE
Add screenshot intelligence loop validation

### DIFF
--- a/backend/tests/test_screenshot_intelligence_loop.py
+++ b/backend/tests/test_screenshot_intelligence_loop.py
@@ -1,0 +1,158 @@
+"""Full-loop tests for screenshot-folder intelligence and reports."""
+
+from __future__ import annotations
+
+import os
+import hashlib
+import json
+from datetime import date, datetime, timezone
+
+import pytest
+
+from config.settings import settings
+
+
+@pytest.mark.asyncio
+async def test_screenshot_folder_analysis_digest_report_and_status_loop(
+    async_db,
+    client,
+    tmp_path,
+    monkeypatch,
+):
+    from src.db.models import Goal, MemoryEpisode, ScreenObservation
+    from src.observer.screenshot_analysis_contract import parse_screenshot_analysis_output
+    from src.observer.screenshot_folder_source import scan_screenshot_folder
+    from src.scheduler.jobs.end_of_day_goal_report import build_end_of_day_goal_report
+    from src.scheduler.jobs.screenshot_observation_digest import build_screenshot_observation_digest
+    from sqlmodel import select
+
+    screenshot_root = tmp_path / "screenshots"
+    screenshot_root.mkdir()
+    image_bytes = b"fake png bytes"
+    image_sha256 = hashlib.sha256(image_bytes).hexdigest()
+    image = screenshot_root / "seraph-loop.png"
+    duplicate_image = screenshot_root / "seraph-loop-copy.png"
+    image.write_bytes(image_bytes)
+    duplicate_image.write_bytes(image_bytes)
+    captured_at = datetime(2026, 6, 30, 10, 5, tzinfo=timezone.utc)
+    os.utime(image, (captured_at.timestamp(), captured_at.timestamp()))
+    os.utime(duplicate_image, (captured_at.timestamp(), captured_at.timestamp()))
+    analysis = parse_screenshot_analysis_output(
+        {
+            "schema_version": "seraph.screenshot_analysis.v1",
+            "prompt_version": "seraph.screenshot_analysis.prompt.v1",
+            "summary": "The user is implementing Seraph screenshot intelligence loop tests.",
+            "detailed_observations": [
+                "A test covers screenshot ingestion, digest creation, and reporting."
+            ],
+            "activity_type": "coding",
+            "project": "seraph",
+            "applications": ["editor"],
+            "visible_artifacts": ["test_screenshot_intelligence_loop.py"],
+            "key_visible_text": ["screenshot intelligence loop"],
+            "user_intent": "Verify the complete Seraph screenshot analysis path.",
+            "goal_alignment": {
+                "status": "aligned",
+                "goal_refs": ["Seraph screenshot intelligence loop"],
+                "evidence": ["The visible work is the screenshot loop test."],
+                "needle_movement": "pushed",
+            },
+            "confidence": 0.9,
+            "sensitive_content_seen": False,
+            "privacy_notes": [],
+            "report_tags": ["screenshots", "daily-report"],
+        }
+    )
+
+    analyzer_calls = []
+
+    async def fake_analyze_screenshot_image(_image_path, _artifacts):
+        analyzer_calls.append((_image_path, dict(_artifacts)))
+        return analysis
+
+    monkeypatch.setattr(
+        "src.observer.screenshot_folder_source.analyze_screenshot_image",
+        fake_analyze_screenshot_image,
+    )
+    monkeypatch.setenv("SERAPH_SCREENSHOT_FOLDER", str(screenshot_root))
+    monkeypatch.setattr("src.api.settings.settings.screen_analysis_provider", "local-vlm")
+    monkeypatch.setattr("src.api.settings.settings.local_vlm_base_url", "http://gpu:8088")
+    monkeypatch.setattr("src.api.settings.settings.local_vlm_model", "gemma-test")
+    async with async_db() as db:
+        db.add(
+            Goal(
+                id="goal-loop",
+                path="/",
+                level="daily",
+                title="Ship Seraph screenshot intelligence loop",
+                domain="productivity",
+                status="active",
+                sort_order=0,
+            )
+        )
+
+    scan_result = await scan_screenshot_folder(screenshot_root, limit=10)
+    duplicate_scan_result = await scan_screenshot_folder(screenshot_root, limit=10)
+    digest_result = await build_screenshot_observation_digest(
+        window_start=datetime(2026, 6, 30, 10, 0, tzinfo=timezone.utc),
+        window_end=datetime(2026, 6, 30, 10, 30, tzinfo=timezone.utc),
+    )
+    with monkeypatch.context() as report_patch:
+        report_patch.setattr(settings, "user_timezone", "UTC")
+        report_patch.setattr(settings, "end_of_day_report_llm_enabled", False)
+        report = await build_end_of_day_goal_report(date(2026, 6, 30))
+
+    status = (await client.get("/api/settings/artifact-storage")).json()
+    async with async_db() as db:
+        observations = list((await db.execute(select(ScreenObservation))).scalars().all())
+        episodes = list((await db.execute(select(MemoryEpisode))).scalars().all())
+
+    assert scan_result.ingested == 1
+    assert scan_result.skipped_duplicates == 1
+    assert duplicate_scan_result.ingested == 0
+    assert duplicate_scan_result.skipped_duplicates == 2
+    assert len(analyzer_calls) == 1
+    analyzed_path, analyzed_artifacts = analyzer_calls[0]
+    assert analyzed_path in {image.resolve(), duplicate_image.resolve()}
+    assert analyzed_artifacts["provider"] == "screenshot_folder"
+    assert analyzed_artifacts["source"] == "local_image_directory"
+    assert analyzed_artifacts["created_at"] == captured_at.isoformat()
+    assert analyzed_artifacts["image_sha256"] == image_sha256
+    assert "manifest" not in analyzed_artifacts
+    assert "service" not in analyzed_artifacts
+    assert len(observations) == 1
+    assert observations[0].timestamp.replace(tzinfo=timezone.utc) == captured_at
+    details = json.loads(observations[0].details_json or "[]")
+    assert f"screenshot_folder_image_sha256:{image_sha256}" in details
+    assert any(str(item).startswith("capture_artifacts:") for item in details)
+    assert any(str(item).startswith("screenshot_analysis:") for item in details)
+    assert any(str(item).startswith("screenshot_analysis_status:") for item in details)
+    assert digest_result.status == "created"
+    assert digest_result.observation_count == 1
+    digest_episode = next(
+        episode for episode in episodes if episode.source_tool_name == "screenshot_observation_digest"
+    )
+    digest_metadata = json.loads(digest_episode.metadata_json or "{}")
+    assert digest_metadata["observation_ids"] == [observations[0].id]
+    assert digest_metadata["observation_count"] == 1
+    assert "Evidence observation IDs:" in digest_episode.content
+    assert observations[0].id in digest_episode.content
+    assert "screenshot intelligence loop" in digest_episode.content
+    assert str(image.resolve()) not in digest_episode.content
+    assert image_sha256 not in digest_episode.content
+    assert report["screenshot_digests"]["count"] == 1
+    assert report["screenshot_digests"]["observation_ids"] == ["[redacted]"]
+    assert observations[0].id not in report["screenshot_digests"]["redacted_text"]
+    assert "[redacted]" in report["screenshot_digests"]["redacted_text"]
+    assert "screenshot intelligence loop" in report["screenshot_digests"]["redacted_text"]
+    assert str(image.resolve()) not in report["screenshot_digests"]["redacted_text"]
+    assert image_sha256 not in report["screenshot_digests"]["redacted_text"]
+    assert report["goal_alignment"][0]["status"] == "aligned"
+    assert report["goal_alignment"][0]["needle_movement"] == "pushed"
+    assert report["goal_alignment"][0]["source_observation_ids"] == ["[redacted]"]
+    assert "- Pushed-the-needle goals: 1" in report["body"]
+    assert status["screenshot_folder"]["analysis"]["observation_count"] == 1
+    assert status["screenshot_folder"]["analysis"]["analysis_status"]["succeeded"] == 1
+    assert status["screenshot_folder"]["analysis"]["analysis_failures"] == 0
+    assert status["screenshot_folder"]["analysis"]["analysis_backlog"] == 0
+    assert status["screenshot_folder"]["analysis"]["digest_count"] == 1

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -98,7 +98,7 @@ The semantic analysis schema captures:
 
 The VLM prompt requires the model to treat screenshot content as untrusted and return only the JSON shape defined by the contract. The parser rejects non-JSON output, unknown fields, invalid enum values, and out-of-range confidence values. It also redacts sensitive-looking strings before the analysis can become a durable observation.
 
-This contract is the boundary for the next implementation slice. The current folder scan still persists metadata observations; the follow-up analyzer will call a configured VLM, validate the output with this contract, and persist the semantic analysis without requiring any direct connection to the screenshot producer.
+This contract is the boundary between local image ingestion and screenshot understanding. The folder scan calls the configured Seraph-side analyzer when one is available, validates the output with this contract, and persists the semantic analysis without requiring any direct connection to the screenshot producer.
 
 End-of-day reports consume screenshot-folder `ScreenObservation` rows through the same report builder as other screen observations. Seraph records the observation source as `screenshot_folder` from its own stored capture-artifact details and includes report-safe screenshot samples using filenames, format, dimensions, and size. Reports do not rely on recorder manifests, sidecars, or service metadata.
 
@@ -251,6 +251,24 @@ Sources checked June 30, 2026:
 - [seraph-quest/vlm-screenshot-server](https://github.com/seraph-quest/vlm-screenshot-server)
 
 ## Verification
+
+Full screenshot intelligence loop receipt:
+
+- local screenshot image file is scanned from the configured folder
+- Seraph computes its own hash and mtime-derived capture timestamp
+- Seraph runs semantic analysis through its own analyzer boundary
+- duplicate image ingestion remains hash-based
+- rolling digest stores redacted text and source observation ids
+- end-of-day report consumes digest text and compares against active goals
+- settings status shows observation, analyzer, backlog, failure, and digest counts
+- no screenshot producer service, manifest, or sidecar is required
+
+Focused receipt command:
+
+```bash
+cd /Users/bigcube/Desktop/repos/seraph/backend
+UV_CACHE_DIR=/tmp/seraph-uv-cache uv run pytest tests/test_screenshot_intelligence_loop.py
+```
 
 This branch verifies the image-source path with:
 


### PR DESCRIPTION
Closes #648
Part of #647
Stacked on #660

## Summary

- Adds a full-loop backend receipt test for the screenshot intelligence pipeline.
- Verifies local image-file ingestion, mtime-derived capture time, Seraph-owned semantic analysis, hash dedupe across duplicate filenames, digest creation, daily goal-report comparison, and settings/status counts.
- Updates the screenshot-folder implementation doc so the analyzer-boundary language matches shipped behavior.

## Validation

```bash
cd /Users/bigcube/Desktop/repos/seraph/backend
uv run pytest -q tests/test_screenshot_intelligence_loop.py tests/test_settings_api.py::test_artifact_storage_exposes_screenshot_folder_status tests/test_end_of_day_goal_report.py tests/test_screenshot_observation_digest.py

cd /Users/bigcube/Desktop/repos/seraph
python3 -m py_compile backend/tests/test_screenshot_intelligence_loop.py
git diff --check
```

Result: 18 backend tests passed; py_compile and diff check passed.

## Review

Agent team:
- Lead: scoped T7 as validation/docs only and kept the branch stacked on the T6 branch.
- Independent Critic: reviewed the staged T7 diff.

Critic disposition:
- Accepted and fixed: initial receipt overclaimed durable/report assertions, duplicate proof was too shallow, analyzer-boundary arguments were not asserted, and docs still described semantic analysis as future work.
- Final re-review: no remaining findings; staged diff acceptable for PR.

## Notes

- The test confirms real source observation IDs are retained in durable digest metadata, while report-facing digest IDs/text are redacted.
- The loop remains producer-neutral: no manifest, service, sidecar, or Framekeeper-specific contract is required.
