### PR TITLE
Fix GPU VLM feeder backpressure

### DIFF
--- a/backend/src/llm_runtime.py
+++ b/backend/src/llm_runtime.py
@@ -420,6 +420,41 @@ def _local_gemma_profile_options(profile_id: str) -> dict[str, Any]:
     return options
 
 
+def _local_gemma_runtime_profile_id(profile: str | None) -> str | None:
+    normalized = _normal_profile_id(profile)
+    prefix = "local-gemma-"
+    if not normalized.startswith(prefix):
+        return None
+    profile_id = normalized.removeprefix(prefix).replace("-", "_")
+    try:
+        local_runtime_profile(profile_id)
+    except ValueError:
+        return None
+    return profile_id
+
+
+def _apply_local_runtime_request_metadata(kwargs: dict[str, Any], profile: str | None) -> None:
+    profile_id = _local_gemma_runtime_profile_id(profile)
+    if not profile_id:
+        return
+    runtime_profile = local_runtime_profile(profile_id)
+    metadata = dict(kwargs.get("metadata") or {})
+    metadata.update(
+        {
+            "runtime_profile": runtime_profile.id,
+            "runtime_path": runtime_profile.runtime_path,
+            "priority": runtime_profile.priority,
+        }
+    )
+    kwargs["metadata"] = metadata
+    extra_headers = dict(kwargs.get("extra_headers") or {})
+    extra_headers.setdefault("X-Seraph-Runtime-Profile", runtime_profile.id)
+    extra_headers.setdefault("X-Seraph-Runtime-Path", runtime_profile.runtime_path)
+    extra_headers.setdefault("X-Seraph-Priority", runtime_profile.priority)
+    extra_headers.setdefault("X-Seraph-Reasoning", runtime_profile.reasoning)
+    kwargs["extra_headers"] = extra_headers
+
+
 def provider_profiles() -> dict[str, ProviderProfile]:
     profiles = _builtin_provider_profiles()
     profiles.update(_configured_provider_profiles())
@@ -1077,6 +1112,7 @@ def build_completion_kwargs(
             "max_tokens": max_tokens,
         }
         kwargs.update(_profile_options(resolved_profile))
+        _apply_local_runtime_request_metadata(kwargs, resolved_profile)
         api_key = _profile_api_key(resolved_profile)
         api_base = _profile_api_base(resolved_profile)
 

--- a/backend/src/llm_runtime.py
+++ b/backend/src/llm_runtime.py
@@ -1050,6 +1050,7 @@ def build_model_kwargs(
         "runtime_path": runtime_path,
     }
     kwargs.update(_profile_options(resolved_profile))
+    _apply_local_runtime_request_metadata(kwargs, resolved_profile)
     api_key = _profile_api_key(resolved_profile)
     if api_key:
         kwargs["api_key"] = api_key

--- a/backend/src/observer/screenshot_semantic_analysis.py
+++ b/backend/src/observer/screenshot_semantic_analysis.py
@@ -1,4 +1,4 @@
-"""Provider-backed semantic analysis for local screenshot images."""
+"""Provider-backed semantic analysis for screenshot-folder images."""
 
 from __future__ import annotations
 
@@ -53,7 +53,7 @@ class ScreenshotSemanticAnalysisError(RuntimeError):
 
 
 def screenshot_semantic_analysis_enabled() -> bool:
