### PR TITLE
Stabilize artifact storage runtime metadata test

### DIFF
--- a/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
+++ b/frontend/src/components/settings/ArtifactStoragePanel.test.tsx
@@ -411,7 +411,7 @@ describe("ArtifactStoragePanel", () => {
 
     render(<ArtifactStoragePanel />);
 
-    expect(await screen.findByText("Local Gemma runtime")).toBeInTheDocument();
+    expect(await screen.findByText("openai/unsloth/gemma-4-26B-A4B-it-qat-GGUF")).toBeInTheDocument();
     expect(screen.getByText("direct route failing · chat:missing")).toBeInTheDocument();
     expect(screen.queryByText("direct route ok")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Done on develop
- [x] Artifact storage settings already exposes VLM reachability and metadata-loading fallback states.

## Working in this PR
- [x] Waits for the loaded local Gemma model value before asserting the VLM reachability label.
- [x] Fixes the release-gate frontend race where the test could assert while metadata was still unavailable.

## Still to do after this PR
- [ ] Merge into develop, re-run #731, merge develop to main, and publish the main-backed release.

## Validation
- npm --prefix frontend test -- src/components/settings/ArtifactStoragePanel.test.tsx -t "does not mark VLM direct route healthy without chat readiness proof" --maxWorkers=1 --reporter=dot
- npm --prefix frontend test -- --maxWorkers=1
- npm --prefix frontend run build
- git diff --check