### PR TITLE
Add governed extension diagnostics drill-down

### DIFF
--- a/backend/src/api/extensions.py
+++ b/backend/src/api/extensions.py
@@ -73,6 +73,22 @@ _BUILTIN_CHANNEL_ADAPTERS = (
 )
 _REDACTED_CONFIG_SENTINEL = "__SERAPH_STORED_SECRET__"
 _NEW_SECRET_CONFIG_SENTINEL = "__SERAPH_NEW_SECRET_VALUE__"
+_SENSITIVE_DIAGNOSTIC_KEY_TOKENS = (
+    "auth",
+    "config",
+    "credential",
+    "header",
+    "password",
+    "secret",
+    "token",
+)
+_PRIVATE_PATH_PATTERN = re.compile(
+    r"(^|[\s'\"=:])("
+    r"/(?:Users|private|tmp|var|home|etc|Volumes|opt|run|srv)/[^\s'\",;)]*"
+    r"|~/?[^\s'\",;)]*"
+    r"|[A-Za-z]:\\[^\s'\",;)]*"
+    r")"
+)
 
 
 def _content_hash(value: str) -> str:
@@ -267,6 +283,177 @@ def _extension_load_error_count(preview: dict[str, Any] | None) -> int:
         return 0
     load_errors = preview.get("load_errors")
     return len(load_errors) if isinstance(load_errors, list) else 0
