### PR TITLE
Fix native daemon permission recovery status

### DIFF
--- a/backend/src/api/observer.py
+++ b/backend/src/api/observer.py
@@ -115,6 +115,8 @@ class DaemonStatusResponse(BaseModel):
     capture_ready: bool = False
     last_error: str | None = None
     last_error_kind: str | None = None
+    status_reason: str | None = None
+    recovery_hint: str | None = None
     pending_notification_count: int
     last_native_notification_at: str | None = None
     last_native_notification_title: str | None = None
@@ -785,9 +787,66 @@ def _continuity_surface(
     return "browser"
 
 
+_AUTOMATION_PERMISSION_NEEDLES = (
+    "-1743",
+    "-10827",
+    "not authorised to send apple events",
+    "not authorized to send apple events",
+    "system events got an error",
+)
+
+_AUTOMATION_PERMISSION_HINT = (
+    "Grant Automation permission for the terminal running Seraph to control "
+    "System Events in System Settings > Privacy & Security > Automation, then "
+    "restart with ./manage.sh -e dev daemon start."
+)
+
+_DAEMON_DISABLED_HINT = (
+    "Set DAEMON_ENABLED=true in .env.dev and start it with "
+    "./manage.sh -e dev daemon start when native desktop presence is wanted."
+)
+
+
+def _classify_daemon_status(
+    daemon_status: dict[str, object],
+) -> dict[str, str | bool | None]:
+    enabled_value = os.environ.get("DAEMON_ENABLED")
+    if enabled_value is not None and enabled_value.strip().lower() != "true":
+        return {
+            "state": "disabled",
+            "last_error": "Native daemon is configured off for this environment.",
+            "last_error_kind": "configured_off",
+            "status_reason": "Native desktop presence is disabled by DAEMON_ENABLED=false.",
+            "recovery_hint": _DAEMON_DISABLED_HINT,
+        }
+
+    last_error = daemon_status.get("last_error")
+    last_error_text = last_error if isinstance(last_error, str) else ""
+    last_error_kind = daemon_status.get("last_error_kind")
+    last_error_kind_text = last_error_kind if isinstance(last_error_kind, str) else None
+    normalized_error = f"{last_error_kind_text or ''} {last_error_text}".lower()
+    if any(needle in normalized_error for needle in _AUTOMATION_PERMISSION_NEEDLES):
+        return {
+            "state": daemon_status.get("state") if isinstance(daemon_status.get("state"), str) else "error",
+            "last_error": last_error_text or "macOS denied Automation access to System Events.",
+            "last_error_kind": "automation_permission_denied",
+            "status_reason": "macOS Automation permission is blocking native desktop presence.",
+            "recovery_hint": _AUTOMATION_PERMISSION_HINT,
+        }
+
+    return {
+        "state": daemon_status.get("state") if isinstance(daemon_status.get("state"), str) else None,
+        "last_error": last_error_text or None,
+        "last_error_kind": last_error_kind_text,
+        "status_reason": None,
+        "recovery_hint": None,
+    }
+
+
 async def _daemon_status_payload() -> dict[str, str | int | float | bool | None]:
     ctx = context_manager.get_context()
     daemon_status = _read_daemon_status_file()
+    classified = _classify_daemon_status(daemon_status)
     connected = context_manager.is_daemon_connected()
     pending_notification_count = await native_notification_queue.count()
     return {
@@ -797,12 +856,14 @@ async def _daemon_status_payload() -> dict[str, str | int | float | bool | None]
         "active_window": ctx.active_window,
         "has_screen_context": bool(ctx.screen_context),
         "capture_mode": ctx.capture_mode,
-        "daemon_state": daemon_status.get("state"),
+        "daemon_state": classified.get("state"),
         "daemon_status_updated_at": daemon_status.get("updated_at"),
         "screen_analysis": daemon_status.get("screen_analysis"),
         "capture_ready": daemon_status.get("capture_ready"),
-        "last_error": daemon_status.get("last_error"),
-        "last_error_kind": daemon_status.get("last_error_kind"),
+        "last_error": classified.get("last_error"),
+        "last_error_kind": classified.get("last_error_kind"),
+        "status_reason": classified.get("status_reason"),
+        "recovery_hint": classified.get("recovery_hint"),
         "pending_notification_count": pending_notification_count,
         "last_native_notification_at": (
             ctx.last_native_notification_at.isoformat()
@@ -2111,6 +2172,15 @@ def _observer_reach_payload() -> dict[str, list[dict[str, Any]]]:
     active_transports = _active_channel_adapters()
     websocket_connection_count = ws_manager.active_count
     daemon_connected = context_manager.is_daemon_connected()
+    daemon_status = _classify_daemon_status(_read_daemon_status_file())
+    daemon_unavailable_status = {
+        "last_error_kind": (
+            daemon_status.get("last_error_kind") if isinstance(daemon_status.get("last_error_kind"), str) else None
+        ),
+        "recovery_hint": (
+            daemon_status.get("recovery_hint") if isinstance(daemon_status.get("recovery_hint"), str) else None
+        ),
+    }
     state_payload = load_extension_state_payload()
     return {
         "transport_statuses": [
@@ -2119,6 +2189,7 @@ def _observer_reach_payload() -> dict[str, list[dict[str, Any]]]:
                 active_transports=active_transports,
                 websocket_connection_count=websocket_connection_count,
                 daemon_connected=daemon_connected,
+                daemon_unavailable_status=daemon_unavailable_status,
             )
             for transport in SUPPORTED_CHANNEL_ROUTE_TRANSPORTS
         ],
@@ -2127,6 +2198,7 @@ def _observer_reach_payload() -> dict[str, list[dict[str, Any]]]:
             active_transports=active_transports,
             websocket_connection_count=websocket_connection_count,
             daemon_connected=daemon_connected,
+            daemon_unavailable_status=daemon_unavailable_status,
         ),
     }
 

--- a/backend/src/extensions/channel_routing.py
+++ b/backend/src/extensions/channel_routing.py
@@ -199,6 +199,7 @@ def transport_runtime_status(
     active_transports: set[str],
     websocket_connection_count: int,
     daemon_connected: bool,
+    daemon_unavailable_status: dict[str, str | None] | None = None,
 ) -> dict[str, Any]:
     websocket_connection_count = _normalized_websocket_connection_count(websocket_connection_count)
     daemon_connected = _normalized_daemon_connected(daemon_connected)
@@ -245,6 +246,30 @@ def transport_runtime_status(
                 "repair_hint": None,
                 "daemon_connected": daemon_connected,
             }
+        daemon_unavailable_status = daemon_unavailable_status or {}
+        daemon_reason = daemon_unavailable_status.get("last_error_kind")
+        if daemon_reason == "configured_off":
+            return {
+                "transport": transport,
+                "label": _transport_label(transport),
+                "status": "daemon_configured_off",
+                "available": False,
+                "summary": "Native daemon is configured off, so desktop delivery is unavailable.",
+                "repair_hint": daemon_unavailable_status.get("recovery_hint")
+                or "Set DAEMON_ENABLED=true and start the native daemon.",
+                "daemon_connected": daemon_connected,
+            }
+        if daemon_reason == "automation_permission_denied":
+            return {
+                "transport": transport,
+                "label": _transport_label(transport),
+                "status": "daemon_permission_denied",
+                "available": False,
+                "summary": "macOS Automation permission is blocking native desktop delivery.",
+                "repair_hint": daemon_unavailable_status.get("recovery_hint")
+                or "Grant Automation permission for System Events, then restart the native daemon.",
+                "daemon_connected": daemon_connected,
+            }
         return {
             "transport": transport,
             "label": _transport_label(transport),
@@ -271,6 +296,7 @@ def route_runtime_status(
     active_transports: set[str],
     websocket_connection_count: int,
     daemon_connected: bool,
+    daemon_unavailable_status: dict[str, str | None] | None = None,
 ) -> tuple[ChannelRouteBinding, dict[str, Any]]:
     binding = get_channel_route_binding(payload, route)
     configured_order: list[str] = []
@@ -284,6 +310,7 @@ def route_runtime_status(
             active_transports=active_transports,
             websocket_connection_count=websocket_connection_count,
             daemon_connected=daemon_connected,
+            daemon_unavailable_status=daemon_unavailable_status,
         )
         for transport in configured_order
     ]
@@ -367,6 +394,7 @@ def route_runtime_statuses(
     active_transports: set[str],
     websocket_connection_count: int,
     daemon_connected: bool,
+    daemon_unavailable_status: dict[str, str | None] | None = None,
 ) -> list[dict[str, Any]]:
     return [
         route_runtime_status(
@@ -375,6 +403,7 @@ def route_runtime_statuses(
             active_transports=active_transports,
             websocket_connection_count=websocket_connection_count,
             daemon_connected=daemon_connected,
+            daemon_unavailable_status=daemon_unavailable_status,
         )[1]
         for spec in _CHANNEL_ROUTE_SPECS
     ]

--- a/backend/tests/test_observer_api.py
+++ b/backend/tests/test_observer_api.py
@@ -177,6 +177,63 @@ class TestObserverAPI:
         assert data["capture_ready"] is True
 
     @pytest.mark.asyncio
+    async def test_daemon_status_reports_configured_off(self, client, tmp_path, monkeypatch):
+        """A disabled daemon is surfaced as configured-off, not a crash."""
+        monkeypatch.setenv("DAEMON_ENABLED", "false")
+        monkeypatch.setenv("SERAPH_DAEMON_STATUS_FILE", str(tmp_path / "missing-daemon-status.json"))
+        mgr = ContextManager()
+        with patch("src.api.observer.context_manager", mgr):
+            resp = await client.get("/api/observer/continuity")
+
+        assert resp.status_code == 200
+        payload = resp.json()
+        daemon = payload["daemon"]
+        assert daemon["connected"] is False
+        assert daemon["daemon_state"] == "disabled"
+        assert daemon["last_error_kind"] == "configured_off"
+        assert "DAEMON_ENABLED=false" in daemon["status_reason"]
+        assert "DAEMON_ENABLED=true" in daemon["recovery_hint"]
+        native_transport = next(
+            item for item in payload["reach"]["transport_statuses"] if item["transport"] == "native_notification"
+        )
+        assert native_transport["status"] == "daemon_configured_off"
+        assert "DAEMON_ENABLED=true" in native_transport["repair_hint"]
+
+    @pytest.mark.asyncio
+    async def test_daemon_status_reports_automation_permission_failure(self, client, tmp_path, monkeypatch):
+        """System Events authorization failures get an actionable recovery kind."""
+        status_file = tmp_path / "daemon-status.json"
+        monkeypatch.setenv("DAEMON_ENABLED", "true")
+        monkeypatch.setenv("SERAPH_DAEMON_STATUS_FILE", str(status_file))
+        status_file.write_text(
+            json.dumps(
+                {
+                    "state": "error",
+                    "last_error": "System Events got an error: Not authorised to send Apple events. (-1743)",
+                    "last_error_kind": "frontmost_app_unavailable",
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        mgr = ContextManager()
+        with patch("src.api.observer.context_manager", mgr):
+            resp = await client.get("/api/observer/continuity")
+
+        assert resp.status_code == 200
+        daemon = resp.json()["daemon"]
+        assert daemon["connected"] is False
+        assert daemon["daemon_state"] == "error"
+        assert daemon["last_error_kind"] == "automation_permission_denied"
+        assert "Automation permission" in daemon["status_reason"]
+        assert "Privacy & Security > Automation" in daemon["recovery_hint"]
+        native_transport = next(
+            item for item in resp.json()["reach"]["transport_statuses"] if item["transport"] == "native_notification"
+        )
+        assert native_transport["status"] == "daemon_permission_denied"
+        assert "Privacy & Security > Automation" in native_transport["repair_hint"]
+
+    @pytest.mark.asyncio
     async def test_post_refresh(self, client):
         mgr = ContextManager()
         mgr.refresh = AsyncMock(return_value=CurrentContext(time_of_day="evening"))

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -167,6 +167,18 @@ The daemon uses AppleScript to read the frontmost window title, which requires t
 
 This is a one-time grant — macOS will not nag you about it again.
 
+### Automation (required for System Events)
+
+macOS can also require Automation permission before the terminal running Seraph
+may control **System Events**. When this is missing, logs or daemon status can
+show `-1743`, `-10827`, or "not authorised to send Apple events".
+
+**To grant:**
+1. Open **System Settings > Privacy & Security > Automation**
+2. Find the terminal app that starts Seraph
+3. Enable permission to control **System Events**
+4. Restart with `./manage.sh -e dev daemon start`
+
 ### Screen Recording (required for `--ocr`)
 
 OCR mode captures screenshots to extract visible text. This requires the Screen Recording permission.

--- a/docs/implementation/04-presence-and-reach.md
+++ b/docs/implementation/04-presence-and-reach.md
@@ -18,6 +18,7 @@
 - [x] observer refresh pipeline across time, calendar, git, goals, and screen context
 - [x] proactive delivery gating and queued-bundle delivery inside the current product
 - [x] first coherent desktop presence surface built on daemon status, capture-mode visibility, pending native-notification state, a safe test-notification path, desktop-notification fallback when browser delivery is unavailable, browser-side controls for pending native notifications, a first learning-driven native-channel preference layer, one continuity snapshot that exposes daemon state, deferred bundle items, pending native notifications, and recent interventions together, plus action-card continuation payloads and an actionable cockpit desktop-shell card with dismiss/follow-up/continue controls
+- [x] native daemon status now separates configured-off, offline, alive-but-not-posting, and macOS Automation-permission failures in the observer continuity payload, Settings native-presence card, and `./manage.sh -e dev daemon status` receipt
 - [x] cross-surface continuity now also exposes explicit open-thread and continue flows across native notifications, queued interventions, and recent interventions
 - [x] route-health snapshots now expose whether browser websocket and native delivery are actually reachable at runtime, including ready, fallback, and unavailable states with operator-readable repair hints instead of only static route bindings
 - [x] queued-bundle native delivery now preserves same-thread resume when every deferred item belongs to the same session, and the shared continuity snapshot now carries one continuation contract across notifications, queued insights, and recent interventions
@@ -53,11 +54,33 @@
 - [x] this workstream now also ships `cross-surface-presence-contracts-v1`
 - [x] this workstream now also ships `broader-reach-inventory-continuity-v2`
 - [x] this workstream now also ships `m4-channels-presence-device-pairing-benchmark-proof-v1`
+- [x] this workstream now also ships `native-daemon-permission-recovery-v1`
 - [x] this workstream now also ships `one-excellent-reach-channel-canary`
 - [x] this workstream now also ships `live-reach-media-proof-v1`
 - [x] this workstream now also ships `production-reach-voice-mobile-proof-v1`
 - [x] this workstream now also ships `broad-reach-field-operations-proof-v1`
 - [x] this workstream now also ships `browser-provider-usability-proof-v1`
+
+## Native Daemon Operations
+
+Native desktop presence is optional and is controlled by `DAEMON_ENABLED` in
+the selected `.env.*` file. `DAEMON_ENABLED=false` is a configured-off state, not
+a daemon crash. Enable it with `DAEMON_ENABLED=true`, then use
+`./manage.sh -e dev daemon start`, `./manage.sh -e dev daemon status`, and
+`./manage.sh -e dev daemon logs` for local operation.
+
+The daemon writes its operator receipt to `SERAPH_DAEMON_STATUS_FILE`, defaulting
+to the local workspace `daemon-status.json`. `/api/observer/daemon-status` and
+`/api/observer/continuity` expose that receipt as daemon state, screen-analysis
+readiness, last error, error kind, status reason, and recovery hint.
+
+macOS permission failures are operator-visible. `-1743`,
+`-10827`, and System Events Apple Events denial are classified as
+`automation_permission_denied` with a recovery hint to grant Automation access in
+System Settings > Privacy & Security > Automation to the terminal application
+running Seraph, then restart the daemon. Window-title presence also requires
+Accessibility permission. OCR or screenshot analysis requires Screen Recording
+or Screen & System Audio Recording permission.
 
 ## Still To Do On `develop`
 

--- a/frontend/src/components/settings/DaemonStatus.test.tsx
+++ b/frontend/src/components/settings/DaemonStatus.test.tsx
@@ -112,6 +112,76 @@ describe("DaemonStatus", () => {
     expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
   });
 
+  it("surfaces configured-off daemon state with recovery guidance", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        daemon: {
+          connected: false,
+          daemon_alive: false,
+          last_post: null,
+          active_window: null,
+          has_screen_context: false,
+          capture_mode: "on_switch",
+          daemon_state: "disabled",
+          last_error: "Native daemon is configured off for this environment.",
+          last_error_kind: "configured_off",
+          status_reason: "Native desktop presence is disabled by DAEMON_ENABLED=false.",
+          recovery_hint: "Set DAEMON_ENABLED=true in .env.dev and start it with ./manage.sh -e dev daemon start when native desktop presence is wanted.",
+          pending_notification_count: 0,
+          last_native_notification_at: null,
+          last_native_notification_title: null,
+          last_native_notification_outcome: null,
+        },
+        notifications: [],
+        queued_insights: [],
+        queued_insight_count: 0,
+        recent_interventions: [],
+      }),
+    );
+
+    render(<DaemonStatus />);
+
+    await waitFor(() => expect(screen.getByText("Daemon disabled")).toBeInTheDocument());
+    expect(screen.getByText("Disabled")).toBeInTheDocument();
+    expect(screen.getByText("Native desktop presence is disabled by DAEMON_ENABLED=false.")).toBeInTheDocument();
+    expect(screen.getByText(/Set DAEMON_ENABLED=true/)).toBeInTheDocument();
+  });
+
+  it("surfaces macOS automation permission failures with an actionable hint", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        daemon: {
+          connected: false,
+          daemon_alive: false,
+          last_post: null,
+          active_window: null,
+          has_screen_context: false,
+          capture_mode: "on_switch",
+          daemon_state: "error",
+          last_error: "System Events got an error: Not authorised to send Apple events. (-1743)",
+          last_error_kind: "automation_permission_denied",
+          status_reason: "macOS Automation permission is blocking native desktop presence.",
+          recovery_hint: "Grant Automation permission for the terminal running Seraph to control System Events in System Settings > Privacy & Security > Automation, then restart with ./manage.sh -e dev daemon start.",
+          pending_notification_count: 0,
+          last_native_notification_at: null,
+          last_native_notification_title: null,
+          last_native_notification_outcome: null,
+        },
+        notifications: [],
+        queued_insights: [],
+        queued_insight_count: 0,
+        recent_interventions: [],
+      }),
+    );
+
+    render(<DaemonStatus />);
+
+    await waitFor(() => expect(screen.getByText("Automation permission needed")).toBeInTheDocument());
+    expect(screen.getByText("Permission")).toBeInTheDocument();
+    expect(screen.getByText(/System Events got an error/)).toBeInTheDocument();
+    expect(screen.getByText(/Privacy & Security > Automation/)).toBeInTheDocument();
+  });
+
   it("queues a test notification and refreshes the visible native status", async () => {
     fetchMock
       .mockResolvedValueOnce(

--- a/frontend/src/components/settings/DaemonStatus.tsx
+++ b/frontend/src/components/settings/DaemonStatus.tsx
@@ -3,9 +3,19 @@ import { API_URL } from "../../config/constants";
 
 interface DaemonStatusData {
   connected: boolean;
+  daemon_alive?: boolean;
   last_post: number | null;
   active_window: string | null;
   has_screen_context: boolean;
+  capture_mode?: string | null;
+  daemon_state?: string | null;
+  daemon_status_updated_at?: string | null;
+  screen_analysis?: string | null;
+  capture_ready?: boolean;
+  last_error?: string | null;
+  last_error_kind?: string | null;
+  status_reason?: string | null;
+  recovery_hint?: string | null;
   pending_notification_count: number;
   last_native_notification_at: string | null;
   last_native_notification_title: string | null;
@@ -176,16 +186,44 @@ export function DaemonStatus() {
   }
 
   const connected = status?.connected ?? false;
-  const dotColor = connected ? "bg-green-400" : "bg-retro-text/30";
+  const isConfiguredOff = status?.last_error_kind === "configured_off" || status?.daemon_state === "disabled";
+  const isPermissionBlocked = status?.last_error_kind === "automation_permission_denied";
+  const needsRecovery = !connected && Boolean(status?.recovery_hint || status?.status_reason || status?.last_error);
+  const dotColor = connected
+    ? "bg-green-400"
+    : isConfiguredOff
+      ? "bg-retro-text/30"
+      : isPermissionBlocked
+        ? "bg-yellow-400"
+        : "bg-retro-text/30";
   const activeWindow = status?.active_window;
   const pendingCount = status?.pending_notification_count ?? 0;
   const lastNativeOutcome = status?.last_native_notification_outcome;
   const lastNativeTitle = status?.last_native_notification_title;
-
   const displayWindow =
     activeWindow && activeWindow.length > 40
       ? activeWindow.slice(0, 37) + "..."
       : activeWindow;
+  const presenceLabel = connected
+    ? "Linked"
+    : isConfiguredOff
+      ? "Disabled"
+      : isPermissionBlocked
+        ? "Permission"
+        : status?.daemon_alive
+          ? "Daemon alive"
+          : "Offline";
+  const headline = connected
+    ? "Desktop link live"
+    : isConfiguredOff
+      ? "Daemon disabled"
+      : isPermissionBlocked
+        ? "Automation permission needed"
+        : status?.daemon_alive
+          ? "Daemon alive, awaiting context"
+          : "Daemon offline";
+  const statusDetail =
+    status?.status_reason ?? (isPermissionBlocked ? status?.last_error : null) ?? displayWindow ?? "No active window yet";
   const lastNativeLabel =
     lastNativeOutcome === "queued"
       ? "Queued for desktop delivery"
@@ -207,10 +245,10 @@ export function DaemonStatus() {
           <div className={`w-2 h-2 rounded-full flex-shrink-0 ${dotColor}`} />
           <div className="flex-1 min-w-0">
             <div className="text-[10px] text-retro-text">
-              {connected ? "Desktop link live" : "Daemon offline"}
+              {headline}
             </div>
             <div className="text-[9px] text-retro-text/40 truncate">
-              {displayWindow ?? "No active window yet"}
+              {statusDetail}
             </div>
           </div>
           {connected && status?.has_screen_context && (
@@ -221,13 +259,23 @@ export function DaemonStatus() {
         <div className="grid grid-cols-2 gap-2 text-[9px] text-retro-text/50 uppercase tracking-wider">
           <div>
             <div className="text-retro-text/30">Presence</div>
-            <div className="text-retro-text">{connected ? "Linked" : "Offline"}</div>
+            <div className="text-retro-text">{presenceLabel}</div>
           </div>
           <div>
             <div className="text-retro-text/30">Pending</div>
             <div className="text-retro-text">{pendingCount}</div>
           </div>
         </div>
+
+        {needsRecovery && (
+          <div className="border border-retro-text/10 rounded px-2 py-1 text-[9px] text-retro-text/50">
+            <div className="text-retro-text/30 uppercase tracking-wider mb-0.5">Recovery</div>
+            {status?.last_error && !isConfiguredOff && (
+              <div className="text-retro-text/40 mb-1 truncate">{status.last_error}</div>
+            )}
+            <div className="text-retro-text">{status?.recovery_hint ?? status?.status_reason}</div>
+          </div>
+        )}
 
         <div className="text-[9px] text-retro-text/50">
           <div className="text-retro-text/30 uppercase tracking-wider mb-0.5">Last native event</div>

--- a/manage.sh
+++ b/manage.sh
@@ -418,6 +418,28 @@ function daemon_status() {
     else
         echo "Daemon is not running"
     fi
+
+    if [ "${DAEMON_ENABLED:-false}" != "true" ]; then
+        echo "Daemon configured off: set DAEMON_ENABLED=true in $ENV_FILE to enable native desktop presence."
+        return 0
+    fi
+
+    if [ -f "$SERAPH_DAEMON_STATUS_FILE" ]; then
+        local status_summary
+        status_summary=$(grep -E '"(state|last_error_kind|last_error|updated_at)"' "$SERAPH_DAEMON_STATUS_FILE" | sed 's/^[[:space:]]*//' || true)
+        if [ -n "$status_summary" ]; then
+            echo "Status file: $SERAPH_DAEMON_STATUS_FILE"
+            echo "$status_summary"
+        fi
+        if grep -Eiq '(-1743|-10827|not authori[sz]ed to send apple events|system events got an error)' "$SERAPH_DAEMON_STATUS_FILE"; then
+            echo "Recovery: grant Automation permission for the terminal running Seraph to control System Events in System Settings > Privacy & Security > Automation, then restart with ./manage.sh -e $ENV daemon start."
+        fi
+    elif [ -f "$DAEMON_LOG_FILE" ] && grep -Eiq '(-1743|-10827|not authori[sz]ed to send apple events|system events got an error)' "$DAEMON_LOG_FILE"; then
+        echo "Recovery: daemon logs show macOS Automation permission denial for System Events."
+        echo "Grant Automation permission for the terminal running Seraph, then restart with ./manage.sh -e $ENV daemon start."
+    else
+        echo "Status file: $SERAPH_DAEMON_STATUS_FILE (not found yet)"
+    fi
 }
 
 function daemon_logs() {


### PR DESCRIPTION
## Summary
- classify native daemon configured-off and macOS Automation/System Events failures in observer daemon status and continuity payloads
- surface disabled and permission-blocked states in the Settings native presence card with operator recovery guidance
- align native-notification route health and manage.sh daemon status with configured-off/permission-denied diagnostics
- document DAEMON_ENABLED, daemon status/log commands, and macOS Automation permission recovery

Closes #704

## Validation
- PYTEST_ADDOPTS=--no-cov backend/.venv/bin/python -m pytest backend/tests/test_observer_api.py::TestObserverAPI::test_daemon_status_reports_configured_off backend/tests/test_observer_api.py::TestObserverAPI::test_daemon_status_reports_automation_permission_failure -q
- PYTEST_ADDOPTS=--no-cov backend/.venv/bin/python -m pytest backend/tests/test_observer_api.py::TestObserverAPI::test_observer_continuity_snapshot backend/tests/test_observer_api.py::TestObserverAPI::test_observer_continuity_surfaces_imported_reach_and_source_adapter_attention -q
- PYTEST_ADDOPTS=--no-cov backend/.venv/bin/python -m pytest backend/tests/test_observer_api.py::TestObserverAPI::test_daemon_status_disconnected backend/tests/test_observer_api.py::TestObserverAPI::test_daemon_status_connected backend/tests/test_observer_api.py::TestObserverAPI::test_daemon_status_stale backend/tests/test_observer_api.py::TestObserverAPI::test_daemon_status_alive_from_fresh_status_file backend/tests/test_observer_api.py::TestObserverAPI::test_daemon_status_reports_configured_off backend/tests/test_observer_api.py::TestObserverAPI::test_daemon_status_reports_automation_permission_failure -q
- npm --prefix frontend test -- src/components/settings/DaemonStatus.test.tsx --maxWorkers=1
- npm --prefix frontend run build
- bash -n manage.sh
- git diff --check
- ./manage.sh -e dev daemon status showed configured-off daemon recovery guidance
- ./manage.sh -e dev local run plus host-local /api/observer/continuity receipt showed daemon_state=disabled, daemon_error_kind=configured_off, native_transport.status=daemon_configured_off, and alert/scheduled fallback routes with DAEMON_ENABLED=true recovery hints

## Review
- Lead/critic pass: independent subagent review was not spawned because this environment only permits subagents when explicitly requested by the user. Local critic finding accepted and fixed: route health originally still said daemon_offline for configured-off state; native route status now reports daemon_configured_off or daemon_permission_denied.