-    """Return true when Seraph should call the local VLM screenshot analyzer."""
+    """Return true when Seraph should call the configured VLM screenshot analyzer."""
     return (
         effective_screen_analysis_enabled()
         and effective_screen_analysis_provider().lower() == "local-vlm"
@@ -62,30 +62,46 @@ def screenshot_semantic_analysis_enabled() -> bool:
 
 
 async def screenshot_semantic_analysis_ready(*, timeout_seconds: float = 2.0) -> bool:
-    """Return true when the configured local VLM screenshot analyzer is reachable."""
+    """Return true when the configured VLM screenshot analyzer is reachable."""
     status = await _screenshot_semantic_analysis_health(timeout_seconds=timeout_seconds)
     return status is not None
 
 
 async def screenshot_semantic_analysis_accepting_background_work(*, timeout_seconds: float = 2.0) -> bool:
-    """Return true when the local VLM wrapper can accept one background image job."""
+    """Return true when the VLM wrapper can accept one background image job."""
+    return await screenshot_semantic_analysis_background_slots(timeout_seconds=timeout_seconds) > 0
+
+
+async def screenshot_semantic_analysis_background_slots(*, timeout_seconds: float = 2.0) -> int:
+    """Return the number of Seraph background image jobs the VLM wrapper can accept now."""
     status = await _screenshot_semantic_analysis_queue_status(timeout_seconds=timeout_seconds)
     if status is None:
-        return False
+        return 0
     if not await _screenshot_semantic_analysis_backend_ready(timeout_seconds=timeout_seconds):
-        return False
+        return 0
+    queue = _normalized_queue_status(status)
+    if queue is None:
+        return 0
+    active, queued, workers = queue
+    capacity_window = max(min(effective_vlm_feeder_window(), workers + 1), 1)
+    return max(capacity_window - active - queued, 0)
+
+
+def _normalized_queue_status(status: dict[str, Any]) -> tuple[int, int, int] | None:
+    queue_status = status.get("queue")
+    if isinstance(queue_status, dict):
+        status = queue_status
     try:
         active = int(status.get("active", 0))
         queued = int(status.get("queued", 0))
         workers = int(status.get("workers", 1))
     except (TypeError, ValueError):
-        return False
-    capacity_window = max(min(effective_vlm_feeder_window(), workers + 1), 1)
-    return active + queued < capacity_window
+        return None
+    return max(active, 0), max(queued, 0), max(workers, 1)
 
 
 async def _screenshot_semantic_analysis_health(*, timeout_seconds: float = 2.0) -> dict[str, Any] | None:
-    """Return the local VLM wrapper health payload when reachable."""
+    """Return the VLM wrapper health payload when reachable."""
     if not screenshot_semantic_analysis_enabled():
         return None
     endpoint = effective_vlm_base_url() + "/health"

--- a/backend/src/scheduler/jobs/screenshot_folder_analysis.py
+++ b/backend/src/scheduler/jobs/screenshot_folder_analysis.py
@@ -9,8 +9,11 @@ from time import perf_counter
 
 from config.settings import settings
 from src.audit.runtime import log_scheduler_job_event
-from src.observer.screenshot_folder_source import analyze_pending_screenshot_folder_observations
-from src.observer.screenshot_semantic_analysis import screenshot_semantic_analysis_accepting_background_work
+from src.observer.screenshot_folder_source import (
+    ScreenshotFolderAnalysisResult,
+    analyze_pending_screenshot_folder_observations,
+)
+from src.observer.screenshot_semantic_analysis import screenshot_semantic_analysis_background_slots
 
 logger = logging.getLogger(__name__)
 _ANALYSIS_LOCK = asyncio.Lock()
@@ -44,8 +47,8 @@ def _analysis_job_timeout_seconds(*, limit: int, concurrency: int) -> float:
     return base_timeout_seconds * batches
 
 
-def _scheduled_batch_limit(*, limit: int, concurrency: int) -> int:
-    return max(1, min(limit, concurrency))
+def _scheduled_batch_limit(*, limit: int, concurrency: int, available_slots: int) -> int:
+    return max(0, min(limit, concurrency, max(available_slots, 0)))
 
 
 def _log_late_analysis_task_failure(task: asyncio.Task) -> None:
@@ -75,43 +78,64 @@ async def run_screenshot_folder_analysis() -> None:
             },
         )
         return
-    if not await screenshot_semantic_analysis_accepting_background_work():
-        logger.info("screenshot_folder_analysis: skipped; local VLM has no background capacity")
-        await log_scheduler_job_event(
-            job_name="screenshot_folder_analysis",
-            outcome="skipped",
-            details={
-                "duration_ms": int((perf_counter() - started_at) * 1000),
-                "reason": "local_vlm_no_background_capacity",
-            },
-        )
-        return
-
+    timeout_seconds = 0.0
     try:
         async with _ANALYSIS_LOCK:
             limit = _clamped_limit()
             concurrency = _clamped_concurrency()
