### PR TITLE
Fix local chat VLM route preflight

### DIFF
--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -29,6 +29,7 @@ from src.operators.local_codex import (
 )
 from src.tools.policy import get_current_tool_policy_mode
 from src.vault.redaction import redact_secrets_in_text
+from src.vlm_runtime import direct_local_chat_route_error
 from src.llm_runtime import (
     _finish_request,
     _mark_request_timed_out,
@@ -126,6 +127,24 @@ async def chat(request: ChatRequest):
         is_onboarding=is_onboarding,
     ):
         started_at = perf_counter()
+        route_error = await direct_local_chat_route_error()
+        if route_error:
+            safe_detail = await redact_secrets_in_text(route_error)
+            await log_agent_run_event(
+                session_id=session.id,
+                transport="rest",
+                is_onboarding=is_onboarding,
+                outcome="failed",
+                policy_mode=get_current_tool_policy_mode(),
+                details={
+                    "duration_ms": int((perf_counter() - started_at) * 1000),
+                    "message_length": len(request.message),
+                    "error": safe_detail,
+                    "runtime": "direct-local-chat",
+                    "failure_stage": "route_preflight",
+                },
+            )
+            raise HTTPException(status_code=503, detail=safe_detail)
         llm_request_id = f"direct-rest:{session.id}:{started_at}"
         _register_request(llm_request_id)
         try:

--- a/backend/src/api/ws.py
+++ b/backend/src/api/ws.py
@@ -33,6 +33,7 @@ from src.operators.local_codex import (
 from src.scheduler.connection_manager import ws_manager
 from src.tools.policy import get_current_tool_policy_mode
 from src.vault.redaction import redact_secrets_for_streaming_snapshot, redact_secrets_in_text
+from src.vlm_runtime import direct_local_chat_route_error
 from src.llm_runtime import (
     _finish_request,
     _mark_request_timed_out,
@@ -300,6 +301,33 @@ async def websocket_chat(websocket: WebSocket):
                 is_onboarding=direct_is_onboarding,
             ):
                 started_at = perf_counter()
+                route_error = await direct_local_chat_route_error()
+                if route_error:
+                    safe_error = await redact_secrets_in_text(route_error)
+                    await log_agent_run_event(
+                        session_id=session.id,
+                        transport="websocket",
+                        is_onboarding=direct_is_onboarding,
+                        outcome="failed",
+                        policy_mode=get_current_tool_policy_mode(),
+                        details={
+                            "duration_ms": int((perf_counter() - started_at) * 1000),
+                            "message_length": len(ws_msg.message),
+                            "error": safe_error,
+                            "runtime": "direct-local-chat",
+                            "failure_stage": "route_preflight",
+                        },
+                    )
+                    active_turn_completed = True
+                    await websocket.send_text(
+                        WSResponse(
+                            type="error",
+                            content=safe_error,
+                            session_id=session.id,
+                            seq=_next_seq(),
+                        ).model_dump_json()
+                    )
+                    continue
                 llm_request_id = f"direct-ws:{session.id}:{started_at}"
                 _register_request(llm_request_id)
                 try:

--- a/backend/src/vlm_runtime.py
+++ b/backend/src/vlm_runtime.py
@@ -136,12 +136,58 @@ async def probe_effective_vlm_runtime(*, timeout_seconds: float = 0.75) -> dict[
     }
 
 
+async def direct_local_chat_route_error(*, timeout_seconds: float = 0.75) -> str | None:
+    """Return an operator-readable route error when local chat cannot run."""
+    status = effective_vlm_status()
+    base_url = str(status.get("base_url") or "")
+    chat_api_base = str(status.get("chat_api_base") or "")
+    chat_health_endpoint = str(status.get("chat_health_endpoint") or "")
+    if not chat_api_base:
+        return (
+            "Local chat runtime is not configured for the Seraph backend. "
+            "Set SERAPH_VLM_BASE_URL or LOCAL_VLM_BASE_URL before using direct local chat."
+        )
+    if not base_url:
+        return None
+
+    probe = await probe_effective_vlm_runtime(timeout_seconds=timeout_seconds)
+    if probe.get("reachable") is True:
+        return None
+
+    detail = _probe_failure_detail(probe)
+    endpoint = chat_health_endpoint or str(status.get("backend_health_endpoint") or status.get("health_endpoint") or base_url)
+    return (
+        "Local chat runtime is unreachable from the Seraph backend at "
+        f"{base_url}. Health endpoint {endpoint} reported {detail}. "
+        "Check the VLM wrapper route before retrying."
+    )
+
+
 def _trim_url(value: str | None) -> str:
     return str(value or "").strip().rstrip("/")
 
 
 def _unprobed_endpoint() -> dict[str, object]:
     return {"checked": False, "ok": False, "status_code": None, "error": ""}
+
+
+def _probe_failure_detail(probe: dict[str, object]) -> str:
+    for key, label in (
+        ("chat_proxy", "chat proxy"),
+        ("backend_health", "backend health"),
+        ("health", "wrapper health"),
+        ("queue_status", "queue status"),
+    ):
+        endpoint = probe.get(key)
+        if not isinstance(endpoint, dict) or endpoint.get("ok") is True:
+            continue
+        error = str(endpoint.get("error") or "unreachable")
+        status_code = endpoint.get("status_code")
+        if status_code is not None:
+            return f"{label} {error} ({status_code})"
+        return f"{label} {error}"
+    reason = str(probe.get("reason") or "unreachable")
+    return _safe_probe_detail(reason)
 
 
 async def _probe_json_endpoint(client: httpx.AsyncClient, endpoint: str) -> dict[str, object]:

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -101,6 +101,7 @@ class TestChatAPI:
         mock_agent.run.assert_called_once_with("Check the website and get the goals from it")
         mock_direct_chat.assert_not_called()
 
+    @patch("src.api.chat.direct_local_chat_route_error", new_callable=AsyncMock)
     @patch("src.api.chat.should_use_direct_local_chat", return_value=True)
     @patch("src.api.chat.run_direct_local_chat", return_value="Hello. What should I call you?")
     @patch("src.api.chat.create_onboarding_agent")
@@ -109,13 +110,16 @@ class TestChatAPI:
         mock_onboarding,
         mock_direct_chat,
         mock_should_use_direct,
+        mock_route_error,
         client,
     ):
