### PR TITLE
Fix screenshot folder picker direct-root settings

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -190,7 +190,7 @@ wheels = [
 
 [[package]]
 name = "backend"
-version = "2026.6.30"
+version = "2026.7.4"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -42,6 +42,8 @@ Seraph resolves the screenshot folder in this order:
 
 The default is a generic Seraph-owned workspace folder so unconfigured Seraph never assumes a specific screenshot producer. To consume screenshots from another app, configure Seraph with that app's screenshot folder explicitly.
 
+The configured folder is the image root. Seraph does not append, require, or special-case a producer-side `captures/` subdirectory; if screenshots are written directly under `/Users/.../Desktop/screenshots`, that exact folder is the Seraph `screenshot_folder`.
+
 Seraph does not migrate or resolve producer-specific screenshot keys. API requests, stored settings, and environment configuration use only `screenshot_folder` or `SERAPH_SCREENSHOT_FOLDER`. `artifact_root` and producer-specific key names are not part of the current contract.
 
 ## Folder Scan

--- a/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
@@ -685,7 +685,7 @@ describe("ArtifactStoragePanel", () => {
       last_artifact_at: null,
       screenshot_folder: "/Users/test/Pictures/Screenshots",
     });
-    const pickedRoot = "/Users/test/Desktop/screenshots/captures";
+    const pickedRoot = "/Users/test/Desktop/screenshots";
     const refreshedStorage = {
       ...artifactStorage,
       screenshot_folder: {
@@ -706,7 +706,7 @@ describe("ArtifactStoragePanel", () => {
 
     render(<ArtifactStoragePanel />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Choose folder" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Choose" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
@@ -715,6 +715,7 @@ describe("ArtifactStoragePanel", () => {
       ),
     );
     expect(await screen.findByDisplayValue(pickedRoot)).toBeInTheDocument();
+    expect(screen.getByText("Choose opens the local folder picker; typing the path is the fallback.")).toBeInTheDocument();
   });
 
   it("does not refresh settings after a save resolves on an unmounted panel", async () => {

--- a/frontend/src/components/settings/ArtifactStoragePanel.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.tsx
@@ -764,29 +764,44 @@ export function ArtifactStoragePanel() {
                     {screenshotFolderSource.status.replace(/_/g, " ")}
                   </div>
                 </div>
-                <div className="grid grid-cols-[92px_minmax(0,1fr)_auto] gap-2 text-[9px] items-center">
+                <div className="grid grid-cols-[92px_minmax(0,1fr)] gap-2 text-[9px] items-center">
                   <div className="text-retro-text/30 uppercase tracking-wider">Folder</div>
-                  <input
-                    aria-label="Screenshot folder"
-                    value={screenshotFolderDraft}
-                    disabled={saving || screenshotFolderLockedByEnv || !screenshotFolderMetadataLoaded}
-                    onChange={(event) => setScreenshotFolderDraft(event.target.value)}
-                    placeholder={screenshotFolderMetadataLoaded ? "Choose a local folder" : "folder metadata not loaded"}
-                    className="min-w-0 border border-retro-text/20 bg-retro-bg px-1 py-0.5 text-retro-text disabled:opacity-50"
-                  />
-                  <button
-                    type="button"
-                    disabled={
-                      saving ||
-                      screenshotFolderLockedByEnv ||
-                      !screenshotFolderMetadataLoaded ||
-                      screenshotFolderDraft.trim() === (screenshotFolderPath ?? "")
-                    }
-                    onClick={() => void saveScreenshotFolder()}
-                    className="border border-retro-text/20 px-2 py-1 uppercase tracking-wider text-retro-text/70 hover:text-retro-text disabled:opacity-40"
-                  >
-                    Save
-                  </button>
+                  <div className="flex min-w-0 flex-wrap items-center gap-2">
+                    <input
+                      aria-label="Screenshot folder"
+                      value={screenshotFolderDraft}
+                      disabled={saving || screenshotFolderLockedByEnv || !screenshotFolderMetadataLoaded}
+                      onChange={(event) => setScreenshotFolderDraft(event.target.value)}
+                      placeholder={screenshotFolderMetadataLoaded ? "Choose a local folder" : "folder metadata not loaded"}
+                      className="min-w-[180px] flex-1 border border-retro-text/20 bg-retro-bg px-1 py-0.5 text-retro-text disabled:opacity-50"
+                    />
+                    <button
+                      type="button"
+                      disabled={saving || screenshotFolderLockedByEnv || screenshotFolderPicking}
+                      onClick={() => void pickScreenshotFolder()}
+                      className="border border-retro-text/20 px-2 py-1 uppercase tracking-wider text-retro-text/70 hover:text-retro-text disabled:opacity-40"
+                    >
+                      {screenshotFolderPicking ? "Choosing" : "Choose"}
+                    </button>
+                    <button
+                      type="button"
+                      disabled={
+                        saving ||
+                        screenshotFolderLockedByEnv ||
+                        !screenshotFolderMetadataLoaded ||
+                        screenshotFolderDraft.trim() === (screenshotFolderPath ?? "")
+                      }
+                      onClick={() => void saveScreenshotFolder()}
+                      className="border border-retro-text/20 px-2 py-1 uppercase tracking-wider text-retro-text/70 hover:text-retro-text disabled:opacity-40"
+                    >
+                      Save
+                    </button>
+                  </div>
+                </div>
+                <div className="text-[9px] text-retro-text/40">
+                  {screenshotFolderLockedByEnv
+                    ? "locked by SERAPH_SCREENSHOT_FOLDER"
+                    : "Choose opens the local folder picker; typing the path is the fallback."}
                 </div>
                 <ArtifactRow label="Folder" value={screenshotFolderDisplayPath(screenshotFolderPath)} tone={screenshotFolderPath ? "normal" : "warn"} />
                 <ArtifactRow label="Source" value={sourceLabel(screenshotFolderPathSource)} />
@@ -915,14 +930,6 @@ export function ArtifactStoragePanel() {
                     className="border border-retro-text/20 px-2 py-1 text-[9px] uppercase tracking-wider text-retro-text/70 hover:text-retro-text disabled:opacity-40"
                   >
                     {screenshotFolderScanning ? "Scanning" : "Scan folder"}
-                  </button>
-                  <button
-                    type="button"
-                    disabled={saving || screenshotFolderLockedByEnv || screenshotFolderPicking}
-                    onClick={() => void pickScreenshotFolder()}
-                    className="border border-retro-text/20 px-2 py-1 text-[9px] uppercase tracking-wider text-retro-text/70 hover:text-retro-text disabled:opacity-40"
-                  >
-                    {screenshotFolderPicking ? "Choosing" : "Choose folder"}
                   </button>
                   <button
                     type="button"


### PR DESCRIPTION
## Done on develop
- [x] Seraph v2026.7.4 and VLM wrapper v0.2.0 are released.
- [x] Screenshot-folder ingestion already resolves configured paths directly when the backend receives them.

## Working in this PR
- [x] Closes #705.
- [x] Settings now keeps the screenshot folder picker in the same control row as the folder path and Save action.
- [x] Typing remains the explicit fallback when native folder picking is unavailable or locked by `SERAPH_SCREENSHOT_FOLDER`.
- [x] Picker regression coverage now uses `/Users/test/Desktop/screenshots`, not a `/captures` subdirectory.
- [x] `docs/implementation/18-screenshot-folder-source.md` states that the configured folder is the direct image root.
- [x] `backend/uv.lock` is aligned with the shipped `2026.7.4` backend package version.

## Still to do after this PR
- [ ] Continue the active Seraph capability-improvement goal with the next board-backed implementation slice.

## Validation
- `npm --prefix frontend test -- src/components/settings/ArtifactStoragePanel.test.tsx --maxWorkers=1` -> 12 passed
- `PYTEST_ADDOPTS=--no-cov backend/.venv/bin/python -m pytest backend/tests/test_settings_api.py -q` -> 31 passed
- `npm --prefix frontend run build` -> passed; Vite reported existing bundle-size and browserslist warnings
- `git diff --check` -> passed
- `./manage.sh -e dev local run` -> backend/frontend started in foreground
- `curl -sS http://127.0.0.1:8004/api/settings/artifact-storage` -> `path=/Users/bigcube/Desktop/screenshots`, `path_source=screen-analysis-settings`, `status=ready`, `image_count=1151`
- `curl -sS http://127.0.0.1:8004/api/settings/screen-analysis` -> `screenshot_folder=/Users/bigcube/Desktop/screenshots`, `screenshot_folder_source=screen-analysis-settings`
- `curl -sS http://127.0.0.1:8004/health` -> `status=ok`

## Agent Team / Review
- Lead: Codex coordinated issue/project state, implementation, validation, and docs.
- Worker: direct lead edit because the tool-level multi-agent policy only allows spawning subagents when explicitly requested by the user.
- Critic/Contrarian: self-run independent pass on the cumulative diff; no blocking findings. Confirmed no touched setting/doc fixture still implies `screenshots/captures`, the direct-root doc wording matches the endpoint receipt, and the UI row wraps controls instead of squeezing the path input.