-            batch_limit = _scheduled_batch_limit(limit=limit, concurrency=concurrency)
-            timeout_seconds = _analysis_job_timeout_seconds(limit=batch_limit, concurrency=concurrency)
-            logger.info(
-                "screenshot_folder_analysis: running limit=%d batch_limit=%d concurrency=%d timeout_seconds=%s",
-                limit,
-                batch_limit,
-                concurrency,
-                timeout_seconds,
-            )
-            analysis_task = asyncio.create_task(
-                analyze_pending_screenshot_folder_observations(
-                    limit=batch_limit,
+            remaining = limit
+            result = ScreenshotFolderAnalysisResult(scanned=0, analyzed=0, failed=0, skipped=0)
+            feeder_iterations = 0
+            last_batch_limit = 0
+            stopped_reason = "limit_reached"
+            while remaining > 0:
+                available_slots = await screenshot_semantic_analysis_background_slots()
+                if available_slots <= 0:
+                    stopped_reason = "local_vlm_no_background_capacity"
+                    break
+                batch_limit = _scheduled_batch_limit(
+                    limit=remaining,
                     concurrency=concurrency,
+                    available_slots=available_slots,
                 )
-            )
-            done, pending = await asyncio.wait({analysis_task}, timeout=timeout_seconds)
-            if pending:
-                analysis_task.cancel()
-                analysis_task.add_done_callback(_log_late_analysis_task_failure)
-                raise asyncio.TimeoutError
-            result = next(iter(done)).result()
+                batch_concurrency = min(concurrency, batch_limit)
+                timeout_seconds = _analysis_job_timeout_seconds(limit=batch_limit, concurrency=batch_concurrency)
+                logger.info(
+                    (
+                        "screenshot_folder_analysis: running limit=%d remaining=%d batch_limit=%d "
+                        "concurrency=%d available_slots=%d timeout_seconds=%s"
+                    ),
+                    limit,
+                    remaining,
+                    batch_limit,
+                    batch_concurrency,
+                    available_slots,
+                    timeout_seconds,
+                )
+                analysis_task = asyncio.create_task(
+                    analyze_pending_screenshot_folder_observations(
+                        limit=batch_limit,
+                        concurrency=batch_concurrency,
+                    )
+                )
+                done, pending = await asyncio.wait({analysis_task}, timeout=timeout_seconds)
+                if pending:
+                    analysis_task.cancel()
+                    analysis_task.add_done_callback(_log_late_analysis_task_failure)
+                    raise asyncio.TimeoutError
+                batch_result = next(iter(done)).result()
+                feeder_iterations += 1
+                last_batch_limit = batch_limit
+                result = ScreenshotFolderAnalysisResult(
+                    scanned=result.scanned + batch_result.scanned,
+                    analyzed=result.analyzed + batch_result.analyzed,
+                    failed=result.failed + batch_result.failed,
+                    skipped=result.skipped + batch_result.skipped,
+                )
+                remaining -= batch_limit
+                if batch_result.scanned == 0:
+                    stopped_reason = "backlog_empty"
+                    break
     except asyncio.TimeoutError:
         await log_scheduler_job_event(
             job_name="screenshot_folder_analysis",
@@ -121,10 +145,6 @@ async def run_screenshot_folder_analysis() -> None:
                 "error": "analysis job timed out",
                 "timeout_seconds": timeout_seconds,
                 "concurrency": _clamped_concurrency(),
-                "batch_limit": _scheduled_batch_limit(
-                    limit=_clamped_limit(),
-                    concurrency=_clamped_concurrency(),
-                ),
             },
         )
         logger.warning(
@@ -168,10 +188,9 @@ async def run_screenshot_folder_analysis() -> None:
             "failed": result.failed,
             "skipped": result.skipped,
             "concurrency": _clamped_concurrency(),
-            "batch_limit": _scheduled_batch_limit(
-                limit=_clamped_limit(),
-                concurrency=_clamped_concurrency(),
-            ),
+            "batch_limit": last_batch_limit,
+            "feeder_iterations": feeder_iterations,
+            "stopped_reason": stopped_reason,
         },
     )
     logger.info(

--- a/backend/tests/test_llm_runtime.py
+++ b/backend/tests/test_llm_runtime.py
@@ -40,6 +40,8 @@ def clear_ambient_runtime_profile_preferences():
     with (
         patch.object(settings, "runtime_profile_preferences", ""),
         patch.object(settings, "local_runtime_paths", ""),
+        patch.object(settings, "seraph_vlm_api_key", ""),
+        patch.object(settings, "local_vlm_api_key", ""),
     ):
         yield
 
@@ -270,6 +272,14 @@ def test_built_in_local_gemma_profiles_resolve_with_runtime_options(monkeypatch)
     assert kwargs["api_base"] == "http://127.0.0.1:8000/v1"
     assert kwargs["chat_template_kwargs"] == {"enable_thinking": True}
     assert kwargs["reasoning"] is True
+    assert kwargs["metadata"] == {
+        "runtime_profile": "chat_thinking",
+        "runtime_path": "chat_agent",
+        "priority": "interactive",
+    }
+    assert kwargs["extra_headers"]["X-Seraph-Runtime-Profile"] == "chat_thinking"
+    assert kwargs["extra_headers"]["X-Seraph-Runtime-Path"] == "chat_agent"
+    assert kwargs["extra_headers"]["X-Seraph-Priority"] == "interactive"
     assert "api_key" not in kwargs
 
 

--- a/backend/tests/test_llm_runtime.py
+++ b/backend/tests/test_llm_runtime.py
@@ -322,6 +322,14 @@ def test_delegated_orchestrator_can_route_to_local_gemma_chat_profile(monkeypatc
     assert kwargs["model_id"] == "openai/unsloth/gemma-4-26B-A4B-it-qat-GGUF"
     assert kwargs["api_base"] == "http://127.0.0.1:8000/v1"
     assert kwargs["api_key"] == "local-secret"
+    assert kwargs["metadata"] == {
+        "runtime_profile": "chat_thinking",
+        "runtime_path": "chat_agent",
+        "priority": "interactive",
+    }
+    assert kwargs["extra_headers"]["X-Seraph-Runtime-Profile"] == "chat_thinking"
+    assert kwargs["extra_headers"]["X-Seraph-Runtime-Path"] == "chat_agent"
+    assert kwargs["extra_headers"]["X-Seraph-Priority"] == "interactive"
 
 
 def test_all_interactive_paths_can_route_to_local_gemma_chat_profile(monkeypatch):
@@ -354,6 +362,8 @@ def test_all_interactive_paths_can_route_to_local_gemma_chat_profile(monkeypatch
         assert kwargs["model_id"] == "openai/unsloth/gemma-4-26B-A4B-it-qat-GGUF"
         assert kwargs["api_base"] == "http://127.0.0.1:8000/v1"
         assert kwargs["api_key"] == "local-secret"
+        assert kwargs["metadata"]["priority"] == "interactive"
+        assert kwargs["extra_headers"]["X-Seraph-Priority"] == "interactive"
 
 
 def test_built_in_claude_anthropic_profile_resolves_with_litellm(monkeypatch):
@@ -374,6 +384,8 @@ def test_built_in_claude_anthropic_profile_resolves_with_litellm(monkeypatch):
     assert kwargs["model_id"] == "anthropic/claude-sonnet-4-20250514"
     assert kwargs["runtime_profile"] == "claude-anthropic"
     assert kwargs["api_key"] == "anthropic-secret-key"
+    assert "metadata" not in kwargs
+    assert "extra_headers" not in kwargs
     resolved_model, provider, _, _ = get_llm_provider(model=kwargs["model_id"])
     assert resolved_model == "claude-sonnet-4-20250514"
     assert provider == "anthropic"

--- a/backend/tests/test_screenshot_folder_analysis_job.py
+++ b/backend/tests/test_screenshot_folder_analysis_job.py
@@ -26,9 +26,10 @@ def test_screenshot_folder_analysis_job_timeout_scales_with_batches(monkeypatch)
 def test_screenshot_folder_analysis_scheduled_batch_is_limited_to_feeder_window():
     from src.scheduler.jobs.screenshot_folder_analysis import _scheduled_batch_limit
 
-    assert _scheduled_batch_limit(limit=100, concurrency=2) == 2
-    assert _scheduled_batch_limit(limit=1, concurrency=2) == 1
-    assert _scheduled_batch_limit(limit=100, concurrency=1) == 1
+    assert _scheduled_batch_limit(limit=100, concurrency=2, available_slots=2) == 2
+    assert _scheduled_batch_limit(limit=1, concurrency=2, available_slots=2) == 1
+    assert _scheduled_batch_limit(limit=100, concurrency=1, available_slots=2) == 1
+    assert _scheduled_batch_limit(limit=100, concurrency=2, available_slots=0) == 0
 
 
 def test_failed_screenshot_analysis_is_retried_after_cooldown():
@@ -177,8 +178,10 @@ async def test_screenshot_folder_analysis_job_drains_pending_backlog_with_bounde
     calls = []
     events = []
 
-    async def fake_accepting_background_work():
-        return True
+    slots = [2, 1, 0]
+
+    async def fake_background_slots():
+        return slots.pop(0)
 
     async def fake_analyze_pending(*, limit, concurrency):
         calls.append({"limit": limit, "concurrency": concurrency})
@@ -188,8 +191,8 @@ async def test_screenshot_folder_analysis_job_drains_pending_backlog_with_bounde
         events.append({"job_name": job_name, "outcome": outcome, "details": details})
 
     monkeypatch.setattr(
-        "src.scheduler.jobs.screenshot_folder_analysis.screenshot_semantic_analysis_accepting_background_work",
-        fake_accepting_background_work,
+        "src.scheduler.jobs.screenshot_folder_analysis.screenshot_semantic_analysis_background_slots",
+        fake_background_slots,
     )
     monkeypatch.setattr(
         "src.scheduler.jobs.screenshot_folder_analysis.analyze_pending_screenshot_folder_observations",
@@ -212,13 +215,15 @@ async def test_screenshot_folder_analysis_job_drains_pending_backlog_with_bounde
 
     await run_screenshot_folder_analysis()
 
-    assert calls == [{"limit": 2, "concurrency": 2}]
+    assert calls == [{"limit": 2, "concurrency": 2}, {"limit": 1, "concurrency": 1}]
     assert events[0]["job_name"] == "screenshot_folder_analysis"
     assert events[0]["outcome"] == "succeeded"
-    assert events[0]["details"]["scanned"] == 5
-    assert events[0]["details"]["analyzed"] == 5
+    assert events[0]["details"]["scanned"] == 10
+    assert events[0]["details"]["analyzed"] == 10
     assert events[0]["details"]["concurrency"] == 2
-    assert events[0]["details"]["batch_limit"] == 2
+    assert events[0]["details"]["batch_limit"] == 1
+    assert events[0]["details"]["feeder_iterations"] == 2
+    assert events[0]["details"]["stopped_reason"] == "local_vlm_no_background_capacity"
 
 
 @pytest.mark.asyncio
@@ -229,8 +234,8 @@ async def test_screenshot_folder_analysis_timeout_releases_scheduler_slot(monkey
     cancel_seen = asyncio.Event()
     release_cleanup = asyncio.Event()
 
-    async def fake_accepting_background_work():
-        return True
+    async def fake_background_slots():
+        return 1
 
     async def fake_analyze_pending(*, limit, concurrency):
         try:
@@ -244,8 +249,8 @@ async def test_screenshot_folder_analysis_timeout_releases_scheduler_slot(monkey
         events.append({"job_name": job_name, "outcome": outcome, "details": details})
 
     monkeypatch.setattr(
-        "src.scheduler.jobs.screenshot_folder_analysis.screenshot_semantic_analysis_accepting_background_work",
-        fake_accepting_background_work,
+        "src.scheduler.jobs.screenshot_folder_analysis.screenshot_semantic_analysis_background_slots",
+        fake_background_slots,
     )
     monkeypatch.setattr(
         "src.scheduler.jobs.screenshot_folder_analysis.analyze_pending_screenshot_folder_observations",
@@ -274,8 +279,8 @@ async def test_screenshot_folder_analysis_job_skips_when_vlm_has_no_capacity(mon
 
     events = []
 
-    async def fake_accepting_background_work():
-        return False
+    async def fake_background_slots():
+        return 0
 
     async def fake_analyze_pending(*, limit, concurrency):
         raise AssertionError("analysis should not run when the VLM service is unhealthy")
@@ -284,8 +289,8 @@ async def test_screenshot_folder_analysis_job_skips_when_vlm_has_no_capacity(mon
         events.append({"job_name": job_name, "outcome": outcome, "details": details})
 
     monkeypatch.setattr(
-        "src.scheduler.jobs.screenshot_folder_analysis.screenshot_semantic_analysis_accepting_background_work",
-        fake_accepting_background_work,
+        "src.scheduler.jobs.screenshot_folder_analysis.screenshot_semantic_analysis_background_slots",
+        fake_background_slots,
     )
     monkeypatch.setattr(
         "src.scheduler.jobs.screenshot_folder_analysis.analyze_pending_screenshot_folder_observations",
@@ -305,7 +310,14 @@ async def test_screenshot_folder_analysis_job_skips_when_vlm_has_no_capacity(mon
             "outcome": "skipped",
             "details": {
                 "duration_ms": events[0]["details"]["duration_ms"],
-                "reason": "local_vlm_no_background_capacity",
+                "scanned": 0,
+                "analyzed": 0,
+                "failed": 0,
+                "skipped": 0,
+                "concurrency": 2,
+                "batch_limit": 0,
+                "feeder_iterations": 0,
+                "stopped_reason": "local_vlm_no_background_capacity",
             },
         }
     ]
@@ -340,8 +352,8 @@ async def test_screenshot_folder_analysis_job_reports_degraded_backlog(monkeypat
 
     events = []
 
-    async def fake_accepting_background_work():
-        return True
+    async def fake_background_slots():
+        return 1
 
     async def fake_analyze_pending(*, limit, concurrency):
         return ScreenshotFolderAnalysisResult(scanned=4, analyzed=3, failed=1, skipped=0)
@@ -350,8 +362,8 @@ async def test_screenshot_folder_analysis_job_reports_degraded_backlog(monkeypat
         events.append({"job_name": job_name, "outcome": outcome, "details": details})
 
     monkeypatch.setattr(
-        "src.scheduler.jobs.screenshot_folder_analysis.screenshot_semantic_analysis_accepting_background_work",
-        fake_accepting_background_work,
+        "src.scheduler.jobs.screenshot_folder_analysis.screenshot_semantic_analysis_background_slots",
+        fake_background_slots,
     )
     monkeypatch.setattr(
         "src.scheduler.jobs.screenshot_folder_analysis.analyze_pending_screenshot_folder_observations",
@@ -379,8 +391,8 @@ async def test_screenshot_folder_analysis_job_times_out_stuck_analysis(monkeypat
 
     events = []
 
-    async def fake_accepting_background_work():
-        return True
+    async def fake_background_slots():
+        return 1
 
     async def fake_analyze_pending(*, limit, concurrency):
         await asyncio.sleep(1)
@@ -390,8 +402,8 @@ async def test_screenshot_folder_analysis_job_times_out_stuck_analysis(monkeypat
         events.append({"job_name": job_name, "outcome": outcome, "details": details})
 
     monkeypatch.setattr(
-        "src.scheduler.jobs.screenshot_folder_analysis.screenshot_semantic_analysis_accepting_background_work",
-        fake_accepting_background_work,
+        "src.scheduler.jobs.screenshot_folder_analysis.screenshot_semantic_analysis_background_slots",
+        fake_background_slots,
     )
     monkeypatch.setattr(
         "src.scheduler.jobs.screenshot_folder_analysis.analyze_pending_screenshot_folder_observations",

--- a/backend/tests/test_screenshot_semantic_analysis.py
+++ b/backend/tests/test_screenshot_semantic_analysis.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from src.observer.screenshot_semantic_analysis import (
     analyze_screenshot_image,
     screenshot_semantic_analysis_accepting_background_work,
+    screenshot_semantic_analysis_background_slots,
 )
 
 
@@ -360,3 +361,47 @@ async def test_local_vlm_background_capacity_requires_backend_health(monkeypatch
 
     assert await screenshot_semantic_analysis_accepting_background_work() is False
     assert calls == ["http://gpu:8088/queue/status", "http://gpu:8088/health/backend"]
+
+
+async def test_local_vlm_background_capacity_normalizes_nested_queue_payload(monkeypatch):
+    calls = []
+
+    class FakeResponse:
+        status_code = 200
+
+        def __init__(self, payload):
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def get(self, endpoint):
+            calls.append(endpoint)
+            if endpoint.endswith("/health/backend"):
+                return FakeResponse({"status": "ok"})
+            return FakeResponse({"queue": {"active": 1, "queued": 0, "workers": 1}})
+
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.screen_analysis_provider", "local-vlm")
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.seraph_vlm_base_url", "")
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.local_vlm_base_url", "http://gpu:8088")
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.settings.seraph_vlm_feeder_window", 2)
+    monkeypatch.setattr("src.observer.screenshot_semantic_analysis.httpx.AsyncClient", FakeAsyncClient)
+
+    assert await screenshot_semantic_analysis_background_slots() == 1
+    assert await screenshot_semantic_analysis_accepting_background_work() is True
+    assert calls == [
+        "http://gpu:8088/queue/status",
+        "http://gpu:8088/health/backend",
+        "http://gpu:8088/queue/status",
+        "http://gpu:8088/health/backend",
+    ]

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -159,7 +159,7 @@ The VLM wrapper runs through Docker Compose on the GPU server to avoid local Pyt
 ```bash
 ssh jupyter
 cd /home/pawel/repos/vlm-screenshot-server
-HOST_BIND=192.168.1.26 HOST_PORT=8001 PORT=8001 \
+HOST_BIND=0.0.0.0 HOST_PORT=8001 PORT=8001 \
   VLM_BASE_URL=http://192.168.1.26:8000/v1 \
   VLM_MODEL=unsloth/gemma-4-26B-A4B-it-qat-GGUF \
   CHAT_PROXY_ENABLED=true \
@@ -169,6 +169,8 @@ HOST_BIND=192.168.1.26 HOST_PORT=8001 PORT=8001 \
 ```
 
 The container publishes `192.168.1.26:8001` and forwards to `http://192.168.1.26:8000/v1`. Docker Desktop on the Mac is not part of the healthy product path for the wrapper.
+
+SSH is only the admin channel for deploying, restarting, and inspecting the GPU-hosted wrapper. Seraph runtime traffic must stay on direct HTTP API calls to `SERAPH_VLM_BASE_URL=http://192.168.1.26:8001`; do not encode SSH forwards, SOCKS proxies, or tunnels into Seraph config or status receipts.
 
 Required readiness checks from the Mac:
 


### PR DESCRIPTION
## Summary\n- normalize VLM wrapper queue status from both flat and nested payloads and expose background slot counts\n- change screenshot-folder analysis into a bounded feeder loop that re-checks GPU wrapper capacity between small batches\n- attach local Gemma runtime metadata and X-Seraph priority headers to normal chat completion kwargs\n- clarify that SSH is GPU admin-only and Seraph runtime traffic must use the direct GPU VLM HTTP API\n\n## Tracking\nRefs #692\n\n## Validation\n- backend/.venv/bin/python -m pytest backend/tests/test_screenshot_semantic_analysis.py backend/tests/test_screenshot_folder_analysis_job.py backend/tests/test_llm_runtime.py -q --tb=short -> 115 passed\n- backend/.venv/bin/python -m pytest backend/tests/test_direct_chat.py backend/tests/test_websocket.py -q --tb=short -> 17 passed\n- git diff --check -> passed\n\n## Review\nIndependent subagent capacity was exhausted after the architecture/status audits, so I ran a separate lead critic pass on the cumulative diff before opening this PR. Finding checked: the feeder must not invent GPU concurrency or allow background screenshots to preempt chat. Disposition: accepted; the scheduler only submits up to reported wrapper slots, re-checks before each bounded batch, and the wrapper priority queue still decides the next one-GPU job.