+        mock_route_error.return_value = None
         response = await client.post("/api/chat", json={"message": "Hello"})
 
         assert response.status_code == 200
         assert response.json()["response"] == "Hello. What should I call you?"
         mock_should_use_direct.assert_called_once()
+        mock_route_error.assert_awaited_once()
         mock_direct_chat.assert_awaited_once()
         mock_onboarding.assert_not_called()
 
@@ -124,6 +128,44 @@ class TestChatAPI:
             event["event_type"] == "agent_run_succeeded"
             and event["tool_name"] == "onboarding_agent"
             and event["details"]["runtime"] == "direct-local-chat"
+            for event in events
+        )
+
+    @patch("src.api.chat.direct_local_chat_route_error", new_callable=AsyncMock)
+    @patch("src.api.chat.should_use_direct_local_chat", return_value=True)
+    @patch("src.api.chat.run_direct_local_chat")
+    @patch("src.api.chat.create_onboarding_agent")
+    async def test_chat_direct_local_preflight_failure_returns_operator_error(
+        self,
+        mock_onboarding,
+        mock_direct_chat,
+        mock_should_use_direct,
+        mock_route_error,
+        client,
+    ):
+        mock_route_error.return_value = (
+            "Local chat runtime is unreachable from the Seraph backend at http://192.168.1.26:8001. "
+            "Health endpoint http://192.168.1.26:8001/health/chat reported chat proxy connect_error."
+        )
+
+        response = await client.post("/api/chat", json={"message": "Hello"})
+
+        assert response.status_code == 503
+        detail = response.json()["detail"]
+        assert "Local chat runtime is unreachable" in detail
+        assert "health/chat" in detail
+        assert "LiteLLM" not in detail
+        mock_should_use_direct.assert_called_once()
+        mock_route_error.assert_awaited_once()
+        mock_direct_chat.assert_not_called()
+        mock_onboarding.assert_not_called()
+
+        events = await audit_repository.list_events(limit=10)
+        assert any(
+            event["event_type"] == "agent_run_failed"
+            and event["tool_name"] == "onboarding_agent"
+            and event["details"]["runtime"] == "direct-local-chat"
+            and event["details"]["failure_stage"] == "route_preflight"
             for event in events
         )
 