+
+
+def _extension_recommended_diagnostic_actions(
+    extension: dict[str, Any],
+    lifecycle: dict[str, Any],
+) -> list[dict[str, Any]]:
+    actions: list[dict[str, Any]] = []
+    diagnostics = extension.get("diagnostics_summary")
+    diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
+    permission_summary = extension.get("permission_summary")
+    permission_summary = permission_summary if isinstance(permission_summary, dict) else {}
+    compatibility = extension.get("compatibility")
+    compatibility = compatibility if isinstance(compatibility, dict) else {}
+    rollback = lifecycle.get("rollback")
+    rollback = rollback if isinstance(rollback, dict) else {}
+    quarantine = lifecycle.get("quarantine")
+    quarantine = quarantine if isinstance(quarantine, dict) else {}
+
+    if diagnostics.get("issue_count") or diagnostics.get("load_error_count"):
+        actions.append({
+            "type": "review",
+            "label": "Review package diagnostics",
+            "reason": "Doctor issues or load errors require operator review before lifecycle changes.",
+            "endpoint": f"/api/extensions/{extension['id']}/review",
+        })
+    if diagnostics.get("degraded_connector_count"):
+        actions.append({
+            "type": "open_studio",
+            "label": "Inspect connector configuration",
+            "reason": "At least one connector is degraded or needs configuration.",
+        })
+    if compatibility.get("compatible") is False:
+        actions.append({
+            "type": "block_lifecycle",
+            "label": "Resolve compatibility before update",
+            "reason": "The package compatibility check is failing for this Seraph build.",
+        })
+    if permission_summary.get("ok") is False:
+        actions.append({
+            "type": "review_permissions",
+            "label": "Review missing permissions",
+            "reason": "Required tools, boundaries, or data access are not currently granted.",
+        })
+    if quarantine.get("active"):
+        actions.append({
+            "type": "reentry",
+            "label": "Run re-entry review",
+            "reason": "The package is quarantined and cannot be enabled until review clears it.",
+            "endpoint": f"/api/extensions/{extension['id']}/reentry",
+        })
+    elif rollback.get("available"):
+        actions.append({
+            "type": "rollback",
+            "label": "Rollback to previous snapshot",
+            "reason": "A rollback snapshot is available if diagnostics indicate a bad update.",
+            "endpoint": f"/api/extensions/{extension['id']}/rollback",
+        })
+    if not actions:
+        actions.append({
+            "type": "review",
+            "label": "Record lifecycle review",
+            "reason": "No blocking diagnostics are present; record an operator review before privileged changes if needed.",
+            "endpoint": f"/api/extensions/{extension['id']}/review",
+        })
+    return actions
+
+
+def _sanitize_extension_diagnostic_value(value: Any, *, key: str | None = None) -> Any:
+    key_text = (key or "").lower()
+    if isinstance(value, dict):
+        return {
+            str(item_key): _sanitize_extension_diagnostic_value(item_value, key=str(item_key))
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, list):
+        return [_sanitize_extension_diagnostic_value(item) for item in value]
+    if isinstance(value, str):
+        if key_text == "path" or key_text.endswith("_path") or key_text in {"package_path", "manifest_path", "root_path"}:
+            return {"redacted": True, "digest": _content_hash(value)}
+        if any(token in key_text for token in _SENSITIVE_DIAGNOSTIC_KEY_TOKENS):
+            return {"redacted": True, "digest": _content_hash(value)}
+        if _PRIVATE_PATH_PATTERN.search(value):
+            return {"redacted": True, "digest": _content_hash(value)}
+    return value
+
+
+def _safe_extension_diagnostics_payload(extension_id: str) -> dict[str, Any]:
+    extension = get_extension(extension_id)
+    lifecycle = extension_lifecycle_status(extension_id)
+    lifecycle_state = lifecycle.get("lifecycle")
+    lifecycle_state = lifecycle_state if isinstance(lifecycle_state, dict) else {}
+    rollback = lifecycle.get("rollback")
+    rollback = rollback if isinstance(rollback, dict) else {}
+    quarantine = lifecycle.get("quarantine")
+    quarantine = quarantine if isinstance(quarantine, dict) else {"active": False, "state": "clear"}
+    snapshots = rollback.get("snapshots")
+    safe_snapshots = [
+        {
+            "id": item.get("id"),
+            "version": item.get("version"),
+            "digest": item.get("digest"),
+            "reason": item.get("reason"),
+            "created_by": item.get("created_by"),
+            "created_at": item.get("created_at"),
+            "path_digest": _content_hash(str(item.get("path") or "")),
+        }
+        for item in snapshots
+        if isinstance(item, dict)
+    ] if isinstance(snapshots, list) else []
+    issues = extension.get("issues")
+    load_errors = extension.get("load_errors")
+    diagnostics_summary = extension.get("diagnostics_summary")
+    diagnostics_summary = diagnostics_summary if isinstance(diagnostics_summary, dict) else {}
+    highlighted_messages = diagnostics_summary.get("highlighted_messages")
+    safe_issues = _sanitize_extension_diagnostic_value(issues) if isinstance(issues, list) else []
+    safe_load_errors = _sanitize_extension_diagnostic_value(load_errors) if isinstance(load_errors, list) else []
+    safe_diagnostics_summary = _sanitize_extension_diagnostic_value(diagnostics_summary)
+    safe_lifecycle_diagnostics = _sanitize_extension_diagnostic_value(lifecycle.get("diagnostics"))
+    return {
+        "extension": {
+            "id": extension.get("id"),
+            "display_name": extension.get("display_name"),
+            "version": extension.get("version"),
+            "version_line": extension.get("version_line"),
+            "kind": extension.get("kind"),
+            "location": extension.get("location"),
+            "status": extension.get("status"),
+            "trust": extension.get("trust"),
+            "source": extension.get("source"),
+            "publisher": extension.get("publisher"),
+            "compatibility": extension.get("compatibility"),
+            "permission_summary": extension.get("permission_summary"),
+            "approval_profile": extension.get("approval_profile"),
+            "connector_summary": extension.get("connector_summary"),
+            "diagnostics_summary": safe_diagnostics_summary,
+            "issue_count": len(issues) if isinstance(issues, list) else 0,
+            "load_error_count": len(load_errors) if isinstance(load_errors, list) else 0,
+        },
+        "issues": safe_issues,
+        "load_errors": safe_load_errors,
+        "highlighted_messages": _sanitize_extension_diagnostic_value(highlighted_messages)
+        if isinstance(highlighted_messages, list)
+        else [],
+        "lifecycle": {
+            "last_event": lifecycle_state.get("last_event"),
+            "rollback": {
+                "available": bool(rollback.get("available")),
+                "snapshots": safe_snapshots,
+            },
+            "quarantine": _sanitize_extension_diagnostic_value(quarantine),
+            "diagnostics": safe_lifecycle_diagnostics,
+        },
+        "recommended_actions": _extension_recommended_diagnostic_actions(extension, lifecycle),
+        "claim_boundary": "metadata_only_extension_diagnostics_no_source_secret_config_or_private_paths",
+        "redaction": {
+            "metadata_only": True,
+            "raw_source_content_exposed": False,
+            "secret_values_exposed": False,
+            "credential_values_exposed": False,
+            "config_values_exposed": False,
+            "private_paths_exposed": False,
+        },
+        "blocked_claims": [
+            "production_secure_marketplace",
+            "solved_third_party_package_security",
+            "marketplace_superiority",
+            "full_parity",
+            "production_readiness",
+            "reference_system_exceedance",
+        ],
+    }
 
 
 async def _log_extension_lifecycle_event(
@@ -887,6 +1074,14 @@ async def get_extension_diagnostics():
             if isinstance(item, dict)
         ],
     }
