### PR TITLE
fix: require authenticated GPU VLM chat readiness

### DIFF
--- a/backend/src/vlm_runtime.py
+++ b/backend/src/vlm_runtime.py
@@ -70,6 +70,10 @@ def effective_vlm_status(*, live_probe: dict[str, object] | None = None) -> dict
         "base_url": base_url,
         "backend_url": backend_url,
         "chat_api_base": effective_vlm_chat_api_base(),
+        "chat_completion_endpoint": f"{effective_vlm_chat_api_base()}/chat/completions"
+        if effective_vlm_chat_api_base()
+        else "",
+        "chat_health_endpoint": f"{base_url}/health/chat" if base_url else "",
         "queue_status_endpoint": f"{base_url}/queue/status" if base_url else "",
         "health_endpoint": f"{base_url}/health" if base_url else "",
         "backend_health_endpoint": f"{base_url}/health/backend" if base_url else "",
@@ -92,22 +96,30 @@ async def probe_effective_vlm_runtime(*, timeout_seconds: float = 0.75) -> dict[
             "health": _unprobed_endpoint(),
             "backend_health": _unprobed_endpoint(),
             "queue_status": _unprobed_endpoint(),
+            "chat_proxy": _unprobed_endpoint(),
         }
 
     timeout = max(min(timeout_seconds, 5.0), 0.1)
     async with httpx.AsyncClient(timeout=timeout) as client:
-        health, backend_health, queue_status = await asyncio.gather(
+        health, backend_health, queue_status, chat_proxy = await asyncio.gather(
             _probe_json_endpoint(client, base_url + "/health"),
             _probe_json_endpoint(client, base_url + "/health/backend"),
             _probe_json_endpoint(client, base_url + "/queue/status"),
+            _probe_chat_health(client, base_url + "/health/chat"),
         )
-    reachable = bool(health.get("ok") and backend_health.get("ok") and queue_status.get("ok"))
+    reachable = bool(
+        health.get("ok")
+        and backend_health.get("ok")
+        and queue_status.get("ok")
+        and chat_proxy.get("ok")
+    )
     return {
         "checked": True,
         "reachable": reachable,
         "health": health,
         "backend_health": backend_health,
         "queue_status": queue_status,
+        "chat_proxy": chat_proxy,
     }
 
 
@@ -161,3 +173,79 @@ async def _probe_json_endpoint(client: httpx.AsyncClient, endpoint: str) -> dict
             if key in payload:
                 result[key] = payload[key]
     return result
+
+
+async def _probe_chat_health(client: httpx.AsyncClient, endpoint: str) -> dict[str, object]:
+    headers = {}
+    api_key = effective_vlm_api_key()
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        response = await client.get(endpoint, headers=headers)
+    except httpx.TimeoutException:
+        return {"checked": True, "ok": False, "status_code": None, "error": "timeout"}
+    except httpx.ConnectError:
+        return {"checked": True, "ok": False, "status_code": None, "error": "connect_error"}
+    except httpx.HTTPError:
+        return {"checked": True, "ok": False, "status_code": None, "error": "http_error"}
+
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {}
+    status = ""
+    enabled = False
+    auth_configured = False
+    auth_ok = False
+    model = ""
+    if isinstance(payload, dict):
+        status = _safe_probe_detail(str(payload.get("status") or ""))
+        enabled = payload.get("enabled") is True
+        auth_configured = payload.get("auth_configured") is True
+        auth_ok = payload.get("auth_ok") is True
+        model_value = payload.get("model")
+        if isinstance(model_value, str):
+            model = _safe_probe_detail(model_value)
+    ok = 200 <= response.status_code < 400 and enabled and auth_configured and auth_ok
+    result: dict[str, object] = {
+        "checked": True,
+        "ok": ok,
+        "status_code": response.status_code,
+        "error": "" if ok else _chat_health_error(response, status, enabled, auth_configured, auth_ok),
+        "enabled": enabled,
+        "auth_configured": auth_configured,
+        "auth_ok": auth_ok,
+    }
+    if status:
+        result["status"] = status
+    if model:
+        result["model"] = model
+    return result
+
+
+def _chat_health_error(
+    response: httpx.Response,
+    status: str,
+    enabled: bool,
+    auth_configured: bool,
+    auth_ok: bool,
+) -> str:
+    if not 200 <= response.status_code < 400:
+        return "bad_status"
+    if status:
+        return _safe_probe_detail(status.strip().lower().replace(" ", "_"))
+    if not enabled:
+        return "disabled"
+    if not auth_configured:
+        return "auth_not_configured"
+    if not auth_ok:
+        return "auth_failed"
+    return "bad_status"
+
+
+def _safe_probe_detail(value: str) -> str:
+    safe = value.strip()
+    for secret in (settings.seraph_vlm_api_key, settings.local_vlm_api_key, settings.local_llm_api_key):
+        if secret:
+            safe = safe.replace(secret, "[redacted]")
+    return safe[:160]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -148,6 +148,7 @@ def stub_vlm_runtime_probe():
             "health": {"checked": False, "ok": False, "status_code": None, "error": ""},
             "backend_health": {"checked": False, "ok": False, "status_code": None, "error": ""},
             "queue_status": {"checked": False, "ok": False, "status_code": None, "error": ""},
+            "chat_proxy": {"checked": False, "ok": False, "status_code": None, "error": ""},
         }
 
     with (

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -11,6 +11,7 @@ _STUBBED_VLM_PROBE = {
     "health": {"checked": False, "ok": False, "status_code": None, "error": ""},
     "backend_health": {"checked": False, "ok": False, "status_code": None, "error": ""},
     "queue_status": {"checked": False, "ok": False, "status_code": None, "error": ""},
+    "chat_proxy": {"checked": False, "ok": False, "status_code": None, "error": ""},
 }
 
 
@@ -113,6 +114,8 @@ async def test_runtime_status_exposes_gpu_vlm_runtime_and_chat_profile(client):
         "base_url": "http://192.168.1.26:8001",
         "backend_url": "http://192.168.1.26:8000/v1",
         "chat_api_base": "http://192.168.1.26:8001/v1",
+        "chat_completion_endpoint": "http://192.168.1.26:8001/v1/chat/completions",
+        "chat_health_endpoint": "http://192.168.1.26:8001/health/chat",
         "queue_status_endpoint": "http://192.168.1.26:8001/queue/status",
         "health_endpoint": "http://192.168.1.26:8001/health",
         "backend_health_endpoint": "http://192.168.1.26:8001/health/backend",

--- a/backend/tests/test_diagnose_gpu_vlm_route_script.py
+++ b/backend/tests/test_diagnose_gpu_vlm_route_script.py
@@ -9,6 +9,7 @@ diagnose_gpu_vlm_route = importlib.util.module_from_spec(_SPEC)
 assert _SPEC.loader is not None
 _SPEC.loader.exec_module(diagnose_gpu_vlm_route)
 _is_direct_route_candidate = diagnose_gpu_vlm_route._is_direct_route_candidate
+_get_chat_health = diagnose_gpu_vlm_route._get_chat_health
 
 
 def test_diagnose_gpu_vlm_route_rejects_loopback_and_unspecified_addresses():
@@ -23,3 +24,59 @@ def test_diagnose_gpu_vlm_route_rejects_loopback_and_unspecified_addresses():
 def test_diagnose_gpu_vlm_route_allows_lan_addresses():
     assert _is_direct_route_candidate("http://192.168.1.26:8001") is True
     assert _is_direct_route_candidate("http://jupyter.local:8001") is True
+
+
+def test_diagnose_gpu_vlm_route_chat_health_requires_auth_ok():
+    calls = []
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "status": "ok",
+                "enabled": True,
+                "auth_configured": True,
+                "auth_ok": True,
+                "model": "gemma",
+            }
+
+    class FakeClient:
+        def get(self, url, headers=None):
+            calls.append((url, headers or {}))
+            return FakeResponse()
+
+    result = _get_chat_health(FakeClient(), "http://192.168.1.26:8001", "secret-token")
+
+    assert calls == [
+        (
+            "http://192.168.1.26:8001/health/chat",
+            {"Authorization": "Bearer secret-token"},
+        )
+    ]
+    assert result["ok"] is True
+    assert result["auth_ok"] is True
+    assert "secret-token" not in str(result)
+
+
+def test_diagnose_gpu_vlm_route_chat_health_fails_auth_mismatch():
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "status": "auth_failed",
+                "enabled": True,
+                "auth_configured": True,
+                "auth_ok": False,
+            }
+
+    class FakeClient:
+        def get(self, url, headers=None):
+            return FakeResponse()
+
+    result = _get_chat_health(FakeClient(), "http://192.168.1.26:8001", "wrong-token")
+
+    assert result["ok"] is False
+    assert result["status"] == "auth_failed"
+    assert "wrong-token" not in str(result)

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -201,6 +201,8 @@ async def test_artifact_storage_exposes_gpu_vlm_runtime_without_secret(client, t
     assert runtime["base_url"] == "http://192.168.1.26:8001"
     assert runtime["backend_url"] == "http://192.168.1.26:8000/v1"
     assert runtime["chat_api_base"] == "http://192.168.1.26:8001/v1"
+    assert runtime["chat_completion_endpoint"] == "http://192.168.1.26:8001/v1/chat/completions"
+    assert runtime["chat_health_endpoint"] == "http://192.168.1.26:8001/health/chat"
     assert runtime["queue_status_endpoint"] == "http://192.168.1.26:8001/queue/status"
     assert runtime["api_key_configured"] is True
     assert runtime["live_probe"]["checked"] is False

--- a/backend/tests/test_vlm_runtime.py
+++ b/backend/tests/test_vlm_runtime.py
@@ -8,7 +8,7 @@ from src.vlm_runtime import effective_vlm_status, probe_effective_vlm_runtime
 
 
 @pytest.mark.asyncio
-async def test_probe_effective_vlm_runtime_reports_health_backend_and_queue():
+async def test_probe_effective_vlm_runtime_reports_health_backend_queue_and_chat_proxy():
     calls = []
 
     class FakeResponse:
@@ -29,14 +29,25 @@ async def test_probe_effective_vlm_runtime_reports_health_backend_and_queue():
         async def __aexit__(self, *_exc):
             return False
 
-        async def get(self, url):
-            calls.append(url)
+        async def get(self, url, headers=None):
+            calls.append(("GET", url, headers or {}))
             if url.endswith("/health/backend"):
                 return FakeResponse(200, {"status": "ok", "backend_status": 200, "model": "gemma"})
             if url.endswith("/queue/status"):
                 return FakeResponse(
                     200,
                     {"queued": 2, "active": 1, "workers": 1, "background_workers": 1},
+                )
+            if url.endswith("/health/chat"):
+                return FakeResponse(
+                    200,
+                    {
+                        "status": "ok",
+                        "enabled": True,
+                        "auth_configured": True,
+                        "auth_ok": True,
+                        "model": "gemma",
+                    },
                 )
             return FakeResponse(
                 200,
@@ -49,21 +60,28 @@ async def test_probe_effective_vlm_runtime_reports_health_backend_and_queue():
 
     with (
         patch.object(settings, "seraph_vlm_base_url", "http://192.168.1.26:8001"),
+        patch.object(settings, "seraph_vlm_api_key", "secret-token"),
+        patch.object(settings, "local_vlm_model", "unsloth/gemma-4-26B-A4B-it-qat-GGUF"),
         patch("src.vlm_runtime.httpx.AsyncClient", FakeAsyncClient),
     ):
         probe = await probe_effective_vlm_runtime()
         status = effective_vlm_status(live_probe=probe)
 
-    assert set(calls) == {
-        "http://192.168.1.26:8001/health",
-        "http://192.168.1.26:8001/health/backend",
-        "http://192.168.1.26:8001/queue/status",
+    assert {(call[0], call[1]) for call in calls} == {
+        ("GET", "http://192.168.1.26:8001/health"),
+        ("GET", "http://192.168.1.26:8001/health/backend"),
+        ("GET", "http://192.168.1.26:8001/queue/status"),
+        ("GET", "http://192.168.1.26:8001/health/chat"),
     }
+    chat_call = next(call for call in calls if call[1].endswith("/health/chat"))
+    assert chat_call[2]["Authorization"] == "Bearer secret-token"
     assert probe["checked"] is True
     assert probe["reachable"] is True
     assert probe["health"]["ok"] is True
     assert probe["backend_health"]["backend_status"] == 200
     assert probe["queue_status"]["ok"] is True
+    assert probe["chat_proxy"]["ok"] is True
+    assert probe["chat_proxy"]["auth_ok"] is True
     assert probe["queue_status"]["queue"] == {
         "queued": 2,
         "active": 1,
@@ -85,7 +103,7 @@ async def test_probe_effective_vlm_runtime_reports_connect_errors_without_secret
         async def __aexit__(self, *_exc):
             return False
 
-        async def get(self, url):
+        async def get(self, url, headers=None):
             raise httpx.ConnectError("cannot reach token-secret")
 
     with (
@@ -100,4 +118,112 @@ async def test_probe_effective_vlm_runtime_reports_connect_errors_without_secret
     assert probe["health"]["error"] == "connect_error"
     assert probe["backend_health"]["error"] == "connect_error"
     assert probe["queue_status"]["error"] == "connect_error"
+    assert probe["chat_proxy"]["error"] == "connect_error"
     assert "token-secret" not in str(probe)
+
+
+@pytest.mark.asyncio
+async def test_probe_effective_vlm_runtime_marks_disabled_chat_proxy_unreachable():
+    class FakeResponse:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def get(self, url, headers=None):
+            if url.endswith("/health/backend"):
+                return FakeResponse(200, {"status": "ok", "backend_status": 200, "model": "gemma"})
+            if url.endswith("/queue/status"):
+                return FakeResponse(200, {"queued": 0, "active": 0, "workers": 1})
+            if url.endswith("/health/chat"):
+                return FakeResponse(
+                    200,
+                    {
+                        "status": "disabled",
+                        "enabled": False,
+                        "auth_configured": True,
+                        "auth_ok": False,
+                    },
+                )
+            return FakeResponse(200, {"status": "ok", "model": "gemma"})
+
+    with (
+        patch.object(settings, "seraph_vlm_base_url", "http://192.168.1.26:8001"),
+        patch.object(settings, "seraph_vlm_api_key", "secret-token"),
+        patch("src.vlm_runtime.httpx.AsyncClient", FakeAsyncClient),
+    ):
+        probe = await probe_effective_vlm_runtime()
+
+    assert probe["health"]["ok"] is True
+    assert probe["backend_health"]["ok"] is True
+    assert probe["queue_status"]["ok"] is True
+    assert probe["chat_proxy"]["ok"] is False
+    assert probe["chat_proxy"]["status_code"] == 200
+    assert probe["chat_proxy"]["error"] == "disabled"
+    assert probe["reachable"] is False
+    assert "secret-token" not in str(probe)
+
+
+@pytest.mark.asyncio
+async def test_probe_effective_vlm_runtime_marks_chat_auth_mismatch_unreachable():
+    class FakeResponse:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def get(self, url, headers=None):
+            if url.endswith("/health/backend"):
+                return FakeResponse(200, {"status": "ok", "backend_status": 200, "model": "gemma"})
+            if url.endswith("/queue/status"):
+                return FakeResponse(200, {"queued": 0, "active": 0, "workers": 1})
+            if url.endswith("/health/chat"):
+                return FakeResponse(
+                    200,
+                    {
+                        "status": "auth_failed",
+                        "enabled": True,
+                        "auth_configured": True,
+                        "auth_ok": False,
+                    },
+                )
+            return FakeResponse(200, {"status": "ok", "model": "gemma"})
+
+    with (
+        patch.object(settings, "seraph_vlm_base_url", "http://192.168.1.26:8001"),
+        patch.object(settings, "seraph_vlm_api_key", "wrong-secret"),
+        patch("src.vlm_runtime.httpx.AsyncClient", FakeAsyncClient),
+    ):
+        probe = await probe_effective_vlm_runtime()
+
+    assert probe["health"]["ok"] is True
+    assert probe["backend_health"]["ok"] is True
+    assert probe["queue_status"]["ok"] is True
+    assert probe["chat_proxy"]["ok"] is False
+    assert probe["chat_proxy"]["error"] == "auth_failed"
+    assert probe["reachable"] is False
+    assert "wrong-secret" not in str(probe)

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -182,6 +182,8 @@ curl http://192.168.1.26:8001/health
 curl http://192.168.1.26:8001/health/backend
 curl http://192.168.1.26:8001/queue/status
 set -a && source .env.dev && set +a
+curl http://192.168.1.26:8001/health/chat \
+  -H "Authorization: Bearer $SERAPH_VLM_API_KEY"
 PYTHONPATH=backend backend/.venv/bin/python scripts/diagnose_gpu_vlm_route.py
 ```
 
@@ -191,7 +193,10 @@ Interpretation:
 - `192.168.1.26:8001/health` proves the Dockerized GPU VLM wrapper is reachable from the Mac.
 - `192.168.1.26:8001/health/backend` proves the wrapper can reach the GPU model server at `192.168.1.26:8000/v1`.
 - `192.168.1.26:8001/queue/status` proves Seraph can observe admission pressure before feeding screenshot work.
+- `192.168.1.26:8001/health/chat` proves the chat proxy is enabled and accepts Seraph's configured bearer key without running inference or adding GPU queue work.
+- The direct-route diagnostic also checks authenticated chat readiness. This catches `CHAT_PROXY_ENABLED=false`, missing `CHAT_PROXY_API_KEY`, and Seraph/wrapper key mismatches that ordinary health checks cannot see.
 - A `502` from `/health/backend` means the wrapper is up but the GPU backend edge is broken.
+- A `disabled`, `auth_not_configured`, or `auth_failed` result from `/health/chat` means screenshot analysis may still work but Seraph chat is not ready.
 
 Run the direct-route receipt from the normal operator shell that starts Seraph
 when Codex/Desktop reports a LAN failure. A normal Terminal-launched receipt on
@@ -209,7 +214,7 @@ inventory, Docker Compose checks, process inspection, listener checks, and log
 reads. Do not use it as a Seraph runtime base URL or a passing direct-route
 acceptance receipt.
 
-Seraph also probes these three wrapper endpoints from the running backend process and exposes the safe result in `/api/runtime/status` and `/api/settings/artifact-storage` as `vlm_runtime.live_probe`. The settings UI renders this as a `Reach` row for both screenshot analysis and the local Gemma runtime. This status distinguishes "configured for GPU wrapper" from "this Seraph process can actually reach the direct LAN route"; diagnostic SSH forwards are not a substitute for `live_probe.reachable=true` on the direct `SERAPH_VLM_BASE_URL`.
+Seraph also probes wrapper health, backend health, queue status, and authenticated `/health/chat` readiness from the running backend process and exposes the safe result in `/api/runtime/status` and `/api/settings/artifact-storage` as `vlm_runtime.live_probe`. The settings UI renders this as a `Reach` row for both screenshot analysis and the local Gemma runtime. This status distinguishes "configured for GPU wrapper" from "this Seraph process can actually reach the direct LAN route and use its chat endpoint"; diagnostic SSH forwards are not a substitute for `live_probe.reachable=true` on the direct `SERAPH_VLM_BASE_URL`.
 
 `scripts/diagnose_gpu_vlm_route.py` is the operator-shell receipt command for the direct route. It reads `SERAPH_VLM_BASE_URL`, `SERAPH_VLM_API_KEY`, and `LOCAL_VLM_MODEL`/`LOCAL_MODEL`, prints sanitized JSON, and exits non-zero when the direct wrapper route, chat check, or requested image check fails. Loopback and localhost base URLs are rejected by default so a tunnel cannot accidentally pass as the direct-route receipt. Use `--allow-non-direct-base-url` only for explicitly labeled diagnostic bridge checks. Use `--image /path/to/screenshot.png` when the validation receipt also needs a wrapper-level `/v1/analyze-file` check.
 

--- a/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
@@ -355,6 +355,67 @@ describe("ArtifactStoragePanel", () => {
     expect(screen.getAllByText("Missing")).toHaveLength(3);
   });
 
+  it("does not mark VLM direct route healthy without chat readiness proof", async () => {
+    const artifactStorage = settingsFromScreenAnalysisFixture({
+      enabled: true,
+      provider: "local-vlm",
+      model: "gemma-4-26b",
+      preserve_captures: true,
+      archive_dir: "/tmp/seraph-dev-data/artifacts/screen-captures",
+      screenshot_folder: "/Users/test/Pictures/Screenshots",
+      capture_mode: "on_switch",
+      cadence_seconds: null,
+      daemon_connected: true,
+      artifact_count: 1,
+      last_artifact_at: null,
+    });
+    (artifactStorage as any).local_runtime = {
+      gateway_configured: true,
+      llm_base_url_configured: true,
+      vlm_base_url_configured: true,
+      model: "openai/unsloth/gemma-4-26B-A4B-it-qat-GGUF",
+      profiles: [],
+      profile_proof: {
+        status: "safe",
+        per_request_reasoning_control: "passed",
+        safe_for_single_backend_profile_routing: true,
+        receipt_count: 1,
+        last_receipt_at: "2026-07-03T18:00:00Z",
+        last_receipt_sha256: "abc123",
+        notes: [],
+      },
+      proof_command: "PYTHONPATH=. uv run python ../scripts/verify_local_gemma_profiles.py",
+    };
+    (artifactStorage as any).local_runtime.vlm_runtime = {
+      mode: "gpu-server",
+      configured: true,
+      base_url: "http://192.168.1.26:8001",
+      backend_url: "http://192.168.1.26:8000/v1",
+      chat_api_base: "http://192.168.1.26:8001/v1",
+      chat_completion_endpoint: "http://192.168.1.26:8001/v1/chat/completions",
+      chat_health_endpoint: "http://192.168.1.26:8001/health/chat",
+      queue_status_endpoint: "http://192.168.1.26:8001/queue/status",
+      health_endpoint: "http://192.168.1.26:8001/health",
+      backend_health_endpoint: "http://192.168.1.26:8001/health/backend",
+      api_key_configured: true,
+      feeder_window: 2,
+      live_probe: {
+        checked: true,
+        reachable: true,
+        health: { checked: true, ok: true, status_code: 200, error: "" },
+        backend_health: { checked: true, ok: true, status_code: 200, error: "" },
+        queue_status: { checked: true, ok: true, status_code: 200, error: "" },
+      },
+    };
+    fetchMock.mockResolvedValueOnce(mockResponse(artifactStorage));
+
+    render(<ArtifactStoragePanel />);
+
+    expect(await screen.findByText("Local Gemma runtime")).toBeInTheDocument();
+    expect(screen.getByText("direct route failing · chat:missing")).toBeInTheDocument();
+    expect(screen.queryByText("direct route ok")).not.toBeInTheDocument();
+  });
+
   it("runs manual report preview and shows safe receipt metadata", async () => {
     const artifactStorage = settingsFromScreenAnalysisFixture({
       enabled: true,

--- a/frontend/src/components/settings/ArtifactStoragePanel.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.tsx
@@ -7,6 +7,8 @@ interface VlmRuntimeStatus {
   base_url: string;
   backend_url: string;
   chat_api_base: string;
+  chat_completion_endpoint: string;
+  chat_health_endpoint: string;
   queue_status_endpoint: string;
   health_endpoint: string;
   backend_health_endpoint: string;
@@ -16,9 +18,10 @@ interface VlmRuntimeStatus {
     checked: boolean;
     reachable: boolean;
     reason?: string;
-    health: VlmProbeEndpoint;
-    backend_health: VlmProbeEndpoint;
-    queue_status: VlmProbeEndpoint;
+    health?: VlmProbeEndpoint;
+    backend_health?: VlmProbeEndpoint;
+    queue_status?: VlmProbeEndpoint;
+    chat_proxy?: VlmProbeEndpoint;
   };
 }
 
@@ -434,16 +437,21 @@ function vlmReachabilityLabel(runtime?: VlmRuntimeStatus): string {
   if (!probe?.checked) {
     return "not checked";
   }
-  if (probe.reachable) {
-    return "direct route ok";
-  }
-  const failing = [
+  const requiredEndpoints = [
     ["health", probe.health],
     ["backend", probe.backend_health],
     ["queue", probe.queue_status],
-  ].filter(([, endpoint]) => !(endpoint as VlmProbeEndpoint).ok);
+    ["chat", probe.chat_proxy],
+  ] as const;
+  if (probe.reachable && requiredEndpoints.every(([, endpoint]) => endpoint?.ok)) {
+    return "direct route ok";
+  }
+  const failing = requiredEndpoints.filter(([, endpoint]) => !endpoint?.ok);
   const reason = failing
-    .map(([label, endpoint]) => `${label}:${(endpoint as VlmProbeEndpoint).error || (endpoint as VlmProbeEndpoint).status_code || "failed"}`)
+    .map(([label, endpoint]) => {
+      const probeEndpoint = endpoint as VlmProbeEndpoint | undefined;
+      return `${label}:${probeEndpoint?.error || probeEndpoint?.status_code || "missing"}`;
+    })
     .join(" ");
   return reason ? `direct route failing · ${reason}` : "direct route failing";
 }
@@ -453,7 +461,13 @@ function vlmReachabilityTone(runtime?: VlmRuntimeStatus): "normal" | "good" | "w
   if (!runtime?.configured || !probe?.checked) {
     return "normal";
   }
-  return probe.reachable ? "good" : "warn";
+  return probe.reachable &&
+    probe.health?.ok &&
+    probe.backend_health?.ok &&
+    probe.queue_status?.ok &&
+    probe.chat_proxy?.ok
+    ? "good"
+    : "warn";
 }
 
 export function ArtifactStoragePanel() {

--- a/scripts/diagnose_gpu_vlm_route.py
+++ b/scripts/diagnose_gpu_vlm_route.py
@@ -58,7 +58,18 @@ def _endpoint_result(response: httpx.Response) -> dict[str, Any]:
         "status_code": response.status_code,
     }
     if isinstance(payload, dict):
-        for key in ("status", "backend_status", "model", "queued", "active", "workers", "background_workers"):
+        for key in (
+            "status",
+            "backend_status",
+            "model",
+            "queued",
+            "active",
+            "workers",
+            "background_workers",
+            "enabled",
+            "auth_configured",
+            "auth_ok",
+        ):
             if key in payload:
                 result[key] = payload[key]
         queue = payload.get("queue")
@@ -83,43 +94,20 @@ def _get_json(client: httpx.Client, url: str) -> dict[str, Any]:
         return {"ok": False, "status_code": None, "error": "http_error"}
 
 
-def _post_chat(client: httpx.Client, base_url: str, model: str, api_key: str) -> dict[str, Any]:
-    headers = {"Content-Type": "application/json"}
+def _get_chat_health(client: httpx.Client, base_url: str, api_key: str) -> dict[str, Any]:
+    headers = {}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     try:
-        response = client.post(
-            base_url.rstrip("/") + "/v1/chat/completions",
-            headers=headers,
-            json={
-                "model": model,
-                "messages": [{"role": "user", "content": "Reply with exactly: GPU VLM OK"}],
-                "temperature": 0,
-                "max_tokens": 16,
-            },
-        )
+        result = _endpoint_result(client.get(base_url.rstrip("/") + "/health/chat", headers=headers))
     except httpx.TimeoutException:
         return {"ok": False, "status_code": None, "error": "timeout"}
     except httpx.ConnectError:
         return {"ok": False, "status_code": None, "error": "connect_error"}
     except httpx.HTTPError:
         return {"ok": False, "status_code": None, "error": "http_error"}
-    try:
-        payload = response.json()
-    except ValueError:
-        payload = {}
-    content = ""
-    if isinstance(payload, dict):
-        choices = payload.get("choices")
-        if isinstance(choices, list) and choices:
-            message = choices[0].get("message") if isinstance(choices[0], dict) else None
-            if isinstance(message, dict):
-                content = str(message.get("content") or "").strip()
-    return {
-        "ok": 200 <= response.status_code < 400 and content == "GPU VLM OK",
-        "status_code": response.status_code,
-        "content": content[:80],
-    }
+    result["ok"] = bool(result.get("ok") and result.get("enabled") and result.get("auth_configured") and result.get("auth_ok"))
+    return result
 
 
 def _post_analyze_file(client: httpx.Client, base_url: str, model: str, api_key: str, image_path: Path) -> dict[str, Any]:
@@ -169,7 +157,7 @@ def main() -> int:
         help="Optional wrapper API key; never printed, but env vars are preferred because CLI args can leak via shell history or process listings",
     )
     parser.add_argument("--timeout-seconds", type=float, default=10.0)
-    parser.add_argument("--skip-chat", action="store_true", help="Only check wrapper health endpoints")
+    parser.add_argument("--skip-chat", action="store_true", help="Only check wrapper and backend health endpoints")
     parser.add_argument("--image", type=Path, default=None, help="Optional screenshot path for /v1/analyze-file")
     parser.add_argument(
         "--allow-non-direct-base-url",
@@ -182,7 +170,7 @@ def main() -> int:
     model = str(args.model or "").strip()
     if not base_url:
         raise SystemExit("missing --base-url or SERAPH_VLM_BASE_URL")
-    if not model and not args.skip_chat:
+    if not model and args.image is not None:
         raise SystemExit("missing --model or LOCAL_VLM_MODEL/LOCAL_MODEL")
     direct_route_candidate = _is_direct_route_candidate(base_url)
     if not direct_route_candidate and not args.allow_non_direct_base_url:
@@ -218,7 +206,7 @@ def main() -> int:
             and result["queue_status"].get("ok")
         )
         if not args.skip_chat:
-            result["chat"] = _post_chat(client, base_url, model, args.api_key)
+            result["chat"] = _get_chat_health(client, base_url, args.api_key)
         if args.image is not None:
             result["analyze_file"] = _post_analyze_file(client, base_url, model, args.api_key, args.image)
         result["validation_ok"] = bool(


### PR DESCRIPTION
Closes #700

## Summary
- require the GPU VLM direct route probe to include authenticated /health/chat readiness, not only wrapper/backend/queue health
- expose chat health endpoint metadata in runtime/status payloads and settings UI
- update diagnose_gpu_vlm_route.py so chat readiness does not run inference or add GPU queue work
- document SSH as admin-only and direct HTTP API as the Seraph runtime path

## Validation
- backend/.venv/bin/python -m pytest backend/tests/test_vlm_runtime.py backend/tests/test_diagnose_gpu_vlm_route_script.py backend/tests/test_app.py::test_runtime_status_exposes_gpu_vlm_runtime_and_chat_profile backend/tests/test_settings_api.py::test_artifact_storage_exposes_gpu_vlm_runtime_without_secret -q --tb=short
- npm test -- ArtifactStoragePanel.test.tsx
- npm run build
- git diff --check

## Critic Review
- Independent critic pass: no blocking findings; pass for commit/deploy contingent on focused tests and live direct-route receipt.