--- a/backend/tests/test_vlm_runtime.py
+++ b/backend/tests/test_vlm_runtime.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 
 from config.settings import settings
-from src.vlm_runtime import effective_vlm_status, probe_effective_vlm_runtime
+from src.vlm_runtime import direct_local_chat_route_error, effective_vlm_status, probe_effective_vlm_runtime
 
 
 @pytest.mark.asyncio
@@ -227,3 +227,55 @@ async def test_probe_effective_vlm_runtime_marks_chat_auth_mismatch_unreachable(
     assert probe["chat_proxy"]["error"] == "auth_failed"
     assert probe["reachable"] is False
     assert "wrong-secret" not in str(probe)
+
+
+@pytest.mark.asyncio
+async def test_direct_local_chat_route_error_names_chat_health_endpoint():
+    probe = {
+        "checked": True,
+        "reachable": False,
+        "health": {"checked": True, "ok": True, "status_code": 200, "error": ""},
+        "backend_health": {"checked": True, "ok": True, "status_code": 200, "error": ""},
+        "queue_status": {"checked": True, "ok": True, "status_code": 200, "error": ""},
+        "chat_proxy": {"checked": True, "ok": False, "status_code": None, "error": "connect_error"},
+    }
+
+    with (
+        patch.object(settings, "seraph_vlm_base_url", "http://192.168.1.26:8001"),
+        patch.object(settings, "local_llm_api_base", ""),
+        patch("src.vlm_runtime.probe_effective_vlm_runtime", return_value=probe),
+    ):
+        error = await direct_local_chat_route_error()
+
+    assert error is not None
+    assert "Local chat runtime is unreachable" in error
+    assert "http://192.168.1.26:8001" in error
+    assert "http://192.168.1.26:8001/health/chat" in error
+    assert "chat proxy connect_error" in error
+
+
+@pytest.mark.asyncio
+async def test_direct_local_chat_route_error_allows_reachable_route():
+    probe = {"checked": True, "reachable": True}
+
+    with (
+        patch.object(settings, "seraph_vlm_base_url", "http://127.0.0.1:8000"),
+        patch.object(settings, "local_llm_api_base", ""),
+        patch("src.vlm_runtime.probe_effective_vlm_runtime", return_value=probe),
+    ):
+        error = await direct_local_chat_route_error()
+
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_direct_local_chat_route_error_allows_explicit_api_base_without_wrapper():
+    with (
+        patch.object(settings, "seraph_vlm_base_url", ""),
+        patch.object(settings, "local_vlm_base_url", ""),
+        patch.object(settings, "local_llm_api_base", "http://127.0.0.1:8000/v1"),
+        patch("src.vlm_runtime.probe_effective_vlm_runtime", side_effect=AssertionError("wrapper probe not available")),
+    ):
+        error = await direct_local_chat_route_error()
+
+    assert error is None

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -164,6 +164,7 @@ class TestWebSocket:
         try:
             with (
                 patch("src.api.ws.should_use_direct_local_chat", return_value=True),
+                patch("src.api.ws.direct_local_chat_route_error", new=AsyncMock(return_value=None)),
                 patch("src.api.ws.stream_direct_local_chat", _fake_stream),
                 patch("src.api.ws.run_direct_local_chat", new=AsyncMock(return_value="Unused.")),
                 client.websocket_connect("/ws/chat") as ws,
@@ -205,6 +206,7 @@ class TestWebSocket:
             with (
                 patch("src.api.ws.should_use_direct_local_chat", side_effect=real_should_use_direct_local_chat),
                 patch("src.agent.direct_chat._uses_local_gemma_profile", return_value=True),
+                patch("src.api.ws.direct_local_chat_route_error", new=AsyncMock(return_value=None)),
                 patch("src.api.ws.stream_direct_local_chat", _fake_stream),
                 patch("src.api.ws.run_direct_local_chat", new=AsyncMock(return_value="Unused.")),
                 client.websocket_connect("/ws/chat") as ws,
@@ -239,6 +241,7 @@ class TestWebSocket:
         try:
             with (
                 patch("src.api.ws.should_use_direct_local_chat", return_value=True),
+                patch("src.api.ws.direct_local_chat_route_error", new=AsyncMock(return_value=None)),
                 patch("src.api.ws.stream_direct_local_chat", _fake_stream),
                 patch("src.api.ws.run_direct_local_chat", new=AsyncMock(return_value="Fallback ready.")),
                 client.websocket_connect("/ws/chat") as ws,
@@ -261,6 +264,45 @@ class TestWebSocket:
             for p in patches:
                 p.stop()
 
+    def test_websocket_direct_chat_preflight_failure_emits_operator_error(self):
+        client, patches, stack = _make_sync_client_with_db()
+
+        async def _fake_stream(*args, **kwargs):
+            yield "unreachable"
+
+        route_error = (
+            "Local chat runtime is unreachable from the Seraph backend at http://192.168.1.26:8001. "
+            "Health endpoint http://192.168.1.26:8001/health/chat reported chat proxy connect_error."
+        )
+        stream_mock = MagicMock(side_effect=_fake_stream)
+
+        try:
+            with (
+                patch("src.api.ws.should_use_direct_local_chat", return_value=True),
+                patch("src.api.ws.direct_local_chat_route_error", new=AsyncMock(return_value=route_error)),
+                patch("src.api.ws.stream_direct_local_chat", stream_mock),
+                patch("src.api.ws.run_direct_local_chat", new=AsyncMock(return_value="Unused.")) as mock_direct,
+                client.websocket_connect("/ws/chat") as ws,
+            ):
+                _ = ws.receive_text()
+                ws.send_text(json.dumps({"type": "message", "message": "Hello"}))
+
+                received = [json.loads(ws.receive_text()) for _ in range(2)]
+
+            assert received[0]["type"] == "status"
+            assert received[0]["content"] == "Seraph received the message."
+            assert received[1]["type"] == "error"
+            assert "Local chat runtime is unreachable" in received[1]["content"]
+            assert "health/chat" in received[1]["content"]
+            assert "LiteLLM" not in received[1]["content"]
+            assert all("local chat runtime" not in msg["content"] for msg in received if msg["type"] == "status")
+            stream_mock.assert_not_called()
+            mock_direct.assert_not_awaited()
+        finally:
+            stack.close()
+            for p in patches:
+                p.stop()
+
     def test_websocket_direct_chat_error_close_does_not_record_interrupted_turn(self):
         client, patches, stack = _make_sync_client_with_db()
 
@@ -271,6 +313,7 @@ class TestWebSocket:
         try:
             with (
                 patch("src.api.ws.should_use_direct_local_chat", return_value=True),
+                patch("src.api.ws.direct_local_chat_route_error", new=AsyncMock(return_value=None)),
                 patch("src.api.ws.stream_direct_local_chat", _fake_stream),
                 patch("src.api.ws.run_direct_local_chat", new=AsyncMock(side_effect=RuntimeError("chat failed"))),
                 client.websocket_connect("/ws/chat") as ws,


### PR DESCRIPTION
## Summary\n\n- gate direct local REST and WebSocket chat on a bounded live VLM wrapper route preflight before generation starts\n- return operator-readable route-preflight errors instead of raw LiteLLM/OpenAI connection failures when the wrapper chat route is unreachable\n- preserve explicit LOCAL_LLM_API_BASE-only direct local routes that do not have a wrapper health contract\n\nCloses #706\n\n## Validation\n\n- PYTEST_ADDOPTS=--no-cov backend/.venv/bin/python -m pytest backend/tests/test_vlm_runtime.py backend/tests/test_chat_api.py backend/tests/test_websocket.py -q -> 28 passed\n- backend/.venv/bin/python -m py_compile backend/src/vlm_runtime.py backend/src/api/chat.py backend/src/api/ws.py backend/tests/test_vlm_runtime.py backend/tests/test_chat_api.py backend/tests/test_websocket.py -> passed\n- git diff --check -> passed\n\n## Critic / Contrarian\n\n- Finding accepted: the first gate shape would have blocked explicit LOCAL_LLM_API_BASE-only local chat routes because those routes have no wrapper base URL to probe. Fixed by gating wrapper-configured routes while allowing explicit API-base-only routes, with a regression test.\n- No remaining material findings in the scoped diff.\n\n## Agent team\n\n- Lead/Worker: implemented the route preflight gate and focused tests directly because this is a small surgical runtime/chat slice.\n- Critic/Contrarian: separate self-pass on the diff and compatibility edge; subagent tooling was not used for this small slice.\n