+
+
+@router.get("/extensions/{extension_id}/diagnostics")
+async def get_extension_package_diagnostics(extension_id: str):
+    try:
+        return _safe_extension_diagnostics_payload(extension_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=f"Extension '{extension_id}' not found") from exc
 
 
 @router.get("/extensions/channel-routing")

--- a/backend/tests/test_extensions_api.py
+++ b/backend/tests/test_extensions_api.py
@@ -873,6 +873,122 @@ async def test_extensions_diagnostics_endpoint_summarizes_package_health(client,
 
 
 @pytest.mark.asyncio
+async def test_extension_diagnostics_drilldown_is_actionable_and_metadata_only(client, extension_runtime, tmp_path):
+    package_dir = _write_installable_extension(tmp_path)
+    updated_package_dir = _write_installable_extension(
+        tmp_path,
+        package_name="installable-pack-update",
+        version="2026.4.01",
+        workflow_description="Updated local installable workflow",
+        workflow_content="Updated private workflow body should not leak through diagnostics.\n",
+    )
+
+    with (
+        patch(
+            "src.extensions.lifecycle.get_base_tools_and_active_skills",
+            return_value=([SimpleNamespace(name="read_file")], [], "approval"),
+        ),
+        patch("src.api.extensions.log_integration_event", AsyncMock()),
+    ):
+        install_response = await client.post("/api/extensions/install", json={"path": str(package_dir)})
+        assert install_response.status_code == 201
+        update_response = await client.post("/api/extensions/update", json={"path": str(updated_package_dir)})
+        assert update_response.status_code == 200
+
+        response = await client.get("/api/extensions/seraph.test-installable/diagnostics")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["extension"]["id"] == "seraph.test-installable"
+    assert payload["redaction"]["metadata_only"] is True
+    assert payload["redaction"]["private_paths_exposed"] is False
+    assert payload["claim_boundary"] == "metadata_only_extension_diagnostics_no_source_secret_config_or_private_paths"
+    assert "production_secure_marketplace" in payload["blocked_claims"]
+    assert payload["lifecycle"]["rollback"]["available"] is True
+    snapshot = payload["lifecycle"]["rollback"]["snapshots"][0]
+    assert snapshot["version"] == "2026.3.21"
+    assert "path" not in snapshot
+    assert isinstance(snapshot["path_digest"], str)
+    assert any(action["type"] == "rollback" for action in payload["recommended_actions"])
+    rendered = str(payload)
+    assert str(package_dir) not in rendered
+    assert str(updated_package_dir) not in rendered
+    assert "Updated private workflow body" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_extension_diagnostics_drilldown_returns_404_for_unknown_extension(client):
+    response = await client.get("/api/extensions/seraph.missing/diagnostics")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_extension_diagnostics_drilldown_redacts_path_and_secret_fields(client):
+    with (
+        patch(
+            "src.api.extensions.get_extension",
+            return_value={
+                "id": "seraph.test-installable",
+                "display_name": "Test Installable",
+                "status": "degraded",
+                "version": "2026.4.01",
+                "version_line": "2026.4",
+                "kind": "capability-pack",
+                "location": "workspace",
+                "source": "manifest",
+                "trust": "local",
+                "publisher": {"name": "Seraph"},
+                "compatibility": {"compatible": True},
+                "permission_summary": {"ok": True},
+                "approval_profile": {},
+                "connector_summary": {},
+                "diagnostics_summary": {
+                    "issue_count": 1,
+                    "load_error_count": 1,
+                    "highlighted_messages": ["review package metadata"],
+                    "manifest_path": "/private/tmp/seraph-extension/manifest.yaml",
+                },
+                "issues": [
+                    {"message": "missing field in /private/tmp/seraph-extension/manifest.yaml"},
+                    {"path": "/private/tmp/seraph-extension/manifest.yaml"},
+                ],
+                "load_errors": [{"secret_token": "super-secret-token", "config": "raw-hidden-config"}],
+            },
+        ),
+        patch(
+            "src.api.extensions.extension_lifecycle_status",
+            return_value={
+                "lifecycle": {"last_event": "install"},
+                "rollback": {"available": False, "snapshots": []},
+                "quarantine": {
+                    "active": False,
+                    "state": "clear",
+                    "review_path": "/private/tmp/seraph-extension/quarantine-review.json",
+                },
+                "diagnostics": {"root_path": "/private/tmp/seraph-extension"},
+            },
+        ),
+    ):
+        response = await client.get("/api/extensions/seraph.test-installable/diagnostics")
+
+    assert response.status_code == 200
+    payload = response.json()
+    rendered = str(payload)
+    assert "/private/tmp/seraph-extension" not in rendered
+    assert "super-secret-token" not in rendered
+    assert "raw-hidden-config" not in rendered
+    assert payload["issues"][0]["message"]["redacted"] is True
+    assert payload["issues"][1]["path"]["redacted"] is True
+    assert payload["load_errors"][0]["secret_token"]["redacted"] is True
+    assert payload["load_errors"][0]["config"]["redacted"] is True
+    assert payload["extension"]["diagnostics_summary"]["manifest_path"]["redacted"] is True
+    assert payload["lifecycle"]["diagnostics"]["root_path"]["redacted"] is True
+    assert payload["lifecycle"]["quarantine"]["review_path"]["redacted"] is True
+
+
+@pytest.mark.asyncio
 async def test_scaffold_extension_package_creates_workspace_skill_pack(client, extension_runtime):
     with patch("src.api.extensions.log_integration_event", AsyncMock()) as log_event:
         response = await client.post(

--- a/frontend/src/components/cockpit/CockpitView.test.tsx
+++ b/frontend/src/components/cockpit/CockpitView.test.tsx
@@ -263,6 +263,97 @@ describe("CockpitView", () => {
     expect(within(consoleRegion).getByRole("button", { name: "install" })).toBeEnabled();
   });
 
+  it("opens extension diagnostics drill-down from the governed extension console", async () => {
+    const diagnosticsPayload = {
+      extension: {
+        id: "seraph.test-installable",
+        display_name: "Test Installable",
+        status: "ready",
+        version_line: "2026.4",
+      },
+      lifecycle: {
+        rollback: {
+          available: true,
+          snapshots: [{ id: "snapshot-1", version: "2026.3.21", path_digest: "abc123" }],
+        },
+      },
+      recommended_actions: [
+        { type: "rollback", label: "Rollback to previous snapshot", reason: "Bad update suspected." },
+      ],
+      claim_boundary: "metadata_only_extension_diagnostics_no_source_secret_config_or_private_paths",
+      blocked_claims: ["production_secure_marketplace"],
+      redaction: { metadata_only: true, private_paths_exposed: false },
+    };
+    mockCockpitBaselineFetch(fetchMock, {
+      extensions: {
+        extensions: [
+          {
+            id: "seraph.test-installable",
+            display_name: "Test Installable",
+            status: "ready",
+            source: "manifest",
+            location: "workspace",
+            trust: "local",
+            version: "2026.4.01",
+            version_line: "2026.4",
+            kind: "capability-pack",
+            publisher: { name: "Seraph" },
+            compatibility: { seraph: ">=2026.4.11", current_version: "2026.7.4", compatible: true },
+            diagnostics_summary: {
+              issue_count: 0,
+              error_issue_count: 0,
+              warning_issue_count: 0,
+              load_error_count: 0,
+              degraded_contribution_count: 0,
+              degraded_connector_count: 0,
+              highlighted_messages: [],
+            },
+            permission_summary: { status: "granted", ok: true, required: {}, missing: {}, risk_level: "low" },
+            approval_profile: { requires_lifecycle_approval: false, requires_runtime_approval: false },
+            connector_summary: { ready: 0, total: 0 },
+            issues: [],
+            load_errors: [],
+            contributions: [{ type: "skills", status: "ready", loaded: true }],
+            disable_supported: true,
+            removable: true,
+            rollback_ready: true,
+            lifecycle: {
+              rollback_snapshots: [{ id: "snapshot-1", version: "2026.3.21" }],
+            },
+          },
+        ],
+        summary: { total: 1 },
+      },
+    });
+    const baselineFetch = fetchMock.getMockImplementation();
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/extensions/seraph.test-installable/diagnostics")) {
+        return Promise.resolve(mockResponse(diagnosticsPayload));
+      }
+      return baselineFetch
+        ? baselineFetch(input)
+        : Promise.resolve(mockResponse({}));
+    });
+
+    render(<CockpitView onSend={() => {}} />);
+
+    const consoleRegion = await screen.findByRole("region", { name: "M9 governed extension console" });
+    fireEvent.click(within(consoleRegion).getByRole("button", { name: "diagnostics" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/extensions/seraph.test-installable/diagnostics"),
+      ),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText("Diagnostics ready: Rollback to previous snapshot"),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getAllByText(/metadata_only_extension_diagnostics/i).length).toBeGreaterThan(0);
+  });
+
   it("renders live browser session controls with degraded fallback and redacted provenance", async () => {
     mockCockpitBaselineFetch(fetchMock, {
       browserProviders: {
@@ -350,7 +441,9 @@ describe("CockpitView", () => {
     render(<CockpitView onSend={() => {}} />);
 
     const browserControls = await screen.findByRole("region", { name: "Browser computer-use live controls" });
-    expect(browserControls).toHaveTextContent(/1 providers · 1 sessions · 1 journaled · 1 degraded · no quarantine/i);
+    await waitFor(() =>
+      expect(browserControls).toHaveTextContent(/1 providers · 1 sessions · 1 journaled · 1 degraded · no quarantine/i),
+    );
     expect(browserControls).toHaveTextContent(/remote-cdp · remote cdp · staged local fallback · local fallback/i);
     expect(browserControls).toHaveTextContent(/degraded fallback labeled · silent fallback blocked/i);
     expect(browserControls).toHaveTextContent(/boundaries: profile · cookie · credential · download · upload · network/i);

--- a/frontend/src/components/cockpit/CockpitView.tsx
+++ b/frontend/src/components/cockpit/CockpitView.tsx
@@ -10642,6 +10642,64 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
     }
   }
 
+  async function inspectExtensionDiagnostics(extensionPackage: ExtensionPackageInfo) {
+    const label = extensionPackage.display_name;
+    setOperatorStatus(`Loading diagnostics for ${label}...`);
+    try {
+      const response = await fetch(`${API_URL}/api/extensions/${encodeURIComponent(extensionPackage.id)}/diagnostics`);
+      const payload = await response.json().catch(() => null);
+      if (!response.ok || !payload || typeof payload !== "object") {
+        setOperatorStatus(`Failed to load diagnostics for ${label}`);
+        appendOperatorFeed(`Failed to load diagnostics for ${label}`, "failed");
+        return;
+      }
+      const record = payload as Record<string, unknown>;
+      const extensionRecord = record.extension && typeof record.extension === "object"
+        ? record.extension as Record<string, unknown>
+        : {};
+      const recommendedActions = Array.isArray(record.recommended_actions)
+        ? record.recommended_actions
+        : [];
+      const rollbackRecord = record.lifecycle && typeof record.lifecycle === "object"
+        ? (record.lifecycle as Record<string, unknown>).rollback
+        : null;
+      const rollbackAvailable = rollbackRecord && typeof rollbackRecord === "object"
+        ? Boolean((rollbackRecord as Record<string, unknown>).available)
+        : false;
+      setSelectedInspector({
+        kind: "operator",
+        entity: {
+          entityType: "extension_manifest",
+          name: label,
+          meta: [
+            typeof extensionRecord.status === "string" ? extensionRecord.status : extensionPackage.status,
+            typeof extensionRecord.version_line === "string" ? extensionRecord.version_line : extensionPackage.version_line,
+            rollbackAvailable ? "rollback available" : null,
+          ].filter(Boolean).join(" · "),
+          summary: recommendedActions.length
+            ? `Diagnostics ready: ${recommendedActions.map((item) => {
+              if (item && typeof item === "object" && typeof (item as Record<string, unknown>).label === "string") {
+                return (item as Record<string, unknown>).label;
+              }
+              return "operator action";
+            }).slice(0, 3).join(", ")}`
+            : "Diagnostics ready",
+          details: {
+            diagnostics: record,
+            claim_boundary: record.claim_boundary,
+            blocked_claims: record.blocked_claims,
+            operator_recommended_actions: recommendedActions,
+          },
+        },
+      });
+      setOperatorStatus(`${label} diagnostics loaded`);
+      appendOperatorFeed(`${label} diagnostics loaded`, "info");
+    } catch {
+      setOperatorStatus(`Failed to load diagnostics for ${label}`);
+      appendOperatorFeed(`Failed to load diagnostics for ${label}`, "failed");
+    }
+  }
+
   function saveRunbookMacro(runbook: RunbookInfo) {
     setSavedRunbooks((current) => {
       if (current.some((item) => item.id === runbook.id)) return current;
@@ -15099,6 +15157,15 @@ export function CockpitView({ onSend, onSkipOnboarding }: CockpitViewProps) {
                               )}
                             >
                               studio
+                            </button>
+                          ) : null}
+                          {row.extensionPackage ? (
+                            <button
+                              type="button"
+                              className="cockpit-operator-button"
+                              onClick={() => void inspectExtensionDiagnostics(row.extensionPackage as ExtensionPackageInfo)}
+                            >
+                              diagnostics
                             </button>
                           ) : null}
                           {row.extensionPackage?.disable_supported && !extensionPackageRevoked(row.extensionPackage) ? (


### PR DESCRIPTION
## Done on develop
- [x] Governed extension console and package lifecycle rows already exist as the baseline surface.
- [x] Extension install/update/rollback lifecycle APIs already expose package state and rollback snapshots.

## Working in this PR
- [x] Adds GET /api/extensions/{extension_id}/diagnostics with extension identity, health summaries, lifecycle/rollback context, quarantine state, recommended operator actions, and explicit unsupported-claim boundaries.
- [x] Enforces a metadata-only diagnostics boundary by redacting path-like, config-like, auth/header-like, and secret-like diagnostic values before returning them to the cockpit.
- [x] Adds a governed-console diagnostics button for installed extension rows that opens the cockpit inspector with the live diagnostics payload and recommended action summary.
- [x] Links this implementation to #729.

## Still to do after this PR
- [ ] Broader Hermes-exceeding capability work remains active beyond this slice: richer extension remediation actions, marketplace hardening, and multi-surface operator workflows.
- [ ] This PR does not claim production secure marketplace parity or full reference-system exceedance; those claims remain explicitly blocked in the endpoint payload.

## Validation
- backend/.venv/bin/pytest backend/tests/test_extensions_api.py -k diagnostics: 4 passed, 66 deselected.
- npm --prefix frontend test -- src/components/cockpit/CockpitView.test.tsx -t "opens extension diagnostics drill-down" --maxWorkers=1 --reporter=dot: 1 passed, 74 skipped.
- npm --prefix frontend test -- src/components/cockpit/CockpitView.test.tsx -t "renders live browser session controls with degraded fallback and redacted provenance" --maxWorkers=1 --reporter=dot: 1 passed, 74 skipped.
- npm --prefix frontend test -- --maxWorkers=1 --reporter=dot: 22 files passed, 217 tests passed.
- npm --prefix frontend run build: passed with existing Browserslist/chunk-size warnings.
- git diff --check: passed.

## Review
- Local critic pass accepted one finding: raw diagnostic issue/load-error payloads could leak path-like strings in generic messages despite the metadata-only claim. Fixed by adding recursive path/config/auth/header/secret redaction and an API regression test.
- Fresh local critic pass accepted one additional finding: lifecycle quarantine metadata was passed through raw and could violate the same private-path/config boundary if future lifecycle state gained path-like fields. Fixed by sanitizing quarantine metadata and extending the redaction regression.
- Independent subagent review was not run because the available subagent tool explicitly requires user authorization for delegation; no material review findings remain from the local critic pass.

Closes #729