### PR TITLE
feat(runtime): run authenticated Seraph core on private GPU stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,9 @@ Mac paired edge target (#749; upload API not shipped)
 
 This Codex workspace already runs on the GPU server, hostname `jupyter`, at
 `/home/pawel/repos/seraph`. The VLM wrapper is run through Docker locally from
-`/home/pawel/repos/vlm-screenshot-server`. The GPU model server is a separate
-local process and may already be running. Use direct local Docker, process,
+`/home/pawel/repos/vlm-screenshot-server`. Production manages the GPU model as
+the private `gpu-model` Compose service; an old host launcher must be stopped
+before managed cutover. Use direct local Docker, process,
 listener, filesystem, and log inspection for administration; `ssh jupyter` is
 neither required nor valid as a hop from this workspace back to its own host.
 Seraph runtime traffic still uses private HTTP/service routes. Operators enter

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,34 +27,24 @@ The current development topology is part of the product contract, not incidental
 developer setup:
 
 ```text
-Seraph frontend       http://127.0.0.1:3001
-  -> Seraph backend   http://127.0.0.1:8004
-  -> GPU VLM wrapper  http://192.168.1.26:8001
-  -> GPU model server http://192.168.1.26:8000/v1
+GPU host `jupyter` (`192.168.1.26`)
+  Seraph frontend/backend + canonical data
+    -> private VLM wrapper
+    -> private GPU model server
+Mac paired edge target (#749; upload API not shipped)
+  capture consented screenshots -> authenticated Seraph ingest on jupyter
 ```
 
-The VLM wrapper is run through Docker on the GPU server from
+This Codex workspace already runs on the GPU server, hostname `jupyter`, at
+`/home/pawel/repos/seraph`. The VLM wrapper is run through Docker locally from
 `/home/pawel/repos/vlm-screenshot-server`. The GPU model server is a separate
-process on the same machine and may already be running. Seraph agents are
-responsible for Seraph and the VLM wrapper lifecycle. SSH is for GPU
-administration only: inventory, Docker deploy/restart, process inspection, and
-logs. Seraph runtime traffic must go over the documented HTTP APIs.
-
-Operator-shell reachability is authoritative for this topology. A normal
-Terminal-launched receipt on July 3, 2026 proved
-`ssh -o BatchMode=yes -o ConnectTimeout=5 jupyter true` exits `0` even though
-Codex/Desktop-launched direct SSH can report `No route to host` for the same
-alias. Seraph should not require the user to set up an SSH tunnel to reach the
-GPU VLM API. If Codex/Desktop commands report `No route to host` or connection
-failures for `192.168.1.26` while the operator shell can reach `jupyter`, treat
-that as a Codex/app network limitation until proven otherwise. Document it in
-the ticket receipt, but do not redesign the Seraph runtime around a tunnel.
-
-Codex GPU administration is a separate access path from Seraph runtime traffic.
-Use `ssh jupyter` only for GPU-host inventory and maintenance. That path has
-confirmed host `jupyter`, user `pawel`, and
-`/home/pawel/repos/vlm-screenshot-server`. Do not translate this admin route
-into a Seraph user requirement or a `.env.dev` runtime base URL.
+local process and may already be running. Use direct local Docker, process,
+listener, filesystem, and log inspection for administration; `ssh jupyter` is
+neither required nor valid as a hop from this workspace back to its own host.
+Seraph runtime traffic still uses private HTTP/service routes. Operators enter
+through one authenticated LAN HTTPS origin. The planned paired Mac edge (#749)
+will push screenshots through authenticated ingest, but no screenshot upload API
+is shipped yet. The Mac must not connect directly to ports 8000, 8001, or 8004.
 
 Two properties shape most Seraph decisions:
 
@@ -163,25 +153,19 @@ design:
 curl -sS http://127.0.0.1:8004/health
 curl -sS http://127.0.0.1:8004/api/runtime/status
 curl -sS http://127.0.0.1:8004/api/settings/artifact-storage
-curl -sS http://192.168.1.26:8001/health
-curl -sS http://192.168.1.26:8001/health/backend
-curl -sS http://192.168.1.26:8001/queue/status
+curl -sS http://127.0.0.1:8001/health
+curl -sS http://127.0.0.1:8001/health/backend
+curl -sS http://127.0.0.1:8001/queue/status
 ```
 
 If sandboxed localhost checks fail but the app is supposed to be running on the
 host, rerun the same probe with the proper approval instead of assuming the
 service is down.
 
-If approved Codex/Desktop probes still fail against the GPU LAN address while
-the operator shell succeeds, ask for or use an operator-shell receipt from the
-same environment that launches Seraph. Do not count a local SSH forward as the
-product proof; use it only to inspect GPU-side state.
-
-For GPU-server inventory from Codex, `ssh jupyter` is acceptable only as the GPU
-administration route. Use it to inspect
-`/home/pawel/repos/vlm-screenshot-server`, Docker Compose, running model
-processes, listeners, logs, and firewall state. Keep any output clearly labeled
-as admin evidence, not direct Seraph runtime acceptance.
+Inspect the local GPU host directly with Docker, process, listener, filesystem,
+and log commands. Do not use an SSH forward or `ssh jupyter` as product proof.
+LAN acceptance is the authenticated HTTPS origin plus negative proof that the
+Mac cannot reach internal ports 8000, 8001, or 8004.
 
 ## Footprint Ladder For New Capability
 
@@ -438,6 +422,9 @@ relevant docs.
 - Reuse the operator's existing scoped approvals for routine `gh issue`,
   `gh pr`, `gh project`, `gh api`, and related Git operations. Do not request
   repeated approval for operations already covered by those scopes.
+- Treat `gh issue comment` and `gh pr comment` as routine operations covered by
+  the existing `gh issue` and `gh pr` approvals. Do not ask the operator for a
+  new approval merely because a comment is multiline or contains Markdown.
 - For issue comments, PR bodies, and other multiline GitHub text, write the
   content to a workspace or `/tmp` file with `apply_patch`, then pass it with
   `--body-file`. Avoid shell-expanded inline bodies such as `$'...'`, command

--- a/README.md
+++ b/README.md
@@ -60,17 +60,22 @@ agent to operate. See the constitution's five
 
 ## Current Development Topology
 
-The currently shipped development path is transitional but supported:
+The current workspace is on GPU host `jupyter` (`192.168.1.26`):
 
 ```text
-Seraph frontend       http://127.0.0.1:3001
-  -> Seraph backend   http://127.0.0.1:8004
-  -> GPU VLM wrapper  http://192.168.1.26:8001
-  -> GPU model server http://192.168.1.26:8000/v1
+GPU host jupyter
+  Seraph frontend/backend + canonical data
+    -> private VLM wrapper
+    -> private GPU model server
+Mac paired edge target (#749)
+  screenshot capture -> future authenticated Seraph upload API
 ```
 
-Runtime traffic uses HTTP APIs. `ssh jupyter` is only an administrator route for
-GPU inventory and maintenance; it is not a Seraph runtime requirement or tunnel.
+The Mac must not call internal ports 8000, 8001, or 8004. Its screenshot push
+is planned in #749; no screenshot upload API is currently shipped.
+
+Runtime traffic uses private HTTP/service routes. This workspace is already on
+`jupyter`, so administration is direct and does not use `ssh jupyter`.
 
 ## Quick Start
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,7 @@
 # Use a Python image with uv pre-installed
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+ARG SERAPH_BUILD_REVISION
+LABEL org.opencontainers.image.revision=$SERAPH_BUILD_REVISION
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 RUN apt update
@@ -14,7 +16,7 @@ RUN apt install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the project into the image
-ADD . /app
+COPY . /app
 
 # Sync the project into a new environment, using the frozen lockfile
 WORKDIR /app
@@ -23,4 +25,8 @@ RUN uv sync --frozen
 # Install Playwright Chromium browser
 RUN uv run playwright install chromium
 
-CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8003", "--reload"]
+RUN chmod 0755 /app/docker-entrypoint.sh
+
+EXPOSE 8004
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["uv", "run", "uvicorn", "src.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8004", "--workers", "1", "--no-server-header"]

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -46,6 +46,21 @@ class Settings(BaseSettings):
     database_echo: bool = False
     workspace_dir: str = "/app/data"
 
+    # Single-operator LAN authentication. Authentication is activated when a
+    # credential is configured (and is mandatory in production).
+    deployment_environment: str = "development"
+    operator_auth_secret: str = ""
+    operator_auth_secret_hash: str = ""
+    operator_auth_cookie_name: str = "seraph_operator_session"
+    operator_auth_cookie_secure: bool = False
+    operator_auth_idle_seconds: int = 3600
+    operator_auth_absolute_seconds: int = 86400
+    operator_auth_allowed_hosts: str = "localhost,127.0.0.1,test"
+    operator_auth_allowed_origins: str = "http://localhost:3001,http://127.0.0.1:3001"
+    operator_auth_trusted_proxy_ips: str = ""
+    operator_auth_allow_unauthenticated_tests: bool = False
+    operator_auth_backend_workers: int = 1
+
     # Phase 1 — Soul & Memory
     soul_file: str = "soul.md"
     embedding_model: str = "all-MiniLM-L6-v2"

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+load_secret() {
+    variable="$1"
+    file_variable="${variable}_FILE"
+    eval "file_path=\${$file_variable:-}"
+    eval "current_value=\${$variable:-}"
+    if [ -n "$file_path" ]; then
+        [ -r "$file_path" ] || { echo "required secret file for $variable is unreadable" >&2; exit 78; }
+        current_value=$(sed -e 's/[[:space:]]*$//' "$file_path")
+        export "$variable=$current_value"
+    fi
+    unset "$file_variable"
+}
+
+load_secret OPERATOR_AUTH_SECRET
+load_secret OPERATOR_AUTH_SECRET_HASH
+load_secret LOCAL_LLM_API_KEY
+load_secret SERAPH_VLM_API_KEY
+
+credential_count=0
+[ -n "${OPERATOR_AUTH_SECRET:-}" ] && credential_count=$((credential_count + 1))
+[ -n "${OPERATOR_AUTH_SECRET_HASH:-}" ] && credential_count=$((credential_count + 1))
+if [ "$credential_count" -ne 1 ]; then
+    echo "production requires exactly one raw or hashed operator credential" >&2
+    exit 78
+fi
+
+exec "$@"

--- a/backend/production_preflight.py
+++ b/backend/production_preflight.py
@@ -1,0 +1,24 @@
+"""Bounded backend-container probe for private GPU model and VLM routes."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+
+def probe(name: str, url: str, key: str = "") -> None:
+    headers = {"Authorization": f"Bearer {key}"} if key else {}
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=5) as response:  # noqa: S310 - configured private route
+        if not 200 <= response.status < 300:
+            raise RuntimeError(f"{name} returned HTTP {response.status}")
+        response.read(4096)
+    print(json.dumps({"route": name, "status": "reachable"}))
+
+
+model_base = os.environ["LOCAL_LLM_API_BASE"].rstrip("/")
+vlm_base = os.environ["SERAPH_VLM_BASE_URL"].rstrip("/")
+probe("gpu_model", f"{model_base}/models", os.getenv("LOCAL_LLM_API_KEY", ""))
+probe("vlm_wrapper", f"{vlm_base}/health", os.getenv("SERAPH_VLM_API_KEY", ""))
+probe("vlm_backend", f"{vlm_base}/health/backend", os.getenv("SERAPH_VLM_API_KEY", ""))

--- a/backend/src/agent/specialists.py
+++ b/backend/src/agent/specialists.py
@@ -345,9 +345,11 @@ def build_all_specialists() -> list[ToolCallingAgent]:
         skill.name
         for skill in skill_manager.get_active_skills([tool.name for tool in executable_tools])
     ]
-    workflow_tools = workflow_manager.build_workflow_tools(
-        executable_tools,
-        active_skill_names,
+    workflow_tools = wrap_tools_for_audit(
+        workflow_manager.build_workflow_tools(
+            executable_tools,
+            active_skill_names,
+        )
     )
     forced_approval_workflows: list = []
     normal_workflows: list = []

--- a/backend/src/api/auth.py
+++ b/backend/src/api/auth.py
@@ -1,0 +1,105 @@
+from fastapi import APIRouter, HTTPException, Request, Response
+from collections import OrderedDict
+import ipaddress
+import time
+from pydantic import BaseModel
+
+from config.settings import settings
+from src.auth.service import AuthFailure, auth_enabled, create_session, revoke_session, verify_secret
+
+router = APIRouter()
+
+_LOGIN_ATTEMPTS: OrderedDict[str, list[float]] = OrderedDict()
+_LOGIN_WINDOW_SECONDS = 60.0
+_LOGIN_LIMIT = 5
+_LOGIN_BUCKET_LIMIT = 1024
+
+
+def _reset_login_throttle_for_tests() -> None:
+    _LOGIN_ATTEMPTS.clear()
+
+
+def _trusted_proxy_ips() -> set[str]:
+    return {value.strip() for value in settings.operator_auth_trusted_proxy_ips.split(",") if value.strip()}
+
+
+def _login_source(request: Request) -> str:
+    peer = request.client.host if request.client else "unknown"
+    forwarded = request.headers.get("x-forwarded-for", "")
+    if forwarded and peer in _trusted_proxy_ips():
+        candidate = forwarded.split(",", 1)[0].strip()
+        try:
+            return str(ipaddress.ip_address(candidate))
+        except ValueError:
+            return peer
+    return peer
+
+
+def _consume_login_attempt(source: str) -> None:
+    now = time.monotonic()
+    attempts = [
+        value for value in _LOGIN_ATTEMPTS.pop(source, [])
+        if now - value < _LOGIN_WINDOW_SECONDS
+    ]
+    if len(attempts) >= _LOGIN_LIMIT:
+        _LOGIN_ATTEMPTS[source] = attempts
+        raise HTTPException(status_code=429, detail={"code": "login_rate_limited"})
+    attempts.append(now)
+    _LOGIN_ATTEMPTS[source] = attempts
+    while len(_LOGIN_ATTEMPTS) > _LOGIN_BUCKET_LIMIT:
+        _LOGIN_ATTEMPTS.popitem(last=False)
+
+
+def _require_configured() -> None:
+    if not auth_enabled():
+        raise HTTPException(status_code=503, detail={"code": "auth_not_configured"})
+
+
+class LoginRequest(BaseModel):
+    password: str
+
+
+def _set_cookie(response: Response, token: str) -> None:
+    response.set_cookie(
+        settings.operator_auth_cookie_name,
+        token,
+        httponly=True,
+        secure=settings.operator_auth_cookie_secure,
+        samesite="strict",
+        path="/",
+        max_age=settings.operator_auth_absolute_seconds,
+    )
+
+
+@router.post("/login")
+async def login(payload: LoginRequest, response: Response, request: Request):
+    _require_configured()
+    _consume_login_attempt(_login_source(request))
+    if not await verify_secret(payload.password):
+        raise HTTPException(status_code=401, detail={"code": "invalid_credentials"})
+    token, operator = await create_session()
+    _set_cookie(response, token)
+    return {"authenticated": True, "principal_id": operator.principal.principal_id, "idle_expires_at": operator.idle_expires_at, "absolute_expires_at": operator.absolute_expires_at}
+
+
+@router.get("/session")
+async def session(request: Request):
+    _require_configured()
+    operator = request.state.operator
+    return {"authenticated": True, "principal_id": operator.principal.principal_id, "idle_expires_at": operator.idle_expires_at, "absolute_expires_at": operator.absolute_expires_at}
+
+
+@router.post("/refresh")
+async def refresh(request: Request, response: Response):
+    _require_configured()
+    operator = request.state.operator
+    token, replacement = await create_session(replace_session_id=operator.session_id)
+    _set_cookie(response, token)
+    return {"authenticated": True, "principal_id": replacement.principal.principal_id, "idle_expires_at": replacement.idle_expires_at, "absolute_expires_at": replacement.absolute_expires_at}
+
+
+@router.post("/logout", status_code=204)
+async def logout(request: Request, response: Response):
+    _require_configured()
+    await revoke_session(request.state.operator.session_id)
+    response.delete_cookie(settings.operator_auth_cookie_name, path="/", secure=settings.operator_auth_cookie_secure, httponly=True, samesite="strict")

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextvars
 import json
 import logging

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -3,7 +3,7 @@ import json
 import logging
 from time import perf_counter
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 
 from src.approval.exceptions import ApprovalRequired
 from src.approval.repository import approval_repository
@@ -30,6 +30,7 @@ from src.llm_runtime import (
     reset_current_llm_request_id,
     set_current_llm_request_id,
 )
+from src.auth.service import bind_operator_principal
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ router = APIRouter()
 
 
 @router.post("/chat", response_model=ChatResponse)
-async def chat(request: ChatRequest):
+async def chat(request: ChatRequest, http_request: Request):
     """Send a message and receive an AI response."""
     session = await session_manager.get_or_create(request.session_id)
     await session_manager.add_message(session.id, "user", request.message)
@@ -79,16 +80,25 @@ async def chat(request: ChatRequest):
         llm_request_id = f"direct-rest:{session.id}:{started_at}"
         _register_request(llm_request_id)
         try:
-            response_text = await asyncio.wait_for(
-                run_direct_local_chat(
-                    request.message,
-                    runtime_path=direct_runtime_path,
-                    is_onboarding=is_onboarding,
-                    session_id=session.id,
-                    request_id=llm_request_id,
-                ),
-                timeout=min(settings.agent_chat_timeout, 60),
+            operator = getattr(http_request.state, "operator", None)
+            auth_tokens = set_runtime_context(
+                session.id,
+                "high_risk",
+                trust_principal=bind_operator_principal(operator, session.id) if operator else None,
             )
+            try:
+                response_text = await asyncio.wait_for(
+                    run_direct_local_chat(
+                        request.message,
+                        runtime_path=direct_runtime_path,
+                        is_onboarding=is_onboarding,
+                        session_id=session.id,
+                        request_id=llm_request_id,
+                    ),
+                    timeout=min(settings.agent_chat_timeout, 60),
+                )
+            finally:
+                reset_runtime_context(auth_tokens)
             response_text = await redact_secrets_in_text(response_text)
         except asyncio.TimeoutError:
             _mark_request_timed_out(llm_request_id)
@@ -169,7 +179,12 @@ async def chat(request: ChatRequest):
         started_at = perf_counter()
         llm_request_id = f"agent-rest:{session.id}:{started_at}"
         _register_request(llm_request_id)
-        tokens = set_runtime_context(session.id, obs_manager.get_context().approval_mode)
+        operator = getattr(http_request.state, "operator", None)
+        tokens = set_runtime_context(
+            session.id,
+            obs_manager.get_context().approval_mode,
+            trust_principal=bind_operator_principal(operator, session.id) if operator else None,
+        )
         llm_request_token = set_current_llm_request_id(llm_request_id)
         run_ctx = contextvars.copy_context()
         reset_runtime_context(tokens)

--- a/backend/src/api/router.py
+++ b/backend/src/api/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from src.api.activity import router as activity_router
+from src.api.auth import router as auth_router
 from src.api.audit import router as audit_router
 from src.api.approvals import router as approvals_router
 from src.api.automation import router as automation_router
@@ -28,6 +29,8 @@ from src.api.workflows import router as workflows_router
 from src.api.ws import router as ws_router
 
 api_router = APIRouter()
+
+api_router.include_router(auth_router, prefix="/api/auth", tags=["auth"])
 
 api_router.include_router(activity_router, prefix="/api", tags=["activity"])
 api_router.include_router(audit_router, prefix="/api", tags=["audit"])

--- a/backend/src/api/ws.py
+++ b/backend/src/api/ws.py
@@ -3,6 +3,7 @@ import contextvars
 import json
 import logging
 from contextlib import suppress
+from threading import Event
 from time import perf_counter
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -35,6 +36,9 @@ from src.llm_runtime import (
     reset_current_llm_request_id,
     set_current_llm_request_id,
 )
+from src.auth.middleware import validate_request_boundary
+from src.auth.service import AuthFailure, auth_enabled, authenticate_token, bind_operator_principal
+from src.auth.cancellation import reset_revocation_guard, set_revocation_guard
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +104,52 @@ async def _build_agent(session_id: str, message: str):
 @router.websocket("/chat")
 async def websocket_chat(websocket: WebSocket):
     """WebSocket endpoint for streaming chat responses."""
+    operator = None
+    if not auth_enabled() and not (
+        settings.operator_auth_allow_unauthenticated_tests
+        and settings.deployment_environment == "test"
+    ):
+        await websocket.close(code=4401, reason="auth_not_configured")
+        return
+    if auth_enabled():
+        boundary_error = validate_request_boundary(
+            host=websocket.headers.get("host", ""),
+            origin=websocket.headers.get("origin"),
+            method="POST",
+        )
+        if boundary_error:
+            await websocket.close(code=4403, reason=boundary_error)
+            return
+        try:
+            operator = await authenticate_token(websocket.cookies.get(settings.operator_auth_cookie_name))
+        except AuthFailure as exc:
+            await websocket.close(code=4401, reason=exc.code)
+            return
     await websocket.accept()
+    auth_revoked = asyncio.Event()
+    thread_revocation_guard = Event()
+    revocation_token = set_revocation_guard(thread_revocation_guard)
+    connection_task = asyncio.current_task()
+
+    async def _auth_watchdog() -> None:
+        if not auth_enabled():
+            return
+        while True:
+            await asyncio.sleep(0.25)
+            try:
+                await authenticate_token(
+                    websocket.cookies.get(settings.operator_auth_cookie_name), touch=False
+                )
+            except AuthFailure as exc:
+                thread_revocation_guard.set()
+                auth_revoked.set()
+                with suppress(Exception):
+                    await websocket.close(code=4401, reason=exc.code)
+                if connection_task is not None:
+                    connection_task.cancel()
+                return
+
+    auth_watchdog = asyncio.create_task(_auth_watchdog())
     ws_manager.connect(websocket)
     _seq = 0
     active_turn_session_id: str | None = None
@@ -143,6 +192,12 @@ async def websocket_chat(websocket: WebSocket):
     try:
         while True:
             raw = await websocket.receive_text()
+            if auth_enabled():
+                try:
+                    operator = await authenticate_token(websocket.cookies.get(settings.operator_auth_cookie_name))
+                except AuthFailure as exc:
+                    await websocket.close(code=4401, reason=exc.code)
+                    return
             try:
                 data = json.loads(raw)
                 ws_msg = WSMessage(**data)
@@ -245,6 +300,11 @@ async def websocket_chat(websocket: WebSocket):
                     continue
                 llm_request_id = f"direct-ws:{session.id}:{started_at}"
                 _register_request(llm_request_id)
+                direct_tokens = set_runtime_context(
+                    session.id,
+                    "high_risk",
+                    trust_principal=bind_operator_principal(operator, session.id) if operator else None,
+                )
                 try:
                     await websocket.send_text(
                         WSResponse(
@@ -265,6 +325,8 @@ async def websocket_chat(websocket: WebSocket):
                             is_onboarding=direct_is_onboarding,
                             session_id=session.id,
                         ):
+                            if auth_revoked.is_set():
+                                raise AuthFailure("session_revoked")
                             streamed_parts.append(delta)
                             safe_delta, emitted_safe_chars = await redact_secrets_for_streaming_snapshot(
                                 "".join(streamed_parts),
@@ -301,6 +363,8 @@ async def websocket_chat(websocket: WebSocket):
                         final_result = ""
 
                     if not final_result:
+                        if auth_revoked.is_set():
+                            raise AuthFailure("session_revoked")
                         final_result = await run_direct_local_chat(
                             ws_msg.message,
                             runtime_path=direct_runtime_path,
@@ -309,6 +373,8 @@ async def websocket_chat(websocket: WebSocket):
                             request_id=llm_request_id,
                         )
                     final_result = await redact_secrets_in_text(final_result, fail_closed=True)
+                except AuthFailure:
+                    return
                 except asyncio.TimeoutError:
                     _mark_request_timed_out(llm_request_id)
                     await log_agent_run_event(
@@ -363,9 +429,12 @@ async def websocket_chat(websocket: WebSocket):
                     )
                     continue
                 finally:
+                    reset_runtime_context(direct_tokens)
                     _finish_request(llm_request_id)
 
                 await session_manager.add_message(session.id, "assistant", final_result)
+                if auth_revoked.is_set():
+                    return
                 active_turn_completed = True
                 await log_agent_run_event(
                     session_id=session.id,
@@ -420,7 +489,11 @@ async def websocket_chat(websocket: WebSocket):
                 loop = asyncio.get_running_loop()
                 llm_request_id = f"agent-ws:{session.id}:{started_at}"
                 _register_request(llm_request_id)
-                tokens = set_runtime_context(session.id, context_manager.get_context().approval_mode)
+                tokens = set_runtime_context(
+                    session.id,
+                    context_manager.get_context().approval_mode,
+                    trust_principal=bind_operator_principal(operator, session.id) if operator else None,
+                )
                 llm_request_token = set_current_llm_request_id(llm_request_id)
                 run_ctx = contextvars.copy_context()
                 reset_runtime_context(tokens)
@@ -433,6 +506,8 @@ async def websocket_chat(websocket: WebSocket):
                         step = await queue.get()
                         if step is _DONE:
                             break
+                        if auth_revoked.is_set():
+                            raise AuthFailure("session_revoked")
                         if isinstance(step, Exception):
                             raise step
 
@@ -482,6 +557,8 @@ async def websocket_chat(websocket: WebSocket):
                             await drain_task
                     raise
 
+            except AuthFailure:
+                return
             except asyncio.TimeoutError:
                 logger.warning("Agent timed out after %ds for session %s", settings.agent_chat_timeout, session.id)
                 run_outcome = "timed_out"
@@ -605,6 +682,8 @@ async def websocket_chat(websocket: WebSocket):
                 if "llm_request_id" in locals():
                     _finish_request(llm_request_id)
 
+            if auth_revoked.is_set():
+                return
             await session_manager.add_message(session.id, "assistant", final_result)
             active_turn_completed = True
             if run_outcome == "succeeded":
@@ -662,3 +741,9 @@ async def websocket_chat(websocket: WebSocket):
             logger.info("WebSocket client disconnected before next receive")
             return
         raise
+    finally:
+        thread_revocation_guard.set()
+        reset_revocation_guard(revocation_token)
+        auth_watchdog.cancel()
+        with suppress(asyncio.CancelledError):
+            await auth_watchdog

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -22,6 +22,8 @@ from src.starter_packs.manager import starter_pack_manager
 from src.tools.mcp_manager import mcp_manager
 from src.utils.background import drain_tracked_tasks
 from src.vlm_runtime import deferred_vlm_live_probe, effective_vlm_status
+from src.auth.middleware import OperatorAuthMiddleware
+from src.auth.service import validate_auth_configuration
 from src.workflows.manager import workflow_manager
 
 limiter = Limiter(key_func=get_remote_address, default_limits=["60/minute"])
@@ -193,6 +195,7 @@ def _effective_runtime_route_status(runtime: dict[str, str], vlm_status: dict[st
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    validate_auth_configuration()
     await init_db()
     ensure_soul_exists()
     init_llm_logging()
@@ -278,10 +281,18 @@ def create_app() -> FastAPI:
 
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_middleware(OperatorAuthMiddleware)
 
+    configured_origins = [
+        value.strip().rstrip("/")
+        for value in settings.operator_auth_allowed_origins.split(",")
+        if value.strip()
+    ]
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["http://localhost:3000", "http://localhost:5173"],
+        allow_origins=list(dict.fromkeys([
+            "http://localhost:3000", "http://localhost:5173", *configured_origins
+        ])),
         allow_origin_regex=_LOCAL_DEV_ORIGIN_REGEX,
         allow_credentials=True,
         allow_methods=["*"],

--- a/backend/src/auth/__init__.py
+++ b/backend/src/auth/__init__.py
@@ -1,0 +1,5 @@
+"""Single-operator authentication boundary."""
+
+from src.auth.service import AuthFailure, AuthenticatedOperator, auth_enabled
+
+__all__ = ["AuthFailure", "AuthenticatedOperator", "auth_enabled"]

--- a/backend/src/auth/cancellation.py
+++ b/backend/src/auth/cancellation.py
@@ -1,0 +1,23 @@
+from contextvars import ContextVar, Token
+from threading import Event
+
+
+class RuntimeRevokedError(PermissionError):
+    pass
+
+
+_guard: ContextVar[Event | None] = ContextVar("operator_revocation_guard", default=None)
+
+
+def set_revocation_guard(guard: Event) -> Token:
+    return _guard.set(guard)
+
+
+def reset_revocation_guard(token: Token) -> None:
+    _guard.reset(token)
+
+
+def assert_runtime_not_revoked() -> None:
+    guard = _guard.get()
+    if guard is not None and guard.is_set():
+        raise RuntimeRevokedError("authenticated operator session was revoked")

--- a/backend/src/auth/middleware.py
+++ b/backend/src/auth/middleware.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from config.settings import settings
+from src.auth.service import AuthFailure, auth_enabled, authenticate_token
+
+
+_SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
+_PUBLIC_PATHS = {"/health", "/api/auth/login"}
+
+
+def _csv(value: str) -> set[str]:
+    return {item.strip().rstrip("/") for item in value.split(",") if item.strip()}
+
+
+def validate_request_boundary(*, host: str, origin: str | None, method: str) -> str | None:
+    allowed_hosts = {item.lower() for item in _csv(settings.operator_auth_allowed_hosts)}
+    if host.strip().lower() not in allowed_hosts:
+        return "origin_forbidden"
+    if method.upper() not in _SAFE_METHODS:
+        if not origin:
+            return "mutation_origin_required"
+        if origin.rstrip("/") not in _csv(settings.operator_auth_allowed_origins):
+            return "origin_forbidden"
+    return None
+
+
+class OperatorAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if not auth_enabled():
+            if (
+                settings.operator_auth_allow_unauthenticated_tests
+                and settings.deployment_environment == "test"
+            ):
+                return await call_next(request)
+            if request.url.path.startswith("/api"):
+                return JSONResponse({"detail": {"code": "auth_not_configured"}}, status_code=503)
+            return await call_next(request)
+        boundary_error = validate_request_boundary(
+            host=request.headers.get("host", ""),
+            origin=request.headers.get("origin"),
+            method=request.method,
+        )
+        if boundary_error:
+            return JSONResponse({"detail": {"code": boundary_error}}, status_code=403)
+        if request.url.path in _PUBLIC_PATHS or not request.url.path.startswith("/api"):
+            return await call_next(request)
+        try:
+            operator = await authenticate_token(request.cookies.get(settings.operator_auth_cookie_name))
+        except AuthFailure as exc:
+            return JSONResponse({"detail": {"code": exc.code}}, status_code=401)
+        request.state.operator = operator
+        return await call_next(request)

--- a/backend/src/auth/service.py
+++ b/backend/src/auth/service.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import base64
+import hashlib
+import hmac
+import secrets
+import asyncio
+from collections import deque
+
+from sqlalchemy import select, update
+
+from config.settings import settings
+from src.db.engine import get_session
+from src.db.models import OperatorSession
+from src.security.trust_contract import AuthorityGrant, PrincipalType, TrustPrincipal
+
+
+class AuthFailure(Exception):
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class AuthenticatedOperator:
+    session_id: str
+    principal: TrustPrincipal
+    idle_expires_at: datetime
+    absolute_expires_at: datetime
+
+
+def auth_enabled() -> bool:
+    return bool(settings.operator_auth_secret or settings.operator_auth_secret_hash)
+
+
+def require_auth_configured() -> None:
+    if not auth_enabled():
+        raise AuthFailure("auth_not_configured")
+
+
+def validate_auth_configuration() -> None:
+    production = settings.deployment_environment.strip().lower() in {"prod", "production"}
+    if production and not auth_enabled():
+        raise RuntimeError("operator authentication credential is required in production")
+    if production and not settings.operator_auth_cookie_secure:
+        raise RuntimeError("secure operator authentication cookies are required in production")
+    if settings.operator_auth_allow_unauthenticated_tests and settings.deployment_environment != "test":
+        raise RuntimeError("unauthenticated auth bypass is permitted only in the test environment")
+    if production and settings.operator_auth_backend_workers != 1:
+        raise RuntimeError("in-process login throttling requires exactly one production backend worker")
+    if settings.operator_auth_secret and settings.operator_auth_secret_hash:
+        raise RuntimeError("configure only one operator authentication credential")
+    if auth_enabled() and (
+        settings.operator_auth_idle_seconds <= 0
+        or settings.operator_auth_absolute_seconds <= 0
+        or settings.operator_auth_idle_seconds > settings.operator_auth_absolute_seconds
+    ):
+        raise RuntimeError("operator authentication expiry configuration is invalid")
+
+
+def _pbkdf2(value: str, salt: bytes, iterations: int = 600_000) -> bytes:
+    return hashlib.pbkdf2_hmac("sha256", value.encode(), salt, iterations)
+
+
+def encode_secret(value: str) -> str:
+    salt = secrets.token_bytes(16)
+    return f"pbkdf2_sha256$600000${base64.urlsafe_b64encode(salt).decode()}${base64.urlsafe_b64encode(_pbkdf2(value, salt)).decode()}"
+
+
+def _verify_secret_sync(value: str) -> bool:
+    if settings.operator_auth_secret:
+        return hmac.compare_digest(value, settings.operator_auth_secret)
+    encoded = settings.operator_auth_secret_hash
+    try:
+        algorithm, rounds, salt_text, digest_text = encoded.split("$", 3)
+        if algorithm != "pbkdf2_sha256" or int(rounds) != 600_000:
+            return False
+        salt = base64.urlsafe_b64decode(salt_text)
+        expected = base64.urlsafe_b64decode(digest_text)
+    except (ValueError, TypeError):
+        return False
+    return hmac.compare_digest(_pbkdf2(value, salt), expected)
+
+
+_VERIFY_LIMIT = asyncio.Semaphore(2)
+
+
+async def verify_secret(value: str) -> bool:
+    require_auth_configured()
+    async with _VERIFY_LIMIT:
+        return await asyncio.to_thread(_verify_secret_sync, value)
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _aware(value: datetime) -> datetime:
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+def _principal(session_id: str) -> TrustPrincipal:
+    return TrustPrincipal(
+        principal_id="operator:single",
+        principal_type=PrincipalType.OPERATOR,
+        authenticated=True,
+        grants=(
+            AuthorityGrant.INGRESS,
+            AuthorityGrant.MODEL_INFERENCE,
+            AuthorityGrant.CAPABILITY_EXECUTE,
+            AuthorityGrant.ARTIFACT_TRANSFER,
+        ),
+        session_id=session_id,
+    )
+
+
+def bind_operator_principal(operator: AuthenticatedOperator, conversation_id: str) -> TrustPrincipal:
+    """Bind authenticated operator authority to one conversation execution scope."""
+    return TrustPrincipal(
+        principal_id=operator.principal.principal_id,
+        principal_type=operator.principal.principal_type,
+        authenticated=True,
+        grants=operator.principal.grants,
+        session_id=conversation_id,
+    )
+
+
+async def create_session(*, replace_session_id: str | None = None) -> tuple[str, AuthenticatedOperator]:
+    require_auth_configured()
+    now = datetime.now(timezone.utc)
+    token = secrets.token_urlsafe(32)
+    async with get_session() as db:
+        absolute_expires_at = now + timedelta(seconds=settings.operator_auth_absolute_seconds)
+        if replace_session_id:
+            old = await db.get(OperatorSession, replace_session_id)
+            if old is None or old.revoked_at is not None:
+                raise AuthFailure("session_revoked")
+            absolute_expires_at = _aware(old.absolute_expires_at)
+            if now >= absolute_expires_at:
+                raise AuthFailure("session_expired")
+        record = OperatorSession(
+            token_hash=_token_hash(token),
+            idle_expires_at=min(
+                now + timedelta(seconds=settings.operator_auth_idle_seconds), absolute_expires_at
+            ),
+            absolute_expires_at=absolute_expires_at,
+        )
+        if replace_session_id:
+            claimed = await db.execute(
+                update(OperatorSession)
+                .where(OperatorSession.id == replace_session_id, OperatorSession.revoked_at.is_(None))
+                .values(revoked_at=now, replaced_by_id=record.id)
+            )
+            if claimed.rowcount != 1:
+                raise AuthFailure("session_revoked")
+        db.add(record)
+    return token, AuthenticatedOperator(
+        record.id, _principal(record.id), record.idle_expires_at, record.absolute_expires_at
+    )
+
+
+async def authenticate_token(token: str | None, *, touch: bool = True) -> AuthenticatedOperator:
+    if not token:
+        raise AuthFailure("authentication_required")
+    now = datetime.now(timezone.utc)
+    async with get_session() as db:
+        result = await db.execute(select(OperatorSession).where(OperatorSession.token_hash == _token_hash(token)))
+        record = result.scalar_one_or_none()
+        if record is None:
+            raise AuthFailure("authentication_required")
+        if record.revoked_at is not None:
+            raise AuthFailure("session_revoked")
+        idle_expires_at = _aware(record.idle_expires_at)
+        absolute_expires_at = _aware(record.absolute_expires_at)
+        if now >= idle_expires_at or now >= absolute_expires_at:
+            record.revoked_at = now
+            db.add(record)
+            raise AuthFailure("session_expired")
+        if touch:
+            record.last_seen_at = now
+            record.idle_expires_at = min(
+                now + timedelta(seconds=settings.operator_auth_idle_seconds), absolute_expires_at
+            )
+            db.add(record)
+        return AuthenticatedOperator(
+            record.id, _principal(record.id), record.idle_expires_at, record.absolute_expires_at
+        )
+
+
+async def revoke_session(session_id: str) -> None:
+    async with get_session() as db:
+        record = await db.get(OperatorSession, session_id)
+        if record and record.revoked_at is None:
+            record.revoked_at = datetime.now(timezone.utc)
+            db.add(record)

--- a/backend/src/db/models.py
+++ b/backend/src/db/models.py
@@ -677,3 +677,18 @@ class ApprovalRequest(SQLModel, table=True):
     details_json: Optional[str] = Field(default=None)
     created_at: datetime = Field(default_factory=_now, index=True)
     resolved_at: Optional[datetime] = Field(default=None)
+
+
+class OperatorSession(SQLModel, table=True):
+    """Revocable single-operator browser session; raw bearer tokens never persist."""
+
+    __tablename__ = "operator_sessions"
+
+    id: str = Field(default_factory=_uuid, primary_key=True)
+    token_hash: str = Field(unique=True, index=True)
+    created_at: datetime = Field(default_factory=_now, index=True)
+    last_seen_at: datetime = Field(default_factory=_now, index=True)
+    idle_expires_at: datetime = Field(index=True)
+    absolute_expires_at: datetime = Field(index=True)
+    revoked_at: Optional[datetime] = Field(default=None, index=True)
+    replaced_by_id: Optional[str] = Field(default=None, index=True)

--- a/backend/src/tools/approval.py
+++ b/backend/src/tools/approval.py
@@ -37,6 +37,7 @@ from src.security.trust_contract import (
     evaluate_trust,
 )
 from src.tools.policy import get_tool_approval_behavior, get_tool_risk_level
+from src.auth.cancellation import assert_runtime_not_revoked
 
 
 def _run_async(coro):
@@ -173,6 +174,7 @@ class ApprovalTool(Tool):
         return self.wrapped_tool(*args, **kwargs)
 
     def __call__(self, *args, sanitize_inputs_outputs: bool = False, **kwargs):
+        assert_runtime_not_revoked()
         approval_mode = get_current_approval_mode()
         session_id = get_current_session_id()
         arguments = self._normalize_invocation(args, kwargs)

--- a/backend/src/tools/audit.py
+++ b/backend/src/tools/audit.py
@@ -13,6 +13,7 @@ from src.audit.formatting import format_tool_call_summary, redact_for_audit, sum
 from src.audit.repository import audit_repository
 from src.llm_runtime import get_current_llm_request_id
 from src.tools.policy import get_current_tool_policy_mode, get_tool_risk_level, get_tool_source_context
+from src.auth.cancellation import assert_runtime_not_revoked
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +130,7 @@ class AuditedTool(Tool):
         return None
 
     def __call__(self, *args, sanitize_inputs_outputs: bool = False, **kwargs):
+        assert_runtime_not_revoked()
         session_id = get_current_session_id()
         arguments = self._normalize_invocation(args, kwargs)
         audit_arguments = _custom_audit_arguments(self.wrapped_tool, arguments)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,6 +16,8 @@ from sqlmodel import SQLModel
 
 os.environ.setdefault("OPENROUTER_API_KEY", "test-key")
 os.environ.setdefault("WORKSPACE_DIR", "/tmp/seraph-test")
+os.environ.setdefault("DEPLOYMENT_ENVIRONMENT", "test")
+os.environ.setdefault("OPERATOR_AUTH_ALLOW_UNAUTHENTICATED_TESTS", "true")
 
 from config.settings import settings
 from src.app import create_app
@@ -29,6 +31,7 @@ from src.utils.background import drain_tracked_tasks
 # Every place get_session is imported — use the local attribute name.
 _PATCH_TARGETS = [
     "src.db.engine.get_session",
+    "src.auth.service.get_session",
     "src.agent.session.get_session",
     "src.approval.repository.get_session",
     "src.goals.repository.get_session",

--- a/backend/tests/test_auth_cancellation.py
+++ b/backend/tests/test_auth_cancellation.py
@@ -1,0 +1,63 @@
+from threading import Event
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.auth.cancellation import RuntimeRevokedError, reset_revocation_guard, set_revocation_guard
+from src.tools.audit import AuditedTool
+from src.tools.audit import wrap_tools_for_audit
+from src.tools.approval import wrap_tools_for_approval
+import inspect
+from src.agent import factory, specialists
+
+
+def test_revoked_executor_guard_blocks_wrapped_tool_before_side_effect():
+    wrapped = MagicMock()
+    wrapped.name = "mutating_tool"
+    wrapped.description = "mutation sentinel"
+    wrapped.inputs = {}
+    wrapped.output_type = "string"
+    tool = AuditedTool(wrapped)
+    guard = Event()
+    token = set_revocation_guard(guard)
+    guard.set()
+    try:
+        with pytest.raises(RuntimeRevokedError):
+            tool()
+    finally:
+        reset_revocation_guard(token)
+    wrapped.assert_not_called()
+
+
+def test_low_risk_specialist_workflow_is_audited_and_cancellation_aware():
+    raw = MagicMock()
+    raw.name = "workflow_low_risk_sentinel"
+    raw.description = "low risk workflow"
+    raw.inputs = {}
+    raw.output_type = "string"
+    assembled = wrap_tools_for_approval(
+        wrap_tools_for_audit([raw]),
+        risk_overrides={raw.name: "low"},
+    )
+    assert len(assembled) == 1
+    assert isinstance(assembled[0], AuditedTool)
+
+    guard = Event()
+    token = set_revocation_guard(guard)
+    guard.set()
+    try:
+        with pytest.raises(RuntimeRevokedError):
+            assembled[0]()
+    finally:
+        reset_revocation_guard(token)
+    raw.assert_not_called()
+
+
+def test_normal_and_specialist_workflow_assembly_audits_before_approval():
+    normal_source = inspect.getsource(factory._append_workflow_tools)
+    specialist_source = inspect.getsource(specialists.build_all_specialists)
+    assert "wrap_tools_for_audit" in normal_source
+    assert "wrap_tools_for_audit" in specialist_source
+    assert specialist_source.index("workflow_tools = wrap_tools_for_audit") < specialist_source.index(
+        "workflow_tools = wrap_tools_for_approval"
+    )

--- a/backend/tests/test_operator_auth.py
+++ b/backend/tests/test_operator_auth.py
@@ -1,0 +1,234 @@
+from datetime import datetime, timedelta, timezone
+import asyncio
+
+import pytest
+from fastapi import HTTPException, Response
+from starlette.requests import Request
+from sqlalchemy import select
+
+from config.settings import settings
+from src.auth.middleware import validate_request_boundary
+from src.auth.middleware import OperatorAuthMiddleware
+from src.api.ws import websocket_chat
+from src.auth.service import AuthFailure, authenticate_token, bind_operator_principal, create_session
+from src.api.auth import _reset_login_throttle_for_tests, _login_source
+from src.api.auth import LoginRequest, login
+
+
+def _request(peer: str = "127.0.0.1", headers: list[tuple[bytes, bytes]] | None = None) -> Request:
+    return Request({"type": "http", "method": "POST", "path": "/api/auth/login", "headers": headers or [], "client": (peer, 1234), "server": ("test", 80), "scheme": "http"})
+
+
+def _path_request(path: str, method: str = "GET") -> Request:
+    return Request({"type": "http", "method": method, "path": path, "query_string": b"", "headers": [(b"host", b"test")], "client": ("127.0.0.1", 1234), "server": ("test", 80), "scheme": "http"})
+from src.db.models import OperatorSession
+from src.security.trust_contract import AuthorityGrant, PrincipalType
+
+
+ORIGIN = "http://localhost:3001"
+
+
+@pytest.fixture(autouse=True)
+def configured_auth(monkeypatch):
+    _reset_login_throttle_for_tests()
+    monkeypatch.setattr(settings, "operator_auth_secret", "correct horse battery staple")
+    monkeypatch.setattr(settings, "operator_auth_secret_hash", "")
+    monkeypatch.setattr(settings, "operator_auth_allowed_hosts", "test,localhost,127.0.0.1")
+    monkeypatch.setattr(settings, "operator_auth_allowed_origins", ORIGIN)
+    monkeypatch.setattr(settings, "operator_auth_idle_seconds", 300)
+    monkeypatch.setattr(settings, "operator_auth_absolute_seconds", 3600)
+    monkeypatch.setattr(settings, "operator_auth_cookie_secure", False)
+    yield
+    _reset_login_throttle_for_tests()
+
+
+async def _login(client):
+    response = await client.post(
+        "/api/auth/login",
+        json={"password": "correct horse battery staple"},
+        headers={"origin": ORIGIN},
+    )
+    assert response.status_code == 200
+    token = response.cookies.get(settings.operator_auth_cookie_name)
+    assert token
+    client.cookies.set(settings.operator_auth_cookie_name, token)
+    return response, token
+
+
+@pytest.mark.asyncio
+async def test_login_cookie_session_refresh_rotation_and_logout(client):
+    login, old_token = await _login(client)
+    original_absolute_expiry = login.json()["absolute_expires_at"]
+    cookie = login.headers["set-cookie"]
+    assert "HttpOnly" in cookie
+    assert "Secure" not in cookie
+    assert "SameSite=strict" in cookie
+    assert "Path=/" in cookie
+
+    session = await client.get("/api/auth/session")
+    assert session.status_code == 200
+    assert session.json()["principal_id"] == "operator:single"
+
+    refreshed = await client.post("/api/auth/refresh", headers={"origin": ORIGIN})
+    assert refreshed.status_code == 200
+    new_token = refreshed.cookies.get(settings.operator_auth_cookie_name)
+    assert new_token and new_token != old_token
+    assert refreshed.json()["principal_id"] == "operator:single"
+    assert refreshed.json()["absolute_expires_at"] == original_absolute_expiry
+
+    with pytest.raises(AuthFailure, match="session_revoked"):
+        await authenticate_token(old_token)
+
+    client.cookies.set(settings.operator_auth_cookie_name, new_token)
+    logout = await client.post("/api/auth/logout", headers={"origin": ORIGIN})
+    assert logout.status_code == 204
+    with pytest.raises(AuthFailure, match="session_revoked"):
+        await authenticate_token(new_token)
+
+
+@pytest.mark.asyncio
+async def test_api_denies_anonymous_foreign_host_origin_and_missing_mutation_origin(client):
+    anonymous = await client.get("/api/auth/session")
+    assert anonymous.status_code == 401
+    assert anonymous.json()["detail"]["code"] == "authentication_required"
+
+    foreign_host = await client.get("/api/auth/session", headers={"host": "evil.example"})
+    assert foreign_host.status_code == 403
+    assert foreign_host.json()["detail"]["code"] == "origin_forbidden"
+
+    missing_origin = await client.post("/api/auth/login", json={"password": "x"})
+    assert missing_origin.status_code == 403
+    assert missing_origin.json()["detail"]["code"] == "mutation_origin_required"
+
+    foreign_origin = await client.post(
+        "/api/auth/login",
+        json={"password": "x"},
+        headers={"origin": "http://evil.example"},
+    )
+    assert foreign_origin.status_code == 403
+    assert foreign_origin.json()["detail"]["code"] == "origin_forbidden"
+
+
+@pytest.mark.asyncio
+async def test_expired_session_is_rejected_and_raw_token_is_not_stored(client, async_db):
+    _, token = await _login(client)
+    async with async_db() as db:
+        result = await db.execute(select(OperatorSession))
+        record = result.scalar_one()
+        assert record.token_hash != token
+        assert len(record.token_hash) == 64
+        record.idle_expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        db.add(record)
+
+    with pytest.raises(AuthFailure, match="session_expired"):
+        await authenticate_token(token)
+
+
+@pytest.mark.asyncio
+async def test_server_mints_operator_principal_and_conversation_id_is_only_scope(client):
+    _, token = await _login(client)
+    operator = await authenticate_token(token)
+    principal = bind_operator_principal(operator, "attacker-chosen-conversation")
+    assert principal.principal_type is PrincipalType.OPERATOR
+    assert principal.principal_id == "operator:single"
+    assert principal.session_id == "attacker-chosen-conversation"
+    assert AuthorityGrant.MODEL_INFERENCE in principal.grants
+    assert AuthorityGrant.EXTERNAL_MUTATION not in principal.grants
+    assert AuthorityGrant.CREDENTIAL_EGRESS not in principal.grants
+
+
+@pytest.mark.asyncio
+async def test_concurrent_refresh_has_exactly_one_winner(client):
+    _, token = await _login(client)
+    operator = await authenticate_token(token, touch=False)
+    results = await asyncio.gather(
+        create_session(replace_session_id=operator.session_id),
+        create_session(replace_session_id=operator.session_id),
+        return_exceptions=True,
+    )
+    assert sum(isinstance(result, tuple) for result in results) == 1
+    loser = next(result for result in results if isinstance(result, Exception))
+    assert isinstance(loser, AuthFailure)
+    assert loser.code == "session_revoked"
+
+
+def test_websocket_boundary_requires_exact_host_and_origin():
+    assert validate_request_boundary(host="test", origin=ORIGIN, method="POST") is None
+    assert validate_request_boundary(host="evil.example", origin=ORIGIN, method="POST") == "origin_forbidden"
+    assert validate_request_boundary(host="test", origin=None, method="POST") == "mutation_origin_required"
+
+
+def test_login_source_only_honors_forwarding_from_trusted_proxy(monkeypatch):
+    forwarded = [(b"x-forwarded-for", b"203.0.113.7, 10.0.0.2")]
+    monkeypatch.setattr(settings, "operator_auth_trusted_proxy_ips", "")
+    assert _login_source(_request("10.0.0.2", forwarded)) == "10.0.0.2"
+    monkeypatch.setattr(settings, "operator_auth_trusted_proxy_ips", "10.0.0.2")
+    assert _login_source(_request("10.0.0.2", forwarded)) == "203.0.113.7"
+    malformed = [(b"x-forwarded-for", b"not-an-ip")]
+    assert _login_source(_request("10.0.0.2", malformed)) == "10.0.0.2"
+
+
+@pytest.mark.asyncio
+async def test_login_fails_stably_when_auth_is_unconfigured(monkeypatch):
+    monkeypatch.setattr(settings, "operator_auth_secret", "")
+    monkeypatch.setattr(settings, "operator_auth_secret_hash", "")
+    with pytest.raises(HTTPException) as captured:
+        await login(LoginRequest(password="anything"), Response(), _request())
+    assert captured.value.status_code == 503
+    assert captured.value.detail["code"] == "auth_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_login_has_dedicated_global_throttle(monkeypatch):
+    async def _invalid(_password: str) -> bool:
+        return False
+
+    monkeypatch.setattr("src.api.auth.verify_secret", _invalid)
+    for _ in range(5):
+        with pytest.raises(HTTPException) as captured:
+            await login(LoginRequest(password="wrong"), Response(), _request())
+        assert captured.value.status_code == 401
+    with pytest.raises(HTTPException) as captured:
+        await login(LoginRequest(password="wrong"), Response(), _request())
+    assert captured.value.status_code == 429
+    assert captured.value.detail["code"] == "login_rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_api_is_locked_before_endpoint_side_effect(monkeypatch):
+    monkeypatch.setattr(settings, "operator_auth_secret", "")
+    monkeypatch.setattr(settings, "operator_auth_secret_hash", "")
+    monkeypatch.setattr(settings, "operator_auth_allow_unauthenticated_tests", False)
+    called = False
+
+    async def endpoint(_request):
+        nonlocal called
+        called = True
+        raise AssertionError("endpoint must not run")
+
+    middleware = OperatorAuthMiddleware(lambda *_args, **_kwargs: None)
+    response = await middleware.dispatch(_path_request("/api/sessions"), endpoint)
+    assert response.status_code == 503
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_websocket_closes_before_accept(monkeypatch):
+    monkeypatch.setattr(settings, "operator_auth_secret", "")
+    monkeypatch.setattr(settings, "operator_auth_secret_hash", "")
+    monkeypatch.setattr(settings, "operator_auth_allow_unauthenticated_tests", False)
+
+    class FakeWebSocket:
+        accepted = False
+        closed = None
+
+        async def accept(self):
+            self.accepted = True
+
+        async def close(self, *, code, reason):
+            self.closed = (code, reason)
+
+    websocket = FakeWebSocket()
+    await websocket_chat(websocket)
+    assert websocket.accepted is False
+    assert websocket.closed == (4401, "auth_not_configured")

--- a/backend/tests/test_production_topology.py
+++ b/backend/tests/test_production_topology.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import subprocess
 import sys
 import time
+import tempfile
 from datetime import datetime, timedelta, timezone
 
 
@@ -34,6 +35,11 @@ def test_production_compose_has_one_tls_ingress_and_no_backend_publication():
     assert "--reload" not in (ROOT / "backend" / "Dockerfile").read_text()
     assert 'CHAT_PROXY_API_KEY="$$(cat /run/secrets/vlm_api_key)"' in compose
     assert "CHAT_PROXY_API_KEY_FILE" not in compose
+    assert "  gpu-model:" in compose
+    assert "172.30.0.40" in compose
+    assert "capabilities: [gpu]" in compose
+    assert "http://gpu-model:8000/v1" in compose
+    assert "host.docker.internal" not in compose
     assert "npm\", \"run\", \"dev" not in (ROOT / "frontend" / "Dockerfile.prod").read_text()
 
 
@@ -59,7 +65,9 @@ def test_production_example_uses_file_backed_secrets_and_exact_origin_placeholde
     assert "SERAPH_TLS_CERT_FILE=" in env
     assert "SERAPH_TLS_KEY_FILE=" in env
     assert "OPERATOR_AUTH_ALLOWED_ORIGINS=https://seraph.example.invalid" in env
-    assert "LOCAL_LLM_API_BASE=http://host.docker.internal:8000/v1" in env
+    assert "LOCAL_LLM_API_BASE=http://gpu-model:8000/v1" in env
+    assert "SERAPH_VLM_BACKEND_URL=http://gpu-model:8000/v1" in env
+    assert "SERAPH_GPU_MODEL_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:" in env
     assert "SERAPH_VLM_BASE_URL=http://vlm-wrapper:8001" in env
     assert "SERAPH_VLM_IMAGE=" in env
     assert "@sha256:" in env
@@ -111,6 +119,16 @@ def test_release_identity_requires_clean_exact_head_and_hex_vlm_digest():
     assert 'sha256:[0-9a-fA-F]{64})$' in manage
     assert "registry RepoDigest or exact local sha256 image ID" in manage
     assert "mismatched build identity; refusing overwrite" in manage
+    assert "seraph.production-acceptance.v2" in manage
+    assert "rollback requires exactly one previously accepted complete GPU release bundle" in manage
+    assert "ACCEPTED_GPU_MODEL_IMAGE" in manage
+    assert 'authority_mode="${2:-active}"' in manage
+    assert "active release requires a v2 Mac-accepted bundle" in manage
+    assert "staged release must contain raw local attestation" in manage
+    assert "glob.glob" not in manage
+    assert "accepted release history index is invalid" in manage
+    assert "--wait-timeout 120" not in manage
+    assert manage.count("--wait-timeout 300") == 4
     non_hex_digest = "ghcr.io/example/wrapper@sha256:" + "z" * 64
     assert not __import__("re").match(r"^[^\s@]+@sha256:[0-9a-fA-F]{64}$", non_hex_digest)
 
@@ -148,7 +166,7 @@ def test_restore_adoption_inventory_and_atomic_state_failure_contracts():
 
 def test_compose_state_validator_requires_complete_healthy_runtime():
     validator = ROOT / "scripts" / "validate_production_compose_state.py"
-    rows = [{"Service": service, "State": "running", "Health": "healthy"} for service in ("backend", "ingress", "vlm-wrapper")]
+    rows = [{"Service": service, "State": "running", "Health": "healthy"} for service in ("backend", "ingress", "vlm-wrapper", "gpu-model")]
     good = subprocess.run([sys.executable, str(validator)], input=json.dumps(rows), text=True, capture_output=True)
     assert good.returncode == 0
     rows[0]["Health"] = "unhealthy"
@@ -176,18 +194,29 @@ def test_compose_state_validator_rejects_duplicate_missing_and_extra_rows():
 
 
 def test_acceptance_bundle_cross_binds_local_container_and_network_evidence(tmp_path):
-    ids={s:s+'-id' for s in ('ingress','backend','vlm-wrapper')}; ips={'ingress':'172.30.0.10','backend':'172.30.0.20','vlm-wrapper':'172.30.0.30'}; app='a'*40
+    ids={s:s+'-id' for s in ('ingress','backend','vlm-wrapper','gpu-model')}; ips={'ingress':'172.30.0.10','backend':'172.30.0.20','vlm-wrapper':'172.30.0.30','gpu-model':'172.30.0.40'}; app='a'*40
     vlm='repo/vlm@sha256:'+'b'*64
-    local={"captured_at":"2026-01-01T00:00:00+00:00","compose_observation":{"project":"seraph-prod","network_name":"seraph-core-prod","containers":{s:{"container_id":ids[s],"image_id":s+'-image',"image_revision":app if s in {'ingress','backend'} else '',"project":"seraph-prod","service":s,"network_name":"seraph-core-prod","network_id":"net-id","ip_address":ips[s]} for s in ids}},"vlm_observation":{"image_id":"vlm-wrapper-image","repo_digests":[vlm]}}
+    gpu_ref='ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:'+'c'*64
+    gpu_release={"image_ref":gpu_ref,"alias":"gemma-test","artifact_root":str(tmp_path.resolve()),"model":{"filename":"model.gguf","sha256":"1"*64,"size":10},"mmproj":{"filename":"mmproj.gguf","sha256":"2"*64,"size":5},"ctx_size":32768,"layers":999,"command_contract":"llama-server-gemma4-v1"}
+    local={"captured_at":"2026-01-01T00:00:00+00:00","compose_observation":{"project":"seraph-prod","network_name":"seraph-core-prod","containers":{s:{"container_id":ids[s],"image_id":s+'-image',"image_revision":app if s in {'ingress','backend'} else '',"repo_digests":[gpu_ref] if s=='gpu-model' else [],"project":"seraph-prod","service":s,"network_name":"seraph-core-prod","network_id":"net-id","ip_address":ips[s]} for s in ids}},"vlm_observation":{"image_id":"vlm-wrapper-image","repo_digests":[vlm]},"gpu_model_observation":{"image_ref":gpu_ref,"image_id":"gpu-model-image","alias":"gemma-test","health":True}}
+    local["gpu_release"]=gpu_release
     local_path=tmp_path/'challenged.json'; local_path.write_text(json.dumps(local)); final_path=tmp_path/'final.json'; final={**local,"captured_at":"2026-01-01T00:01:00+00:00"}; final_path.write_text(json.dumps(final))
     mac_path, mac_env = _signed_mac_receipt(tmp_path, datetime.now(timezone.utc).isoformat())
     sha=lambda p: hashlib.sha256(p.read_bytes()).hexdigest()
-    challenge={"schema":"seraph.acceptance-challenge.v1","stage":"candidate","app_sha":app,"vlm_image":vlm,"local_attestation_sha256":sha(local_path),"compose_project":"seraph-prod","network_name":"seraph-core-prod","network_id":"net-id","container_ids":ids,"image_identities":{s:{"image_id":s+'-image',"image_revision":app if s in {'ingress','backend'} else ''} for s in ids},"expected_origin":"https://seraph.lan","lan_host":"seraph.lan","lan_ip":"192.168.1.26","client_identity":"operator-mac","server_nonce":"f"*64,"issued_at":datetime.now(timezone.utc).isoformat()}
+    challenge={"schema":"seraph.acceptance-challenge.v1","stage":"candidate","app_sha":app,"vlm_image":vlm,"gpu_model_image":gpu_ref,"gpu_model_alias":"gemma-test","gpu_release":gpu_release,"local_attestation_sha256":sha(local_path),"compose_project":"seraph-prod","network_name":"seraph-core-prod","network_id":"net-id","container_ids":ids,"image_identities":{s:{"image_id":s+'-image',"image_revision":app if s in {'ingress','backend'} else ''} for s in ids},"expected_origin":"https://seraph.lan","lan_host":"seraph.lan","lan_ip":"192.168.1.26","client_identity":"operator-mac","server_nonce":"f"*64,"issued_at":datetime.now(timezone.utc).isoformat()}
     mac=json.loads(mac_path.read_text()); mac["challenge"]=challenge; mac["challenge_sha256"]=hashlib.sha256(json.dumps(challenge,sort_keys=True,separators=(',',':')).encode()).hexdigest(); mac.pop("hmac_sha256"); mac["hmac_sha256"]=hmac.new(Path(mac_env["SERAPH_MAC_PROBE_KEY_FILE"]).read_bytes(),json.dumps(mac,sort_keys=True,separators=(',',':')).encode(),hashlib.sha256).hexdigest(); mac_path.write_text(json.dumps(mac))
-    bundle={"schema":"seraph.production-acceptance.v1","stage":"candidate","app_sha":app,"vlm_image":vlm,"compose_project":"seraph-prod","network_name":"seraph-core-prod","network_id":"net-id","container_ids":ids,"challenged_attestation":{"path":str(local_path),"sha256":sha(local_path)},"final_attestation":{"path":str(final_path),"sha256":sha(final_path)},"mac_receipt":{"path":str(mac_path),"sha256":sha(mac_path)},"acceptance_challenge":challenge,"expected_origin":"https://seraph.lan","client_identity":"operator-mac"}
-    env=os.environ.copy(); env.update(mac_env); env.update(SERAPH_BUNDLE_APP_SHA=app,SERAPH_BUNDLE_VLM_IMAGE=vlm,SERAPH_EXPECTED_HTTPS_ORIGIN='https://seraph.lan',SERAPH_MAC_PROBE_CLIENT_ID='operator-mac',SERAPH_LAN_HOST='seraph.lan',SERAPH_LAN_IP='192.168.1.26')
+    bundle={"schema":"seraph.production-acceptance.v2","stage":"candidate","app_sha":app,"vlm_image":vlm,"gpu_release":gpu_release,"compose_project":"seraph-prod","network_name":"seraph-core-prod","network_id":"net-id","container_ids":ids,"challenged_attestation":{"path":str(local_path),"sha256":sha(local_path)},"final_attestation":{"path":str(final_path),"sha256":sha(final_path)},"mac_receipt":{"path":str(mac_path),"sha256":sha(mac_path)},"acceptance_challenge":challenge,"expected_origin":"https://seraph.lan","client_identity":"operator-mac"}
+    env=os.environ.copy(); env.update(mac_env); env.update(SERAPH_BUNDLE_APP_SHA=app,SERAPH_BUNDLE_VLM_IMAGE=vlm,SERAPH_GPU_MODEL_IMAGE=gpu_ref,SERAPH_GPU_MODEL_ALIAS='gemma-test',SERAPH_EXPECTED_HTTPS_ORIGIN='https://seraph.lan',SERAPH_MAC_PROBE_CLIENT_ID='operator-mac',SERAPH_LAN_HOST='seraph.lan',SERAPH_LAN_IP='192.168.1.26')
     validator=ROOT/'scripts'/'validate_acceptance_bundle.py'
     assert subprocess.run([sys.executable,str(validator)],input=json.dumps(bundle),env=env,text=True).returncode == 0
+    drift_root=tmp_path/'current-models'; drift_root.mkdir()
+    drift_env=env.copy(); drift_env["SERAPH_GPU_MODEL_IMAGE"]="repo/other@sha256:"+"e"*64; drift_env["SERAPH_GPU_MODEL_ALIAS"]="other"; drift_env["SERAPH_GPU_MODEL_DIR"]=str(drift_root)
+    assert subprocess.run([sys.executable,str(validator)],input=json.dumps(bundle),env=drift_env,text=True,capture_output=True).returncode == 0
+    assert bundle["gpu_release"]["artifact_root"] == str(tmp_path.resolve())
+    manage=(ROOT/'manage.sh').read_text()
+    assert 'ACCEPTED_GPU_MODEL_DIR=' in manage
+    assert 'SERAPH_GPU_MODEL_DIR="$ACCEPTED_GPU_MODEL_DIR"' in manage
+    assert '["gpu_release"]["artifact_root"]' in manage
     bundle['container_ids']['backend']='swapped'
     assert subprocess.run([sys.executable,str(validator)],input=json.dumps(bundle),env=env,text=True,capture_output=True).returncode != 0
     bundle['container_ids']['backend']='backend-id'; bundle['acceptance_challenge']['container_ids']['backend']='backend-id'; bundle['acceptance_challenge']['image_identities']['backend']['image_revision']='c'*40
@@ -201,10 +230,16 @@ def test_acceptance_bundle_cross_binds_local_container_and_network_evidence(tmp_
 
 def test_two_phase_predeploy_and_mac_negative_validators(tmp_path):
     env = os.environ.copy()
-    env.update(SERAPH_GPU_EXPECTED_HOSTNAME="jupyter", SERAPH_GPU_MACHINE_IDENTITY_SHA256="c" * 64)
-    predeploy = {"local_hostname": "jupyter", "machine_identity_sha256": "c" * 64, "captured_at": datetime.now(timezone.utc).isoformat(), "ss_lntp": "LISTEN 0 4096 172.17.0.1:8000 0.0.0.0:*", "docker_bridge_addresses": ["172.17.0.1"], "docker_network_bindings": {"host-gateway": "172.17.0.1"}}
+    (tmp_path/"model.gguf").write_bytes(b"model"); (tmp_path/"mmproj.gguf").write_bytes(b"mmproj")
+    gpu_release={"image_ref":"repo/model@sha256:"+"d"*64,"alias":"gemma-test","artifact_root":str(tmp_path.resolve()),"model":{"filename":"model.gguf","sha256":hashlib.sha256(b"model").hexdigest(),"size":5},"mmproj":{"filename":"mmproj.gguf","sha256":hashlib.sha256(b"mmproj").hexdigest(),"size":6},"ctx_size":32768,"layers":999,"command_contract":"llama-server-gemma4-v1"}
+    env.update(SERAPH_GPU_EXPECTED_HOSTNAME="jupyter", SERAPH_GPU_MACHINE_IDENTITY_SHA256="c" * 64,SERAPH_GPU_MODEL_DIR=str(tmp_path),SERAPH_GPU_MODEL_FILE="model.gguf",SERAPH_GPU_MMPROJ_FILE="mmproj.gguf",SERAPH_GPU_MODEL_IMAGE=gpu_release["image_ref"],SERAPH_GPU_MODEL_ALIAS="gemma-test",SERAPH_GPU_MODEL_CTX_SIZE="32768",SERAPH_GPU_MODEL_LAYERS="999")
+    predeploy = {"local_hostname": "jupyter", "machine_identity_sha256": "c" * 64, "captured_at": datetime.now(timezone.utc).isoformat(), "ss_lntp": "", "docker_bridge_addresses": ["172.17.0.1"], "docker_network_bindings": {"host-gateway": "172.17.0.1"}, "gpu_release":gpu_release}
     validator = ROOT / "scripts" / "validate_gpu_predeploy.py"
     assert subprocess.run([sys.executable, str(validator)], input=json.dumps(predeploy), env=env, text=True).returncode == 0
+    (tmp_path/"model.gguf").write_bytes(b"mutated")
+    mutated=subprocess.run([sys.executable,str(validator)],input=json.dumps(predeploy),env=env,text=True,capture_output=True)
+    assert mutated.returncode != 0 and "artifact manifest mismatch" in mutated.stderr
+    (tmp_path/"model.gguf").write_bytes(b"model")
     predeploy["ss_lntp"] += "\nLISTEN 0 4096 0.0.0.0:8001 0.0.0.0:*"
     assert subprocess.run([sys.executable, str(validator)], input=json.dumps(predeploy), env=env, text=True, capture_output=True).returncode != 0
     mac_validator = ROOT / "scripts" / "validate_mac_lan_negative.py"
@@ -323,7 +358,86 @@ production_write_accepted_state "{tmp_path / 'accepted'}" "{receipt}" || exit 23
     result = subprocess.run(["bash", "-c", script], text=True, capture_output=True)
     assert result.returncode == 0, result.stderr
     call_text = calls.read_text()
-    assert "compose" in call_text and "exec -T backend" in call_text
+    assert "ps --format" in call_text
+
+
+def test_active_history_uses_persisted_bundle_path_and_hash(tmp_path):
+    content=tmp_path/"bundle.tmp"; persisted=tmp_path/"bundle-final.json"; state=tmp_path/"active"; prepared=tmp_path/"active.tmp"
+    content.write_text('{"schema":"seraph.production-acceptance.v2"}')
+    persisted.write_bytes(content.read_bytes())
+    app="a"*40; vlm="repo/vlm@sha256:"+"b"*64
+    script=f'''export SERAPH_MANAGE_SOURCE_ONLY=true; source "{ROOT/'manage.sh'}"; production_prepare_active_state "{state}" "{prepared}" "{content}" "{persisted}" "{app}" "{vlm}"'''
+    result=subprocess.run(["bash","-c",script],text=True,capture_output=True)
+    assert result.returncode == 0, result.stderr
+    lines=prepared.read_text().splitlines(); assert len(lines)==4 and lines[2]==str(persisted)
+    history=json.loads(lines[3]); assert len(history)==1 and history[0]["bundle"]==lines[2]
+    assert Path(history[0]["bundle"]).is_file()
+    assert history[0]["sha256"]==hashlib.sha256(persisted.read_bytes()).hexdigest()
+
+
+def test_staged_reader_restores_gpu_tuple_before_cross_process_validation(tmp_path):
+    fake_bin=tmp_path/'bin'; fake_bin.mkdir(); tag='a'*40; vlm='repo/vlm@sha256:'+'b'*64
+    docker=fake_bin/'docker'; docker.write_text(f'''#!/bin/sh
+case " $* " in *" --format "*) echo "{tag}";; esac
+exit 0
+'''); docker.chmod(0o755)
+    accepted_root=tmp_path/'accepted-models'; accepted_root.mkdir()
+    (accepted_root/'model.gguf').write_bytes(b'model'); (accepted_root/'mmproj.gguf').write_bytes(b'mmproj')
+    release={"image_ref":"repo/model@sha256:"+'c'*64,"alias":"accepted-alias","artifact_root":str(accepted_root.resolve()),"model":{"filename":"model.gguf","sha256":hashlib.sha256(b'model').hexdigest(),"size":5},"mmproj":{"filename":"mmproj.gguf","sha256":hashlib.sha256(b'mmproj').hexdigest(),"size":6},"ctx_size":16384,"layers":77,"command_contract":"llama-server-gemma4-v1"}
+    receipt_data={"gpu_release":release}
+    content=json.dumps(receipt_data).encode(); receipt=tmp_path/f'{tag}-{hashlib.sha256(content).hexdigest()}.json'; receipt.write_bytes(content); receipt.chmod(0o444)
+    state=tmp_path/'staged'; state.write_text(f'{tag}\n{vlm}\n{receipt}\n')
+    drift=tmp_path/'current-models'; drift.mkdir()
+    script=f'''
+export SERAPH_MANAGE_SOURCE_ONLY=true PATH="{fake_bin}:$PATH"
+export SERAPH_GPU_MODEL_DIR="{drift}" SERAPH_GPU_MODEL_IMAGE="repo/other@sha256:{'d'*64}" SERAPH_GPU_MODEL_ALIAS=other
+source "{ROOT/'manage.sh'}"
+production_host_inventory_validate() {{ [ "$SERAPH_GPU_MODEL_DIR" = "{accepted_root.resolve()}" ] && [ "$SERAPH_GPU_MODEL_ALIAS" = accepted-alias ] && [ "$SERAPH_GPU_MODEL_CTX_SIZE" = 16384 ]; }}
+production_read_validate_accepted_state "{state}" staged || exit 41
+[ "$ACCEPTED_GPU_MODEL_DIR" = "{accepted_root.resolve()}" ] || exit 42
+[ "$SERAPH_GPU_MODEL_DIR" = "{accepted_root.resolve()}" ] || exit 43
+[ "$SERAPH_GPU_MODEL_LAYERS" = 77 ] || exit 44
+'''
+    result=subprocess.run(['bash','-c',script],text=True,capture_output=True)
+    assert result.returncode == 0, result.stderr
+    incomplete=dict(receipt_data); incomplete['gpu_release']=dict(release); incomplete['gpu_release'].pop('artifact_root')
+    bad_content=json.dumps(incomplete).encode(); bad=tmp_path/f'{tag}-{hashlib.sha256(bad_content).hexdigest()}.json'; bad.write_bytes(bad_content); bad.chmod(0o444)
+    bad_state=tmp_path/'bad-staged'; bad_state.write_text(f'{tag}\n{vlm}\n{bad}\n')
+    rejected=subprocess.run(['bash','-c',script.replace(str(state),str(bad_state))],text=True,capture_output=True)
+    assert rejected.returncode != 0 and 'complete absolute GPU release tuple' in rejected.stderr
+
+
+def test_preserve_mode_keeps_candidate_and_rollback_target_gpu_precedence(tmp_path):
+    fake_bin=tmp_path/'bin'; fake_bin.mkdir(); tag='a'*40; vlm='repo/vlm@sha256:'+'b'*64
+    docker=fake_bin/'docker'; docker.write_text(f'''#!/bin/sh
+case " $* " in *" --format "*) echo "{tag}";; esac
+exit 0
+'''); docker.chmod(0o755)
+    active_root=tmp_path/'active-models'; active_root.mkdir()
+    (active_root/'model.gguf').write_bytes(b'active'); (active_root/'mmproj.gguf').write_bytes(b'mmproj')
+    release={"image_ref":"repo/active@sha256:"+'c'*64,"alias":"active","artifact_root":str(active_root.resolve()),"model":{"filename":"model.gguf","sha256":hashlib.sha256(b'active').hexdigest(),"size":6},"mmproj":{"filename":"mmproj.gguf","sha256":hashlib.sha256(b'mmproj').hexdigest(),"size":6},"ctx_size":8192,"layers":55,"command_contract":"llama-server-gemma4-v1"}
+    content=json.dumps({"gpu_release":release}).encode(); receipt=tmp_path/f'{tag}-{hashlib.sha256(content).hexdigest()}.json'; receipt.write_bytes(content); receipt.chmod(0o444)
+    state=tmp_path/'authority'; state.write_text(f'{tag}\n{vlm}\n{receipt}\n')
+    requested_root=tmp_path/'requested-models'; requested_root.mkdir()
+    target_root=tmp_path/'rollback-target-models'; target_root.mkdir()
+    script=f'''
+export SERAPH_MANAGE_SOURCE_ONLY=true PATH="{fake_bin}:$PATH"
+source "{ROOT/'manage.sh'}"
+production_host_inventory_validate() {{ [ "$SERAPH_GPU_MODEL_DIR" = "{active_root.resolve()}" ]; }}
+export SERAPH_GPU_MODEL_DIR="{requested_root}" SERAPH_GPU_MODEL_IMAGE="repo/candidate@sha256:{'d'*64}" SERAPH_GPU_MODEL_ALIAS=candidate SERAPH_GPU_MODEL_CTX_SIZE=32768 SERAPH_GPU_MODEL_LAYERS=99
+production_read_validate_accepted_state "{state}" staged preserve || exit 51
+[ "$SERAPH_GPU_MODEL_DIR" = "{requested_root}" ] && [ "$SERAPH_GPU_MODEL_ALIAS" = candidate ] || exit 52
+export SERAPH_GPU_MODEL_DIR="{target_root}" SERAPH_GPU_MODEL_IMAGE="repo/target@sha256:{'e'*64}" SERAPH_GPU_MODEL_ALIAS=rollback-target SERAPH_GPU_MODEL_CTX_SIZE=16384 SERAPH_GPU_MODEL_LAYERS=77
+production_read_validate_accepted_state "{state}" staged preserve || exit 53
+[ "$SERAPH_GPU_MODEL_DIR" = "{target_root}" ] && [ "$SERAPH_GPU_MODEL_ALIAS" = rollback-target ] || exit 54
+'''
+    result=subprocess.run(['bash','-c',script],text=True,capture_output=True)
+    assert result.returncode == 0, result.stderr
+    manage=(ROOT/'manage.sh').read_text()
+    start=manage.split('function production_start()',1)[1].split('function production_accept()',1)[0]
+    rollback=manage.split('function production_rollback()',1)[1].split('if [ "${SERAPH_MANAGE_SOURCE_ONLY',1)[0]
+    assert 'production_read_validate_accepted_state "$active_tag_file" active preserve' in start
+    assert 'production_read_validate_accepted_state "$active_tag_file" active preserve' in rollback
 
 
 def test_sourced_two_phase_accept_rejects_container_swap_and_stale_mac(tmp_path):
@@ -399,12 +513,22 @@ def test_entrypoint_accepts_exactly_one_raw_or_hash_credential(tmp_path):
 
 
 def _inventory(receipt: dict[str, object], vlm_image: str = "") -> subprocess.CompletedProcess[str]:
+    receipt = json.loads(json.dumps(receipt))
+    model_dir=Path(tempfile.mkdtemp()); (model_dir/"model.gguf").write_bytes(b"model"); (model_dir/"mmproj.gguf").write_bytes(b"mmproj")
+    gpu_ref = "ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:" + "d" * 64
+    containers = receipt.setdefault("compose_observation", {}).setdefault("containers", {})
+    containers.setdefault("gpu-model", {"container_id":"gpu-model-1","image_id":"gpu-model-image","image_revision":"","repo_digests":[gpu_ref],"project":"seraph-prod","service":"gpu-model","network_name":"seraph-core-prod","network_id":"net-1","ip_address":"172.30.0.40"})
+    receipt.setdefault("gpu_model_observation", {"image_ref":gpu_ref,"image_id":"gpu-model-image","alias":"gemma-test","health":True})
+    receipt.setdefault("gpu_release", {"image_ref":gpu_ref,"alias":"gemma-test","artifact_root":str(model_dir.resolve()),"model":{"filename":"model.gguf","sha256":hashlib.sha256(b"model").hexdigest(),"size":5},"mmproj":{"filename":"mmproj.gguf","sha256":hashlib.sha256(b"mmproj").hexdigest(),"size":6},"ctx_size":32768,"layers":999,"command_contract":"llama-server-gemma4-v1"})
     env = os.environ.copy()
     env.update(
         SERAPH_GPU_EXPECTED_HOSTNAME="jupyter",
         SERAPH_GPU_MACHINE_IDENTITY_SHA256="c" * 64,
         SERAPH_VLM_IMAGE=vlm_image or "ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64,
         SERAPH_VLM_INTERFACE_CONTRACT="vlm-health-backend-queue-chat-auth-v1",
+        SERAPH_GPU_MODEL_IMAGE=gpu_ref,
+        SERAPH_GPU_MODEL_ALIAS="gemma-test",
+        SERAPH_GPU_MODEL_DIR=str(model_dir),SERAPH_GPU_MODEL_FILE="model.gguf",SERAPH_GPU_MMPROJ_FILE="mmproj.gguf",SERAPH_GPU_MODEL_CTX_SIZE="32768",SERAPH_GPU_MODEL_LAYERS="999",
         SERAPH_HOST_INVENTORY_MAX_AGE_SECONDS="900",
     )
     return subprocess.run(
@@ -422,7 +546,7 @@ def test_host_inventory_gate_accepts_private_listener_and_rejects_lan_listener()
         "local_hostname": "jupyter",
         "machine_identity_sha256": "c" * 64,
         "captured_at": datetime.now(timezone.utc).isoformat(),
-        "ss_lntp": 'LISTEN 0 4096 172.17.0.1:8000 0.0.0.0:* users:(("model",pid=1,fd=1))',
+        "ss_lntp": 'LISTEN 0 4096 127.0.0.1:22 0.0.0.0:* users:(("sshd",pid=1,fd=1))',
         "docker_bridge_addresses": ["172.17.0.1"],
         "docker_network_bindings": {"host-gateway": "172.17.0.1"},
         "firewall": {f"lan_ingress_{port}": "blocked" for port in (8000, 8001, 8004)},
@@ -458,7 +582,7 @@ def test_host_inventory_gate_rejects_stale_and_identity_or_contract_mismatch():
         "local_hostname": "jupyter",
         "machine_identity_sha256": "c" * 64,
         "captured_at": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
-        "ss_lntp": "LISTEN 0 4096 172.17.0.1:8000 0.0.0.0:*",
+        "ss_lntp": "LISTEN 0 4096 127.0.0.1:22 0.0.0.0:*",
         "docker_bridge_addresses": ["172.17.0.1"],
         "docker_network_bindings": {"host-gateway": "172.17.0.1"},
         "firewall": {f"lan_ingress_{port}": "blocked" for port in (8000, 8001, 8004)},

--- a/backend/tests/test_production_topology.py
+++ b/backend/tests/test_production_topology.py
@@ -84,6 +84,9 @@ def test_managed_start_probes_private_gpu_routes_and_rolls_back_on_failure():
     assert start.index("production_prepare_app_images") < start.index(" up -d --no-build --wait")
     assert start.index(" up -d --no-build --wait") < start.index("production_preflight.py")
     assert start.index("production_restore_after_failure") > start.index("candidate containers did not become healthy")
+    production_dispatch = manage.split('if [ "$COMMAND" = "production" ]', 1)[1].split('if [ "$COMMAND" = "local" ]', 1)[0]
+    assert "exit $?" in production_dispatch
+    assert "exit 0" not in production_dispatch
 
 
 def test_release_tuple_failure_paths_restore_or_emit_catastrophic_diagnostics():

--- a/backend/tests/test_production_topology.py
+++ b/backend/tests/test_production_topology.py
@@ -105,7 +105,8 @@ def test_release_identity_requires_clean_exact_head_and_hex_vlm_digest():
     assert 'git -C "$SCRIPT_DIR" rev-parse HEAD' in manage
     assert 'git -C "$SCRIPT_DIR" status --porcelain' in manage
     assert 'SERAPH_IMAGE_TAG:-}" =~ ^[0-9a-f]{40}$' in manage
-    assert '@sha256:[0-9a-fA-F]{64}$' in manage
+    assert 'sha256:[0-9a-fA-F]{64})$' in manage
+    assert "registry RepoDigest or exact local sha256 image ID" in manage
     assert "mismatched build identity; refusing overwrite" in manage
     non_hex_digest = "ghcr.io/example/wrapper@sha256:" + "z" * 64
     assert not __import__("re").match(r"^[^\s@]+@sha256:[0-9a-fA-F]{64}$", non_hex_digest)
@@ -174,7 +175,7 @@ def test_compose_state_validator_rejects_duplicate_missing_and_extra_rows():
 def test_acceptance_bundle_cross_binds_local_container_and_network_evidence(tmp_path):
     ids={s:s+'-id' for s in ('ingress','backend','vlm-wrapper')}; ips={'ingress':'172.30.0.10','backend':'172.30.0.20','vlm-wrapper':'172.30.0.30'}; app='a'*40
     vlm='repo/vlm@sha256:'+'b'*64
-    local={"captured_at":"2026-01-01T00:00:00+00:00","compose_observation":{"project":"seraph-prod","network_name":"seraph-core-prod","containers":{s:{"container_id":ids[s],"image_id":s+'-image',"image_revision":app if s in {'ingress','backend'} else '',"project":"seraph-prod","service":s,"network_name":"seraph-core-prod","network_id":"net-id","ip_address":ips[s]} for s in ids}},"vlm_observation":{"repo_digests":[vlm]}}
+    local={"captured_at":"2026-01-01T00:00:00+00:00","compose_observation":{"project":"seraph-prod","network_name":"seraph-core-prod","containers":{s:{"container_id":ids[s],"image_id":s+'-image',"image_revision":app if s in {'ingress','backend'} else '',"project":"seraph-prod","service":s,"network_name":"seraph-core-prod","network_id":"net-id","ip_address":ips[s]} for s in ids}},"vlm_observation":{"image_id":"vlm-wrapper-image","repo_digests":[vlm]}}
     local_path=tmp_path/'challenged.json'; local_path.write_text(json.dumps(local)); final_path=tmp_path/'final.json'; final={**local,"captured_at":"2026-01-01T00:01:00+00:00"}; final_path.write_text(json.dumps(final))
     mac_path, mac_env = _signed_mac_receipt(tmp_path, datetime.now(timezone.utc).isoformat())
     sha=lambda p: hashlib.sha256(p.read_bytes()).hexdigest()
@@ -394,12 +395,12 @@ def test_entrypoint_accepts_exactly_one_raw_or_hash_credential(tmp_path):
     assert _entrypoint(tmp_path, "", "").returncode == 78
 
 
-def _inventory(receipt: dict[str, object]) -> subprocess.CompletedProcess[str]:
+def _inventory(receipt: dict[str, object], vlm_image: str = "") -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.update(
         SERAPH_GPU_EXPECTED_HOSTNAME="jupyter",
         SERAPH_GPU_MACHINE_IDENTITY_SHA256="c" * 64,
-        SERAPH_VLM_IMAGE="ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64,
+        SERAPH_VLM_IMAGE=vlm_image or "ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64,
         SERAPH_VLM_INTERFACE_CONTRACT="vlm-health-backend-queue-chat-auth-v1",
         SERAPH_HOST_INVENTORY_MAX_AGE_SECONDS="900",
     )
@@ -426,10 +427,15 @@ def test_host_inventory_gate_accepts_private_listener_and_rejects_lan_listener()
         "vlm_image": "ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64,
         "vlm_interface_contract": "vlm-health-backend-queue-chat-auth-v1",
         "vlm_wrapper_contract_verified": True,
-        "vlm_observation": {"container_id": "candidate-1", "running": True, "published_ports": {}, "checks": {"health": True, "backend": True, "queue": True, "auth_closed": True, "auth_interface": True}},
+        "vlm_observation": {"container_id": "candidate-1", "image_id": "vlm-wrapper-image", "repo_digests": ["ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64], "running": True, "published_ports": {}, "checks": {"health": True, "backend": True, "queue": True, "auth_closed": True, "auth_interface": True}},
         "compose_observation": {"project": "seraph-prod", "network_name": "seraph-core-prod", "containers": {service: {"container_id": service+"-1", "image_id": service+"-image", "image_revision": "a"*40 if service in {"ingress","backend"} else "", "project": "seraph-prod", "service": service, "network_name": "seraph-core-prod", "network_id": "net-1", "ip_address": ip} for service,ip in {"ingress":"172.30.0.10","backend":"172.30.0.20","vlm-wrapper":"172.30.0.30"}.items()}},
     }
     assert _inventory(receipt).returncode == 0
+    local_id = "sha256:" + "d" * 64
+    local_receipt = json.loads(json.dumps(receipt)); local_receipt["vlm_image"] = local_id; local_receipt["vlm_observation"]["image_id"] = local_id; local_receipt["vlm_observation"]["repo_digests"] = []
+    assert _inventory(local_receipt, local_id).returncode == 0
+    local_receipt["vlm_observation"]["image_id"] = "sha256:" + "e" * 64
+    assert _inventory(local_receipt, local_id).returncode != 0
     receipt["vlm_observation"]["checks"]["auth_interface"] = False
     forged_contract = _inventory(receipt)
     assert forged_contract.returncode != 0
@@ -457,7 +463,7 @@ def test_host_inventory_gate_rejects_stale_and_identity_or_contract_mismatch():
         "vlm_image": "ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64,
         "vlm_interface_contract": "vlm-health-backend-queue-chat-auth-v1",
         "vlm_wrapper_contract_verified": True,
-        "vlm_observation": {"container_id": "candidate-1", "running": True, "published_ports": {}, "checks": {"health": True, "backend": True, "queue": True, "auth_closed": True, "auth_interface": True}},
+        "vlm_observation": {"container_id": "candidate-1", "image_id": "vlm-wrapper-image", "repo_digests": ["ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64], "running": True, "published_ports": {}, "checks": {"health": True, "backend": True, "queue": True, "auth_closed": True, "auth_interface": True}},
         "compose_observation": {"project": "seraph-prod", "network_name": "seraph-core-prod", "containers": {service: {"container_id": service+"-1", "image_id": service+"-image", "image_revision": "a"*40 if service in {"ingress","backend"} else "", "project": "seraph-prod", "service": service, "network_name": "seraph-core-prod", "network_id": "net-1", "ip_address": ip} for service,ip in {"ingress":"172.30.0.10","backend":"172.30.0.20","vlm-wrapper":"172.30.0.30"}.items()}},
     }
     assert "stale" in _inventory(receipt).stderr

--- a/backend/tests/test_production_topology.py
+++ b/backend/tests/test_production_topology.py
@@ -149,6 +149,15 @@ def test_candidate_generator_observes_container_and_auth_without_firewall_claims
     assert "http://127.0.0.1:8000/health" in generator
     assert "http://172.30.0.40:8000/health" not in generator
     assert "base_url" not in generator
+    assert "closed_status == 200" in generator
+    assert "closed.get('status') == 'auth_failed'" in generator
+    assert "closed.get('auth_ok') is False" in generator
+    assert "opened.get('status') == 'ok'" in generator
+    assert "opened.get('auth_ok') is True" in generator
+    assert "model_identity == args.expected_gpu_model_alias" in generator
+    assert "model_identity is None or" not in generator
+    assert '"checks": checks' in generator
+    assert '"responses"' not in generator
 
 
 def test_restore_adoption_inventory_and_atomic_state_failure_contracts():

--- a/backend/tests/test_production_topology.py
+++ b/backend/tests/test_production_topology.py
@@ -532,7 +532,8 @@ def _inventory(receipt: dict[str, object], vlm_image: str = "") -> subprocess.Co
     model_dir=Path(tempfile.mkdtemp()); (model_dir/"model.gguf").write_bytes(b"model"); (model_dir/"mmproj.gguf").write_bytes(b"mmproj")
     gpu_ref = "ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:" + "d" * 64
     containers = receipt.setdefault("compose_observation", {}).setdefault("containers", {})
-    containers.setdefault("gpu-model", {"container_id":"gpu-model-1","image_id":"gpu-model-image","image_revision":"","repo_digests":[gpu_ref],"project":"seraph-prod","service":"gpu-model","network_name":"seraph-core-prod","network_id":"net-1","ip_address":"172.30.0.40"})
+    canonical_gpu_ref = gpu_ref.replace(":server-cuda@", "@")
+    containers.setdefault("gpu-model", {"container_id":"gpu-model-1","image_id":"gpu-model-image","image_revision":"","repo_digests":[canonical_gpu_ref],"project":"seraph-prod","service":"gpu-model","network_name":"seraph-core-prod","network_id":"net-1","ip_address":"172.30.0.40"})
     receipt.setdefault("gpu_model_observation", {"image_ref":gpu_ref,"image_id":"gpu-model-image","alias":"gemma-test","health":True})
     receipt.setdefault("gpu_release", {"image_ref":gpu_ref,"alias":"gemma-test","artifact_root":str(model_dir.resolve()),"model":{"filename":"model.gguf","sha256":hashlib.sha256(b"model").hexdigest(),"size":5},"mmproj":{"filename":"mmproj.gguf","sha256":hashlib.sha256(b"mmproj").hexdigest(),"size":6},"ctx_size":32768,"layers":999,"command_contract":"llama-server-gemma4-v1"})
     env = os.environ.copy()
@@ -573,6 +574,13 @@ def test_host_inventory_gate_accepts_private_listener_and_rejects_lan_listener()
         "compose_observation": {"project": "seraph-prod", "network_name": "seraph-core-prod", "containers": {service: {"container_id": service+"-1", "image_id": service+"-image", "image_revision": "a"*40 if service in {"ingress","backend"} else "", "project": "seraph-prod", "service": service, "network_name": "seraph-core-prod", "network_id": "net-1", "ip_address": ip} for service,ip in {"ingress":"172.30.0.10","backend":"172.30.0.20","vlm-wrapper":"172.30.0.30"}.items()}},
     }
     assert _inventory(receipt).returncode == 0
+    tagged_vlm="ghcr.io/seraph-quest/vlm-screenshot-server:cuda@sha256:"+"a"*64
+    tagged_receipt=json.loads(json.dumps(receipt)); tagged_receipt["vlm_image"]=tagged_vlm; tagged_receipt["vlm_observation"]["repo_digests"]=["ghcr.io/seraph-quest/vlm-screenshot-server@sha256:"+"a"*64]
+    assert _inventory(tagged_receipt,tagged_vlm).returncode == 0
+    wrong_gpu=json.loads(json.dumps(receipt)); wrong_gpu["compose_observation"]["containers"]["gpu-model"]={"container_id":"gpu-model-1","image_id":"gpu-model-image","image_revision":"","repo_digests":["ghcr.io/wrong/llama.cpp@sha256:"+"d"*64],"project":"seraph-prod","service":"gpu-model","network_name":"seraph-core-prod","network_id":"net-1","ip_address":"172.30.0.40"}
+    assert "immutable identity" in _inventory(wrong_gpu).stderr
+    wrong_digest=json.loads(json.dumps(wrong_gpu)); wrong_digest["compose_observation"]["containers"]["gpu-model"]["repo_digests"]=["ghcr.io/ggml-org/llama.cpp@sha256:"+"e"*64]
+    assert "immutable identity" in _inventory(wrong_digest).stderr
     local_id = "sha256:" + "d" * 64
     local_receipt = json.loads(json.dumps(receipt)); local_receipt["vlm_image"] = local_id; local_receipt["vlm_observation"]["image_id"] = local_id; local_receipt["vlm_observation"]["repo_digests"] = []
     assert _inventory(local_receipt, local_id).returncode == 0

--- a/backend/tests/test_production_topology.py
+++ b/backend/tests/test_production_topology.py
@@ -143,6 +143,12 @@ def test_candidate_generator_observes_container_and_auth_without_firewall_claims
     assert 'run(["docker", "inspect", args.vlm_container])' in generator
     assert "'/health/chat'" in generator
     assert "auth_closed" in generator
+    assert "['docker','exec','-i',container_id,'python','-c',VLM_PROBE,path]" in generator
+    assert "input=key" in generator
+    assert "['docker','exec',container_id,'curl'" in generator
+    assert "http://127.0.0.1:8000/health" in generator
+    assert "http://172.30.0.40:8000/health" not in generator
+    assert "base_url" not in generator
 
 
 def test_restore_adoption_inventory_and_atomic_state_failure_contracts():

--- a/backend/tests/test_production_topology.py
+++ b/backend/tests/test_production_topology.py
@@ -1,12 +1,26 @@
 import json
 import os
+import hashlib
+import hmac
 from pathlib import Path
 import subprocess
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 
 
 ROOT = Path(__file__).resolve().parents[2]
+
+def _signed_mac_receipt(tmp_path: Path, captured_at: str, *, open_port: str = "", denied_error: str = "connection_refused", origin: str = "https://seraph.lan", host: str = "seraph.lan", client: str = "operator-mac", nonce: str = "a" * 48) -> tuple[Path, dict[str, str]]:
+    key_file=tmp_path/'probe.key'; key_file.write_bytes(b'k'*32)
+    challenge={'schema':'seraph.acceptance-challenge.v1','stage':'candidate','expected_origin':'https://seraph.lan','lan_host':'seraph.lan','lan_ip':'192.168.1.26','client_identity':'operator-mac','server_nonce':'f'*64}
+    challenge_file=tmp_path/'challenge.json'; challenge_file.write_text(json.dumps(challenge))
+    challenge_hash=hashlib.sha256(json.dumps(challenge,sort_keys=True,separators=(',',':')).encode()).hexdigest()
+    receipt={'schema':'seraph.mac-lan-acceptance.v1','challenge':challenge,'challenge_sha256':challenge_hash,'https_origin':origin,'lan_host':host,'lan_ip':'192.168.1.26','client_identity':client,'captured_at':captured_at,'nonce':nonce,'authenticated_session':True,'port_probes':{p:{'connected':p==open_port,'error_class':'' if p==open_port else denied_error,'latency_ms':1} for p in ('8000','8001','8004')}}
+    receipt['hmac_sha256']=hmac.new(key_file.read_bytes(),json.dumps(receipt,sort_keys=True,separators=(',',':')).encode(),hashlib.sha256).hexdigest()
+    path=tmp_path/('mac-'+nonce[:8]+'-'+client+'-'+captured_at.replace(':','_')+'.json'); path.write_text(json.dumps(receipt))
+    env=os.environ.copy(); env.update(SERAPH_EXPECTED_HTTPS_ORIGIN='https://seraph.lan',SERAPH_LAN_HOST='seraph.lan',SERAPH_LAN_IP='192.168.1.26',SERAPH_MAC_PROBE_CLIENT_ID='operator-mac',SERAPH_MAC_PROBE_KEY_FILE=str(key_file),SERAPH_ACCEPTANCE_CHALLENGE_FILE=str(challenge_file))
+    return path,env
 
 
 def test_production_compose_has_one_tls_ingress_and_no_backend_publication():
@@ -18,6 +32,8 @@ def test_production_compose_has_one_tls_ingress_and_no_backend_publication():
     assert "OPERATOR_AUTH_BACKEND_WORKERS: \"1\"" in backend
     assert 'OPERATOR_AUTH_TRUSTED_PROXY_IPS: "172.30.0.10"' in backend
     assert "--reload" not in (ROOT / "backend" / "Dockerfile").read_text()
+    assert 'CHAT_PROXY_API_KEY="$$(cat /run/secrets/vlm_api_key)"' in compose
+    assert "CHAT_PROXY_API_KEY_FILE" not in compose
     assert "npm\", \"run\", \"dev" not in (ROOT / "frontend" / "Dockerfile.prod").read_text()
 
 
@@ -61,7 +77,7 @@ def test_managed_start_probes_private_gpu_routes_and_rolls_back_on_failure():
     assert "validate_production_listeners.py" in manage
     assert "validate_gpu_host_inventory.py" in manage
     restart_case = manage.split('restart)', 1)[1].split(';;', 1)[0]
-    assert "production_start" in restart_case
+    assert "production_restart" in restart_case
     assert " down " not in restart_case
     assert "restoring previous production release" in manage
     start = manage.split("function production_start()", 1)[1].split("function production_rollback()", 1)[0]
@@ -80,7 +96,8 @@ def test_release_tuple_failure_paths_restore_or_emit_catastrophic_diagnostics():
     assert "requested rollback tuple failed; restoring original active tuple" in rollback
     assert 'production_restore_after_failure "$original_tag" "$original_vlm" "$original_receipt"' in rollback
     assert "seraph-prod-failed-rollback.log" in rollback
-    assert 'production_host_inventory_validate "$target_receipt" "$vlm_image"' in rollback
+    assert 'production_host_inventory_validate "$target_attestation" "$vlm_image"' in rollback
+    assert "rollback awaiting fresh Mac LAN acceptance" in rollback
 
 
 def test_release_identity_requires_clean_exact_head_and_hex_vlm_digest():
@@ -94,12 +111,26 @@ def test_release_identity_requires_clean_exact_head_and_hex_vlm_digest():
     assert not __import__("re").match(r"^[^\s@]+@sha256:[0-9a-fA-F]{64}$", non_hex_digest)
 
 
+def test_candidate_generator_observes_container_and_auth_without_firewall_claims():
+    generator = (ROOT / "scripts" / "generate_local_gpu_inventory.py").read_text()
+    assert 'default="bridge"' in generator
+    assert 'default="seraph-core-prod"' not in generator
+    assert '"nft"' not in generator
+    assert "--lan-ingress-" not in generator
+    assert "--vlm-contract-verified" not in generator
+    assert 'run(["docker", "inspect", args.vlm_container])' in generator
+    assert "'/health/chat'" in generator
+    assert "auth_closed" in generator
+
+
 def test_restore_adoption_inventory_and_atomic_state_failure_contracts():
     manage = (ROOT / "manage.sh").read_text()
     restore = manage.split("function production_restore_previous()", 1)[1].split("function production_restore_after_failure()", 1)[0]
     assert "production_preflight.py" in restore
     assert "seraph-prod-failed-restore.log" in restore
     assert "failed inference preflight" in restore
+    assert '["final_attestation"]["path"]' in restore
+    assert '["local_attestation"]["path"]' not in restore
     start = manage.split("function production_start()", 1)[1].split("function production_write_accepted_state()", 1)[0]
     refusal = start.index("explicit adoption is required")
     assert refusal < start.index("production_prepare_app_images")
@@ -138,6 +169,116 @@ def test_compose_state_validator_rejects_duplicate_missing_and_extra_rows():
         )
         assert result.returncode != 0
         assert "exactly one row per service" in result.stderr
+
+
+def test_acceptance_bundle_cross_binds_local_container_and_network_evidence(tmp_path):
+    ids={s:s+'-id' for s in ('ingress','backend','vlm-wrapper')}; ips={'ingress':'172.30.0.10','backend':'172.30.0.20','vlm-wrapper':'172.30.0.30'}; app='a'*40
+    vlm='repo/vlm@sha256:'+'b'*64
+    local={"captured_at":"2026-01-01T00:00:00+00:00","compose_observation":{"project":"seraph-prod","network_name":"seraph-core-prod","containers":{s:{"container_id":ids[s],"image_id":s+'-image',"image_revision":app if s in {'ingress','backend'} else '',"project":"seraph-prod","service":s,"network_name":"seraph-core-prod","network_id":"net-id","ip_address":ips[s]} for s in ids}},"vlm_observation":{"repo_digests":[vlm]}}
+    local_path=tmp_path/'challenged.json'; local_path.write_text(json.dumps(local)); final_path=tmp_path/'final.json'; final={**local,"captured_at":"2026-01-01T00:01:00+00:00"}; final_path.write_text(json.dumps(final))
+    mac_path, mac_env = _signed_mac_receipt(tmp_path, datetime.now(timezone.utc).isoformat())
+    sha=lambda p: hashlib.sha256(p.read_bytes()).hexdigest()
+    challenge={"schema":"seraph.acceptance-challenge.v1","stage":"candidate","app_sha":app,"vlm_image":vlm,"local_attestation_sha256":sha(local_path),"compose_project":"seraph-prod","network_name":"seraph-core-prod","network_id":"net-id","container_ids":ids,"image_identities":{s:{"image_id":s+'-image',"image_revision":app if s in {'ingress','backend'} else ''} for s in ids},"expected_origin":"https://seraph.lan","lan_host":"seraph.lan","lan_ip":"192.168.1.26","client_identity":"operator-mac","server_nonce":"f"*64,"issued_at":datetime.now(timezone.utc).isoformat()}
+    mac=json.loads(mac_path.read_text()); mac["challenge"]=challenge; mac["challenge_sha256"]=hashlib.sha256(json.dumps(challenge,sort_keys=True,separators=(',',':')).encode()).hexdigest(); mac.pop("hmac_sha256"); mac["hmac_sha256"]=hmac.new(Path(mac_env["SERAPH_MAC_PROBE_KEY_FILE"]).read_bytes(),json.dumps(mac,sort_keys=True,separators=(',',':')).encode(),hashlib.sha256).hexdigest(); mac_path.write_text(json.dumps(mac))
+    bundle={"schema":"seraph.production-acceptance.v1","stage":"candidate","app_sha":app,"vlm_image":vlm,"compose_project":"seraph-prod","network_name":"seraph-core-prod","network_id":"net-id","container_ids":ids,"challenged_attestation":{"path":str(local_path),"sha256":sha(local_path)},"final_attestation":{"path":str(final_path),"sha256":sha(final_path)},"mac_receipt":{"path":str(mac_path),"sha256":sha(mac_path)},"acceptance_challenge":challenge,"expected_origin":"https://seraph.lan","client_identity":"operator-mac"}
+    env=os.environ.copy(); env.update(mac_env); env.update(SERAPH_BUNDLE_APP_SHA=app,SERAPH_BUNDLE_VLM_IMAGE=vlm,SERAPH_EXPECTED_HTTPS_ORIGIN='https://seraph.lan',SERAPH_MAC_PROBE_CLIENT_ID='operator-mac',SERAPH_LAN_HOST='seraph.lan',SERAPH_LAN_IP='192.168.1.26')
+    validator=ROOT/'scripts'/'validate_acceptance_bundle.py'
+    assert subprocess.run([sys.executable,str(validator)],input=json.dumps(bundle),env=env,text=True).returncode == 0
+    bundle['container_ids']['backend']='swapped'
+    assert subprocess.run([sys.executable,str(validator)],input=json.dumps(bundle),env=env,text=True,capture_output=True).returncode != 0
+    bundle['container_ids']['backend']='backend-id'; bundle['acceptance_challenge']['container_ids']['backend']='backend-id'; bundle['acceptance_challenge']['image_identities']['backend']['image_revision']='c'*40
+    mismatch=subprocess.run([sys.executable,str(validator)],input=json.dumps(bundle),env=env,text=True,capture_output=True)
+    assert mismatch.returncode != 0 and 'challenge immutable field mismatch' in mismatch.stderr
+    bundle['acceptance_challenge']['image_identities']['backend']['image_revision']=app
+    mutated=json.loads(final_path.read_text()); mutated['compose_observation']['containers']['backend']['image_id']='raced-image'; final_path.write_text(json.dumps(mutated)); bundle['final_attestation']['sha256']=sha(final_path)
+    race=subprocess.run([sys.executable,str(validator)],input=json.dumps(bundle),env=env,text=True,capture_output=True)
+    assert race.returncode != 0 and ('immutable binding mismatch' in race.stderr or 'container binding mismatch' in race.stderr)
+
+
+def test_two_phase_predeploy_and_mac_negative_validators(tmp_path):
+    env = os.environ.copy()
+    env.update(SERAPH_GPU_EXPECTED_HOSTNAME="jupyter", SERAPH_GPU_MACHINE_IDENTITY_SHA256="c" * 64)
+    predeploy = {"local_hostname": "jupyter", "machine_identity_sha256": "c" * 64, "captured_at": datetime.now(timezone.utc).isoformat(), "ss_lntp": "LISTEN 0 4096 172.17.0.1:8000 0.0.0.0:*", "docker_bridge_addresses": ["172.17.0.1"], "docker_network_bindings": {"host-gateway": "172.17.0.1"}}
+    validator = ROOT / "scripts" / "validate_gpu_predeploy.py"
+    assert subprocess.run([sys.executable, str(validator)], input=json.dumps(predeploy), env=env, text=True).returncode == 0
+    predeploy["ss_lntp"] += "\nLISTEN 0 4096 0.0.0.0:8001 0.0.0.0:*"
+    assert subprocess.run([sys.executable, str(validator)], input=json.dumps(predeploy), env=env, text=True, capture_output=True).returncode != 0
+    mac_validator = ROOT / "scripts" / "validate_mac_lan_negative.py"
+    mac_path, mac_env = _signed_mac_receipt(tmp_path, datetime.now(timezone.utc).isoformat())
+    assert subprocess.run([sys.executable, str(mac_validator)], input=mac_path.read_text(), env=mac_env, text=True).returncode == 0
+    open_path, open_env = _signed_mac_receipt(tmp_path, datetime.now(timezone.utc).isoformat(), open_port="8001")
+    assert subprocess.run([sys.executable, str(mac_validator)], input=open_path.read_text(), env=open_env, text=True, capture_output=True).returncode != 0
+    assert "container/network binding changed before acceptance" in (ROOT / "manage.sh").read_text()
+
+
+def test_mac_hmac_identity_tamper_and_nonce_replay(tmp_path):
+    validator=ROOT/"scripts"/"validate_mac_lan_negative.py"; now=datetime.now(timezone.utc).isoformat()
+    valid,env=_signed_mac_receipt(tmp_path,now,nonce="1"*48)
+    tampered=json.loads(valid.read_text()); tampered["port_probes"]["8000"]["latency_ms"]=999
+    assert "HMAC mismatch" in subprocess.run([sys.executable,str(validator)],input=json.dumps(tampered),env=env,text=True,capture_output=True).stderr
+    for kwargs in ({"origin":"https://wrong.lan","nonce":"2"*48},{"host":"wrong.lan","nonce":"3"*48},{"client":"wrong-mac","nonce":"4"*48}):
+        path,bad_env=_signed_mac_receipt(tmp_path,now,**kwargs)
+        result=subprocess.run([sys.executable,str(validator)],input=path.read_text(),env=env,text=True,capture_output=True)
+        assert result.returncode != 0
+    script=f'''export SERAPH_MANAGE_SOURCE_ONLY=true SERAPH_EXPECTED_HTTPS_ORIGIN=https://seraph.lan SERAPH_LAN_HOST=seraph.lan SERAPH_MAC_PROBE_CLIENT_ID=operator-mac SERAPH_MAC_PROBE_KEY_FILE="{env['SERAPH_MAC_PROBE_KEY_FILE']}"; source "{ROOT/'manage.sh'}"; PID_DIR="{tmp_path/'nonce-pids'}"; mkdir -p "$PID_DIR"; production_validate_mac_receipt "{valid}"; production_record_mac_nonce; production_validate_mac_receipt "{valid}" && exit 9; exit 0'''
+    assert subprocess.run(["bash","-c",script],text=True,capture_output=True).returncode == 0
+
+
+def test_mac_challenge_mismatch_and_unclassified_network_error_fail_closed(tmp_path):
+    validator = ROOT / "scripts" / "validate_mac_lan_negative.py"
+    receipt, env = _signed_mac_receipt(tmp_path, datetime.now(timezone.utc).isoformat())
+    other = json.loads(Path(env["SERAPH_ACCEPTANCE_CHALLENGE_FILE"]).read_text())
+    other["server_nonce"] = "e" * 64
+    other_path = tmp_path / "other-challenge.json"
+    other_path.write_text(json.dumps(other))
+    mismatch_env = env.copy()
+    mismatch_env["SERAPH_ACCEPTANCE_CHALLENGE_FILE"] = str(other_path)
+    mismatch = subprocess.run([sys.executable, str(validator)], input=receipt.read_text(), env=mismatch_env, text=True, capture_output=True)
+    assert mismatch.returncode != 0
+    assert "acceptance challenge mismatch" in mismatch.stderr
+    mismatch_env["SERAPH_MAC_RECEIPT_HISTORICAL"] = "true"
+    historical_mismatch = subprocess.run([sys.executable, str(validator)], input=receipt.read_text(), env=mismatch_env, text=True, capture_output=True)
+    assert historical_mismatch.returncode != 0
+    assert "acceptance challenge mismatch" in historical_mismatch.stderr
+
+    no_route, no_route_env = _signed_mac_receipt(
+        tmp_path,
+        datetime.now(timezone.utc).isoformat(),
+        denied_error="invalid_network_error",
+        nonce="d" * 48,
+    )
+    rejected = subprocess.run([sys.executable, str(validator)], input=no_route.read_text(), env=no_route_env, text=True, capture_output=True)
+    assert rejected.returncode != 0
+    assert "measured LAN denial missing" in rejected.stderr
+    generator = (ROOT / "scripts" / "generate_mac_lan_acceptance.py").read_text()
+    assert "socket.getaddrinfo" in generator and "resolved!={a.lan_ip}" in generator
+    assert "socket.create_connection((a.lan_ip,port)" in generator
+    assert "server_hostname=expected_host" in generator
+    assert "self.sock.getpeername()[0]!=a.lan_ip" in generator
+
+
+def test_lifecycle_lock_and_server_challenge_ledger_reject_reuse(tmp_path):
+    lock_file = tmp_path / "pids" / "seraph-prod-lifecycle.lock"
+    lock_file.parent.mkdir()
+    holder = subprocess.Popen(["flock", str(lock_file), "sleep", "2"])
+    try:
+        time.sleep(0.1)
+        probe = f'''export SERAPH_MANAGE_SOURCE_ONLY=true; source "{ROOT/'manage.sh'}"; PID_DIR="{lock_file.parent}"; production_lock_run true'''
+        result = subprocess.run(["bash", "-c", probe], text=True, capture_output=True)
+        assert result.returncode != 0
+        assert "another production lifecycle mutation is running" in result.stderr
+    finally:
+        holder.terminate()
+        holder.wait(timeout=3)
+
+    receipt, env = _signed_mac_receipt(tmp_path, datetime.now(timezone.utc).isoformat(), nonce="9" * 48)
+    consumed = tmp_path / "ledger-pids"
+    consumed.mkdir()
+    (consumed / "seraph-prod-consumed-acceptance").write_text("challenge:" + "f" * 64 + "\n")
+    script = f'''export SERAPH_MANAGE_SOURCE_ONLY=true SERAPH_EXPECTED_HTTPS_ORIGIN=https://seraph.lan SERAPH_LAN_HOST=seraph.lan SERAPH_LAN_IP=192.168.1.26 SERAPH_MAC_PROBE_CLIENT_ID=operator-mac SERAPH_MAC_PROBE_KEY_FILE="{env['SERAPH_MAC_PROBE_KEY_FILE']}"; source "{ROOT/'manage.sh'}"; PID_DIR="{consumed}"; production_validate_mac_receipt "{receipt}" "{env['SERAPH_ACCEPTANCE_CHALLENGE_FILE']}"'''
+    replay = subprocess.run(["bash", "-c", script], text=True, capture_output=True)
+    assert replay.returncode != 0
+    assert "server acceptance challenge was already used" in replay.stderr
 
 
 def test_sourced_lifecycle_behavior_with_fake_docker(tmp_path):
@@ -181,6 +322,50 @@ production_write_accepted_state "{tmp_path / 'accepted'}" "{receipt}" || exit 23
     assert "compose" in call_text and "exec -T backend" in call_text
 
 
+def test_sourced_two_phase_accept_rejects_container_swap_and_stale_mac(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "docker").write_text('#!/bin/sh\n[ "$CONTAINER_MODE" = swapped ] && echo candidate-2 || echo candidate-1\n')
+    (fake_bin / "docker").chmod(0o755)
+    (fake_bin / "python3").write_text('#!/bin/sh\ncase "$*" in *validate_mac_lan_negative.py*) exec /usr/bin/python3 "$@";; *"-c"*) echo candidate-1;; *generate_local_gpu_inventory.py*) echo "{}";; esac\nexec /usr/bin/python3 "$@"\n')
+    (fake_bin / "python3").chmod(0o755)
+    now = datetime.now(timezone.utc).isoformat()
+    stale = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    valid_mac, mac_env = _signed_mac_receipt(tmp_path, now)
+    stale_mac, _ = _signed_mac_receipt(tmp_path, stale)
+    rollback_mac, _ = _signed_mac_receipt(tmp_path, now, nonce="b"*48)
+    restore_mac, _ = _signed_mac_receipt(tmp_path, now, nonce="c"*48)
+    script = f'''
+export SERAPH_MANAGE_SOURCE_ONLY=true PATH="{fake_bin}:$PATH" CONTAINER_MODE=stable SERAPH_EXPECTED_HTTPS_ORIGIN=https://seraph.lan SERAPH_LAN_HOST=seraph.lan SERAPH_LAN_IP=192.168.1.26 SERAPH_MAC_PROBE_CLIENT_ID=operator-mac SERAPH_MAC_PROBE_KEY_FILE="{mac_env['SERAPH_MAC_PROBE_KEY_FILE']}" SERAPH_ACCEPTANCE_CHALLENGE_FILE="{mac_env['SERAPH_ACCEPTANCE_CHALLENGE_FILE']}"
+source "{ROOT / 'manage.sh'}"
+python3() {{ if [ "$1" = "-c" ]; then echo candidate-1; elif echo "$1" | grep -q generate_local_gpu_inventory; then echo '{{}}'; else /usr/bin/python3 "$@"; fi; }}
+production_validate_mac_receipt() {{ /usr/bin/python3 "{ROOT/'scripts/validate_mac_lan_negative.py'}" <"$1" || return 1; MAC_RECEIPT_NONCE=$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["nonce"])' "$1"); local nf="$PID_DIR/seraph-prod-mac-nonces"; [ -r "$nf" ] && grep -Fx "$MAC_RECEIPT_NONCE" "$nf" >/dev/null && return 1; return 0; }}
+PID_DIR="{tmp_path / 'pids'}"; LOG_DIR="{tmp_path / 'logs'}"; mkdir -p "$PID_DIR" "$LOG_DIR"
+ENV_FILE=/dev/null; COMPOSE_FILES=(-f /dev/null); SERAPH_VLM_API_KEY_FILE=/dev/null
+touch "$PID_DIR/seraph-prod-candidate-release"
+echo '{{"vlm_observation":{{"container_id":"candidate-1"}}}}' >"{tmp_path / 'candidate.json'}"
+production_read_validate_accepted_state() {{ ACCEPTED_APP_TAG={'a' * 40}; ACCEPTED_VLM_IMAGE='repo/vlm@sha256:{'b' * 64}'; ACCEPTED_INVENTORY_RECEIPT="{tmp_path / 'candidate.json'}"; return 0; }}
+production_host_inventory_validate() {{ return 0; }}
+production_compose_state_validate() {{ return 0; }}
+production_generate_local_attestation() {{ [ "$CONTAINER_MODE" != swapped ] || return 1; echo '{{}}' >"$1"; }}
+production_write_accepted_state() {{ touch "$1"; return 0; }}
+production_write_acceptance_bundle() {{ touch "$1"; return 0; }}
+production_accept "{valid_mac}" || exit 31
+[ -f "$PID_DIR/seraph-prod-active-release" ] || exit 32
+touch "$PID_DIR/seraph-prod-candidate-release"; export CONTAINER_MODE=swapped
+production_accept "{valid_mac}" && exit 33
+export CONTAINER_MODE=stable
+production_accept "{stale_mac}" && exit 34
+touch "$PID_DIR/seraph-prod-rollback-release"; export CONTAINER_MODE=stable
+production_accept_staged rollback "{rollback_mac}" || exit 35
+touch "$PID_DIR/seraph-prod-restore-release"
+production_accept_staged restore "{restore_mac}" || exit 36
+exit 0
+'''
+    result = subprocess.run(["bash", "-c", script], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+
+
 def _entrypoint(tmp_path: Path, raw: str, hashed: str) -> subprocess.CompletedProcess[str]:
     raw_file = tmp_path / "raw"
     hash_file = tmp_path / "hash"
@@ -212,10 +397,10 @@ def test_entrypoint_accepts_exactly_one_raw_or_hash_credential(tmp_path):
 def _inventory(receipt: dict[str, object]) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.update(
-        SERAPH_GPU_SSH_HOST="jupyter",
-        SERAPH_GPU_SSH_HOST_FINGERPRINT="SHA256:test-receipt",
+        SERAPH_GPU_EXPECTED_HOSTNAME="jupyter",
+        SERAPH_GPU_MACHINE_IDENTITY_SHA256="c" * 64,
         SERAPH_VLM_IMAGE="ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64,
-        SERAPH_VLM_INTERFACE_CONTRACT="vlm-screenshot-server/v0.2-file-secrets",
+        SERAPH_VLM_INTERFACE_CONTRACT="vlm-health-backend-queue-chat-auth-v1",
         SERAPH_HOST_INVENTORY_MAX_AGE_SECONDS="900",
     )
     return subprocess.run(
@@ -230,19 +415,29 @@ def _inventory(receipt: dict[str, object]) -> subprocess.CompletedProcess[str]:
 
 def test_host_inventory_gate_accepts_private_listener_and_rejects_lan_listener():
     receipt = {
-        "ssh_host": "jupyter",
-        "host_key_verified": True,
-        "host_key_fingerprint": "SHA256:test-receipt",
+        "local_hostname": "jupyter",
+        "machine_identity_sha256": "c" * 64,
         "captured_at": datetime.now(timezone.utc).isoformat(),
         "ss_lntp": 'LISTEN 0 4096 172.17.0.1:8000 0.0.0.0:* users:(("model",pid=1,fd=1))',
         "docker_bridge_addresses": ["172.17.0.1"],
         "docker_network_bindings": {"host-gateway": "172.17.0.1"},
         "firewall": {f"lan_ingress_{port}": "blocked" for port in (8000, 8001, 8004)},
+        "firewall_provenance": {"source_command": "nft list ruleset", "captured_at": datetime.now(timezone.utc).isoformat(), "raw_output": "table inet filter { chain input { drop } }", "output_sha256": __import__("hashlib").sha256(b"table inet filter { chain input { drop } }").hexdigest()},
         "vlm_image": "ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64,
-        "vlm_interface_contract": "vlm-screenshot-server/v0.2-file-secrets",
+        "vlm_interface_contract": "vlm-health-backend-queue-chat-auth-v1",
         "vlm_wrapper_contract_verified": True,
+        "vlm_observation": {"container_id": "candidate-1", "running": True, "published_ports": {}, "checks": {"health": True, "backend": True, "queue": True, "auth_closed": True, "auth_interface": True}},
+        "compose_observation": {"project": "seraph-prod", "network_name": "seraph-core-prod", "containers": {service: {"container_id": service+"-1", "image_id": service+"-image", "image_revision": "a"*40 if service in {"ingress","backend"} else "", "project": "seraph-prod", "service": service, "network_name": "seraph-core-prod", "network_id": "net-1", "ip_address": ip} for service,ip in {"ingress":"172.30.0.10","backend":"172.30.0.20","vlm-wrapper":"172.30.0.30"}.items()}},
     }
     assert _inventory(receipt).returncode == 0
+    receipt["vlm_observation"]["checks"]["auth_interface"] = False
+    forged_contract = _inventory(receipt)
+    assert forged_contract.returncode != 0
+    assert "active interface checks" in forged_contract.stderr
+    receipt["vlm_observation"]["checks"]["auth_interface"] = True
+    receipt["vlm_observation"]["checks"]["auth_closed"] = False
+    assert "active interface checks" in _inventory(receipt).stderr
+    receipt["vlm_observation"]["checks"]["auth_closed"] = True
     receipt["ss_lntp"] = "LISTEN 0 4096 0.0.0.0:8000 0.0.0.0:*"
     result = _inventory(receipt)
     assert result.returncode != 0
@@ -251,22 +446,30 @@ def test_host_inventory_gate_accepts_private_listener_and_rejects_lan_listener()
 
 def test_host_inventory_gate_rejects_stale_and_identity_or_contract_mismatch():
     receipt = {
-        "ssh_host": "jupyter",
-        "host_key_verified": True,
-        "host_key_fingerprint": "SHA256:test-receipt",
+        "local_hostname": "jupyter",
+        "machine_identity_sha256": "c" * 64,
         "captured_at": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
         "ss_lntp": "LISTEN 0 4096 172.17.0.1:8000 0.0.0.0:*",
         "docker_bridge_addresses": ["172.17.0.1"],
         "docker_network_bindings": {"host-gateway": "172.17.0.1"},
         "firewall": {f"lan_ingress_{port}": "blocked" for port in (8000, 8001, 8004)},
+        "firewall_provenance": {"source_command": "nft list ruleset", "captured_at": datetime.now(timezone.utc).isoformat(), "raw_output": "table inet filter { chain input { drop } }", "output_sha256": __import__("hashlib").sha256(b"table inet filter { chain input { drop } }").hexdigest()},
         "vlm_image": "ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64,
-        "vlm_interface_contract": "vlm-screenshot-server/v0.2-file-secrets",
+        "vlm_interface_contract": "vlm-health-backend-queue-chat-auth-v1",
         "vlm_wrapper_contract_verified": True,
+        "vlm_observation": {"container_id": "candidate-1", "running": True, "published_ports": {}, "checks": {"health": True, "backend": True, "queue": True, "auth_closed": True, "auth_interface": True}},
+        "compose_observation": {"project": "seraph-prod", "network_name": "seraph-core-prod", "containers": {service: {"container_id": service+"-1", "image_id": service+"-image", "image_revision": "a"*40 if service in {"ingress","backend"} else "", "project": "seraph-prod", "service": service, "network_name": "seraph-core-prod", "network_id": "net-1", "ip_address": ip} for service,ip in {"ingress":"172.30.0.10","backend":"172.30.0.20","vlm-wrapper":"172.30.0.30"}.items()}},
     }
     assert "stale" in _inventory(receipt).stderr
     receipt["captured_at"] = datetime.now(timezone.utc).isoformat()
-    receipt["ssh_host"] = "unexpected"
-    assert "identity" in _inventory(receipt).stderr
-    receipt["ssh_host"] = "jupyter"
+    receipt["local_hostname"] = "unexpected"
+    assert "hostname" in _inventory(receipt).stderr
+    receipt["local_hostname"] = "jupyter"
+    receipt["machine_identity_sha256"] = "d" * 64
+    assert "machine identity" in _inventory(receipt).stderr
+    receipt["machine_identity_sha256"] = "c" * 64
     receipt["vlm_interface_contract"] = "wrong"
     assert "interface contract" in _inventory(receipt).stderr
+    receipt["vlm_interface_contract"] = "vlm-health-backend-queue-chat-auth-v1"
+    receipt["raw_machine_id"] = "forged-secret-machine-id"
+    assert "raw machine identity" in _inventory(receipt).stderr

--- a/backend/tests/test_production_topology.py
+++ b/backend/tests/test_production_topology.py
@@ -1,0 +1,272 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_production_compose_has_one_tls_ingress_and_no_backend_publication():
+    compose = (ROOT / "docker-compose.prod.yaml").read_text()
+    assert '"${SERAPH_HTTPS_BIND:-0.0.0.0}:${SERAPH_HTTPS_PORT:-443}:443"' in compose
+    backend = compose.split("\n  backend:\n", 1)[1].split("\nnetworks:\n", 1)[0]
+    assert "ports:" not in backend
+    assert "OPERATOR_AUTH_COOKIE_SECURE: \"true\"" in backend
+    assert "OPERATOR_AUTH_BACKEND_WORKERS: \"1\"" in backend
+    assert 'OPERATOR_AUTH_TRUSTED_PROXY_IPS: "172.30.0.10"' in backend
+    assert "--reload" not in (ROOT / "backend" / "Dockerfile").read_text()
+    assert "npm\", \"run\", \"dev" not in (ROOT / "frontend" / "Dockerfile.prod").read_text()
+
+
+def test_ingress_overwrites_forwarded_identity_and_keeps_model_routes_server_side():
+    nginx = (ROOT / "frontend" / "production" / "nginx.conf").read_text()
+    assert "proxy_set_header X-Forwarded-For $remote_addr;" in nginx
+    assert "proxy_add_x_forwarded_for" not in nginx
+    assert "location /api/" in nginx
+    assert "location /ws/" in nginx
+    health = nginx.split("location = /health", 1)[1].split("location /api/", 1)[0]
+    assert "proxy_pass http://seraph_backend/health;" in health
+    assert "try_files" not in health
+    app = (ROOT / "backend" / "src" / "app.py").read_text()
+    health_route = app.split('@app.get("/health")', 1)[1].split('@app.get("/api/runtime/status")', 1)[0]
+    assert 'return {"status": "ok"}' in health_route
+    assert "8000" not in nginx
+    assert "8001" not in nginx
+
+
+def test_production_example_uses_file_backed_secrets_and_exact_origin_placeholders():
+    env = (ROOT / "env.prod.example").read_text()
+    assert "OPERATOR_AUTH_SECRET_FILE=" in env
+    assert "SERAPH_TLS_CERT_FILE=" in env
+    assert "SERAPH_TLS_KEY_FILE=" in env
+    assert "OPERATOR_AUTH_ALLOWED_ORIGINS=https://seraph.example.invalid" in env
+    assert "LOCAL_LLM_API_BASE=http://host.docker.internal:8000/v1" in env
+    assert "SERAPH_VLM_BASE_URL=http://vlm-wrapper:8001" in env
+    assert "SERAPH_VLM_IMAGE=" in env
+    assert "@sha256:" in env
+
+
+def test_managed_start_probes_private_gpu_routes_and_rolls_back_on_failure():
+    manage = (ROOT / "manage.sh").read_text()
+    assert "production_preflight.py" in manage
+    assert "candidate GPU model/VLM preflight failed" in manage
+    preflight = (ROOT / "backend" / "production_preflight.py").read_text()
+    assert 'probe("gpu_model"' in preflight
+    assert 'probe("vlm_wrapper"' in preflight
+    assert 'probe("vlm_backend"' in preflight
+    assert "Authorization" in preflight
+    assert "validate_production_listeners.py" in manage
+    assert "validate_gpu_host_inventory.py" in manage
+    restart_case = manage.split('restart)', 1)[1].split(';;', 1)[0]
+    assert "production_start" in restart_case
+    assert " down " not in restart_case
+    assert "restoring previous production release" in manage
+    start = manage.split("function production_start()", 1)[1].split("function production_rollback()", 1)[0]
+    assert start.index("production_prepare_app_images") < start.index(" up -d --no-build --wait")
+    assert start.index(" up -d --no-build --wait") < start.index("production_preflight.py")
+    assert start.index("production_restore_after_failure") > start.index("candidate containers did not become healthy")
+
+
+def test_release_tuple_failure_paths_restore_or_emit_catastrophic_diagnostics():
+    manage = (ROOT / "manage.sh").read_text()
+    restore = manage.split("function production_restore_previous()", 1)[1].split("function production_start()", 1)[0]
+    assert 'SERAPH_IMAGE_TAG="$previous_tag" SERAPH_VLM_IMAGE="$previous_vlm"' in restore
+    assert "CATASTROPHIC: previous production release tuple could not be restored" in restore
+    assert "return 2" in restore
+    rollback = manage.split("function production_rollback()", 1)[1].split("if [ \"${SERAPH_MANAGE_SOURCE_ONLY", 1)[0]
+    assert "requested rollback tuple failed; restoring original active tuple" in rollback
+    assert 'production_restore_after_failure "$original_tag" "$original_vlm" "$original_receipt"' in rollback
+    assert "seraph-prod-failed-rollback.log" in rollback
+    assert 'production_host_inventory_validate "$target_receipt" "$vlm_image"' in rollback
+
+
+def test_release_identity_requires_clean_exact_head_and_hex_vlm_digest():
+    manage = (ROOT / "manage.sh").read_text()
+    assert 'git -C "$SCRIPT_DIR" rev-parse HEAD' in manage
+    assert 'git -C "$SCRIPT_DIR" status --porcelain' in manage
+    assert 'SERAPH_IMAGE_TAG:-}" =~ ^[0-9a-f]{40}$' in manage
+    assert '@sha256:[0-9a-fA-F]{64}$' in manage
+    assert "mismatched build identity; refusing overwrite" in manage
+    non_hex_digest = "ghcr.io/example/wrapper@sha256:" + "z" * 64
+    assert not __import__("re").match(r"^[^\s@]+@sha256:[0-9a-fA-F]{64}$", non_hex_digest)
+
+
+def test_restore_adoption_inventory_and_atomic_state_failure_contracts():
+    manage = (ROOT / "manage.sh").read_text()
+    restore = manage.split("function production_restore_previous()", 1)[1].split("function production_restore_after_failure()", 1)[0]
+    assert "production_preflight.py" in restore
+    assert "seraph-prod-failed-restore.log" in restore
+    assert "failed inference preflight" in restore
+    start = manage.split("function production_start()", 1)[1].split("function production_write_accepted_state()", 1)[0]
+    refusal = start.index("explicit adoption is required")
+    assert refusal < start.index("production_prepare_app_images")
+    assert "production_docker_inventory_validate true" in start
+    assert "production_compose_state_validate" in start
+    writer = manage.split("function production_write_accepted_state()", 1)[1].split("function production_rollback()", 1)[0]
+    assert writer.index('cp "$receipt" "$receipt_tmp"') < writer.index('mv "$receipt_tmp" "$receipt_copy"')
+    assert writer.index('printf \'%s\\n%s\\n%s\\n\'') < writer.index('mv "$state_tmp" "$state_file"')
+    assert "chmod 0444" in writer and "chmod 0600" in writer
+
+
+def test_compose_state_validator_requires_complete_healthy_runtime():
+    validator = ROOT / "scripts" / "validate_production_compose_state.py"
+    rows = [{"Service": service, "State": "running", "Health": "healthy"} for service in ("backend", "ingress", "vlm-wrapper")]
+    good = subprocess.run([sys.executable, str(validator)], input=json.dumps(rows), text=True, capture_output=True)
+    assert good.returncode == 0
+    rows[0]["Health"] = "unhealthy"
+    bad = subprocess.run([sys.executable, str(validator)], input=json.dumps(rows), text=True, capture_output=True)
+    assert bad.returncode != 0
+
+
+def test_compose_state_validator_rejects_duplicate_missing_and_extra_rows():
+    validator = ROOT / "scripts" / "validate_production_compose_state.py"
+    healthy = lambda service: {"Service": service, "State": "running", "Health": "healthy"}
+    cases = [
+        [healthy("backend"), healthy("backend"), healthy("ingress")],
+        [healthy("backend"), healthy("ingress")],
+        [healthy("backend"), healthy("ingress"), healthy("vlm-wrapper"), healthy("extra")],
+    ]
+    for rows in cases:
+        result = subprocess.run(
+            [sys.executable, str(validator)],
+            input=json.dumps(rows),
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode != 0
+        assert "exactly one row per service" in result.stderr
+
+
+def test_sourced_lifecycle_behavior_with_fake_docker(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker = fake_bin / "docker"
+    docker.write_text(
+        "#!/bin/sh\n"
+        "echo \"$*\" >>\"$DOCKER_CALLS\"\n"
+        "[ \"$DOCKER_MODE\" = ps_fail ] && [ \"$1\" = ps ] && exit 9\n"
+        "case \" $* \" in *\" exec -T backend \"*) exit 7;; esac\n"
+        "case \" $* \" in *\"--format\"*) printf '%s\\n' \"$TEST_SHA\";; esac\n"
+        "exit 0\n"
+    )
+    docker.chmod(0o755)
+    calls = tmp_path / "calls"
+    state = tmp_path / "state"
+    state.write_text("truncated\nstate\n")
+    receipt = tmp_path / "receipt.json"
+    receipt.write_text("{}")
+    script = f'''
+set -u
+export SERAPH_MANAGE_SOURCE_ONLY=true PATH="{fake_bin}:$PATH" DOCKER_CALLS="{calls}" TEST_SHA="{'a' * 40}"
+source "{ROOT / 'manage.sh'}"
+PID_DIR="{tmp_path / 'pids'}"; LOG_DIR="{tmp_path / 'logs'}"; mkdir -p "$PID_DIR" "$LOG_DIR"
+ENV_FILE=/dev/null; COMPOSE_FILES=(-f /dev/null)
+production_host_inventory_validate() {{ return 0; }}
+production_read_validate_accepted_state "{state}" && exit 20
+export DOCKER_MODE=ps_fail
+production_docker_inventory_validate false && exit 21
+export DOCKER_MODE=restore_fail
+production_restore_previous "{'a' * 40}" "repo/wrapper@sha256:{'b' * 64}" "{receipt}"
+[ "$?" -eq 2 ] || exit 22
+export SERAPH_IMAGE_TAG="{'a' * 40}" SERAPH_VLM_IMAGE="repo/wrapper@sha256:{'b' * 64}"
+production_write_accepted_state "{tmp_path / 'accepted'}" "{receipt}" || exit 23
+[ "$(wc -l <"{tmp_path / 'accepted'}")" -eq 3 ] || exit 24
+'''
+    result = subprocess.run(["bash", "-c", script], text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+    call_text = calls.read_text()
+    assert "compose" in call_text and "exec -T backend" in call_text
+
+
+def _entrypoint(tmp_path: Path, raw: str, hashed: str) -> subprocess.CompletedProcess[str]:
+    raw_file = tmp_path / "raw"
+    hash_file = tmp_path / "hash"
+    raw_file.write_text(raw)
+    hash_file.write_text(hashed)
+    env = os.environ.copy()
+    env.update(
+        OPERATOR_AUTH_SECRET_FILE=str(raw_file),
+        OPERATOR_AUTH_SECRET_HASH_FILE=str(hash_file),
+        LOCAL_LLM_API_KEY_FILE="/dev/null",
+        SERAPH_VLM_API_KEY_FILE="/dev/null",
+    )
+    return subprocess.run(
+        ["sh", str(ROOT / "backend" / "docker-entrypoint.sh"), "/bin/true"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_entrypoint_accepts_exactly_one_raw_or_hash_credential(tmp_path):
+    assert _entrypoint(tmp_path, "raw-secret\n", "").returncode == 0
+    assert _entrypoint(tmp_path, "", "hash-value\n").returncode == 0
+    assert _entrypoint(tmp_path, "raw-secret\n", "hash-value\n").returncode == 78
+    assert _entrypoint(tmp_path, "", "").returncode == 78
+
+
+def _inventory(receipt: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        SERAPH_GPU_SSH_HOST="jupyter",
+        SERAPH_GPU_SSH_HOST_FINGERPRINT="SHA256:test-receipt",
+        SERAPH_VLM_IMAGE="ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64,
+        SERAPH_VLM_INTERFACE_CONTRACT="vlm-screenshot-server/v0.2-file-secrets",
+        SERAPH_HOST_INVENTORY_MAX_AGE_SECONDS="900",
+    )
+    return subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "validate_gpu_host_inventory.py")],
+        input=json.dumps(receipt),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_host_inventory_gate_accepts_private_listener_and_rejects_lan_listener():
+    receipt = {
+        "ssh_host": "jupyter",
+        "host_key_verified": True,
+        "host_key_fingerprint": "SHA256:test-receipt",
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "ss_lntp": 'LISTEN 0 4096 172.17.0.1:8000 0.0.0.0:* users:(("model",pid=1,fd=1))',
+        "docker_bridge_addresses": ["172.17.0.1"],
+        "docker_network_bindings": {"host-gateway": "172.17.0.1"},
+        "firewall": {f"lan_ingress_{port}": "blocked" for port in (8000, 8001, 8004)},
+        "vlm_image": "ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64,
+        "vlm_interface_contract": "vlm-screenshot-server/v0.2-file-secrets",
+        "vlm_wrapper_contract_verified": True,
+    }
+    assert _inventory(receipt).returncode == 0
+    receipt["ss_lntp"] = "LISTEN 0 4096 0.0.0.0:8000 0.0.0.0:*"
+    result = _inventory(receipt)
+    assert result.returncode != 0
+    assert "wildcard/LAN" in result.stderr
+
+
+def test_host_inventory_gate_rejects_stale_and_identity_or_contract_mismatch():
+    receipt = {
+        "ssh_host": "jupyter",
+        "host_key_verified": True,
+        "host_key_fingerprint": "SHA256:test-receipt",
+        "captured_at": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+        "ss_lntp": "LISTEN 0 4096 172.17.0.1:8000 0.0.0.0:*",
+        "docker_bridge_addresses": ["172.17.0.1"],
+        "docker_network_bindings": {"host-gateway": "172.17.0.1"},
+        "firewall": {f"lan_ingress_{port}": "blocked" for port in (8000, 8001, 8004)},
+        "vlm_image": "ghcr.io/seraph-quest/vlm-screenshot-server@sha256:" + "a" * 64,
+        "vlm_interface_contract": "vlm-screenshot-server/v0.2-file-secrets",
+        "vlm_wrapper_contract_verified": True,
+    }
+    assert "stale" in _inventory(receipt).stderr
+    receipt["captured_at"] = datetime.now(timezone.utc).isoformat()
+    receipt["ssh_host"] = "unexpected"
+    assert "identity" in _inventory(receipt).stderr
+    receipt["ssh_host"] = "jupyter"
+    receipt["vlm_interface_contract"] = "wrong"
+    assert "interface contract" in _inventory(receipt).stderr

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,26 +1,122 @@
-# ------------------------------------------------------------------
-#         Infrastructure Services (Third-Party)
-# ------------------------------------------------------------------
-# Defines the core third-party services like databases and message queues.
+name: seraph-prod
 
 services:
-  backend-prod:
-    container_name: backend-prod
+  ingress:
+    image: seraph/frontend-ingress:${SERAPH_IMAGE_TAG:-current}
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.prod
+      args:
+        SERAPH_BUILD_REVISION: ${SERAPH_IMAGE_TAG:?set exact git revision}
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - "${SERAPH_HTTPS_BIND:-0.0.0.0}:${SERAPH_HTTPS_PORT:-443}:443"
+    secrets:
+      - tls_cert
+      - tls_key
+    networks:
+      seraph-core:
+        ipv4_address: 172.30.0.10
+    healthcheck:
+      test: ["CMD", "nginx", "-t"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+
+  backend:
+    image: seraph/backend:${SERAPH_IMAGE_TAG:-current}
     build:
       context: ./backend
-      dockerfile: ./Dockerfile
-    volumes:
-      - ${BACKEND_DATA_PATH_PROD}:/app/data
-      - ${BACKEND_LOGS_PATH_PROD}:/app/logs
-      - ./shared:/app/shared
+      dockerfile: Dockerfile
+      args:
+        SERAPH_BUILD_REVISION: ${SERAPH_IMAGE_TAG:?set exact git revision}
+    restart: unless-stopped
+    depends_on:
+      vlm-wrapper:
+        condition: service_healthy
     env_file:
       - .env.prod
+    environment:
+      DEPLOYMENT_ENVIRONMENT: production
+      OPERATOR_AUTH_COOKIE_SECURE: "true"
+      OPERATOR_AUTH_BACKEND_WORKERS: "1"
+      OPERATOR_AUTH_TRUSTED_PROXY_IPS: "172.30.0.10"
+      OPERATOR_AUTH_SECRET_FILE: /run/secrets/operator_auth_secret
+      OPERATOR_AUTH_SECRET_HASH_FILE: /run/secrets/operator_auth_secret_hash
+      LOCAL_LLM_API_KEY_FILE: /run/secrets/local_llm_api_key
+      SERAPH_VLM_API_KEY_FILE: /run/secrets/vlm_api_key
+      SERAPH_VLM_BASE_URL: http://vlm-wrapper:8001
+      SERAPH_VLM_BACKEND_URL: http://host.docker.internal:8000/v1
+      WORKSPACE_DIR: /app/data
+      LLM_LOG_DIR: /app/logs
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ${BACKEND_DATA_PATH_PROD:?set BACKEND_DATA_PATH_PROD}:/app/data
+      - ${BACKEND_LOGS_PATH_PROD:?set BACKEND_LOGS_PATH_PROD}:/app/logs
+      - ./shared:/app/shared:ro
+    secrets:
+      - operator_auth_secret
+      - operator_auth_secret_hash
+      - local_llm_api_key
+      - vlm_api_key
     networks:
-      - seraph-network-prod
-    ports:
-      - "8003:8003"
+      seraph-core:
+        ipv4_address: 172.30.0.20
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "--header", "Host: ${SERAPH_LAN_HOST:?set SERAPH_LAN_HOST}", "http://127.0.0.1:8004/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  vlm-wrapper:
+    image: ${SERAPH_VLM_IMAGE:?set immutable SERAPH_VLM_IMAGE}
     restart: unless-stopped
+    environment:
+      HOST: 0.0.0.0
+      PORT: "8001"
+      VLM_BASE_URL: http://host.docker.internal:8000/v1
+      VLM_MODEL: ${LOCAL_VLM_MODEL:?set LOCAL_VLM_MODEL}
+      CHAT_PROXY_ENABLED: "true"
+      CHAT_PROXY_API_KEY_FILE: /run/secrets/vlm_api_key
+      QUEUE_WORKERS: "1"
+      QUEUE_BACKGROUND_WORKERS: "1"
+      QUEUE_MAX_SIZE: ${SERAPH_VLM_QUEUE_MAX_SIZE:-1000}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    secrets:
+      - vlm_api_key
+    networks:
+      seraph-core:
+        ipv4_address: 172.30.0.30
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://127.0.0.1:8001/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
 networks:
-  seraph-network-prod:
-    name: seraph-network-prod
+  seraph-core:
+    name: seraph-core-prod
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24
+
+secrets:
+  tls_cert:
+    file: ${SERAPH_TLS_CERT_FILE:?set SERAPH_TLS_CERT_FILE}
+  tls_key:
+    file: ${SERAPH_TLS_KEY_FILE:?set SERAPH_TLS_KEY_FILE}
+  operator_auth_secret:
+    file: ${OPERATOR_AUTH_SECRET_FILE:-/dev/null}
+  operator_auth_secret_hash:
+    file: ${OPERATOR_AUTH_SECRET_HASH_FILE:-/dev/null}
+  local_llm_api_key:
+    file: ${LOCAL_LLM_API_KEY_FILE:-/dev/null}
+  vlm_api_key:
+    file: ${SERAPH_VLM_API_KEY_FILE:-/dev/null}

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -97,7 +97,7 @@ services:
       seraph-core:
         ipv4_address: 172.30.0.30
     healthcheck:
-      test: ["CMD", "curl", "--fail", "--silent", "http://127.0.0.1:8001/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8001/health', timeout=5).read()"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -82,7 +82,6 @@ services:
       VLM_BASE_URL: http://host.docker.internal:8000/v1
       VLM_MODEL: ${LOCAL_VLM_MODEL:?set LOCAL_VLM_MODEL}
       CHAT_PROXY_ENABLED: "true"
-      CHAT_PROXY_API_KEY_FILE: /run/secrets/vlm_api_key
       QUEUE_WORKERS: "1"
       QUEUE_BACKGROUND_WORKERS: "1"
       QUEUE_MAX_SIZE: ${SERAPH_VLM_QUEUE_MAX_SIZE:-1000}
@@ -90,6 +89,10 @@ services:
       - "host.docker.internal:host-gateway"
     secrets:
       - vlm_api_key
+    command:
+      - sh
+      - -c
+      - 'set -eu; CHAT_PROXY_API_KEY="$$(cat /run/secrets/vlm_api_key)"; [ -n "$${CHAT_PROXY_API_KEY}" ]; export CHAT_PROXY_API_KEY; exec sh -c "python scripts/preflight.py && exec uvicorn app.main:app --host $${HOST} --port $${PORT}"'
     networks:
       seraph-core:
         ipv4_address: 172.30.0.30

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -37,6 +37,8 @@ services:
     depends_on:
       vlm-wrapper:
         condition: service_healthy
+      gpu-model:
+        condition: service_healthy
     env_file:
       - .env.prod
     environment:
@@ -49,11 +51,10 @@ services:
       LOCAL_LLM_API_KEY_FILE: /run/secrets/local_llm_api_key
       SERAPH_VLM_API_KEY_FILE: /run/secrets/vlm_api_key
       SERAPH_VLM_BASE_URL: http://vlm-wrapper:8001
-      SERAPH_VLM_BACKEND_URL: http://host.docker.internal:8000/v1
+      LOCAL_LLM_API_BASE: http://gpu-model:8000/v1
+      SERAPH_VLM_BACKEND_URL: http://gpu-model:8000/v1
       WORKSPACE_DIR: /app/data
       LLM_LOG_DIR: /app/logs
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     volumes:
       - ${BACKEND_DATA_PATH_PROD:?set BACKEND_DATA_PATH_PROD}:/app/data
       - ${BACKEND_LOGS_PATH_PROD:?set BACKEND_LOGS_PATH_PROD}:/app/logs
@@ -76,17 +77,18 @@ services:
   vlm-wrapper:
     image: ${SERAPH_VLM_IMAGE:?set immutable SERAPH_VLM_IMAGE}
     restart: unless-stopped
+    depends_on:
+      gpu-model:
+        condition: service_healthy
     environment:
       HOST: 0.0.0.0
       PORT: "8001"
-      VLM_BASE_URL: http://host.docker.internal:8000/v1
+      VLM_BASE_URL: http://gpu-model:8000/v1
       VLM_MODEL: ${LOCAL_VLM_MODEL:?set LOCAL_VLM_MODEL}
       CHAT_PROXY_ENABLED: "true"
       QUEUE_WORKERS: "1"
       QUEUE_BACKGROUND_WORKERS: "1"
       QUEUE_MAX_SIZE: ${SERAPH_VLM_QUEUE_MAX_SIZE:-1000}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     secrets:
       - vlm_api_key
     command:
@@ -102,6 +104,51 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+
+  gpu-model:
+    image: ${SERAPH_GPU_MODEL_IMAGE:?set immutable SERAPH_GPU_MODEL_IMAGE}
+    restart: unless-stopped
+    command:
+      - --model
+      - /models/${SERAPH_GPU_MODEL_FILE:?set SERAPH_GPU_MODEL_FILE}
+      - --mmproj
+      - /models/${SERAPH_GPU_MMPROJ_FILE:?set SERAPH_GPU_MMPROJ_FILE}
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+      - --ctx-size
+      - ${SERAPH_GPU_MODEL_CTX_SIZE:-32768}
+      - --n-gpu-layers
+      - ${SERAPH_GPU_MODEL_LAYERS:-999}
+      - --temp
+      - "1.0"
+      - --top-p
+      - "0.95"
+      - --top-k
+      - "64"
+      - --alias
+      - ${SERAPH_GPU_MODEL_ALIAS:?set SERAPH_GPU_MODEL_ALIAS}
+      - --chat-template-kwargs
+      - '{"enable_thinking":false}'
+    volumes:
+      - ${SERAPH_GPU_MODEL_DIR:?set protected SERAPH_GPU_MODEL_DIR}:/models:ro
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    networks:
+      seraph-core:
+        ipv4_address: 172.30.0.40
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail --silent http://127.0.0.1:8000/health >/dev/null"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 180s
 
 networks:
   seraph-core:

--- a/docs/implementation/03-runtime-reliability.md
+++ b/docs/implementation/03-runtime-reliability.md
@@ -27,6 +27,11 @@
 - [ ] **Branch-local #740; intended until the epic integration PR lands:** the model-fabric operator surface separates configured candidates from selected/attempted routes and the last actual successful route. The intended `model_fabric` status also exposes runtime-path-specific text/VLM truth, fallback and degradation codes, receipt persistence, and fresh/stale/missing capability proof.
 - [ ] **Branch-local #740; intended until the epic integration PR lands:** `/api/settings/model-fabric` exposes sanitized configuration and policy truth, while the Settings canary is explicit, authenticated, exact-profile, bounded, and no-fallback. Metadata polling never launches inference.
 - [ ] Interactive REST/WebSocket ingress intentionally remains zero-transport when no authenticated principal is bound. The model fabric does not synthesize identity; #741 owns authenticated LAN/operator identity binding before this path is functional.
+- [ ] #741 also owns the one-origin trusted-CA HTTPS deployment contract,
+  session lifecycle, ingress rejection/throttling, single-worker lifecycle,
+  degraded-state, and rollback receipts documented in
+  [GPU Core LAN Operations](./19-gpu-core-lan-operations.md). No live GPU-core
+  deployment is claimed before those receipts exist.
 - [x] cockpit baseline refresh now stays bounded to cheap status, observer, audit, approval, capability, extension, browser, and settings calls; deep continuity, activity-ledger, workflow-run, control-plane, orchestration, background, M5/M6/M7/M8, guardian-memory, benchmark-proof, engineering-memory, and continuity-graph panes load through explicit operator controls with stale/unavailable states instead of rejoining the global heartbeat
 - [x] timeout-safe audit visibility into primary-vs-fallback completion and agent-model behavior
 - [x] browser and sandbox timeout receipts are grouped and rate-limited per integration/action window, so repeated provider timeouts still leave one operator-visible degraded audit receipt without flooding status/audit surfaces while chat or VLM work is active

--- a/docs/implementation/12-current-app-guide.md
+++ b/docs/implementation/12-current-app-guide.md
@@ -27,6 +27,9 @@ paired Mac edge. Until their
 migration tickets ship, the backend and frontend remain local and GPU services
 are reached over documented HTTP APIs. `ssh jupyter` is an administrator path
 for inventory and maintenance, not application transport or a required tunnel.
+The planned authenticated deployment and its acceptance boundaries are defined
+in [GPU Core LAN Operations](./19-gpu-core-lan-operations.md); it is not yet a
+live-deployment receipt.
 
 ## Run The Current App
 
@@ -122,6 +125,10 @@ stages and should expose separate failures.
 **Planned:** a paired, revocable Mac edge supplies observation and native
 interaction to the GPU core. Pairing must not implicitly authorize execution or
 data egress.
+
+Until that edge ships, a browser connected to a remote GPU core cannot invoke
+the Mac native folder picker. Screenshot-folder selection must show that edge as
+unavailable/degraded rather than presenting a GPU-host path as a Mac folder.
 
 ## Memory
 

--- a/docs/implementation/12-current-app-guide.md
+++ b/docs/implementation/12-current-app-guide.md
@@ -90,7 +90,7 @@ the effective route, including degraded state and fallback.
 
 The target GPU topology has three distinct inference transports:
 
-- `LOCAL_LLM_API_BASE=http://host.docker.internal:8000/v1` is the private local
+- `LOCAL_LLM_API_BASE=http://gpu-model:8000/v1` is the private local
   GPU text route used from the backend container;
 - `SERAPH_VLM_BASE_URL=http://vlm-wrapper:8001` also exposes an optional
   OpenAI-compatible text chat proxy under `/v1`;

--- a/docs/implementation/12-current-app-guide.md
+++ b/docs/implementation/12-current-app-guide.md
@@ -16,17 +16,21 @@ detail, read [Development Status](./STATUS.md).
 ## Current Topology
 
 ```text
-Seraph frontend       http://127.0.0.1:3001
-  -> Seraph backend   http://127.0.0.1:8004
-  -> GPU VLM wrapper  http://192.168.1.26:8001
-  -> GPU model server http://192.168.1.26:8000/v1
+GPU host `jupyter` (`192.168.1.26`)
+  Seraph frontend/backend + canonical data
+    -> private VLM wrapper
+    -> private GPU model server
+Mac paired edge
+  capture -> authenticated HTTPS ingress on jupyter
 ```
 
-The accepted architecture decision places the core on the GPU host and uses a
-paired Mac edge. Until their
-migration tickets ship, the backend and frontend remain local and GPU services
-are reached over documented HTTP APIs. `ssh jupyter` is an administrator path
-for inventory and maintenance, not application transport or a required tunnel.
+The repository and Codex workspace are already local to `jupyter`; administer
+the host directly rather than using an SSH hop to itself. Canonical authority
+stays on this GPU core. The target Mac edge is paired and revocable: it captures
+consented screenshots and pushes them through authenticated Seraph ingest for
+storage and analysis. That upload API is not shipped yet and is owned by #749.
+Until then, screenshot push is a visible gap, not a working capability. The Mac
+does not connect directly to backend, wrapper, or model ports.
 The planned authenticated deployment and its acceptance boundaries are defined
 in [GPU Core LAN Operations](./19-gpu-core-lan-operations.md); it is not yet a
 live-deployment receipt.
@@ -54,9 +58,9 @@ Useful probes:
 curl -sS http://127.0.0.1:8004/health
 curl -sS http://127.0.0.1:8004/api/runtime/status
 curl -sS http://127.0.0.1:8004/api/settings/artifact-storage
-curl -sS http://192.168.1.26:8001/health
-curl -sS http://192.168.1.26:8001/health/backend
-curl -sS http://192.168.1.26:8001/queue/status
+curl -sS http://127.0.0.1:8001/health
+curl -sS http://127.0.0.1:8001/health/backend
+curl -sS http://127.0.0.1:8001/queue/status
 ```
 
 The wrapper's `/health` and model backend's `/health/backend` are separate
@@ -86,9 +90,9 @@ the effective route, including degraded state and fallback.
 
 The target GPU topology has three distinct inference transports:
 
-- `LOCAL_LLM_API_BASE=http://192.168.1.26:8000/v1` is the chosen direct GPU text
-  endpoint for Seraph text workloads;
-- `SERAPH_VLM_BASE_URL=http://192.168.1.26:8001` also exposes an optional
+- `LOCAL_LLM_API_BASE=http://host.docker.internal:8000/v1` is the private local
+  GPU text route used from the backend container;
+- `SERAPH_VLM_BASE_URL=http://vlm-wrapper:8001` also exposes an optional
   OpenAI-compatible text chat proxy under `/v1`;
 - that same wrapper performs screenshot vision through `/v1/analyze-file`.
 

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -158,22 +158,29 @@ The reusable service repo is public under the Seraph organization:
 
 ### Current Local Topology
 
+> **Historical migration evidence — do not run these wildcard/direct-LAN
+> recipes.** The command blocks and `192.168.1.26:8000/8001` examples in this
+> section document the pre-#741 topology only. Active operation uses the private
+> loopback/bridge/service routes in GPU Core LAN Operations, and LAN acceptance
+> requires the Mac negative-port receipt.
+
 The development topology is concrete and should be verified exactly before debugging screenshot or chat routing:
 
 ```text
-Seraph frontend       http://127.0.0.1:3001
-  -> Seraph backend   http://127.0.0.1:8004
-  -> GPU VLM wrapper  http://192.168.1.26:8001
-  -> GPU model server http://192.168.1.26:8000/v1
+GPU host `jupyter` (`192.168.1.26`)
+  Seraph frontend/backend + canonical data
+    -> private VLM wrapper
+    -> private GPU model server
+Mac paired edge
+  capture -> authenticated screenshot ingest on jupyter
 ```
 
 The VLM wrapper runs through Docker Compose on the GPU server to avoid local Python/runtime drift and to keep request admission next to the one GPU:
 
 ```bash
-ssh jupyter
 cd /home/pawel/repos/vlm-screenshot-server
 HOST_BIND=0.0.0.0 HOST_PORT=8001 PORT=8001 \
-  VLM_BASE_URL=http://192.168.1.26:8000/v1 \
+  VLM_BASE_URL=http://host.docker.internal:8000/v1 \
   VLM_MODEL=unsloth/gemma-4-26B-A4B-it-qat-GGUF \
   CHAT_PROXY_ENABLED=true \
   CHAT_PROXY_API_KEY=<strong-token> \
@@ -181,51 +188,51 @@ HOST_BIND=0.0.0.0 HOST_PORT=8001 PORT=8001 \
   docker compose up -d --build screenshot-vlm
 ```
 
-The container publishes `192.168.1.26:8001` and forwards to `http://192.168.1.26:8000/v1`. Docker Desktop on the Mac is not part of the healthy product path for the wrapper.
+The wrapper and model are local services on `jupyter`. Under the authenticated
+LAN topology their ports are private; the Seraph backend reaches them through
+local Docker/service HTTP routes. Docker Desktop on the Mac is not part of the
+product path. Administer them directly from this workspace rather than using an
+SSH hop to the same host.
 
-SSH is only the admin channel for deploying, restarting, and inspecting the GPU-hosted wrapper. Seraph runtime traffic must stay on direct HTTP API calls to `SERAPH_VLM_BASE_URL=http://192.168.1.26:8001`; do not encode SSH forwards, SOCKS proxies, or tunnels into Seraph config or status receipts.
-
-Required readiness checks from the Mac:
+Required local service checks on `jupyter`:
 
 ```bash
-cd /Users/bigcube/Desktop/repos/seraph
 ./manage.sh -e dev local status
 curl http://127.0.0.1:8004/health
-curl http://192.168.1.26:8001/health
-curl http://192.168.1.26:8001/health/backend
-curl http://192.168.1.26:8001/queue/status
+curl http://127.0.0.1:8001/health
+curl http://127.0.0.1:8001/health/backend
+curl http://127.0.0.1:8001/queue/status
 set -a && source .env.dev && set +a
-curl http://192.168.1.26:8001/health/chat \
+curl http://127.0.0.1:8001/health/chat \
   -H "Authorization: Bearer $SERAPH_VLM_API_KEY"
 PYTHONPATH=backend backend/.venv/bin/python scripts/diagnose_gpu_vlm_route.py
 ```
 
+Verified local evidence on this host: `jupyter` is `192.168.1.26` with an RTX
+3090; `unsloth/gemma-4-26B-A4B-it-qat-GGUF` answers on local port 8000; the
+wrapper is healthy on local port 8001; and its default `/v1/analyze-file`
+canary returns HTTP 200. The legacy wrapper currently binds `0.0.0.0:8001`;
+#741 must make that service private before LAN acceptance.
+
+There is no shipped Seraph screenshot-upload API. The Mac-to-jupyter capture
+push is the paired-edge target owned by #749. Current folder ingestion remains
+server-local/transitional and must not be described as a working remote Mac
+push path.
+
 Interpretation:
 
 - `127.0.0.1:8004/health` proves Seraph backend is running.
-- `192.168.1.26:8001/health` proves the Dockerized GPU VLM wrapper is reachable from the Mac.
-- `192.168.1.26:8001/health/backend` proves the wrapper can reach the GPU model server at `192.168.1.26:8000/v1`.
-- `192.168.1.26:8001/queue/status` proves Seraph can observe admission pressure before feeding screenshot work.
-- `192.168.1.26:8001/health/chat` proves the chat proxy is enabled and accepts Seraph's configured bearer key without running inference or adding GPU queue work.
+- `127.0.0.1:8001/health` proves the local wrapper is healthy.
+- `127.0.0.1:8001/health/backend` proves the wrapper can reach the local GPU model server.
+- `127.0.0.1:8001/queue/status` proves Seraph can observe admission pressure.
+- `127.0.0.1:8001/health/chat` proves the local chat proxy accepts the configured bearer key.
 - The direct-route diagnostic also checks authenticated chat readiness. This catches `CHAT_PROXY_ENABLED=false`, missing `CHAT_PROXY_API_KEY`, and Seraph/wrapper key mismatches that ordinary health checks cannot see.
 - A `502` from `/health/backend` means the wrapper is up but the GPU backend edge is broken.
 - A `disabled`, `auth_not_configured`, or `auth_failed` result from `/health/chat` means screenshot analysis may still work but Seraph chat is not ready.
 
-Run the direct-route receipt from the normal operator shell that starts Seraph
-when Codex/Desktop reports a LAN failure. A normal Terminal-launched receipt on
-July 3, 2026 proved `ssh -o BatchMode=yes -o ConnectTimeout=5 jupyter true`
-exits `0` for this GPU host, even though Codex/Desktop-launched direct SSH can
-report `No route to host` for the same alias. If Codex reports `No route to
-host` or connection failures for `192.168.1.26` while the operator shell can
-reach `jupyter`, record the Codex result as an agent-network limitation, not as
-evidence that the product topology requires a tunnel.
-
-Codex maintenance access is allowed to use `ssh jupyter` for GPU-host
-administration. That route has confirmed host `jupyter`, user `pawel`, and the
-GPU wrapper repo at `/home/pawel/repos/vlm-screenshot-server`. Use it for
-inventory, Docker Compose checks, process inspection, listener checks, and log
-reads. Do not use it as a Seraph runtime base URL or a passing direct-route
-acceptance receipt.
+Run service receipts directly on `jupyter`, the host of this workspace. Use
+local Docker, process, listener, filesystem, and log inspection; an SSH hop to
+`jupyter` is not part of administration or runtime validation.
 
 Fast metadata endpoints must not block on live GPU route probes. `/api/runtime/status` and `/api/settings/artifact-storage` expose the configured and effective VLM runtime shape with `vlm_runtime.live_probe.checked=false` and `reason=deferred_fast_metadata`; that keeps cockpit and settings refreshes usable even when the LAN route is slow, down, or unreachable from the Codex process. The explicit route receipts remain the wrapper `/health`, `/health/backend`, `/queue/status`, authenticated `/health/chat`, and `scripts/diagnose_gpu_vlm_route.py` checks below. Diagnostic SSH forwards are still not a substitute for a passing direct `SERAPH_VLM_BASE_URL` route receipt.
 
@@ -252,16 +259,15 @@ llama serve \
 The GPU model backend exposes an OpenAI-compatible API on the GPU host at:
 
 ```text
-http://192.168.1.26:8000/v1
+http://127.0.0.1:8000/v1
 ```
 
 Run the screenshot-analysis wrapper on the GPU server with Docker Compose. The
-repo on the GPU host is `/home/pawel/repos/vlm-screenshot-server`; the wrapper
-publishes `http://192.168.1.26:8001` and forwards to the local GPU model
-backend above.
+local repo is `/home/pawel/repos/vlm-screenshot-server`. The legacy wrapper
+currently publishes `0.0.0.0:8001`; this is transitional evidence only. Issue
+#741 makes the wrapper private behind the authenticated Seraph ingress.
 
 ```bash
-ssh jupyter
 cd /home/pawel/repos/vlm-screenshot-server
 cp .env.example .env
 ```
@@ -273,7 +279,7 @@ HOST=0.0.0.0
 PORT=8001
 HOST_BIND=0.0.0.0
 HOST_PORT=8001
-VLM_BASE_URL=http://192.168.1.26:8000/v1
+VLM_BASE_URL=http://host.docker.internal:8000/v1
 VLM_MODEL=unsloth/gemma-4-26B-A4B-it-qat-GGUF
 VLM_API_KEY=
 VLM_TIMEOUT_SECONDS=180
@@ -291,15 +297,14 @@ Then start the wrapper:
 docker compose up -d --build
 ```
 
-Test the wrapper and backend from the Mac/operator shell through direct HTTP
-API calls:
+Test the wrapper and backend locally on `jupyter`:
 
 ```bash
-curl http://192.168.1.26:8001/health
-curl http://192.168.1.26:8001/health/backend
-curl http://192.168.1.26:8001/queue/status
+curl http://127.0.0.1:8001/health
+curl http://127.0.0.1:8001/health/backend
+curl http://127.0.0.1:8001/queue/status
 curl -F "file=@/path/to/screenshot.png" \
-  http://192.168.1.26:8001/v1/analyze-file
+  http://127.0.0.1:8001/v1/analyze-file
 ```
 
 Seraph-side first-class `local-vlm` wiring is available behind explicit settings:
@@ -307,8 +312,8 @@ Seraph-side first-class `local-vlm` wiring is available behind explicit settings
 ```env
 SCREEN_ANALYSIS_PROVIDER=local-vlm
 SERAPH_VLM_MODE=gpu-server
-SERAPH_VLM_BASE_URL=http://192.168.1.26:8001
-SERAPH_VLM_BACKEND_URL=http://192.168.1.26:8000/v1
+SERAPH_VLM_BASE_URL=http://vlm-wrapper:8001
+SERAPH_VLM_BACKEND_URL=http://host.docker.internal:8000/v1
 SERAPH_VLM_API_KEY=<same-token-as-wrapper-CHAT_PROXY_API_KEY>
 SERAPH_VLM_FEEDER_WINDOW=2
 LOCAL_VLM_MODEL=unsloth/gemma-4-26B-A4B-it-qat-GGUF
@@ -321,25 +326,19 @@ SCREEN_DERIVED_LLM_REQUIRE_PROFILE_PROOF=true
 
 Quote `RUNTIME_PROFILE_PREFERENCES` whenever it contains semicolons. The managed local launcher sources `.env.dev` as shell, so an unquoted value is split into partial shell assignments and Seraph can silently lose the `chat_agent` profile preference.
 
-The production-like local topology is direct private LAN, not an SSH tunnel:
+The target production topology uses private same-host service routes:
 
 ```text
 Seraph backend     http://127.0.0.1:8004
-  -> GPU VLM       http://192.168.1.26:8001
-  -> llama.cpp     http://192.168.1.26:8000/v1
+  -> GPU VLM       http://vlm-wrapper:8001
+  -> llama.cpp     http://host.docker.internal:8000/v1
 ```
 
-SSH forwarding is acceptable only as a diagnostic bridge for an agent sandbox that cannot open the LAN route. It is not the operator runtime contract, and Seraph status must not require or imply a tunnel.
+This workspace is already on the GPU host. Use the private local service routes;
+SSH forwarding is neither necessary nor accepted as runtime proof.
 
-The user should not have to set up tunnels to access Seraph's GPU VLM API. If a
-tunnel is needed for a Codex diagnostic session, keep it out of `.env.dev`, do
-not use it as a passing acceptance receipt, and prefer an operator-shell
-`scripts/diagnose_gpu_vlm_route.py` receipt against
-`http://192.168.1.26:8001`.
-
-When Codex needs to administer the GPU host, use `ssh jupyter` for admin work
-only. Keep that maintenance route labeled separately from the product topology
-above.
+Administer the GPU host directly from this workspace. The Mac must not use these
+internal URLs.
 
 When configured, `screenshot_folder_analysis` posts the screenshot image plus Seraph's strict analysis prompt to `/v1/analyze-file`, validates the returned JSON against `seraph.screenshot_analysis.v1`, and stores the privacy-safe semantic payload inside the existing Seraph `ScreenObservation`.
 If the provider is not configured or fails, Seraph still keeps the screenshot metadata observation and records a bounded analyzer status instead of retrying the same image as a new screenshot.
@@ -377,7 +376,7 @@ Seraph-side controls:
 - `GUARDIAN_STATE_TIMEOUT_SECONDS` bounds chat context assembly. If guardian/operator context is slow or degraded, chat falls back to a minimal agent context instead of leaving the operator stuck at "responding" before the model request is dispatched.
 - `LOCAL_RUNTIME_CONTEXT_WINDOW_TOKENS` is Seraph's configured prompt budget for local Gemma-compatible chat backends. It must match the GPU server `--ctx-size` operationally; the current local target is `32768`.
 - `LOCAL_RUNTIME_PROMPT_SAFETY_RATIO`, `LOCAL_RUNTIME_TOOL_RESERVE_TOKENS`, and `LOCAL_RUNTIME_MIN_SECTION_TOKENS` control deterministic prompt compaction for local runtime profiles. Seraph compacts guardian state, observer context, memories, active skills, and conversation history before creating the `ToolCallingAgent`, while preserving the fixed Seraph identity instructions. `FallbackLiteLLMModel.generate` and `completion_with_fallback_sync` also run a final profile-aware message compaction pass for local-profile targets, preserving the current user turn and reserving the effective output-token budget before LiteLLM sees the request. Local profile status exposes the configured context window, safety ratio, tool reserve, and prompt budget so operators can verify the runtime contract. This is the Seraph-side guardrail that prevents oversized local prompts from reaching the backend as raw `exceed_context_size_error`.
-- **Branch-local #740 target; not shipped `develop` truth:** governed model-fabric text calls use Seraph's direct HTTPX OpenAI-compatible adapter, not LiteLLM transport. Canonical model-fabric profiles therefore carry the exact model identifier accepted by their configured backend. The legacy `LOCAL_MODEL`/`local-gemma-*` registration path still uses its existing LiteLLM-oriented `openai/` naming until #739 removes that transitional path. The target topology sends text to `LOCAL_LLM_API_BASE=http://192.168.1.26:8000/v1`; `${SERAPH_VLM_BASE_URL}/v1` remains an optional wrapper chat proxy, while screenshot analysis remains the distinct `${SERAPH_VLM_BASE_URL}/v1/analyze-file` adapter.
+- **Branch-local #740 target; not shipped `develop` truth:** governed model-fabric text calls use Seraph's direct HTTPX OpenAI-compatible adapter, not LiteLLM transport. Canonical model-fabric profiles therefore carry the exact model identifier accepted by their configured backend. The legacy `LOCAL_MODEL`/`local-gemma-*` registration path still uses its existing LiteLLM-oriented `openai/` naming until #739 removes that transitional path. The target topology sends text through the private `LOCAL_LLM_API_BASE=http://host.docker.internal:8000/v1`; `${SERAPH_VLM_BASE_URL}/v1` remains an optional wrapper chat proxy, while screenshot analysis remains the distinct `${SERAPH_VLM_BASE_URL}/v1/analyze-file` adapter.
 - **Branch-local #740 pricing provenance:** remote profile `cost_source` is a bounded source identifier (`[A-Za-z0-9_.:-]`, at most 128 characters), not a free-form label or URL. This matches the sanitized receipt contract, so accepted configuration cannot fail only after a model response is transported and receipt construction begins.
 - Fresh profiles use `onboarding_agent` before normal chat. Configure `onboarding_agent=local-gemma-chat-thinking` alongside `chat_agent=local-gemma-chat-thinking`, or the first "Hello" from a new operator can still route through the cloud default while the normal chat profile is correctly registered.
 - If delegation is enabled, chat uses `orchestrator_agent`, so `orchestrator_agent=local-gemma-chat-thinking` must also be configured. Otherwise the delegated chat surface can still route through the cloud default while the local chat profile is correctly registered.
@@ -403,7 +402,7 @@ Seraph ships a proof harness for local Gemma profile behavior:
 ```bash
 PYTHONPATH=. WORKSPACE_DIR=/tmp/seraph-dev-data \
   uv run python ../scripts/verify_local_gemma_profiles.py \
-  --base-url http://192.168.1.26:8001/v1 \
+  --base-url http://127.0.0.1:8001/v1 \
   --timeout-seconds 120
 ```
 

--- a/docs/implementation/18-screenshot-folder-source.md
+++ b/docs/implementation/18-screenshot-folder-source.md
@@ -142,6 +142,13 @@ Seraph can keep screenshot production separate from analysis while still using a
 2. Seraph scans that folder and owns observation/report persistence.
 3. A separate image-analysis service accepts image bytes and forwards them to a private LAN/VPN vision-language model backend.
 
+This section describes the current transitional direct-route evidence. Under
+the accepted GPU-core target, model and wrapper ports become host-internal and
+operators enter through the single authenticated HTTPS origin described in
+[GPU Core LAN Operations](./19-gpu-core-lan-operations.md). The existing queue,
+wrapper/backend health, and direct-route receipts remain useful migration
+evidence; they do not authorize anonymous public service ports.
+
 The reusable service repo is public under the Seraph organization:
 
 - repo: [seraph-quest/vlm-screenshot-server](https://github.com/seraph-quest/vlm-screenshot-server)

--- a/docs/implementation/19-gpu-core-lan-operations.md
+++ b/docs/implementation/19-gpu-core-lan-operations.md
@@ -18,6 +18,12 @@ connect directly to backend, VLM-wrapper, model-server, database, or worker
 ports. Those services remain host-internal; the HTTPS ingress is the sole
 product entry point.
 
+On the current rootless-Docker `jupyter` host, that origin is
+`https://192.168.1.26:8443`. Rootless Docker cannot publish privileged port
+443 with the host's current `net.ipv4.ip_unprivileged_port_start=1024`
+setting. Port 8443 preserves the same TLS and authentication boundary without
+granting Docker extra privilege or changing a host-wide sysctl.
+
 Authentication must provide login, server-side session validation, bounded
 session refresh, and logout/revocation. Session cookies are `Secure`,
 `HttpOnly`, and use an explicit `SameSite` policy. Ingress rejects unexpected
@@ -86,8 +92,8 @@ the GPU host to the Mac. Then run:
 ```bash
 python3 scripts/generate_mac_lan_acceptance.py \
   --challenge-file /path/to/seraph-prod-candidate-challenge.json \
-  --https-origin https://seraph.lan \
-  --lan-host seraph.lan \
+  --https-origin https://192.168.1.26:8443 \
+  --lan-host 192.168.1.26 \
   --lan-ip 192.168.1.26 \
   --trusted-ca /path/to/seraph-lan-ca.pem \
   --operator-secret-file /path/to/operator-login-secret \

--- a/docs/implementation/19-gpu-core-lan-operations.md
+++ b/docs/implementation/19-gpu-core-lan-operations.md
@@ -1,0 +1,118 @@
+---
+slug: /gpu-core-lan-operations
+title: 19. GPU Core LAN Operations
+---
+
+# GPU Core LAN Operations
+
+**Status:** Planned for issue [#741](https://github.com/seraph-quest/seraph/issues/741)
+
+This runbook defines the acceptance contract for moving the Seraph core to the
+GPU host. It does not claim that the deployment is live. The current shipped
+Mac-core topology remains in [Current App Guide](./12-current-app-guide.md).
+
+## Supported Boundary
+
+The operator uses one trusted-CA HTTPS origin on the LAN. The browser must not
+connect directly to backend, VLM-wrapper, model-server, database, or worker
+ports. Those services remain host-internal; the HTTPS ingress is the sole
+product entry point.
+
+Authentication must provide login, server-side session validation, bounded
+session refresh, and logout/revocation. Session cookies are `Secure`,
+`HttpOnly`, and use an explicit `SameSite` policy. Ingress rejects unexpected
+`Host` and mutating cross-origin requests, applies bounded login and API
+throttles, and trusts forwarded client information only from the configured
+local reverse proxy. Seraph runs as a single application worker while SQLite
+and in-process scheduling remain authoritative.
+
+The Mac native folder picker is not remotely available through the browser.
+Screenshot-folder selection and Mac capture therefore remain explicitly
+degraded until the paired edge ships; a server-local path is not presented as
+a Mac folder.
+
+## Lifecycle And Verification
+
+Production commands are explicit and always use the production environment:
+
+```bash
+./manage.sh -e prod production config-validate
+./manage.sh -e prod production start
+./manage.sh -e prod production status
+./manage.sh -e prod production logs
+./manage.sh -e prod production restart
+./manage.sh -e prod production rollback <40-hex-app-sha> <wrapper-image@sha256:64-hex-digest> </path/to/target-inventory.json>
+./manage.sh -e prod production stop
+```
+
+`SERAPH_IMAGE_TAG` must equal the full current Git `HEAD`, and production builds
+require a clean worktree. The wrapper image is digest-pinned. The active release
+record stores the application SHA, wrapper digest, and accepted inventory
+receipt path so a failed candidate or rollback can restore the entire tuple.
+
+Before `start` or `rollback`, generate a fresh inventory JSON from the verified
+GPU administrator shell. It must contain the configured SSH alias and exact
+out-of-band-verified host-key fingerprint, an explicit UTC `captured_at`, raw
+`ss -lntp` output, current Docker bridge addresses and `host-gateway` binding,
+firewall results proving LAN ingress to 8000/8001/8004 is blocked, and the exact
+wrapper digest/interface contract being accepted. Set its path in
+`SERAPH_HOST_INVENTORY_RECEIPT`; rollback takes the target tuple's receipt as an
+explicit third argument. Missing, stale, mismatched, wildcard-listener, or
+unverified receipts fail closed.
+
+The acceptance receipt must cover start, status, health, logs, restart
+persistence, degraded dependency reporting, and rollback to the previous
+known-good release. Do not infer readiness from a running process or configured
+URL alone.
+
+From the operator machine, verify the public origin with the trusted CA file:
+
+```bash
+curl --cacert /path/to/seraph-lan-ca.pem https://seraph.lan/health
+```
+
+Never use `curl -k` or disabled certificate verification as an acceptance
+receipt. Record the effective origin, certificate identity, authenticated
+login/session/refresh/logout results, restart result, and sanitized health
+payload. Exercise Host, Origin, unauthenticated, revoked-session, and throttle
+negative cases. Confirm internal service ports are not reachable as product
+entry points from the LAN.
+
+If an SSH host key changes, stop and compare the observed fingerprint with a
+trusted out-of-band administrator record. A changed or unverified fingerprint
+is a deployment blocker; do not bypass host-key verification. SSH remains an
+administrator route for inventory, deployment, process inspection, and logs.
+It is never Seraph application transport and must not become a user tunnel.
+
+Operator-shell receipts are authoritative. When a Codex/Desktop process cannot
+reach the LAN but the normal shell that launches Seraph can, record the agent
+network limitation and retain the direct HTTPS operator-shell receipt. Do not
+replace the product topology with a tunnel.
+
+## Degraded Operation And Rollback
+
+The public health/status surface must distinguish ingress, authentication,
+backend, VLM wrapper, model backend, queue, storage, and paired-edge state.
+Loss of the Mac edge degrades capture/native interaction without moving
+canonical authority. Loss of VLM/model services leaves the cockpit and recovery
+controls available and reports the failed dependency. Rollback restores the
+last known-good application release and compatible persistent state; backup and
+restore proof remains a separate migration gate.
+
+An accepted in-flight request may finish during a graceful deployment or
+configuration sync. New work must stop entering the retiring instance, and no
+tool may claim that an external side effect was cancelled once execution has
+crossed that boundary. The receipt must distinguish drained, cancelled-before-
+execution, completed, and outcome-unknown work.
+
+## Ticket And Evidence Mapping
+
+- [#688](https://github.com/seraph-quest/seraph/issues/688) remains the
+  production-readiness gate; #741 supplies a deployment receipt, not a blanket
+  production-ready claim.
+- [#695](https://github.com/seraph-quest/seraph/issues/695) owns the durable
+  documentation slice represented by this runbook and linked guides.
+- [#687](https://github.com/seraph-quest/seraph/issues/687) retains useful
+  queue, wrapper-health, and direct-route evidence. Its Mac-core/public-service-
+  port target is superseded by ADR-004 and the one-origin authenticated GPU-core
+  contract.

--- a/docs/implementation/19-gpu-core-lan-operations.md
+++ b/docs/implementation/19-gpu-core-lan-operations.md
@@ -115,16 +115,36 @@ the receipt.
 
 Start, rollback, restart, and automatic restoration stop in explicit
 candidate/rollback/restart/restore-awaiting-LAN states. Their matching
-`accept*` command freshly reattests the unchanged three-container/network
+`accept*` command freshly reattests the unchanged four-container/network
 binding. Every mutating production command is serialized by one nonblocking
 lifecycle `flock`; a concurrent mutation is rejected. Acceptance prepares the
 local and Mac evidence copies, validates the completed immutable bundle, and
 prepares the consumed nonce/challenge ledger and active state before publishing
 the active state last. The immutable bundle contains the app/VLM tuple, Compose
-project and network ID, ingress/backend/VLM container IDs, ingress/backend image
+project and network ID, ingress/backend/VLM/GPU-model container IDs, ingress/backend image
 IDs and revision labels through the local attestation, the configured immutable
 wrapper reference and observed image ID (plus RepoDigest when registry-backed),
-hashed evidence copies, and expected origin/client identity. Live identities
+and the complete version-2 GPU release tuple: image RepoDigest, alias, normalized
+absolute artifact root, model and mmproj filenames/SHA-256 hashes/sizes, context
+size, GPU layers, and command contract.
+The challenged and final attestations must carry the identical tuple; artifacts
+are rehashed before start, restart, rollback, restoration, and acceptance.
+Historical validation and recovery load the accepted artifact root from that
+tuple rather than the current environment, so changing `SERAPH_GPU_MODEL_DIR`
+cannot redirect an older accepted release to a different model directory.
+Staged candidate, rollback, restart, and restore receipts carry the same complete
+tuple. A later acceptance process restores and exports it before revalidation or
+final attestation; incomplete staged receipts are rejected.
+Authority reads used only to capture a recovery tuple run in preserve mode: a
+new candidate keeps its requested GPU tuple, and rollback keeps its selected
+historical target while recording the current active tuple for failure recovery.
+Active state is distinct from staged local evidence: only a v2 Mac-accepted
+bundle can authorize active state. The active-state file atomically carries the
+hash-bound accepted-release history index used by rollback, so unindexed orphan
+files under `releases/` are never rollback authority. Managed Compose cutovers
+use a 300-second wait timeout, covering the GPU model's 180-second health start
+window plus initialization buffer.
+Hashed evidence copies and expected origin/client identity are also retained. Live identities
 are read again immediately before publication. A failed pre-publication attempt
 can leave only hash-named, read-only orphan evidence in `releases/`; it cannot
 create active state, and those unreferenced files may be removed during a later
@@ -146,12 +166,15 @@ python3 scripts/generate_local_gpu_inventory.py \
   --ingress-container seraph-prod-ingress-1 \
   --backend-container seraph-prod-backend-1 \
   --vlm-container seraph-prod-vlm-wrapper-1 \
+  --gpu-model-container seraph-prod-gpu-model-1 \
+  --expected-gpu-model-image "$SERAPH_GPU_MODEL_IMAGE" \
+  --expected-gpu-model-alias "$SERAPH_GPU_MODEL_ALIAS" \
   --vlm-api-key-file "$SERAPH_VLM_API_KEY_FILE" \
   > /path/to/gpu-host-inventory.json
 ```
 
 The script hashes the local machine-id in memory and emits only its SHA-256
-digest. It inspects all three containers, their immutable image identities,
+digest. It inspects all four containers, their immutable image identities,
 revision labels, shared network identity and fixed private addresses, the
 running wrapper's configured immutable reference and observed image ID, plus
 its RepoDigest when registry-backed, network/port state, and tested interface

--- a/docs/implementation/19-gpu-core-lan-operations.md
+++ b/docs/implementation/19-gpu-core-lan-operations.md
@@ -60,8 +60,12 @@ Production commands are explicit and always use the production environment:
 ```
 
 `SERAPH_IMAGE_TAG` must equal the full current Git `HEAD`, and production builds
-require a clean worktree. The wrapper image is digest-pinned. The active release
-record stores the application SHA, wrapper digest, and accepted inventory
+require a clean worktree. The wrapper is pinned either by a real registry
+`name@sha256:<64-hex>` RepoDigest or by an exact local Docker
+`sha256:<64-hex>` image ID. For the current local wrapper repository, build it,
+read `.Id` with `docker image inspect`, and configure that exact ID; do not
+assume a nonexistent GHCR package. Mutable tags are rejected. The active release
+record stores the application SHA, wrapper immutable reference, and accepted inventory
 receipt path so a failed candidate or rollback can restore the entire tuple.
 
 `production start` is a staged operation. Before cutover it automatically
@@ -112,7 +116,8 @@ local and Mac evidence copies, validates the completed immutable bundle, and
 prepares the consumed nonce/challenge ledger and active state before publishing
 the active state last. The immutable bundle contains the app/VLM tuple, Compose
 project and network ID, ingress/backend/VLM container IDs, ingress/backend image
-IDs and revision labels through the local attestation, the wrapper RepoDigest,
+IDs and revision labels through the local attestation, the configured immutable
+wrapper reference and observed image ID (plus RepoDigest when registry-backed),
 hashed evidence copies, and expected origin/client identity. Live identities
 are read again immediately before publication. A failed pre-publication attempt
 can leave only hash-named, read-only orphan evidence in `releases/`; it cannot
@@ -142,8 +147,9 @@ python3 scripts/generate_local_gpu_inventory.py \
 The script hashes the local machine-id in memory and emits only its SHA-256
 digest. It inspects all three containers, their immutable image identities,
 revision labels, shared network identity and fixed private addresses, the
-running wrapper's RepoDigest, network/port state, and tested interface
-behaviors. Locally built legacy images without the pinned identity are
+running wrapper's configured immutable reference and observed image ID, plus
+its RepoDigest when registry-backed, network/port state, and tested interface
+behaviors. Local images whose ID differs from the configured pin are
 non-accepted. Local firewall parsing is not an acceptance gate; the Mac-side
 negative reachability receipt is authoritative for LAN isolation.
 

--- a/docs/implementation/19-gpu-core-lan-operations.md
+++ b/docs/implementation/19-gpu-core-lan-operations.md
@@ -187,6 +187,10 @@ backend, queue, unauthenticated `auth_failed`/`auth_ok=false`, and authenticated
 `status=ok`/`auth_ok=true` interface checks use wrapper loopback; the API key is
 supplied over probe stdin. Probe bodies are bounded and reduced to booleans in
 the receipt. GPU health uses the pinned model container's loopback interface.
+Registry comparisons canonicalize only Docker's tag-stripping representation:
+`repository:tag@sha256:digest` and `repository@sha256:digest` are equivalent.
+The repository and digest must still match exactly, and accepted bundles retain
+the operator-configured immutable reference.
 
 Bootstrap `SERAPH_GPU_MACHINE_IDENTITY_SHA256` once at a trusted local console
 by hashing `/etc/machine-id` without printing its raw value. Review and pin the

--- a/docs/implementation/19-gpu-core-lan-operations.md
+++ b/docs/implementation/19-gpu-core-lan-operations.md
@@ -181,6 +181,11 @@ its RepoDigest when registry-backed, network/port state, and tested interface
 behaviors. Local images whose ID differs from the configured pin are
 non-accepted. Local firewall parsing is not an acceptance gate; the Mac-side
 negative reachability receipt is authoritative for LAN isolation.
+Private service behavior is probed from inside the owning container namespace,
+not by routing from the rootless Docker host to `172.30.0.0/24`. VLM health,
+backend, queue, unauthenticated rejection, and authenticated interface checks
+use wrapper loopback; the API key is supplied over probe stdin. GPU health uses
+the pinned model container's loopback interface.
 
 Bootstrap `SERAPH_GPU_MACHINE_IDENTITY_SHA256` once at a trusted local console
 by hashing `/etc/machine-id` without printing its raw value. Review and pin the

--- a/docs/implementation/19-gpu-core-lan-operations.md
+++ b/docs/implementation/19-gpu-core-lan-operations.md
@@ -7,9 +7,9 @@ title: 19. GPU Core LAN Operations
 
 **Status:** Planned for issue [#741](https://github.com/seraph-quest/seraph/issues/741)
 
-This runbook defines the acceptance contract for moving the Seraph core to the
-GPU host. It does not claim that the deployment is live. The current shipped
-Mac-core topology remains in [Current App Guide](./12-current-app-guide.md).
+This runbook defines the acceptance contract for operating the Seraph core on
+the current GPU host, `jupyter` (`192.168.1.26`). It does not by itself claim
+that every production acceptance gate is complete.
 
 ## Supported Boundary
 
@@ -26,6 +26,15 @@ throttles, and trusts forwarded client information only from the configured
 local reverse proxy. Seraph runs as a single application worker while SQLite
 and in-process scheduling remain authoritative.
 
+The repository, frontend, backend, canonical data, VLM wrapper, and model
+server are local to `jupyter`. Administrators use direct Docker, process,
+listener, filesystem, and log inspection; they do not SSH from jupyter back to
+jupyter. The target Mac edge captures consented screenshots and pushes them
+through authenticated ingest. That paired-edge upload is planned in #749; no
+current screenshot upload API exists, so this is not shipped push support. The
+Mac owns no canonical state and has no direct access to ports 8000, 8001, or
+8004.
+
 The Mac native folder picker is not remotely available through the browser.
 Screenshot-folder selection and Mac capture therefore remain explicitly
 degraded until the paired edge ships; a server-local path is not presented as
@@ -38,10 +47,15 @@ Production commands are explicit and always use the production environment:
 ```bash
 ./manage.sh -e prod production config-validate
 ./manage.sh -e prod production start
+./manage.sh -e prod production accept /path/to/signed-mac-receipt.json
 ./manage.sh -e prod production status
 ./manage.sh -e prod production logs
 ./manage.sh -e prod production restart
-./manage.sh -e prod production rollback <40-hex-app-sha> <wrapper-image@sha256:64-hex-digest> </path/to/target-inventory.json>
+./manage.sh -e prod production accept-restart /path/to/signed-mac-receipt.json
+./manage.sh -e prod production rollback <40-hex-app-sha> <wrapper-image@sha256:64-hex-digest>
+./manage.sh -e prod production accept-rollback /path/to/signed-mac-receipt.json
+./manage.sh -e prod production accept-restore /path/to/signed-mac-receipt.json
+./manage.sh -e prod production abort <candidate|rollback|restore|restart>
 ./manage.sh -e prod production stop
 ```
 
@@ -50,15 +64,94 @@ require a clean worktree. The wrapper image is digest-pinned. The active release
 record stores the application SHA, wrapper digest, and accepted inventory
 receipt path so a failed candidate or rollback can restore the entire tuple.
 
-Before `start` or `rollback`, generate a fresh inventory JSON from the verified
-GPU administrator shell. It must contain the configured SSH alias and exact
-out-of-band-verified host-key fingerprint, an explicit UTC `captured_at`, raw
-`ss -lntp` output, current Docker bridge addresses and `host-gateway` binding,
-firewall results proving LAN ingress to 8000/8001/8004 is blocked, and the exact
-wrapper digest/interface contract being accepted. Set its path in
-`SERAPH_HOST_INVENTORY_RECEIPT`; rollback takes the target tuple's receipt as an
-explicit third argument. Missing, stale, mismatched, wildcard-listener, or
-unverified receipts fail closed.
+`production start` is a staged operation. Before cutover it automatically
+generates a local identity/listener receipt and refuses a wildcard/LAN model
+listener, an old wrapper on 8001, or an unexpected backend on 8004. After the
+private Compose candidate starts, it automatically binds an attestation to the
+actual wrapper container/image/network and tests `/health`, `/health/backend`,
+`/queue/status`, unauthenticated `/health/chat` denial, and authenticated
+`/health/chat` success. It then stops at `candidate awaiting LAN acceptance`
+without writing accepted state.
+
+From the operator Mac, generate measured and signed evidence (this is deployment
+acceptance, not #749 paired-edge identity). First copy the non-secret exact
+stage challenge from
+`$PID_DIR/seraph-prod-<candidate|rollback|restore|restart>-challenge.json` on
+the GPU host to the Mac. Then run:
+
+```bash
+python3 scripts/generate_mac_lan_acceptance.py \
+  --challenge-file /path/to/seraph-prod-candidate-challenge.json \
+  --https-origin https://seraph.lan \
+  --lan-host seraph.lan \
+  --lan-ip 192.168.1.26 \
+  --trusted-ca /path/to/seraph-lan-ca.pem \
+  --operator-secret-file /path/to/operator-login-secret \
+  --probe-key-file /path/to/distinct-mac-probe-hmac-key \
+  --client-identity operator-mac > /path/to/signed-mac-receipt.json
+```
+
+The generator requires DNS for the HTTPS hostname to include the pinned LAN IP,
+logs in, proves the authenticated session, actively attempts TCP connections to
+that exact IP on 8000/8001/8004, records only bounded refusal/timeout classes,
+and signs canonical JSON with HMAC-SHA256. DNS mismatch, no-route, and
+unclassified network errors fail closed. The GPU host pins the exact expected
+origin, LAN hostname, LAN IP, client label, and a distinct nonempty probe HMAC
+key file. That HMAC key is separate from the operator login secret. The receipt
+must contain the exact server challenge and its digest. Mac receipt nonces and
+server challenge nonces are recorded as separate consumed authorities and
+neither can be replayed. Operator login and probe key material never appear in
+the receipt.
+
+Start, rollback, restart, and automatic restoration stop in explicit
+candidate/rollback/restart/restore-awaiting-LAN states. Their matching
+`accept*` command freshly reattests the unchanged three-container/network
+binding. Every mutating production command is serialized by one nonblocking
+lifecycle `flock`; a concurrent mutation is rejected. Acceptance prepares the
+local and Mac evidence copies, validates the completed immutable bundle, and
+prepares the consumed nonce/challenge ledger and active state before publishing
+the active state last. The immutable bundle contains the app/VLM tuple, Compose
+project and network ID, ingress/backend/VLM container IDs, ingress/backend image
+IDs and revision labels through the local attestation, the wrapper RepoDigest,
+hashed evidence copies, and expected origin/client identity. Live identities
+are read again immediately before publication. A failed pre-publication attempt
+can leave only hash-named, read-only orphan evidence in `releases/`; it cannot
+create active state, and those unreferenced files may be removed during a later
+maintenance cleanup after confirming no state or bundle references them.
+
+`production abort <stage>` runs under the same lifecycle lock, removes only the
+named stage and its challenge, and never accepts it. When previous accepted
+state exists, abort restores that tuple locally and leaves it in `restore
+awaiting LAN acceptance`, requiring fresh `accept-restore` evidence. With no
+previously accepted tuple, abort stops production. A failed local restoration
+is catastrophic; a successful restoration is not called accepted until
+`accept-restore` receives new Mac evidence.
+
+The candidate attestation can also be reproduced locally for diagnosis:
+
+```bash
+python3 scripts/generate_local_gpu_inventory.py \
+  --expected-vlm-image "$SERAPH_VLM_IMAGE" \
+  --ingress-container seraph-prod-ingress-1 \
+  --backend-container seraph-prod-backend-1 \
+  --vlm-container seraph-prod-vlm-wrapper-1 \
+  --vlm-api-key-file "$SERAPH_VLM_API_KEY_FILE" \
+  > /path/to/gpu-host-inventory.json
+```
+
+The script hashes the local machine-id in memory and emits only its SHA-256
+digest. It inspects all three containers, their immutable image identities,
+revision labels, shared network identity and fixed private addresses, the
+running wrapper's RepoDigest, network/port state, and tested interface
+behaviors. Locally built legacy images without the pinned identity are
+non-accepted. Local firewall parsing is not an acceptance gate; the Mac-side
+negative reachability receipt is authoritative for LAN isolation.
+
+Bootstrap `SERAPH_GPU_MACHINE_IDENTITY_SHA256` once at a trusted local console
+by hashing `/etc/machine-id` without printing its raw value. Review and pin the
+digest in protected deployment configuration. Inventory generation reports the
+observed digest but never updates the expected value; mismatches require an
+explicit identity investigation and repinning ceremony.
 
 The acceptance receipt must cover start, status, health, logs, restart
 persistence, degraded dependency reporting, and rollback to the previous
@@ -78,16 +171,11 @@ payload. Exercise Host, Origin, unauthenticated, revoked-session, and throttle
 negative cases. Confirm internal service ports are not reachable as product
 entry points from the LAN.
 
-If an SSH host key changes, stop and compare the observed fingerprint with a
-trusted out-of-band administrator record. A changed or unverified fingerprint
-is a deployment blocker; do not bypass host-key verification. SSH remains an
-administrator route for inventory, deployment, process inspection, and logs.
-It is never Seraph application transport and must not become a user tunnel.
-
-Operator-shell receipts are authoritative. When a Codex/Desktop process cannot
-reach the LAN but the normal shell that launches Seraph can, record the agent
-network limitation and retain the direct HTTPS operator-shell receipt. Do not
-replace the product topology with a tunnel.
+Administration from this workspace is local. A separate remote administrator
+would still verify host identity normally, but that is not the repository's
+local lifecycle path and never becomes Seraph application transport. LAN
+acceptance uses the authenticated HTTPS origin plus negative reachability proof
+for internal ports; do not replace the product topology with a tunnel.
 
 ## Degraded Operation And Rollback
 

--- a/docs/implementation/19-gpu-core-lan-operations.md
+++ b/docs/implementation/19-gpu-core-lan-operations.md
@@ -183,9 +183,10 @@ non-accepted. Local firewall parsing is not an acceptance gate; the Mac-side
 negative reachability receipt is authoritative for LAN isolation.
 Private service behavior is probed from inside the owning container namespace,
 not by routing from the rootless Docker host to `172.30.0.0/24`. VLM health,
-backend, queue, unauthenticated rejection, and authenticated interface checks
-use wrapper loopback; the API key is supplied over probe stdin. GPU health uses
-the pinned model container's loopback interface.
+backend, queue, unauthenticated `auth_failed`/`auth_ok=false`, and authenticated
+`status=ok`/`auth_ok=true` interface checks use wrapper loopback; the API key is
+supplied over probe stdin. Probe bodies are bounded and reduced to booleans in
+the receipt. GPU health uses the pinned model container's loopback interface.
 
 Bootstrap `SERAPH_GPU_MACHINE_IDENTITY_SHA256` once at a trusted local console
 by hashing `/etc/machine-id` without printing its raw value. Review and pin the

--- a/docs/implementation/19-gpu-core-lan-operations.md
+++ b/docs/implementation/19-gpu-core-lan-operations.md
@@ -101,7 +101,7 @@ python3 scripts/generate_mac_lan_acceptance.py \
   --client-identity operator-mac > /path/to/signed-mac-receipt.json
 ```
 
-The generator requires DNS for the HTTPS hostname to include the pinned LAN IP,
+The generator requires the HTTPS host or address to resolve exclusively to the pinned LAN IP,
 logs in, proves the authenticated session, actively attempts TCP connections to
 that exact IP on 8000/8001/8004, records only bounded refusal/timeout classes,
 and signs canonical JSON with HMAC-SHA256. DNS mismatch, no-route, and
@@ -173,7 +173,7 @@ URL alone.
 From the operator machine, verify the public origin with the trusted CA file:
 
 ```bash
-curl --cacert /path/to/seraph-lan-ca.pem https://seraph.lan/health
+curl --cacert /path/to/seraph-lan-ca.pem https://192.168.1.26:8443/health
 ```
 
 Never use `curl -k` or disabled certificate verification as an acceptance

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -88,6 +88,13 @@ High-risk strategic wording in this status page remains governed by [19. Strateg
 - [x] Runtime status retains the legacy route-aware `effective_runtime` metadata for compatibility, including wrapper/backend/queue endpoints and active profile.
 - [ ] **Branch-local #740; intended until the epic integration PR lands:** model-fabric runtime and settings truth distinguish configured profiles, selected and attempted routes, last actual success, runtime-path-specific text/VLM topology, fallback, degradation, receipt persistence, and capability proof. This is not shipped `develop` truth yet.
 - [ ] Model-fabric interactive REST/WebSocket ingress is deliberately fail-closed with zero transport when no authenticated principal is bound. #741 owns LAN/operator identity binding; #740 does not synthesize identity to make chat appear functional.
+- [ ] The authenticated GPU-core LAN deployment remains Planned under #741:
+  one trusted-CA HTTPS origin, login/session/refresh/logout, ingress trust and
+  throttle boundaries, internal-only service ports, managed lifecycle and
+  rollback receipts are not shipped merely because the branch is configured.
+  See [GPU Core LAN Operations](./19-gpu-core-lan-operations.md).
+- [ ] Remote browser use cannot invoke the Mac native screenshot-folder picker.
+  Mac capture and native selection remain degraded until the paired edge ships.
 - [x] The extension platform now also exposes package version lines, compatibility truth, publisher metadata, and diagnostics summaries consistently across lifecycle, catalog, and capability surfaces, while the cockpit operator surface summarizes extension health plus update/studio actions instead of leaving package triage buried in separate inventories.
 - [x] M9 governed ecosystem foundations now have deterministic local proof: `m9_governed_ecosystem` plus `/api/operator/m9-governed-ecosystem-benchmark` cover manifest governance, lifecycle review gates, managed-connector degradation truth, marketplace governance flow, diagnostics/update triage, benchmark-proof posture, and the claim boundary that this is not competitor superiority or production marketplace security proof.
 - [x] Backend CI now also applies per-file watchdog timeouts for the heaviest backend suites, so hung `test_workflows.py` or `test_eval_harness.py` files stop consuming an entire shard budget on hosted runners.

--- a/docs/implementation/STATUS.md
+++ b/docs/implementation/STATUS.md
@@ -11,7 +11,7 @@ Seraph is an AI guardian that remembers, watches, and acts. This page is the fas
 **Target authority:** [Project Constitution](./00-project-constitution.md).
 
 The detailed inventory below records the large existing baseline. Some shipped
-surfaces remain transitional, including the Mac-hosted core, and Epic #736
+surfaces remain transitional, including production acceptance of the jupyter-hosted core, and Epic #736
 tracks their replacement. New target capabilities remain **Planned** until
 merged to `develop` with the required validation receipts.
 

--- a/docs/implementation/decisions/004-gpu-core-mac-edge-topology.md
+++ b/docs/implementation/decisions/004-gpu-core-mac-edge-topology.md
@@ -10,9 +10,13 @@ title: "ADR-004: GPU Core And Paired Mac Edge"
 
 ## Context
 
-Seraph currently runs its browser/backend development surfaces on the Mac and
-uses GPU-hosted model services over LAN. The target is an always-available core
-on the GPU server while retaining consented Mac observation and interaction.
+Seraph's current repository workspace and canonical core are on the GPU host,
+`jupyter`; the production LAN deployment remains gated by #741/#742 receipts.
+The earlier arrangement in which browser/backend development surfaces ran on
+the Mac and used GPU-hosted model services over LAN is historical context, not
+current topology. The target retains consented Mac observation and native
+interaction through a paired edge without moving canonical authority back to
+the Mac.
 
 ## Decision
 
@@ -22,17 +26,23 @@ LAN. The Mac runs a paired, revocable edge for screen observation and native
 interaction. Edge loss degrades those capabilities but does not transfer
 authority or canonical state to the edge.
 
-SSH is an administrator path, never the application transport. Runtime traffic
-uses authenticated documented APIs. LAN exposure is not anonymous exposure.
+Administration from the GPU-host workspace is local; an SSH hop back to
+`jupyter` is not part of the lifecycle. Any genuinely remote administration is
+separate from application transport. Runtime traffic uses authenticated
+documented APIs. LAN exposure is not anonymous exposure.
 
 ## Consequences
 
 - Pairing, consent, revocation, freshness, and capture state are visible.
 - Migration requires backup/restore proof before the GPU copy is canonical.
-- The shipped Mac-core topology remains supported until issues #741, #742, and
-  #749 provide migration and edge receipts.
+- The current workspace and canonical core are on `jupyter`. Issues #741 and
+  #742 provide deployment and data receipts. The Mac screenshot-push edge is
+  not shipped until #749 provides pairing, upload, and revoke/offline receipts.
 
 ## Verification
 
 Acceptance needs authenticated LAN probes, restart persistence, backup/restore,
 edge revoke/offline tests, and UI/API proof of effective topology.
+Internal model, wrapper, and backend ports are accepted only with an independent
+Mac-side negative reachability receipt; local firewall interpretation alone is
+not acceptance evidence.

--- a/docs/sidebars.implementation.ts
+++ b/docs/sidebars.implementation.ts
@@ -22,6 +22,7 @@ const sidebars: SidebarsConfig = {
           ],
         },
         'docs-contract',
+        'gpu-core-lan-operations',
         'screenshot-folder-source',
         'release-2026-07-04',
         'release-2026-06-30',

--- a/env.prod.example
+++ b/env.prod.example
@@ -68,7 +68,9 @@ SERAPH_VLM_BASE_URL=http://vlm-wrapper:8001
 SERAPH_VLM_BACKEND_URL=http://host.docker.internal:8000/v1
 LOCAL_LLM_API_KEY_FILE=/dev/null
 SERAPH_VLM_API_KEY_FILE=/etc/seraph/secrets/vlm-api-key
-SERAPH_VLM_IMAGE=ghcr.io/seraph-quest/vlm-screenshot-server@sha256:replace-with-64-hex-digest
+# Pin a real registry RepoDigest (name@sha256:...) or exact local image ID
+# (sha256:...). Mutable tags are rejected.
+SERAPH_VLM_IMAGE=sha256:replace-with-64-hex-local-image-id
 SERAPH_VLM_INTERFACE_CONTRACT=vlm-health-backend-queue-chat-auth-v1
 LOCAL_VLM_MODEL=unsloth/gemma-4-26B-A4B-it-qat-GGUF
 

--- a/env.prod.example
+++ b/env.prod.example
@@ -1,10 +1,33 @@
-HOST_DATA_ROOT_DEV=./docker-data/prod
+# Copy to .env.prod and replace every example.invalid value.
+# Production exposes one HTTPS origin. Backend/model/VLM ports stay private.
+SERAPH_HTTPS_BIND=0.0.0.0
+SERAPH_HTTPS_PORT=443
+SERAPH_IMAGE_TAG=git-revision-required
+SERAPH_LAN_HOST=seraph.example.invalid
+SERAPH_TLS_CERT_FILE=/etc/seraph/secrets/tls.crt
+SERAPH_TLS_KEY_FILE=/etc/seraph/secrets/tls.key
+
+# Configure exactly one non-empty credential file. Never place its value here.
+OPERATOR_AUTH_SECRET_FILE=/etc/seraph/secrets/operator-auth-secret
+OPERATOR_AUTH_SECRET_HASH_FILE=/dev/null
+SERAPH_HOST_INVENTORY_RECEIPT=/etc/seraph/inventory/gpu-host.json
+SERAPH_GPU_SSH_HOST=jupyter
+SERAPH_GPU_SSH_HOST_FINGERPRINT=SHA256:replace-with-verified-fingerprint
+SERAPH_HOST_INVENTORY_MAX_AGE_SECONDS=900
+OPERATOR_AUTH_ALLOWED_HOSTS=seraph.example.invalid
+OPERATOR_AUTH_ALLOWED_ORIGINS=https://seraph.example.invalid
+OPERATOR_AUTH_COOKIE_SECURE=true
+OPERATOR_AUTH_BACKEND_WORKERS=1
+OPERATOR_AUTH_TRUSTED_PROXY_IPS=172.30.0.10
+DEPLOYMENT_ENVIRONMENT=production
+
+HOST_DATA_ROOT_PROD=./docker-data/prod
 
 # Root directory for shared services like Ollama.
 SHARED_DATA_ROOT=./docker-data/shared
 
-BACKEND_DATA_PATH_DEV=${HOST_DATA_ROOT_DEV}/backend/data
-BACKEND_LOGS_PATH_DEV=${HOST_DATA_ROOT_DEV}/backend/logs
+BACKEND_DATA_PATH_PROD=${HOST_DATA_ROOT_PROD}/backend/data
+BACKEND_LOGS_PATH_PROD=${HOST_DATA_ROOT_PROD}/backend/logs
 
 # Production provider profile.
 # OpenRouter remains the default example; override LLM_API_BASE/LLM_API_KEY for
@@ -33,9 +56,17 @@ SANDBOX_URL=http://sandbox:8060
 # routes explicit: LOCAL_LLM_API_BASE is direct text; SERAPH_VLM_BASE_URL is the
 # wrapper whose /v1 path is the optional chat proxy and whose /v1/analyze-file
 # path performs screenshot vision. Do not point text status at the image route.
-# SERAPH_VLM_MODE=gpu-server
-# SERAPH_VLM_BASE_URL=http://gpu-host:8001
-# SERAPH_VLM_BACKEND_URL=http://gpu-host:8000/v1
+SERAPH_VLM_MODE=gpu-server
+# Backend-only host routes. Inventory must confirm that these host processes
+# are bound for container access before production start.
+LOCAL_LLM_API_BASE=http://host.docker.internal:8000/v1
+SERAPH_VLM_BASE_URL=http://vlm-wrapper:8001
+SERAPH_VLM_BACKEND_URL=http://host.docker.internal:8000/v1
+LOCAL_LLM_API_KEY_FILE=/dev/null
+SERAPH_VLM_API_KEY_FILE=/etc/seraph/secrets/vlm-api-key
+SERAPH_VLM_IMAGE=ghcr.io/seraph-quest/vlm-screenshot-server@sha256:replace-with-64-hex-digest
+SERAPH_VLM_INTERFACE_CONTRACT=vlm-screenshot-server/v0.2-file-secrets
+LOCAL_VLM_MODEL=unsloth/gemma-4-26B-A4B-it-qat-GGUF
 
 # Optional typed inference profiles. Built-ins include openrouter,
 # openai-compatible, codex-openai, claude-anthropic, gpt-5.5-low, and

--- a/env.prod.example
+++ b/env.prod.example
@@ -4,6 +4,10 @@ SERAPH_HTTPS_BIND=0.0.0.0
 SERAPH_HTTPS_PORT=443
 SERAPH_IMAGE_TAG=git-revision-required
 SERAPH_LAN_HOST=seraph.example.invalid
+SERAPH_LAN_IP=192.168.1.26
+SERAPH_EXPECTED_HTTPS_ORIGIN=https://seraph.example.invalid
+SERAPH_MAC_PROBE_CLIENT_ID=operator-mac
+SERAPH_MAC_PROBE_KEY_FILE=/etc/seraph/secrets/mac-probe-hmac-key
 SERAPH_TLS_CERT_FILE=/etc/seraph/secrets/tls.crt
 SERAPH_TLS_KEY_FILE=/etc/seraph/secrets/tls.key
 
@@ -11,8 +15,8 @@ SERAPH_TLS_KEY_FILE=/etc/seraph/secrets/tls.key
 OPERATOR_AUTH_SECRET_FILE=/etc/seraph/secrets/operator-auth-secret
 OPERATOR_AUTH_SECRET_HASH_FILE=/dev/null
 SERAPH_HOST_INVENTORY_RECEIPT=/etc/seraph/inventory/gpu-host.json
-SERAPH_GPU_SSH_HOST=jupyter
-SERAPH_GPU_SSH_HOST_FINGERPRINT=SHA256:replace-with-verified-fingerprint
+SERAPH_GPU_EXPECTED_HOSTNAME=jupyter
+SERAPH_GPU_MACHINE_IDENTITY_SHA256=replace-with-sha256-of-local-machine-id
 SERAPH_HOST_INVENTORY_MAX_AGE_SECONDS=900
 OPERATOR_AUTH_ALLOWED_HOSTS=seraph.example.invalid
 OPERATOR_AUTH_ALLOWED_ORIGINS=https://seraph.example.invalid
@@ -65,7 +69,7 @@ SERAPH_VLM_BACKEND_URL=http://host.docker.internal:8000/v1
 LOCAL_LLM_API_KEY_FILE=/dev/null
 SERAPH_VLM_API_KEY_FILE=/etc/seraph/secrets/vlm-api-key
 SERAPH_VLM_IMAGE=ghcr.io/seraph-quest/vlm-screenshot-server@sha256:replace-with-64-hex-digest
-SERAPH_VLM_INTERFACE_CONTRACT=vlm-screenshot-server/v0.2-file-secrets
+SERAPH_VLM_INTERFACE_CONTRACT=vlm-health-backend-queue-chat-auth-v1
 LOCAL_VLM_MODEL=unsloth/gemma-4-26B-A4B-it-qat-GGUF
 
 # Optional typed inference profiles. Built-ins include openrouter,

--- a/env.prod.example
+++ b/env.prod.example
@@ -56,16 +56,15 @@ SANDBOX_URL=http://sandbox:8060
 # LOCAL_RUNTIME_PATHS=session_title_generation,mcp_*
 # RUNTIME_PROFILE_PREFERENCES="session_title_generation=local|default;mcp_*=local|default"
 
-# When a deployment uses a separate GPU model server and VLM wrapper, keep the
+# Production runs the GPU model server and VLM wrapper as private Compose
+# services. Keep the routes explicit:
 # routes explicit: LOCAL_LLM_API_BASE is direct text; SERAPH_VLM_BASE_URL is the
 # wrapper whose /v1 path is the optional chat proxy and whose /v1/analyze-file
 # path performs screenshot vision. Do not point text status at the image route.
 SERAPH_VLM_MODE=gpu-server
-# Backend-only host routes. Inventory must confirm that these host processes
-# are bound for container access before production start.
-LOCAL_LLM_API_BASE=http://host.docker.internal:8000/v1
+LOCAL_LLM_API_BASE=http://gpu-model:8000/v1
 SERAPH_VLM_BASE_URL=http://vlm-wrapper:8001
-SERAPH_VLM_BACKEND_URL=http://host.docker.internal:8000/v1
+SERAPH_VLM_BACKEND_URL=http://gpu-model:8000/v1
 LOCAL_LLM_API_KEY_FILE=/dev/null
 SERAPH_VLM_API_KEY_FILE=/etc/seraph/secrets/vlm-api-key
 # Pin a real registry RepoDigest (name@sha256:...) or exact local image ID
@@ -73,6 +72,13 @@ SERAPH_VLM_API_KEY_FILE=/etc/seraph/secrets/vlm-api-key
 SERAPH_VLM_IMAGE=sha256:replace-with-64-hex-local-image-id
 SERAPH_VLM_INTERFACE_CONTRACT=vlm-health-backend-queue-chat-auth-v1
 LOCAL_VLM_MODEL=unsloth/gemma-4-26B-A4B-it-qat-GGUF
+SERAPH_GPU_MODEL_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:8d1e8ddc42585632d7bd625c2285eba891ed2ed4428e9eda25ca71ce2f6cce27
+SERAPH_GPU_MODEL_DIR=/home/pawel/models/gemma-4-26B-A4B-it-qat-GGUF
+SERAPH_GPU_MODEL_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf
+SERAPH_GPU_MMPROJ_FILE=mmproj-BF16.gguf
+SERAPH_GPU_MODEL_ALIAS=unsloth/gemma-4-26B-A4B-it-qat-GGUF
+SERAPH_GPU_MODEL_CTX_SIZE=32768
+SERAPH_GPU_MODEL_LAYERS=999
 
 # Optional typed inference profiles. Built-ins include openrouter,
 # openai-compatible, codex-openai, claude-anthropic, gpt-5.5-low, and

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,0 +1,15 @@
+FROM node:22-alpine AS build
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine
+ARG SERAPH_BUILD_REVISION
+LABEL org.opencontainers.image.revision=$SERAPH_BUILD_REVISION
+COPY production/nginx.conf /etc/nginx/nginx.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 443
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/production/nginx.conf
+++ b/frontend/production/nginx.conf
@@ -1,0 +1,67 @@
+user nginx;
+worker_processes auto;
+pid /var/run/nginx.pid;
+
+events { worker_connections 1024; }
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    server_tokens off;
+    access_log /dev/stdout;
+    error_log /dev/stderr warn;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    upstream seraph_backend { server backend:8004; }
+
+    server {
+        listen 443 ssl;
+        ssl_certificate /run/secrets/tls_cert;
+        ssl_certificate_key /run/secrets/tls_key;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        add_header Strict-Transport-Security "max-age=31536000" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options DENY always;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        location = /health {
+            proxy_pass http://seraph_backend/health;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-For $remote_addr;
+        }
+
+        location /api/ {
+            proxy_pass http://seraph_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Host $host;
+            # Deliberately overwrite, rather than append to, client-controlled XFF.
+            proxy_set_header X-Forwarded-For $remote_addr;
+        }
+
+        location /ws/ {
+            proxy_pass http://seraph_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_read_timeout 300s;
+        }
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,9 +6,15 @@ import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { CockpitView } from "./components/cockpit/CockpitView";
 import { applyThemePreference } from "./lib/theme";
 import { useChatStore } from "./stores/chatStore";
+import { AuthGate } from "./auth/AuthGate";
+import { useAuthStore } from "./auth/authStore";
 
 export default function App() {
-  const { sendMessage, skipOnboarding } = useWebSocket();
+  const authenticated = useAuthStore((state) => state.status === "authenticated");
+  const authRevision = useAuthStore((state) => state.revision);
+  const operatorName = useAuthStore((state) => state.operatorName);
+  const logout = useAuthStore((state) => state.logout);
+  const { sendMessage, skipOnboarding } = useWebSocket(authenticated, authRevision);
   const themePreference = useChatStore((s) => s.themePreference);
   useKeyboardShortcuts();
 
@@ -39,11 +45,14 @@ export default function App() {
     return () => media.removeListener(handleChange);
   }, [themePreference]);
 
-  return (
+  return <AuthGate>{(
     <>
       <CockpitView onSend={sendMessage} onSkipOnboarding={skipOnboarding} />
       <QuestPanel />
       <SettingsPanel />
+      <button className="auth-logout" onClick={() => void logout()} type="button" title="Lock operator cockpit">
+        LOCK{operatorName ? ` · ${operatorName}` : ""}
+      </button>
     </>
-  );
+  )}</AuthGate>;
 }

--- a/frontend/src/auth/AuthGate.test.tsx
+++ b/frontend/src/auth/AuthGate.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthGate } from "./AuthGate";
+import { authClient, AuthConfigurationError, AuthRequiredError } from "./authClient";
+import { useAuthStore } from "./authStore";
+
+describe("operator lock screen", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useAuthStore.setState({ status: "bootstrapping", operatorName: null, revision: 0, error: null });
+  });
+
+  it("keeps anonymous visitors locked and unlocks after login", async () => {
+    vi.spyOn(authClient, "session").mockRejectedValue(new AuthRequiredError());
+    vi.spyOn(authClient, "login").mockResolvedValue({ authenticated: true, principal_id: "operator:single" });
+
+    render(<AuthGate><p>PRIVATE COCKPIT</p></AuthGate>);
+
+    expect(await screen.findByRole("heading", { name: "Operator access" })).toBeInTheDocument();
+    expect(screen.queryByText("PRIVATE COCKPIT")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Passphrase"), { target: { value: "memory-only-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "UNLOCK" }));
+    expect(await screen.findByText("PRIVATE COCKPIT")).toBeInTheDocument();
+  });
+
+  it("restores an authenticated cockpit from the cookie session", async () => {
+    vi.spyOn(authClient, "session").mockResolvedValue({ authenticated: true, principal_id: "operator:single" });
+
+    render(<AuthGate><p>PRIVATE COCKPIT</p></AuthGate>);
+
+    await waitFor(() => expect(screen.getByText("PRIVATE COCKPIT")).toBeInTheDocument());
+    expect(screen.queryByLabelText("Passphrase")).not.toBeInTheDocument();
+  });
+
+  it("shows fail-closed setup guidance and can recover on retry", async () => {
+    vi.spyOn(authClient, "session")
+      .mockRejectedValueOnce(new AuthConfigurationError())
+      .mockResolvedValueOnce({ authenticated: true, principal_id: "operator:single" });
+
+    render(<AuthGate><p>PRIVATE COCKPIT</p></AuthGate>);
+
+    expect(await screen.findByRole("heading", { name: "Operator access needs setup" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Passphrase")).not.toBeInTheDocument();
+    expect(screen.queryByText("PRIVATE COCKPIT")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "RETRY CONNECTION" }));
+    expect(await screen.findByText("PRIVATE COCKPIT")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/auth/AuthGate.tsx
+++ b/frontend/src/auth/AuthGate.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState, type FormEvent, type ReactNode } from "react";
+import { useAuthStore } from "./authStore";
+
+export function AuthGate({ children }: { children: ReactNode }) {
+  const status = useAuthStore((state) => state.status);
+  const error = useAuthStore((state) => state.error);
+  const bootstrap = useAuthStore((state) => state.bootstrap);
+  const login = useAuthStore((state) => state.login);
+  const refresh = useAuthStore((state) => state.refresh);
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => { void bootstrap(); }, [bootstrap]);
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    const interval = window.setInterval(() => { void refresh(); }, 5 * 60 * 1000);
+    return () => window.clearInterval(interval);
+  }, [refresh, status]);
+
+  if (status === "authenticated") return children;
+  if (status === "bootstrapping") {
+    return <main className="auth-lock" aria-label="Checking operator session"><p>CONNECTING TO SERAPH…</p></main>;
+  }
+  if (status === "setup_required") {
+    return (
+      <main className="auth-lock">
+        <section className="auth-card glass-panel" aria-labelledby="auth-setup-title">
+          <p className="auth-kicker">SERAPH GUARDIAN CORE</p>
+          <h1 id="auth-setup-title">Operator access needs setup</h1>
+          <p className="auth-copy">Configure the operator credential and this LAN host/origin on the server, then restart or retry. Access remains locked until the server confirms authentication is ready.</p>
+          <button onClick={() => void bootstrap()} type="button">RETRY CONNECTION</button>
+        </section>
+      </main>
+    );
+  }
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    setSubmitting(true);
+    const ok = await login(password);
+    if (ok) setPassword("");
+    setSubmitting(false);
+  };
+
+  return (
+    <main className="auth-lock">
+      <form className="auth-card glass-panel" onSubmit={submit}>
+        <p className="auth-kicker">SERAPH GUARDIAN CORE</p>
+        <h1>Operator access</h1>
+        <p className="auth-copy">Authenticate to unlock this cockpit.</p>
+        <label>Passphrase<input autoComplete="current-password" name="password" required type="password" value={password} onChange={(e) => setPassword(e.target.value)} /></label>
+        {error && <p className="auth-error" role="alert">{error}</p>}
+        <button disabled={submitting} type="submit">{submitting ? "AUTHENTICATING…" : "UNLOCK"}</button>
+      </form>
+    </main>
+  );
+}

--- a/frontend/src/auth/authClient.test.ts
+++ b/frontend/src/auth/authClient.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { authClient, AuthConfigurationError, authenticatedFetch, installAuthenticatedFetch, setUnauthorizedHandler } from "./authClient";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setUnauthorizedHandler(null);
+});
+
+describe("cookie-only authentication client", () => {
+  it("sends only the passphrase and includes browser credentials", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ authenticated: true, principal_id: "operator" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await authClient.login("correct horse battery staple");
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("/api/auth/login"), expect.objectContaining({ credentials: "include" }));
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({ password: "correct horse battery staple" });
+    expect(String(init.body)).not.toContain("username");
+  });
+
+  it("locks centrally when an authenticated request receives 401", async () => {
+    const lock = vi.fn();
+    setUnauthorizedHandler(lock);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 401 })));
+
+    await authenticatedFetch("/api/goals");
+
+    expect(lock).toHaveBeenCalledOnce();
+  });
+
+  it("installs credentials and 401 handling for existing fetch call sites", async () => {
+    const native = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+    vi.stubGlobal("fetch", native);
+    const lock = vi.fn();
+    setUnauthorizedHandler(lock);
+    const restore = installAuthenticatedFetch();
+
+    await fetch("/api/runtime/status", { method: "POST" });
+
+    expect(native).toHaveBeenCalledWith("/api/runtime/status", expect.objectContaining({ method: "POST", credentials: "include" }));
+    expect(lock).toHaveBeenCalledOnce();
+    restore();
+  });
+
+  it("distinguishes an unconfigured backend from invalid credentials", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ detail: { code: "auth_not_configured" } }),
+      { status: 503, headers: { "Content-Type": "application/json" } },
+    )));
+
+    await expect(authClient.session()).rejects.toBeInstanceOf(AuthConfigurationError);
+  });
+});

--- a/frontend/src/auth/authClient.ts
+++ b/frontend/src/auth/authClient.ts
@@ -1,0 +1,79 @@
+import { apiUrl } from "../config/constants";
+
+export type AuthSession = {
+  authenticated: boolean;
+  principal_id?: string | null;
+  username?: string | null;
+  operator?: { username?: string | null; display_name?: string | null } | null;
+};
+
+export class AuthRequiredError extends Error {
+  constructor(public readonly code = "authentication_required") {
+    super("Authentication required");
+    this.name = "AuthRequiredError";
+  }
+}
+
+export class AuthConfigurationError extends Error {
+  constructor() {
+    super("Operator authentication is not configured");
+    this.name = "AuthConfigurationError";
+  }
+}
+
+let unauthorizedHandler: (() => void) | null = null;
+let restoreFetch: (() => void) | null = null;
+
+export function setUnauthorizedHandler(handler: (() => void) | null): void {
+  unauthorizedHandler = handler;
+}
+
+export function installAuthenticatedFetch(): () => void {
+  if (restoreFetch) return restoreFetch;
+  const nativeFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = async (input: RequestInfo | URL, init: RequestInit = {}) => {
+    const response = await nativeFetch(input, { ...init, credentials: "include" });
+    if (response.status === 401) unauthorizedHandler?.();
+    return response;
+  };
+  restoreFetch = () => {
+    globalThis.fetch = nativeFetch;
+    restoreFetch = null;
+  };
+  return restoreFetch;
+}
+
+export async function authenticatedFetch(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  const response = await fetch(input, { ...init, credentials: "include" });
+  if (response.status === 401) unauthorizedHandler?.();
+  return response;
+}
+
+async function authJson(path: string, init?: RequestInit): Promise<AuthSession> {
+  const response = await authenticatedFetch(apiUrl(path), init);
+  const payload = await response.json().catch(() => null);
+  const code = payload?.detail?.code;
+  if (response.status === 503 && code === "auth_not_configured") throw new AuthConfigurationError();
+  if (response.status === 401) throw new AuthRequiredError(typeof code === "string" ? code : undefined);
+  if (!response.ok) {
+    throw new Error(payload?.detail?.message ?? payload?.detail ?? "Authentication request failed");
+  }
+  return payload;
+}
+
+export const authClient = {
+  session: () => authJson("/api/auth/session"),
+  login: (password: string) => authJson("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ password }),
+  }),
+  refresh: () => authJson("/api/auth/refresh", { method: "POST" }),
+  logout: async () => {
+    const response = await authenticatedFetch(apiUrl("/api/auth/logout"), { method: "POST" });
+    if (!response.ok && response.status !== 401) throw new Error("Logout failed");
+  },
+};

--- a/frontend/src/auth/authStore.test.ts
+++ b/frontend/src/auth/authStore.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authClient, AuthConfigurationError } from "./authClient";
+import { useAuthStore } from "./authStore";
+import { useChatStore } from "../stores/chatStore";
+
+describe("auth store continuity", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAuthStore.setState({ status: "locked", operatorName: null, revision: 0, error: null });
+    useChatStore.getState().clearAuthenticatedContinuity();
+    vi.restoreAllMocks();
+  });
+
+  it("unlocks from a valid session without persisting a secret", async () => {
+    vi.spyOn(authClient, "login").mockResolvedValue({ authenticated: true, principal_id: "operator" });
+
+    expect(await useAuthStore.getState().login("private-passphrase")).toBe(true);
+
+    expect(useAuthStore.getState()).toMatchObject({ status: "authenticated", operatorName: "operator", revision: 1 });
+    expect(JSON.stringify(localStorage)).not.toContain("private-passphrase");
+  });
+
+  it("rotates the session revision so the websocket reconnects", async () => {
+    useAuthStore.setState({ status: "authenticated", revision: 3 });
+    vi.spyOn(authClient, "refresh").mockResolvedValue({ authenticated: true, principal_id: "operator" });
+
+    expect(await useAuthStore.getState().refresh()).toBe(true);
+    expect(useAuthStore.getState().revision).toBe(4);
+  });
+
+  it("logout locks and removes conversation continuity", async () => {
+    localStorage.setItem("seraph_last_session_id", "session-secret-pointer");
+    useChatStore.setState({ sessionId: "session-secret-pointer", messages: [{ id: "m1", role: "user", content: "hello", timestamp: 1, sessionId: "session-secret-pointer" }] });
+    vi.spyOn(authClient, "logout").mockResolvedValue();
+
+    await useAuthStore.getState().logout();
+
+    expect(useAuthStore.getState().status).toBe("locked");
+    expect(useChatStore.getState()).toMatchObject({ sessionId: null, messages: [], connectionStatus: "disconnected" });
+    expect(localStorage.getItem("seraph_last_session_id")).toBeNull();
+  });
+
+  it("blocks login while server authentication is unconfigured", async () => {
+    vi.spyOn(authClient, "session").mockRejectedValue(new AuthConfigurationError());
+    const login = vi.spyOn(authClient, "login");
+
+    await useAuthStore.getState().bootstrap();
+    expect(useAuthStore.getState().status).toBe("setup_required");
+    expect(await useAuthStore.getState().login("must-not-be-sent")).toBe(false);
+    expect(login).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/auth/authStore.ts
+++ b/frontend/src/auth/authStore.ts
@@ -1,0 +1,95 @@
+import { create } from "zustand";
+import { authClient, AuthConfigurationError, AuthRequiredError, setUnauthorizedHandler, type AuthSession } from "./authClient";
+import { useChatStore } from "../stores/chatStore";
+
+export type AuthStatus = "bootstrapping" | "setup_required" | "locked" | "authenticated";
+
+type AuthStore = {
+  status: AuthStatus;
+  operatorName: string | null;
+  revision: number;
+  error: string | null;
+  bootstrap: () => Promise<void>;
+  login: (password: string) => Promise<boolean>;
+  refresh: () => Promise<boolean>;
+  logout: () => Promise<void>;
+  lock: () => void;
+};
+
+function nameFromSession(session: AuthSession): string | null {
+  return session.operator?.display_name ?? session.operator?.username ?? session.username ?? session.principal_id ?? null;
+}
+
+function clearBrowserContinuity(): void {
+  useChatStore.getState().clearAuthenticatedContinuity();
+}
+
+export const useAuthStore = create<AuthStore>((set, get) => ({
+  status: "bootstrapping",
+  operatorName: null,
+  revision: 0,
+  error: null,
+
+  bootstrap: async () => {
+    try {
+      const session = await authClient.session();
+      if (!session.authenticated) throw new AuthRequiredError();
+      set((state) => ({
+        status: "authenticated",
+        operatorName: nameFromSession(session),
+        revision: state.revision + 1,
+        error: null,
+      }));
+    } catch (error) {
+      if (error instanceof AuthConfigurationError) {
+        clearBrowserContinuity();
+        set({ status: "setup_required", operatorName: null, error: null });
+        return;
+      }
+      if (!(error instanceof AuthRequiredError)) console.warn("Auth bootstrap failed", error);
+      get().lock();
+    }
+  },
+
+  login: async (password) => {
+    if (get().status === "setup_required") return false;
+    set({ error: null });
+    try {
+      const session = await authClient.login(password);
+      if (!session.authenticated) throw new AuthRequiredError();
+      set((state) => ({
+        status: "authenticated",
+        operatorName: nameFromSession(session),
+        revision: state.revision + 1,
+        error: null,
+      }));
+      return true;
+    } catch (error) {
+      set({ status: "locked", error: error instanceof AuthRequiredError ? "Invalid credentials" : (error as Error).message });
+      return false;
+    }
+  },
+
+  refresh: async () => {
+    try {
+      const session = await authClient.refresh();
+      if (!session.authenticated) throw new AuthRequiredError();
+      set((state) => ({ operatorName: nameFromSession(session), revision: state.revision + 1, error: null }));
+      return true;
+    } catch {
+      get().lock();
+      return false;
+    }
+  },
+
+  logout: async () => {
+    try { await authClient.logout(); } finally { get().lock(); }
+  },
+
+  lock: () => {
+    clearBrowserContinuity();
+    set({ status: "locked", operatorName: null, error: null });
+  },
+}));
+
+setUnauthorizedHandler(() => useAuthStore.getState().lock());

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -23,6 +23,11 @@ const localApiUrl = () => {
 export const API_URL = configuredApiUrl === "/api" ? "" : configuredApiUrl || localApiUrl();
 export const WS_URL = import.meta.env.VITE_WS_URL || localWsUrl();
 
+export function apiUrl(path: string): string {
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return `${API_URL}${normalized}`;
+}
+
 export const WALK_DURATION_MS = 800;
 export const SPEECH_DISPLAY_MS = 3000;
 export const WS_RECONNECT_DELAY_MS = 3000;

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -122,7 +122,7 @@ export function buildClarificationMessage(
   };
 }
 
-export function useWebSocket() {
+export function useWebSocket(enabled = true, authRevision = 0) {
   const wsRef = useRef<WebSocket | null>(null);
   const pingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -383,6 +383,7 @@ export function useWebSocket() {
   }, [addMessage, buildErrorMessage, buildUserMessage, onThinking, setAgentBusy, setSessionId]);
 
   const connect = useCallback(() => {
+    if (!enabled) return;
     if (wsRef.current?.readyState === WebSocket.OPEN) return;
 
     setConnectionStatus("connecting");
@@ -613,7 +614,7 @@ export function useWebSocket() {
       setConnectionStatus("error");
       ws.close();
     };
-  }, [addMessage, appendAssistantDelta, clearResponseTimeout, clearStreamingMessage, markSessionContinuity, reconcileFinalAnswer, setSessionId, setConnectionStatus, setAgentBusy, setAmbientState, setChatPanelOpen]);
+  }, [addMessage, appendAssistantDelta, clearResponseTimeout, clearStreamingMessage, enabled, markSessionContinuity, reconcileFinalAnswer, setSessionId, setConnectionStatus, setAgentBusy, setAmbientState, setChatPanelOpen]);
 
   const skipOnboarding = useCallback(() => {
     if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
@@ -655,7 +656,7 @@ export function useWebSocket() {
     };
 
     appEventBus.on("approval-resume", handleApprovalResume);
-    connect();
+    if (enabled) connect();
     return () => {
       appEventBus.off("approval-resume", handleApprovalResume);
       if (pingRef.current) clearInterval(pingRef.current);
@@ -666,7 +667,7 @@ export function useWebSocket() {
       wsRef.current = null;
       ws?.close();
     };
-  }, [connect]);
+  }, [authRevision, clearResponseTimeout, connect, enabled]);
 
   return { sendMessage, skipOnboarding };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -40,6 +40,19 @@ body {
   line-height: 1.6;
 }
 
+.auth-lock { min-height: 100%; display: grid; place-items: center; background: radial-gradient(circle at 50% 35%, rgba(27, 111, 139, .2), transparent 42%), var(--app-bg); }
+.auth-card { width: min(420px, calc(100vw - 48px)); padding: 32px; display: grid; gap: 16px; box-shadow: 0 24px 90px rgba(0, 0, 0, .45); }
+.auth-card h1 { margin: 0; color: #d8fbff; font-size: 20px; }
+.auth-kicker { color: #58d4e8; letter-spacing: .15em; margin: 0; }
+.auth-copy { color: #9bb2bd; margin: 0 0 8px; }
+.auth-card label { display: grid; gap: 7px; color: #a9c5ce; }
+.auth-card input { font: inherit; color: var(--app-text); background: rgba(0, 0, 0, .28); border: 1px solid var(--app-glass-border); padding: 12px; outline: none; }
+.auth-card input:focus { border-color: #58d4e8; box-shadow: 0 0 0 2px rgba(88, 212, 232, .16); }
+.auth-card button, .auth-logout { font: inherit; cursor: pointer; border: 1px solid rgba(88, 212, 232, .5); color: #baf7ff; background: rgba(16, 87, 105, .42); padding: 11px 14px; }
+.auth-card button:disabled { opacity: .55; cursor: wait; }
+.auth-error { color: #ff8e8e; margin: 0; }
+.auth-logout { position: fixed; z-index: 80; top: 12px; right: 14px; font-size: 8px; opacity: .76; }
+
 .glow-text {
   text-shadow: 0 0 10px currentColor;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,8 +3,10 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import { applyThemePreference, readThemePreference } from "./lib/theme";
 import "./index.css";
+import { installAuthenticatedFetch } from "./auth/authClient";
 
 applyThemePreference(readThemePreference());
+installAuthenticatedFetch();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/frontend/src/stores/chatStore.ts
+++ b/frontend/src/stores/chatStore.ts
@@ -62,6 +62,7 @@ interface ChatStore {
   deleteSession: (sessionId: string) => Promise<void>;
   renameSession: (sessionId: string, title: string) => Promise<void>;
   generateSessionTitle: (sessionId: string) => Promise<void>;
+  clearAuthenticatedContinuity: () => void;
 }
 
 const LAST_SESSION_KEY = "seraph_last_session_id";
@@ -434,5 +435,23 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     } catch (err) {
       console.error("Failed to generate session title:", err);
     }
+  },
+
+  clearAuthenticatedContinuity: () => {
+    safeStorageRemove(LAST_SESSION_KEY);
+    restoreLastSessionPromise = null;
+    set({
+      messages: [],
+      sessionId: null,
+      sessions: [],
+      sessionContinuity: {},
+      connectionStatus: "disconnected",
+      isAgentBusy: false,
+      agentVisual: { ...defaultVisual },
+      ambientState: "idle",
+      ambientTooltip: "",
+      onboardingCompleted: null,
+      toolRegistry: [],
+    });
   },
 }));

--- a/manage.sh
+++ b/manage.sh
@@ -66,6 +66,7 @@ function display_help() {
     echo "  local   Manage the direct local frontend/backend stack: up, down, status, logs, run."
     echo "  daemon  Manage screen daemon: start, stop, status, logs."
     echo "  proxy   Manage stdio-to-HTTP MCP proxy: start, stop, status, logs."
+    echo "  production  Validated GPU/LAN lifecycle: config-validate, start, stop, restart, status, logs, rollback."
     echo
     echo "Examples:"
     echo "  $PROG_NAME -e dev up -d"
@@ -748,6 +749,273 @@ function local_run() {
     local_logs all
 }
 
+# --- Production GPU/LAN Stack Functions ---
+function production_require_file() {
+    local variable="$1"
+    local value="${!variable:-}"
+    [ -n "$value" ] || error_exit "$variable is required for production"
+    [ -r "$value" ] || error_exit "$variable does not name a readable file: $value"
+}
+
+function production_config_validate() {
+    [ "$ENV" = "prod" ] || error_exit "production lifecycle requires -e prod"
+    production_require_file SERAPH_TLS_CERT_FILE
+    production_require_file SERAPH_TLS_KEY_FILE
+    local credential_count=0
+    if [ -n "${OPERATOR_AUTH_SECRET_FILE:-}" ] && [ -s "$OPERATOR_AUTH_SECRET_FILE" ]; then credential_count=$((credential_count + 1)); fi
+    if [ -n "${OPERATOR_AUTH_SECRET_HASH_FILE:-}" ] && [ -s "$OPERATOR_AUTH_SECRET_HASH_FILE" ]; then credential_count=$((credential_count + 1)); fi
+    [ "$credential_count" -eq 1 ] || error_exit "exactly one non-empty operator raw-secret or hash file is required"
+    [ "${DEPLOYMENT_ENVIRONMENT:-}" = "production" ] || error_exit "DEPLOYMENT_ENVIRONMENT must be production"
+    [ "${OPERATOR_AUTH_COOKIE_SECURE:-}" = "true" ] || error_exit "OPERATOR_AUTH_COOKIE_SECURE must be true"
+    [ "${OPERATOR_AUTH_BACKEND_WORKERS:-}" = "1" ] || error_exit "OPERATOR_AUTH_BACKEND_WORKERS must be 1"
+    [ "${OPERATOR_AUTH_TRUSTED_PROXY_IPS:-}" = "172.30.0.10" ] || error_exit "trusted proxy must be exactly 172.30.0.10"
+    [ -n "${OPERATOR_AUTH_ALLOWED_HOSTS:-}" ] || error_exit "OPERATOR_AUTH_ALLOWED_HOSTS must be exact and non-empty"
+    [ -n "${OPERATOR_AUTH_ALLOWED_ORIGINS:-}" ] || error_exit "OPERATOR_AUTH_ALLOWED_ORIGINS must be exact and non-empty"
+    case "${OPERATOR_AUTH_ALLOWED_HOSTS},${OPERATOR_AUTH_ALLOWED_ORIGINS}" in
+        *'*'*|*example.invalid*) error_exit "replace wildcard/example auth hosts and origins" ;;
+    esac
+    case "${OPERATOR_AUTH_ALLOWED_ORIGINS}" in https://*) ;; *) error_exit "OPERATOR_AUTH_ALLOWED_ORIGINS must use https" ;; esac
+    local current_revision
+    current_revision=$(git -C "$SCRIPT_DIR" rev-parse HEAD) || error_exit "cannot determine source revision"
+    [[ "${SERAPH_IMAGE_TAG:-}" =~ ^[0-9a-f]{40}$ ]] || error_exit "SERAPH_IMAGE_TAG must be an exact full git SHA"
+    if [ "${SERAPH_VALIDATING_ROLLBACK:-false}" != "true" ]; then
+        [ "$SERAPH_IMAGE_TAG" = "$current_revision" ] || error_exit "SERAPH_IMAGE_TAG must equal current HEAD $current_revision"
+        [ -z "$(git -C "$SCRIPT_DIR" status --porcelain)" ] || error_exit "production builds require a clean working tree"
+    fi
+    [[ "${SERAPH_VLM_IMAGE:-}" =~ ^[^[:space:]@]+@sha256:[0-9a-fA-F]{64}$ ]] || error_exit "SERAPH_VLM_IMAGE must use an exact hexadecimal @sha256 digest"
+    [ -n "${SERAPH_VLM_INTERFACE_CONTRACT:-}" ] || error_exit "SERAPH_VLM_INTERFACE_CONTRACT is required"
+    [ -n "${SERAPH_GPU_SSH_HOST:-}" ] || error_exit "SERAPH_GPU_SSH_HOST is required"
+    [ -n "${SERAPH_GPU_SSH_HOST_FINGERPRINT:-}" ] || error_exit "SERAPH_GPU_SSH_HOST_FINGERPRINT is required"
+    local config_file
+    config_file=$(mktemp /tmp/seraph-prod-compose.XXXXXX.json)
+    if ! docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" config --format json >"$config_file"; then
+        rm -f "$config_file"
+        return 1
+    fi
+    python3 "$SCRIPT_DIR/scripts/validate_production_topology.py" <"$config_file" || { rm -f "$config_file"; return 1; }
+    rm -f "$config_file"
+    echo "compose config valid; host inference privacy is not asserted until the separate inventory gate passes"
+}
+
+function production_host_inventory_validate() {
+    local receipt="${1:-${SERAPH_HOST_INVENTORY_RECEIPT:-}}"
+    local vlm_image="${2:-${SERAPH_VLM_IMAGE:-}}"
+    [ -r "$receipt" ] || error_exit "host inventory receipt is unreadable: $receipt"
+    SERAPH_VLM_IMAGE="$vlm_image" python3 "$SCRIPT_DIR/scripts/validate_gpu_host_inventory.py" <"$receipt"
+}
+
+function production_status() {
+    production_config_validate
+    production_host_inventory_validate
+    production_compose_state_validate
+    echo "Published TLS listener owned by this compose project:"
+    docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" port ingress 443 2>/dev/null || echo "ingress not running"
+    echo "Docker container listener ownership:"
+    production_docker_inventory_validate true
+}
+
+function production_docker_inventory_validate() {
+    local require_nonempty="${1:-false}"
+    local inventory
+    inventory=$(mktemp /tmp/seraph-docker-inventory.XXXXXX)
+    if ! docker ps --format '{{json .}}' >"$inventory"; then rm -f "$inventory"; return 1; fi
+    if [ "$require_nonempty" = true ] && [ ! -s "$inventory" ]; then rm -f "$inventory"; echo "Docker inventory is unexpectedly empty" >&2; return 1; fi
+    python3 "$SCRIPT_DIR/scripts/validate_production_listeners.py" <"$inventory"
+    local rc=$?
+    rm -f "$inventory"
+    return "$rc"
+}
+
+function production_compose_state_validate() {
+    local state
+    state=$(mktemp /tmp/seraph-compose-state.XXXXXX)
+    if ! docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps --format json >"$state"; then rm -f "$state"; return 1; fi
+    python3 "$SCRIPT_DIR/scripts/validate_production_compose_state.py" <"$state"
+    local rc=$?
+    rm -f "$state"
+    return "$rc"
+}
+
+function production_restore_previous() {
+    local previous_tag="$1"
+    local previous_vlm="$2"
+    local previous_receipt="$3"
+    if [ -n "$previous_tag" ] && [ -n "$previous_vlm" ] && [ -r "$previous_receipt" ] && docker image inspect "seraph/backend:$previous_tag" >/dev/null 2>&1 && docker image inspect "seraph/frontend-ingress:$previous_tag" >/dev/null 2>&1 && docker image inspect "$previous_vlm" >/dev/null 2>&1 && SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$previous_receipt" "$previous_vlm"; then
+        echo "restoring previous production release tuple $previous_tag + $previous_vlm" >&2
+        if ! SERAPH_IMAGE_TAG="$previous_tag" SERAPH_VLM_IMAGE="$previous_vlm" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 120; then
+            echo "CATASTROPHIC: previous production release tuple could not be restored; diagnostics retained in $LOG_DIR" >&2
+            return 2
+        fi
+        if ! SERAPH_IMAGE_TAG="$previous_tag" SERAPH_VLM_IMAGE="$previous_vlm" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" exec -T backend uv run python production_preflight.py; then
+            docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" logs --no-color --tail 500 >"$LOG_DIR/seraph-prod-failed-restore.log" 2>&1 || true
+            echo "CATASTROPHIC: previous release restored containers but failed inference preflight" >&2
+            return 2
+        fi
+        return 0
+    else
+        echo "no verified previous release is available; stopping failed first deployment" >&2
+        docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" down
+        return 1
+    fi
+}
+
+function production_restore_after_failure() {
+    production_restore_previous "$1" "$2" "$3"
+    local restore_rc=$?
+    [ "$restore_rc" -eq 2 ] && return 2
+    return 1
+}
+
+function production_prepare_app_images() {
+    local present=0
+    local image revision
+    for image in "seraph/backend:$SERAPH_IMAGE_TAG" "seraph/frontend-ingress:$SERAPH_IMAGE_TAG"; do
+        if docker image inspect "$image" >/dev/null 2>&1; then
+            revision=$(docker image inspect "$image" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')
+            [ "$revision" = "$SERAPH_IMAGE_TAG" ] || error_exit "existing $image has mismatched build identity; refusing overwrite"
+            present=$((present + 1))
+        fi
+    done
+    [ "$present" -ne 1 ] || error_exit "partial release image tuple exists; refusing overwrite"
+    if [ "$present" -eq 0 ]; then
+        docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" build ingress backend
+    else
+        echo "reusing verified application images for $SERAPH_IMAGE_TAG"
+    fi
+}
+
+function production_start() {
+    production_config_validate
+    production_host_inventory_validate || return 1
+    production_docker_inventory_validate false || return 1
+    ensure_runtime_dirs
+    local active_tag_file="$PID_DIR/seraph-prod-active-release"
+    local previous_tag=""
+    local previous_vlm=""
+    local previous_receipt=""
+    local running_backend_id running_vlm_id
+    running_backend_id=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q backend 2>/dev/null || true)
+    running_vlm_id=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q vlm-wrapper 2>/dev/null || true)
+    if { [ -n "$running_backend_id" ] || [ -n "$running_vlm_id" ]; } && [ ! -r "$active_tag_file" ]; then
+        echo "running production containers lack an accepted release tuple; explicit adoption is required" >&2
+        return 1
+    fi
+    if [ -r "$active_tag_file" ]; then
+        production_read_validate_accepted_state "$active_tag_file" || { echo "accepted release state is invalid; explicit adoption is required" >&2; return 1; }
+        previous_tag="$ACCEPTED_APP_TAG"
+        previous_vlm="$ACCEPTED_VLM_IMAGE"
+        previous_receipt="$ACCEPTED_INVENTORY_RECEIPT"
+    fi
+    production_prepare_app_images || return 1
+    docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" pull vlm-wrapper || return 1
+    production_host_inventory_validate "$SERAPH_HOST_INVENTORY_RECEIPT" "$SERAPH_VLM_IMAGE" || return 1
+    if ! docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 120; then
+        echo "candidate containers did not become healthy" >&2
+        docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" logs --no-color --tail 500 >"$LOG_DIR/seraph-prod-failed-candidate.log" 2>&1 || true
+        production_restore_after_failure "$previous_tag" "$previous_vlm" "$previous_receipt"; return $?
+    fi
+    if ! docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" exec -T backend uv run python production_preflight.py; then
+        echo "candidate GPU model/VLM preflight failed" >&2
+        docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" logs --no-color --tail 500 >"$LOG_DIR/seraph-prod-failed-candidate.log" 2>&1 || true
+        production_restore_after_failure "$previous_tag" "$previous_vlm" "$previous_receipt"; return $?
+    fi
+    if ! production_host_inventory_validate "$SERAPH_HOST_INVENTORY_RECEIPT" "$SERAPH_VLM_IMAGE" || ! production_docker_inventory_validate true || ! production_compose_state_validate; then
+        echo "final production acceptance gate failed" >&2
+        production_restore_after_failure "$previous_tag" "$previous_vlm" "$previous_receipt"; return $?
+    fi
+    if ! production_write_accepted_state "$active_tag_file" "$SERAPH_HOST_INVENTORY_RECEIPT"; then
+        echo "failed to persist accepted release state" >&2
+        production_restore_after_failure "$previous_tag" "$previous_vlm" "$previous_receipt"; return $?
+    fi
+    echo "production release tuple accepted"
+}
+
+function production_write_accepted_state() {
+    local state_file="$1"
+    local receipt="$2"
+    local release_dir="$PID_DIR/releases"
+    mkdir -p "$release_dir"
+    local receipt_hash receipt_copy receipt_tmp state_tmp
+    receipt_hash=$(sha256sum "$receipt" | awk '{print $1}') || return 1
+    receipt_copy="$release_dir/$SERAPH_IMAGE_TAG-$receipt_hash.json"
+    receipt_tmp="$receipt_copy.tmp.$$"
+    cp "$receipt" "$receipt_tmp" || return 1
+    chmod 0444 "$receipt_tmp" || return 1
+    sync "$receipt_tmp" 2>/dev/null || true
+    mv "$receipt_tmp" "$receipt_copy" || return 1
+    state_tmp="$state_file.tmp.$$"
+    printf '%s\n%s\n%s\n' "$SERAPH_IMAGE_TAG" "$SERAPH_VLM_IMAGE" "$receipt_copy" >"$state_tmp" || return 1
+    chmod 0600 "$state_tmp" || return 1
+    sync "$state_tmp" 2>/dev/null || true
+    mv "$state_tmp" "$state_file"
+}
+
+function production_read_validate_accepted_state() {
+    local state_file="$1"
+    [ -r "$state_file" ] || { echo "accepted release state is missing" >&2; return 1; }
+    [ "$(awk 'END {print NR}' "$state_file")" -eq 3 ] || { echo "accepted release state must contain exactly three lines" >&2; return 1; }
+    local tag vlm receipt hash expected_name mode revision image
+    tag=$(sed -n '1p' "$state_file")
+    vlm=$(sed -n '2p' "$state_file")
+    receipt=$(sed -n '3p' "$state_file")
+    [[ "$tag" =~ ^[0-9a-f]{40}$ ]] || { echo "accepted application SHA is invalid" >&2; return 1; }
+    [[ "$vlm" =~ ^[^[:space:]@]+@sha256:[0-9a-fA-F]{64}$ ]] || { echo "accepted VLM digest is invalid" >&2; return 1; }
+    [ -r "$receipt" ] || { echo "accepted inventory copy is unreadable" >&2; return 1; }
+    hash=$(sha256sum "$receipt" | awk '{print $1}') || return 1
+    expected_name="$tag-$hash.json"
+    [ "$(basename "$receipt")" = "$expected_name" ] || { echo "accepted inventory copy is not hash-bound" >&2; return 1; }
+    mode=$(stat -c '%a' "$receipt" 2>/dev/null || stat -f '%Lp' "$receipt")
+    [ "$mode" = "444" ] || { echo "accepted inventory copy must be mode 0444" >&2; return 1; }
+    for image in "seraph/backend:$tag" "seraph/frontend-ingress:$tag"; do
+        docker image inspect "$image" >/dev/null 2>&1 || { echo "accepted image missing: $image" >&2; return 1; }
+        revision=$(docker image inspect "$image" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')
+        [ "$revision" = "$tag" ] || { echo "accepted image label mismatch: $image" >&2; return 1; }
+    done
+    docker image inspect "$vlm" >/dev/null 2>&1 || { echo "accepted VLM image missing" >&2; return 1; }
+    SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$receipt" "$vlm" || return 1
+    ACCEPTED_APP_TAG="$tag"
+    ACCEPTED_VLM_IMAGE="$vlm"
+    ACCEPTED_INVENTORY_RECEIPT="$receipt"
+}
+
+function production_rollback() {
+    local tag="${1:-}"
+    local vlm_image="${2:-}"
+    local target_receipt="${3:-}"
+    [ -n "$tag" ] && [ -n "$vlm_image" ] && [ -n "$target_receipt" ] || error_exit "rollback requires application SHA, VLM digest, and target inventory receipt"
+    [[ "$tag" =~ ^[0-9a-f]{40}$ ]] || error_exit "rollback application tag must be a full git SHA"
+    [[ "$vlm_image" =~ ^[^[:space:]@]+@sha256:[0-9a-fA-F]{64}$ ]] || error_exit "rollback VLM image must use an exact hexadecimal @sha256 digest"
+    docker image inspect "seraph/backend:$tag" >/dev/null 2>&1 || error_exit "missing seraph/backend:$tag"
+    docker image inspect "seraph/frontend-ingress:$tag" >/dev/null 2>&1 || error_exit "missing seraph/frontend-ingress:$tag"
+    docker image inspect "$vlm_image" >/dev/null 2>&1 || error_exit "missing $vlm_image"
+    SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" SERAPH_VALIDATING_ROLLBACK=true production_config_validate
+    production_host_inventory_validate "$target_receipt" "$vlm_image"
+    ensure_runtime_dirs
+    local active_tag_file="$PID_DIR/seraph-prod-active-release"
+    local original_tag=""
+    local original_vlm=""
+    local original_receipt=""
+    local running_backend_id running_vlm_id
+    running_backend_id=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q backend 2>/dev/null || true)
+    running_vlm_id=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q vlm-wrapper 2>/dev/null || true)
+    if { [ -n "$running_backend_id" ] || [ -n "$running_vlm_id" ]; } && [ ! -r "$active_tag_file" ]; then echo "running production containers require explicit adoption before rollback" >&2; return 1; fi
+    if [ -r "$active_tag_file" ]; then
+        production_read_validate_accepted_state "$active_tag_file" || { echo "accepted release state is invalid; refusing rollback cutover" >&2; return 1; }
+        original_tag="$ACCEPTED_APP_TAG"; original_vlm="$ACCEPTED_VLM_IMAGE"; original_receipt="$ACCEPTED_INVENTORY_RECEIPT"
+    fi
+    production_host_inventory_validate "$target_receipt" "$vlm_image" || return 1
+    if ! SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 120 || ! SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" exec -T backend uv run python production_preflight.py; then
+        docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" logs --no-color --tail 500 >"$LOG_DIR/seraph-prod-failed-rollback.log" 2>&1 || true
+        echo "requested rollback tuple failed; restoring original active tuple" >&2
+        production_restore_after_failure "$original_tag" "$original_vlm" "$original_receipt"; return $?
+    fi
+    production_host_inventory_validate "$target_receipt" "$vlm_image" || { production_restore_after_failure "$original_tag" "$original_vlm" "$original_receipt"; return $?; }
+    if ! SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" production_write_accepted_state "$active_tag_file" "$target_receipt"; then
+        production_restore_after_failure "$original_tag" "$original_vlm" "$original_receipt"; return $?
+    fi
+    echo "rolled back production containers to release tuple $tag + $vlm_image"
+}
+
 if [ "${SERAPH_MANAGE_SOURCE_ONLY:-false}" = "true" ]; then
     return 0 2>/dev/null || exit 0
 fi
@@ -842,6 +1110,21 @@ if [ "$COMMAND" = "local" ]; then
 fi
 
 # --- Execution ---
+
+if [ "$COMMAND" = "production" ]; then
+    PROD_SUB="${1:-}"
+    case "$PROD_SUB" in
+        config-validate) production_config_validate ;;
+        start) production_start ;;
+        stop) docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" down ;;
+        restart) production_start ;;
+        status) production_status ;;
+        logs) shift || true; docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" logs "$@" ;;
+        rollback) production_rollback "${2:-}" "${3:-}" "${4:-}" ;;
+        *) error_exit "Unknown production subcommand '$PROD_SUB'. Use: config-validate, start, stop, restart, status, logs, rollback" ;;
+    esac
+    exit 0
+fi
 
 if [ "$COMMAND" = "local" ]; then
     LOCAL_SUB="${1:-}"

--- a/manage.sh
+++ b/manage.sh
@@ -66,7 +66,7 @@ function display_help() {
     echo "  local   Manage the direct local frontend/backend stack: up, down, status, logs, run."
     echo "  daemon  Manage screen daemon: start, stop, status, logs."
     echo "  proxy   Manage stdio-to-HTTP MCP proxy: start, stop, status, logs."
-    echo "  production  Validated GPU/LAN lifecycle: config-validate, start, stop, restart, status, logs, rollback."
+    echo "  production  GPU/LAN lifecycle: start/accept, rollback/accept-rollback, restart/accept-restart, accept-restore, status, logs, stop."
     echo
     echo "Examples:"
     echo "  $PROG_NAME -e dev up -d"
@@ -761,6 +761,12 @@ function production_config_validate() {
     [ "$ENV" = "prod" ] || error_exit "production lifecycle requires -e prod"
     production_require_file SERAPH_TLS_CERT_FILE
     production_require_file SERAPH_TLS_KEY_FILE
+    production_require_file SERAPH_MAC_PROBE_KEY_FILE
+    [ -s "$SERAPH_MAC_PROBE_KEY_FILE" ] || error_exit "SERAPH_MAC_PROBE_KEY_FILE must be nonempty"
+    [ -n "${SERAPH_LAN_IP:-}" ] || error_exit "SERAPH_LAN_IP is required"
+    [ -s "${SERAPH_VLM_API_KEY_FILE:-/dev/null}" ] || error_exit "SERAPH_VLM_API_KEY_FILE must be nonempty"
+    [ -n "${SERAPH_EXPECTED_HTTPS_ORIGIN:-}" ] || error_exit "SERAPH_EXPECTED_HTTPS_ORIGIN is required"
+    [ -n "${SERAPH_MAC_PROBE_CLIENT_ID:-}" ] || error_exit "SERAPH_MAC_PROBE_CLIENT_ID is required"
     local credential_count=0
     if [ -n "${OPERATOR_AUTH_SECRET_FILE:-}" ] && [ -s "$OPERATOR_AUTH_SECRET_FILE" ]; then credential_count=$((credential_count + 1)); fi
     if [ -n "${OPERATOR_AUTH_SECRET_HASH_FILE:-}" ] && [ -s "$OPERATOR_AUTH_SECRET_HASH_FILE" ]; then credential_count=$((credential_count + 1)); fi
@@ -784,8 +790,8 @@ function production_config_validate() {
     fi
     [[ "${SERAPH_VLM_IMAGE:-}" =~ ^[^[:space:]@]+@sha256:[0-9a-fA-F]{64}$ ]] || error_exit "SERAPH_VLM_IMAGE must use an exact hexadecimal @sha256 digest"
     [ -n "${SERAPH_VLM_INTERFACE_CONTRACT:-}" ] || error_exit "SERAPH_VLM_INTERFACE_CONTRACT is required"
-    [ -n "${SERAPH_GPU_SSH_HOST:-}" ] || error_exit "SERAPH_GPU_SSH_HOST is required"
-    [ -n "${SERAPH_GPU_SSH_HOST_FINGERPRINT:-}" ] || error_exit "SERAPH_GPU_SSH_HOST_FINGERPRINT is required"
+    [ -n "${SERAPH_GPU_EXPECTED_HOSTNAME:-}" ] || error_exit "SERAPH_GPU_EXPECTED_HOSTNAME is required"
+    [[ "${SERAPH_GPU_MACHINE_IDENTITY_SHA256:-}" =~ ^[0-9a-fA-F]{64}$ ]] || error_exit "SERAPH_GPU_MACHINE_IDENTITY_SHA256 must be a SHA-256 digest"
     local config_file
     config_file=$(mktemp /tmp/seraph-prod-compose.XXXXXX.json)
     if ! docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" config --format json >"$config_file"; then
@@ -798,7 +804,7 @@ function production_config_validate() {
 }
 
 function production_host_inventory_validate() {
-    local receipt="${1:-${SERAPH_HOST_INVENTORY_RECEIPT:-}}"
+    local receipt="${1:-}"
     local vlm_image="${2:-${SERAPH_VLM_IMAGE:-}}"
     [ -r "$receipt" ] || error_exit "host inventory receipt is unreadable: $receipt"
     SERAPH_VLM_IMAGE="$vlm_image" python3 "$SCRIPT_DIR/scripts/validate_gpu_host_inventory.py" <"$receipt"
@@ -806,12 +812,71 @@ function production_host_inventory_validate() {
 
 function production_status() {
     production_config_validate
-    production_host_inventory_validate
-    production_compose_state_validate
+    ensure_runtime_dirs
+    if [ -r "$PID_DIR/seraph-prod-restore-release" ]; then
+        production_read_validate_accepted_state "$PID_DIR/seraph-prod-restore-release" || return 1
+        echo "Release state: restore awaiting LAN acceptance (previous accepted evidence retained, not current)"
+    elif [ -r "$PID_DIR/seraph-prod-rollback-release" ]; then
+        production_read_validate_accepted_state "$PID_DIR/seraph-prod-rollback-release" || return 1
+        echo "Release state: rollback awaiting LAN acceptance (previous accepted tuple retained, not current)"
+    elif [ -r "$PID_DIR/seraph-prod-restart-release" ]; then
+        production_read_validate_accepted_state "$PID_DIR/seraph-prod-restart-release" || return 1
+        echo "Release state: restart awaiting LAN acceptance (prior accepted receipt is stale)"
+    elif [ -r "$PID_DIR/seraph-prod-candidate-release" ]; then
+        production_read_validate_accepted_state "$PID_DIR/seraph-prod-candidate-release" || return 1
+        if [ -r "$PID_DIR/seraph-prod-active-release" ]; then echo "Release state: candidate awaiting Mac LAN acceptance (previous accepted tuple retained for rollback)"; else echo "Release state: candidate awaiting Mac LAN acceptance"; fi
+    elif [ -r "$PID_DIR/seraph-prod-active-release" ]; then
+        production_read_validate_accepted_state "$PID_DIR/seraph-prod-active-release" || return 1
+        echo "Release state: accepted"
+    else
+        echo "Release state: none"
+    fi
+    docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps
     echo "Published TLS listener owned by this compose project:"
     docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" port ingress 443 2>/dev/null || echo "ingress not running"
     echo "Docker container listener ownership:"
     production_docker_inventory_validate true
+}
+
+function production_cleanup_candidate_state() {
+    local stage="${1:-candidate}"
+    rm -f "$PID_DIR/seraph-prod-$stage-release" "$PID_DIR/seraph-prod-$stage-challenge.json" "$PID_DIR/seraph-prod-final-attestation.json"
+    [ "$stage" = candidate ] && rm -f "$PID_DIR/seraph-prod-candidate-attestation.json"
+}
+
+function production_lock_run() {
+    ensure_runtime_dirs
+    exec 9>"$PID_DIR/seraph-prod-lifecycle.lock"
+    flock -n 9 || { echo "another production lifecycle mutation is running" >&2; return 1; }
+    "$@"
+}
+
+function production_any_staged_state() {
+    [ -r "$PID_DIR/seraph-prod-candidate-release" ] || [ -r "$PID_DIR/seraph-prod-rollback-release" ] || [ -r "$PID_DIR/seraph-prod-restore-release" ] || [ -r "$PID_DIR/seraph-prod-restart-release" ]
+}
+
+function production_validate_mac_receipt() {
+    local receipt="$1"
+    local challenge_file="${2:-}"
+    [ -r "$challenge_file" ] || { echo "acceptance challenge is missing" >&2; return 1; }
+    SERAPH_ACCEPTANCE_CHALLENGE_FILE="$challenge_file" python3 "$SCRIPT_DIR/scripts/validate_mac_lan_negative.py" <"$receipt" || return 1
+    MAC_RECEIPT_NONCE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["nonce"])' "$receipt") || return 1
+    MAC_CHALLENGE_NONCE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["challenge"]["server_nonce"])' "$receipt") || return 1
+    local consumed_file="$PID_DIR/seraph-prod-consumed-acceptance"
+    if [ -r "$consumed_file" ] && grep -Fx "nonce:$MAC_RECEIPT_NONCE" "$consumed_file" >/dev/null; then
+        echo "Mac acceptance nonce was already used" >&2
+        return 1
+    fi
+    if [ -r "$consumed_file" ] && grep -Fx "challenge:$MAC_CHALLENGE_NONCE" "$consumed_file" >/dev/null; then
+        echo "server acceptance challenge was already used" >&2
+        return 1
+    fi
+}
+
+function production_issue_challenge() {
+    local stage="$1" app="$2" vlm="$3" attestation="$4" output="$PID_DIR/seraph-prod-$1-challenge.json" tmp="$output.tmp.$$"
+    python3 "$SCRIPT_DIR/scripts/generate_acceptance_challenge.py" --stage "$stage" --app-sha "$app" --vlm-image "$vlm" --local-attestation "$attestation" --origin "$SERAPH_EXPECTED_HTTPS_ORIGIN" --lan-host "$SERAPH_LAN_HOST" --lan-ip "$SERAPH_LAN_IP" --client-identity "$SERAPH_MAC_PROBE_CLIENT_ID" >"$tmp" || return 1
+    chmod 0444 "$tmp" && mv "$tmp" "$output"
 }
 
 function production_docker_inventory_validate() {
@@ -836,11 +901,25 @@ function production_compose_state_validate() {
     return "$rc"
 }
 
+function production_generate_local_attestation() {
+    local output="$1" vlm_image="$2"
+    local ingress_id backend_id vlm_id
+    ingress_id=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q ingress) || return 1
+    backend_id=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q backend) || return 1
+    vlm_id=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q vlm-wrapper) || return 1
+    python3 "$SCRIPT_DIR/scripts/generate_local_gpu_inventory.py" --expected-vlm-image "$vlm_image" --ingress-container "$ingress_id" --backend-container "$backend_id" --vlm-container "$vlm_id" --vlm-api-key-file "$SERAPH_VLM_API_KEY_FILE" >"$output"
+}
+
 function production_restore_previous() {
     local previous_tag="$1"
     local previous_vlm="$2"
     local previous_receipt="$3"
-    if [ -n "$previous_tag" ] && [ -n "$previous_vlm" ] && [ -r "$previous_receipt" ] && docker image inspect "seraph/backend:$previous_tag" >/dev/null 2>&1 && docker image inspect "seraph/frontend-ingress:$previous_tag" >/dev/null 2>&1 && docker image inspect "$previous_vlm" >/dev/null 2>&1 && SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$previous_receipt" "$previous_vlm"; then
+    local previous_local_receipt="$previous_receipt" previous_schema
+    if [ -r "$previous_receipt" ]; then
+        previous_schema=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("schema",""))' "$previous_receipt" 2>/dev/null || true)
+        if [ "$previous_schema" = "seraph.production-acceptance.v1" ]; then previous_local_receipt=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["final_attestation"]["path"])' "$previous_receipt") || return 2; fi
+    fi
+    if [ -n "$previous_tag" ] && [ -n "$previous_vlm" ] && [ -r "$previous_local_receipt" ] && docker image inspect "seraph/backend:$previous_tag" >/dev/null 2>&1 && docker image inspect "seraph/frontend-ingress:$previous_tag" >/dev/null 2>&1 && docker image inspect "$previous_vlm" >/dev/null 2>&1 && SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$previous_local_receipt" "$previous_vlm"; then
         echo "restoring previous production release tuple $previous_tag + $previous_vlm" >&2
         if ! SERAPH_IMAGE_TAG="$previous_tag" SERAPH_VLM_IMAGE="$previous_vlm" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 120; then
             echo "CATASTROPHIC: previous production release tuple could not be restored; diagnostics retained in $LOG_DIR" >&2
@@ -851,6 +930,14 @@ function production_restore_previous() {
             echo "CATASTROPHIC: previous release restored containers but failed inference preflight" >&2
             return 2
         fi
+        ensure_runtime_dirs
+        local restore_attestation="$PID_DIR/seraph-prod-restore-attestation.json"
+        if ! SERAPH_IMAGE_TAG="$previous_tag" SERAPH_VLM_IMAGE="$previous_vlm" production_generate_local_attestation "$restore_attestation" "$previous_vlm" || ! SERAPH_VLM_IMAGE="$previous_vlm" production_host_inventory_validate "$restore_attestation" "$previous_vlm" || ! SERAPH_IMAGE_TAG="$previous_tag" SERAPH_VLM_IMAGE="$previous_vlm" production_write_accepted_state "$PID_DIR/seraph-prod-restore-release" "$restore_attestation"; then
+            echo "CATASTROPHIC: restored tuple failed fresh local attestation" >&2
+            return 2
+        fi
+        production_issue_challenge restore "$previous_tag" "$previous_vlm" "$restore_attestation" || return 2
+        echo "previous tuple restored locally; restore awaiting fresh Mac LAN acceptance" >&2
         return 0
     else
         echo "no verified previous release is available; stopping failed first deployment" >&2
@@ -886,9 +973,15 @@ function production_prepare_app_images() {
 
 function production_start() {
     production_config_validate
-    production_host_inventory_validate || return 1
-    production_docker_inventory_validate false || return 1
     ensure_runtime_dirs
+    if production_any_staged_state; then
+        echo "a production stage already awaits LAN acceptance; complete that exact stage before starting another mutation" >&2
+        return 1
+    fi
+    local predeploy_receipt="$PID_DIR/seraph-gpu-predeploy.json"
+    python3 "$SCRIPT_DIR/scripts/generate_local_gpu_predeploy.py" >"$predeploy_receipt" || return 1
+    python3 "$SCRIPT_DIR/scripts/validate_gpu_predeploy.py" <"$predeploy_receipt" || return 1
+    production_docker_inventory_validate false || return 1
     local active_tag_file="$PID_DIR/seraph-prod-active-release"
     local previous_tag=""
     local previous_vlm=""
@@ -908,7 +1001,8 @@ function production_start() {
     fi
     production_prepare_app_images || return 1
     docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" pull vlm-wrapper || return 1
-    production_host_inventory_validate "$SERAPH_HOST_INVENTORY_RECEIPT" "$SERAPH_VLM_IMAGE" || return 1
+    python3 "$SCRIPT_DIR/scripts/generate_local_gpu_predeploy.py" >"$predeploy_receipt" || return 1
+    python3 "$SCRIPT_DIR/scripts/validate_gpu_predeploy.py" <"$predeploy_receipt" || return 1
     if ! docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 120; then
         echo "candidate containers did not become healthy" >&2
         docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" logs --no-color --tail 500 >"$LOG_DIR/seraph-prod-failed-candidate.log" 2>&1 || true
@@ -919,15 +1013,86 @@ function production_start() {
         docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" logs --no-color --tail 500 >"$LOG_DIR/seraph-prod-failed-candidate.log" 2>&1 || true
         production_restore_after_failure "$previous_tag" "$previous_vlm" "$previous_receipt"; return $?
     fi
-    if ! production_host_inventory_validate "$SERAPH_HOST_INVENTORY_RECEIPT" "$SERAPH_VLM_IMAGE" || ! production_docker_inventory_validate true || ! production_compose_state_validate; then
+    local candidate_receipt="$PID_DIR/seraph-prod-candidate-attestation.json"
+    local candidate_state="$PID_DIR/seraph-prod-candidate-release"
+    local vlm_container
+    vlm_container=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q vlm-wrapper) || return 1
+    if ! production_generate_local_attestation "$candidate_receipt" "$SERAPH_VLM_IMAGE" || ! production_host_inventory_validate "$candidate_receipt" "$SERAPH_VLM_IMAGE" || ! production_docker_inventory_validate true || ! production_compose_state_validate; then
         echo "final production acceptance gate failed" >&2
         production_restore_after_failure "$previous_tag" "$previous_vlm" "$previous_receipt"; return $?
     fi
-    if ! production_write_accepted_state "$active_tag_file" "$SERAPH_HOST_INVENTORY_RECEIPT"; then
-        echo "failed to persist accepted release state" >&2
+    if ! production_write_accepted_state "$candidate_state" "$candidate_receipt"; then
+        echo "failed to persist candidate release state" >&2
         production_restore_after_failure "$previous_tag" "$previous_vlm" "$previous_receipt"; return $?
     fi
-    echo "production release tuple accepted"
+    production_issue_challenge candidate "$SERAPH_IMAGE_TAG" "$SERAPH_VLM_IMAGE" "$candidate_receipt" || return 1
+    echo "candidate awaiting Mac LAN acceptance; run: ./manage.sh -e prod production accept <mac-negative-receipt>"
+}
+
+function production_accept() {
+    production_accept_staged "candidate" "$1"
+}
+
+function production_abort() {
+    local stage="${1:-}"
+    if [ "$stage" != candidate ] && [ "$stage" != rollback ] && [ "$stage" != restore ] && [ "$stage" != restart ]; then
+        error_exit "production abort requires one exact stage: candidate, rollback, restore, or restart"
+    fi
+    local staged="$PID_DIR/seraph-prod-$stage-release" active="$PID_DIR/seraph-prod-active-release"
+    [ -r "$staged" ] || error_exit "production $stage stage does not exist"
+    local previous_tag="" previous_vlm="" previous_receipt=""
+    if [ -r "$active" ]; then
+        production_read_validate_accepted_state "$active" || return 1
+        previous_tag="$ACCEPTED_APP_TAG"; previous_vlm="$ACCEPTED_VLM_IMAGE"; previous_receipt="$ACCEPTED_INVENTORY_RECEIPT"
+    fi
+    production_cleanup_candidate_state "$stage"
+    if [ -n "$previous_tag" ]; then
+        production_restore_previous "$previous_tag" "$previous_vlm" "$previous_receipt" || return $?
+        echo "production $stage aborted; previous accepted tuple restored locally and awaits a fresh restore acceptance"
+    else
+        docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" down || return 1
+        echo "production $stage aborted; no previously accepted tuple existed, so production was stopped"
+    fi
+}
+
+function production_accept_staged() {
+    local stage="$1"
+    local mac_receipt="${1:-}"
+    mac_receipt="${2:-}"
+    [ -r "$mac_receipt" ] || error_exit "production accept requires a readable Mac negative receipt"
+    ensure_runtime_dirs
+    local candidate_state="$PID_DIR/seraph-prod-$stage-release"
+    local active_state="$PID_DIR/seraph-prod-active-release"
+    production_read_validate_accepted_state "$candidate_state" || return 1
+    production_validate_mac_receipt "$mac_receipt" "$PID_DIR/seraph-prod-$stage-challenge.json" || return 1
+    local prior_binding fresh_binding fresh_receipt challenged_receipt
+    challenged_receipt="$ACCEPTED_INVENTORY_RECEIPT"
+    prior_binding=$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["compose_observation"]["containers"],sort_keys=True))' "$challenged_receipt") || return 1
+    fresh_receipt="$PID_DIR/seraph-prod-final-attestation.json"
+    production_generate_local_attestation "$fresh_receipt" "$ACCEPTED_VLM_IMAGE" || return 1
+    fresh_binding=$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["compose_observation"]["containers"],sort_keys=True))' "$fresh_receipt") || return 1
+    [ "$prior_binding" = "$fresh_binding" ] || { echo "$stage container/network binding changed before acceptance" >&2; return 1; }
+    SERAPH_VLM_IMAGE="$ACCEPTED_VLM_IMAGE" production_host_inventory_validate "$fresh_receipt" "$ACCEPTED_VLM_IMAGE" || return 1
+    production_compose_state_validate || return 1
+    SERAPH_IMAGE_TAG="$ACCEPTED_APP_TAG" SERAPH_VLM_IMAGE="$ACCEPTED_VLM_IMAGE" production_write_acceptance_bundle "$active_state" "$challenged_receipt" "$fresh_receipt" "$mac_receipt" "$stage" || return 1
+    production_cleanup_candidate_state "$stage"
+    echo "production $stage release accepted with fresh local and Mac evidence"
+}
+
+function production_restart() {
+    production_config_validate
+    ensure_runtime_dirs
+    production_any_staged_state && error_exit "restart refused while another stage awaits LAN acceptance"
+    local active="$PID_DIR/seraph-prod-active-release"
+    production_read_validate_accepted_state "$active" || error_exit "restart requires an accepted release"
+    [ "$ACCEPTED_APP_TAG" = "$SERAPH_IMAGE_TAG" ] && [ "$ACCEPTED_VLM_IMAGE" = "$SERAPH_VLM_IMAGE" ] || error_exit "restart only supports the identical accepted tuple; use start for a new candidate"
+    production_cleanup_candidate_state restart
+    docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --force-recreate --wait --wait-timeout 120 || return 1
+    docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" exec -T backend uv run python production_preflight.py || return 1
+    local receipt="$PID_DIR/seraph-prod-restart-attestation.json"
+    production_generate_local_attestation "$receipt" "$SERAPH_VLM_IMAGE" && production_host_inventory_validate "$receipt" "$SERAPH_VLM_IMAGE" && production_write_accepted_state "$PID_DIR/seraph-prod-restart-release" "$receipt" || return 1
+    production_issue_challenge restart "$SERAPH_IMAGE_TAG" "$SERAPH_VLM_IMAGE" "$receipt" || return 1
+    echo "restart locally attested; restart awaiting fresh Mac LAN acceptance"
 }
 
 function production_write_accepted_state() {
@@ -947,6 +1112,36 @@ function production_write_accepted_state() {
     printf '%s\n%s\n%s\n' "$SERAPH_IMAGE_TAG" "$SERAPH_VLM_IMAGE" "$receipt_copy" >"$state_tmp" || return 1
     chmod 0600 "$state_tmp" || return 1
     sync "$state_tmp" 2>/dev/null || true
+    mv "$state_tmp" "$state_file"
+}
+
+function production_write_acceptance_bundle() {
+    local state_file="$1" challenged_receipt="$2" final_receipt="$3" mac_receipt="$4" stage="$5"
+    local release_dir="$PID_DIR/releases" challenged_hash final_hash mac_hash challenged_copy final_copy mac_copy bundle_tmp bundle_hash bundle_copy state_tmp
+    local consumed_file="$PID_DIR/seraph-prod-consumed-acceptance" consumed_tmp="$PID_DIR/seraph-prod-consumed-acceptance.tmp.$$"
+    mkdir -p "$release_dir"
+    if [ -r "$consumed_file" ] && grep -Fx "nonce:$MAC_RECEIPT_NONCE" "$consumed_file" >/dev/null; then echo "Mac acceptance nonce was already used" >&2; return 1; fi
+    if [ -r "$consumed_file" ] && grep -Fx "challenge:$MAC_CHALLENGE_NONCE" "$consumed_file" >/dev/null; then echo "server acceptance challenge was already used" >&2; return 1; fi
+    challenged_hash=$(sha256sum "$challenged_receipt" | awk '{print $1}') || return 1
+    final_hash=$(sha256sum "$final_receipt" | awk '{print $1}') || return 1
+    mac_hash=$(sha256sum "$mac_receipt" | awk '{print $1}') || return 1
+    challenged_copy="$release_dir/$SERAPH_IMAGE_TAG-challenged-$challenged_hash.json"; final_copy="$release_dir/$SERAPH_IMAGE_TAG-final-$final_hash.json"; mac_copy="$release_dir/$SERAPH_IMAGE_TAG-mac-$mac_hash.json"
+    cp "$challenged_receipt" "$challenged_copy" && cp "$final_receipt" "$final_copy" && cp "$mac_receipt" "$mac_copy" && chmod 0444 "$challenged_copy" "$final_copy" "$mac_copy" || return 1
+    local ingress_id backend_id vlm_id network_id
+    ingress_id=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["compose_observation"]["containers"]["ingress"]["container_id"])' "$final_receipt") || return 1
+    backend_id=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["compose_observation"]["containers"]["backend"]["container_id"])' "$final_receipt") || return 1
+    vlm_id=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["compose_observation"]["containers"]["vlm-wrapper"]["container_id"])' "$final_receipt") || return 1
+    network_id=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["compose_observation"]["containers"]["ingress"]["network_id"])' "$final_receipt") || return 1
+    bundle_tmp="$release_dir/bundle.tmp.$$"
+    python3 -c 'import json,sys; print(json.dumps({"schema":"seraph.production-acceptance.v1","stage":sys.argv[15],"app_sha":sys.argv[1],"vlm_image":sys.argv[2],"compose_project":"seraph-prod","network_name":"seraph-core-prod","network_id":sys.argv[3],"container_ids":{"ingress":sys.argv[4],"backend":sys.argv[5],"vlm-wrapper":sys.argv[6]},"challenged_attestation":{"path":sys.argv[7],"sha256":sys.argv[8]},"final_attestation":{"path":sys.argv[9],"sha256":sys.argv[10]},"mac_receipt":{"path":sys.argv[11],"sha256":sys.argv[12]},"acceptance_challenge":json.load(open(sys.argv[11]))["challenge"],"expected_origin":sys.argv[13],"client_identity":sys.argv[14]},sort_keys=True,separators=(",",":")))' "$SERAPH_IMAGE_TAG" "$SERAPH_VLM_IMAGE" "$network_id" "$ingress_id" "$backend_id" "$vlm_id" "$challenged_copy" "$challenged_hash" "$final_copy" "$final_hash" "$mac_copy" "$mac_hash" "$SERAPH_EXPECTED_HTTPS_ORIGIN" "$SERAPH_MAC_PROBE_CLIENT_ID" "$stage" >"$bundle_tmp" || return 1
+    SERAPH_BUNDLE_APP_SHA="$SERAPH_IMAGE_TAG" SERAPH_BUNDLE_VLM_IMAGE="$SERAPH_VLM_IMAGE" python3 "$SCRIPT_DIR/scripts/validate_acceptance_bundle.py" <"$bundle_tmp" || return 1
+    bundle_hash=$(sha256sum "$bundle_tmp" | awk '{print $1}'); bundle_copy="$release_dir/$SERAPH_IMAGE_TAG-$bundle_hash.json"
+    state_tmp="$state_file.tmp.$$"; printf '%s\n%s\n%s\n' "$SERAPH_IMAGE_TAG" "$SERAPH_VLM_IMAGE" "$bundle_copy" >"$state_tmp" || return 1
+    { [ -r "$consumed_file" ] && cat "$consumed_file"; printf 'nonce:%s\nchallenge:%s\n' "$MAC_RECEIPT_NONCE" "$MAC_CHALLENGE_NONCE"; } >"$consumed_tmp" || return 1
+    chmod 0444 "$bundle_tmp" && chmod 0600 "$state_tmp" "$consumed_tmp" || return 1
+    sync "$challenged_copy" "$final_copy" "$mac_copy" "$bundle_tmp" "$state_tmp" "$consumed_tmp" 2>/dev/null || true
+    mv "$bundle_tmp" "$bundle_copy" || return 1
+    mv "$consumed_tmp" "$consumed_file" || return 1
     mv "$state_tmp" "$state_file"
 }
 
@@ -972,7 +1167,17 @@ function production_read_validate_accepted_state() {
         [ "$revision" = "$tag" ] || { echo "accepted image label mismatch: $image" >&2; return 1; }
     done
     docker image inspect "$vlm" >/dev/null 2>&1 || { echo "accepted VLM image missing" >&2; return 1; }
-    SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$receipt" "$vlm" || return 1
+    local receipt_schema challenged_attestation final_attestation
+    receipt_schema=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("schema",""))' "$receipt") || return 1
+    if [ "$receipt_schema" = "seraph.production-acceptance.v1" ]; then
+        SERAPH_BUNDLE_APP_SHA="$tag" SERAPH_BUNDLE_VLM_IMAGE="$vlm" python3 "$SCRIPT_DIR/scripts/validate_acceptance_bundle.py" <"$receipt" || return 1
+        challenged_attestation=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["challenged_attestation"]["path"])' "$receipt") || return 1
+        final_attestation=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["final_attestation"]["path"])' "$receipt") || return 1
+        SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$challenged_attestation" "$vlm" || return 1
+        SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$final_attestation" "$vlm" || return 1
+    else
+        SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$receipt" "$vlm" || return 1
+    fi
     ACCEPTED_APP_TAG="$tag"
     ACCEPTED_VLM_IMAGE="$vlm"
     ACCEPTED_INVENTORY_RECEIPT="$receipt"
@@ -981,15 +1186,15 @@ function production_read_validate_accepted_state() {
 function production_rollback() {
     local tag="${1:-}"
     local vlm_image="${2:-}"
-    local target_receipt="${3:-}"
-    [ -n "$tag" ] && [ -n "$vlm_image" ] && [ -n "$target_receipt" ] || error_exit "rollback requires application SHA, VLM digest, and target inventory receipt"
+    [ -n "$tag" ] && [ -n "$vlm_image" ] || error_exit "rollback requires application SHA and VLM digest"
+    ensure_runtime_dirs
+    production_any_staged_state && error_exit "rollback refused while another stage awaits LAN acceptance"
     [[ "$tag" =~ ^[0-9a-f]{40}$ ]] || error_exit "rollback application tag must be a full git SHA"
     [[ "$vlm_image" =~ ^[^[:space:]@]+@sha256:[0-9a-fA-F]{64}$ ]] || error_exit "rollback VLM image must use an exact hexadecimal @sha256 digest"
     docker image inspect "seraph/backend:$tag" >/dev/null 2>&1 || error_exit "missing seraph/backend:$tag"
     docker image inspect "seraph/frontend-ingress:$tag" >/dev/null 2>&1 || error_exit "missing seraph/frontend-ingress:$tag"
     docker image inspect "$vlm_image" >/dev/null 2>&1 || error_exit "missing $vlm_image"
     SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" SERAPH_VALIDATING_ROLLBACK=true production_config_validate
-    production_host_inventory_validate "$target_receipt" "$vlm_image"
     ensure_runtime_dirs
     local active_tag_file="$PID_DIR/seraph-prod-active-release"
     local original_tag=""
@@ -1003,17 +1208,21 @@ function production_rollback() {
         production_read_validate_accepted_state "$active_tag_file" || { echo "accepted release state is invalid; refusing rollback cutover" >&2; return 1; }
         original_tag="$ACCEPTED_APP_TAG"; original_vlm="$ACCEPTED_VLM_IMAGE"; original_receipt="$ACCEPTED_INVENTORY_RECEIPT"
     fi
-    production_host_inventory_validate "$target_receipt" "$vlm_image" || return 1
     if ! SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 120 || ! SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" exec -T backend uv run python production_preflight.py; then
         docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" logs --no-color --tail 500 >"$LOG_DIR/seraph-prod-failed-rollback.log" 2>&1 || true
         echo "requested rollback tuple failed; restoring original active tuple" >&2
         production_restore_after_failure "$original_tag" "$original_vlm" "$original_receipt"; return $?
     fi
-    production_host_inventory_validate "$target_receipt" "$vlm_image" || { production_restore_after_failure "$original_tag" "$original_vlm" "$original_receipt"; return $?; }
-    if ! SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" production_write_accepted_state "$active_tag_file" "$target_receipt"; then
+    local target_attestation="$PID_DIR/seraph-prod-rollback-attestation.json" target_container
+    target_container=$(SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q vlm-wrapper) || return 1
+    if ! production_generate_local_attestation "$target_attestation" "$vlm_image" || ! SERAPH_VLM_IMAGE="$vlm_image" production_host_inventory_validate "$target_attestation" "$vlm_image"; then
         production_restore_after_failure "$original_tag" "$original_vlm" "$original_receipt"; return $?
     fi
-    echo "rolled back production containers to release tuple $tag + $vlm_image"
+    if ! SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" production_write_accepted_state "$PID_DIR/seraph-prod-rollback-release" "$target_attestation"; then
+        production_restore_after_failure "$original_tag" "$original_vlm" "$original_receipt"; return $?
+    fi
+    production_issue_challenge rollback "$tag" "$vlm_image" "$target_attestation" || { production_restore_after_failure "$original_tag" "$original_vlm" "$original_receipt"; return $?; }
+    echo "rollback deployed and locally attested; rollback awaiting fresh Mac LAN acceptance"
 }
 
 if [ "${SERAPH_MANAGE_SOURCE_ONLY:-false}" = "true" ]; then
@@ -1115,13 +1324,18 @@ if [ "$COMMAND" = "production" ]; then
     PROD_SUB="${1:-}"
     case "$PROD_SUB" in
         config-validate) production_config_validate ;;
-        start) production_start ;;
-        stop) docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" down ;;
-        restart) production_start ;;
+        start) production_lock_run production_start ;;
+        stop) production_lock_run docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" down ;;
+        restart) production_lock_run production_restart ;;
         status) production_status ;;
+        accept) production_lock_run production_accept "${2:-}" ;;
+        accept-rollback) production_lock_run production_accept_staged "rollback" "${2:-}" ;;
+        accept-restore) production_lock_run production_accept_staged "restore" "${2:-}" ;;
+        accept-restart) production_lock_run production_accept_staged "restart" "${2:-}" ;;
+        abort) production_lock_run production_abort "${2:-}" ;;
         logs) shift || true; docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" logs "$@" ;;
-        rollback) production_rollback "${2:-}" "${3:-}" "${4:-}" ;;
-        *) error_exit "Unknown production subcommand '$PROD_SUB'. Use: config-validate, start, stop, restart, status, logs, rollback" ;;
+        rollback) production_lock_run production_rollback "${2:-}" "${3:-}" ;;
+        *) error_exit "Unknown production subcommand '$PROD_SUB'. Use: config-validate, start, accept, rollback, accept-rollback, restart, accept-restart, accept-restore, abort, status, logs, stop" ;;
     esac
     exit 0
 fi

--- a/manage.sh
+++ b/manage.sh
@@ -788,7 +788,7 @@ function production_config_validate() {
         [ "$SERAPH_IMAGE_TAG" = "$current_revision" ] || error_exit "SERAPH_IMAGE_TAG must equal current HEAD $current_revision"
         [ -z "$(git -C "$SCRIPT_DIR" status --porcelain)" ] || error_exit "production builds require a clean working tree"
     fi
-    [[ "${SERAPH_VLM_IMAGE:-}" =~ ^[^[:space:]@]+@sha256:[0-9a-fA-F]{64}$ ]] || error_exit "SERAPH_VLM_IMAGE must use an exact hexadecimal @sha256 digest"
+    [[ "${SERAPH_VLM_IMAGE:-}" =~ ^([^[:space:]@]+@sha256:[0-9a-fA-F]{64}|sha256:[0-9a-fA-F]{64})$ ]] || error_exit "SERAPH_VLM_IMAGE must use a registry RepoDigest or exact local sha256 image ID"
     [ -n "${SERAPH_VLM_INTERFACE_CONTRACT:-}" ] || error_exit "SERAPH_VLM_INTERFACE_CONTRACT is required"
     [ -n "${SERAPH_GPU_EXPECTED_HOSTNAME:-}" ] || error_exit "SERAPH_GPU_EXPECTED_HOSTNAME is required"
     [[ "${SERAPH_GPU_MACHINE_IDENTITY_SHA256:-}" =~ ^[0-9a-fA-F]{64}$ ]] || error_exit "SERAPH_GPU_MACHINE_IDENTITY_SHA256 must be a SHA-256 digest"
@@ -1000,7 +1000,11 @@ function production_start() {
         previous_receipt="$ACCEPTED_INVENTORY_RECEIPT"
     fi
     production_prepare_app_images || return 1
-    docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" pull vlm-wrapper || return 1
+    if [[ "$SERAPH_VLM_IMAGE" =~ ^sha256:[0-9a-fA-F]{64}$ ]]; then
+        docker image inspect "$SERAPH_VLM_IMAGE" >/dev/null 2>&1 || { echo "pinned local VLM image ID is missing" >&2; return 1; }
+    else
+        docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" pull vlm-wrapper || return 1
+    fi
     python3 "$SCRIPT_DIR/scripts/generate_local_gpu_predeploy.py" >"$predeploy_receipt" || return 1
     python3 "$SCRIPT_DIR/scripts/validate_gpu_predeploy.py" <"$predeploy_receipt" || return 1
     if ! docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 120; then
@@ -1154,7 +1158,7 @@ function production_read_validate_accepted_state() {
     vlm=$(sed -n '2p' "$state_file")
     receipt=$(sed -n '3p' "$state_file")
     [[ "$tag" =~ ^[0-9a-f]{40}$ ]] || { echo "accepted application SHA is invalid" >&2; return 1; }
-    [[ "$vlm" =~ ^[^[:space:]@]+@sha256:[0-9a-fA-F]{64}$ ]] || { echo "accepted VLM digest is invalid" >&2; return 1; }
+    [[ "$vlm" =~ ^([^[:space:]@]+@sha256:[0-9a-fA-F]{64}|sha256:[0-9a-fA-F]{64})$ ]] || { echo "accepted VLM immutable reference is invalid" >&2; return 1; }
     [ -r "$receipt" ] || { echo "accepted inventory copy is unreadable" >&2; return 1; }
     hash=$(sha256sum "$receipt" | awk '{print $1}') || return 1
     expected_name="$tag-$hash.json"
@@ -1190,7 +1194,7 @@ function production_rollback() {
     ensure_runtime_dirs
     production_any_staged_state && error_exit "rollback refused while another stage awaits LAN acceptance"
     [[ "$tag" =~ ^[0-9a-f]{40}$ ]] || error_exit "rollback application tag must be a full git SHA"
-    [[ "$vlm_image" =~ ^[^[:space:]@]+@sha256:[0-9a-fA-F]{64}$ ]] || error_exit "rollback VLM image must use an exact hexadecimal @sha256 digest"
+    [[ "$vlm_image" =~ ^([^[:space:]@]+@sha256:[0-9a-fA-F]{64}|sha256:[0-9a-fA-F]{64})$ ]] || error_exit "rollback VLM image must use a registry RepoDigest or exact local sha256 image ID"
     docker image inspect "seraph/backend:$tag" >/dev/null 2>&1 || error_exit "missing seraph/backend:$tag"
     docker image inspect "seraph/frontend-ingress:$tag" >/dev/null 2>&1 || error_exit "missing seraph/frontend-ingress:$tag"
     docker image inspect "$vlm_image" >/dev/null 2>&1 || error_exit "missing $vlm_image"

--- a/manage.sh
+++ b/manage.sh
@@ -1341,7 +1341,7 @@ if [ "$COMMAND" = "production" ]; then
         rollback) production_lock_run production_rollback "${2:-}" "${3:-}" ;;
         *) error_exit "Unknown production subcommand '$PROD_SUB'. Use: config-validate, start, accept, rollback, accept-rollback, restart, accept-restart, accept-restore, abort, status, logs, stop" ;;
     esac
-    exit 0
+    exit $?
 fi
 
 if [ "$COMMAND" = "local" ]; then

--- a/manage.sh
+++ b/manage.sh
@@ -789,6 +789,13 @@ function production_config_validate() {
         [ -z "$(git -C "$SCRIPT_DIR" status --porcelain)" ] || error_exit "production builds require a clean working tree"
     fi
     [[ "${SERAPH_VLM_IMAGE:-}" =~ ^([^[:space:]@]+@sha256:[0-9a-fA-F]{64}|sha256:[0-9a-fA-F]{64})$ ]] || error_exit "SERAPH_VLM_IMAGE must use a registry RepoDigest or exact local sha256 image ID"
+    [[ "${SERAPH_GPU_MODEL_IMAGE:-}" =~ ^[^[:space:]@]+@sha256:[0-9a-fA-F]{64}$ ]] || error_exit "SERAPH_GPU_MODEL_IMAGE must use an exact registry RepoDigest"
+    [[ "${SERAPH_GPU_MODEL_DIR:-}" = /* ]] || error_exit "SERAPH_GPU_MODEL_DIR must be an absolute protected host path"
+    [[ "${SERAPH_GPU_MODEL_FILE:-}" =~ ^[^/]+\.gguf$ ]] || error_exit "SERAPH_GPU_MODEL_FILE must be one GGUF filename"
+    [[ "${SERAPH_GPU_MMPROJ_FILE:-}" =~ ^[^/]+\.gguf$ ]] || error_exit "SERAPH_GPU_MMPROJ_FILE must be one GGUF filename"
+    [ -r "$SERAPH_GPU_MODEL_DIR/$SERAPH_GPU_MODEL_FILE" ] || error_exit "configured GPU model artifact is unreadable"
+    [ -r "$SERAPH_GPU_MODEL_DIR/$SERAPH_GPU_MMPROJ_FILE" ] || error_exit "configured GPU mmproj artifact is unreadable"
+    [ -n "${SERAPH_GPU_MODEL_ALIAS:-}" ] || error_exit "SERAPH_GPU_MODEL_ALIAS is required"
     [ -n "${SERAPH_VLM_INTERFACE_CONTRACT:-}" ] || error_exit "SERAPH_VLM_INTERFACE_CONTRACT is required"
     [ -n "${SERAPH_GPU_EXPECTED_HOSTNAME:-}" ] || error_exit "SERAPH_GPU_EXPECTED_HOSTNAME is required"
     [[ "${SERAPH_GPU_MACHINE_IDENTITY_SHA256:-}" =~ ^[0-9a-fA-F]{64}$ ]] || error_exit "SERAPH_GPU_MACHINE_IDENTITY_SHA256 must be a SHA-256 digest"
@@ -811,25 +818,35 @@ function production_host_inventory_validate() {
 }
 
 function production_status() {
-    production_config_validate
     ensure_runtime_dirs
+    local loaded_release=false
     if [ -r "$PID_DIR/seraph-prod-restore-release" ]; then
-        production_read_validate_accepted_state "$PID_DIR/seraph-prod-restore-release" || return 1
+        production_read_validate_accepted_state "$PID_DIR/seraph-prod-restore-release" staged || return 1
+        loaded_release=true
         echo "Release state: restore awaiting LAN acceptance (previous accepted evidence retained, not current)"
     elif [ -r "$PID_DIR/seraph-prod-rollback-release" ]; then
-        production_read_validate_accepted_state "$PID_DIR/seraph-prod-rollback-release" || return 1
+        production_read_validate_accepted_state "$PID_DIR/seraph-prod-rollback-release" staged || return 1
+        loaded_release=true
         echo "Release state: rollback awaiting LAN acceptance (previous accepted tuple retained, not current)"
     elif [ -r "$PID_DIR/seraph-prod-restart-release" ]; then
-        production_read_validate_accepted_state "$PID_DIR/seraph-prod-restart-release" || return 1
+        production_read_validate_accepted_state "$PID_DIR/seraph-prod-restart-release" staged || return 1
+        loaded_release=true
         echo "Release state: restart awaiting LAN acceptance (prior accepted receipt is stale)"
     elif [ -r "$PID_DIR/seraph-prod-candidate-release" ]; then
-        production_read_validate_accepted_state "$PID_DIR/seraph-prod-candidate-release" || return 1
+        production_read_validate_accepted_state "$PID_DIR/seraph-prod-candidate-release" staged || return 1
+        loaded_release=true
         if [ -r "$PID_DIR/seraph-prod-active-release" ]; then echo "Release state: candidate awaiting Mac LAN acceptance (previous accepted tuple retained for rollback)"; else echo "Release state: candidate awaiting Mac LAN acceptance"; fi
     elif [ -r "$PID_DIR/seraph-prod-active-release" ]; then
-        production_read_validate_accepted_state "$PID_DIR/seraph-prod-active-release" || return 1
+        production_read_validate_accepted_state "$PID_DIR/seraph-prod-active-release" active || return 1
+        loaded_release=true
         echo "Release state: accepted"
     else
         echo "Release state: none"
+    fi
+    if [ "$loaded_release" = true ]; then
+        SERAPH_IMAGE_TAG="$ACCEPTED_APP_TAG" SERAPH_VLM_IMAGE="$ACCEPTED_VLM_IMAGE" SERAPH_VALIDATING_ROLLBACK=true production_config_validate
+    else
+        production_config_validate
     fi
     docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps
     echo "Published TLS listener owned by this compose project:"
@@ -903,11 +920,12 @@ function production_compose_state_validate() {
 
 function production_generate_local_attestation() {
     local output="$1" vlm_image="$2"
-    local ingress_id backend_id vlm_id
+    local ingress_id backend_id vlm_id gpu_model_id
     ingress_id=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q ingress) || return 1
     backend_id=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q backend) || return 1
     vlm_id=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q vlm-wrapper) || return 1
-    python3 "$SCRIPT_DIR/scripts/generate_local_gpu_inventory.py" --expected-vlm-image "$vlm_image" --ingress-container "$ingress_id" --backend-container "$backend_id" --vlm-container "$vlm_id" --vlm-api-key-file "$SERAPH_VLM_API_KEY_FILE" >"$output"
+    gpu_model_id=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q gpu-model) || return 1
+    python3 "$SCRIPT_DIR/scripts/generate_local_gpu_inventory.py" --expected-vlm-image "$vlm_image" --expected-gpu-model-image "$SERAPH_GPU_MODEL_IMAGE" --expected-gpu-model-alias "$SERAPH_GPU_MODEL_ALIAS" --gpu-model-dir "$SERAPH_GPU_MODEL_DIR" --gpu-model-file "$SERAPH_GPU_MODEL_FILE" --gpu-mmproj-file "$SERAPH_GPU_MMPROJ_FILE" --gpu-ctx-size "$SERAPH_GPU_MODEL_CTX_SIZE" --gpu-layers "$SERAPH_GPU_MODEL_LAYERS" --ingress-container "$ingress_id" --backend-container "$backend_id" --vlm-container "$vlm_id" --gpu-model-container "$gpu_model_id" --vlm-api-key-file "$SERAPH_VLM_API_KEY_FILE" >"$output"
 }
 
 function production_restore_previous() {
@@ -917,11 +935,23 @@ function production_restore_previous() {
     local previous_local_receipt="$previous_receipt" previous_schema
     if [ -r "$previous_receipt" ]; then
         previous_schema=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("schema",""))' "$previous_receipt" 2>/dev/null || true)
-        if [ "$previous_schema" = "seraph.production-acceptance.v1" ]; then previous_local_receipt=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["final_attestation"]["path"])' "$previous_receipt") || return 2; fi
+        if [ "$previous_schema" = "seraph.production-acceptance.v2" ]; then
+            previous_local_receipt=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["final_attestation"]["path"])' "$previous_receipt") || return 2
+            SERAPH_GPU_MODEL_IMAGE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["image_ref"])' "$previous_receipt") || return 2
+            SERAPH_GPU_MODEL_ALIAS=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["alias"])' "$previous_receipt") || return 2
+            SERAPH_GPU_MODEL_DIR=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["artifact_root"])' "$previous_receipt") || return 2
+            SERAPH_GPU_MODEL_FILE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["model"]["filename"])' "$previous_receipt") || return 2
+            SERAPH_GPU_MMPROJ_FILE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["mmproj"]["filename"])' "$previous_receipt") || return 2
+            SERAPH_GPU_MODEL_CTX_SIZE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["ctx_size"])' "$previous_receipt") || return 2
+            SERAPH_GPU_MODEL_LAYERS=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["layers"])' "$previous_receipt") || return 2
+            export SERAPH_GPU_MODEL_IMAGE SERAPH_GPU_MODEL_ALIAS SERAPH_GPU_MODEL_DIR SERAPH_GPU_MODEL_FILE SERAPH_GPU_MMPROJ_FILE SERAPH_GPU_MODEL_CTX_SIZE SERAPH_GPU_MODEL_LAYERS
+        else
+            echo "previous release lacks complete GPU tuple" >&2; return 2
+        fi
     fi
     if [ -n "$previous_tag" ] && [ -n "$previous_vlm" ] && [ -r "$previous_local_receipt" ] && docker image inspect "seraph/backend:$previous_tag" >/dev/null 2>&1 && docker image inspect "seraph/frontend-ingress:$previous_tag" >/dev/null 2>&1 && docker image inspect "$previous_vlm" >/dev/null 2>&1 && SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$previous_local_receipt" "$previous_vlm"; then
         echo "restoring previous production release tuple $previous_tag + $previous_vlm" >&2
-        if ! SERAPH_IMAGE_TAG="$previous_tag" SERAPH_VLM_IMAGE="$previous_vlm" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 120; then
+        if ! SERAPH_IMAGE_TAG="$previous_tag" SERAPH_VLM_IMAGE="$previous_vlm" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 300; then
             echo "CATASTROPHIC: previous production release tuple could not be restored; diagnostics retained in $LOG_DIR" >&2
             return 2
         fi
@@ -994,7 +1024,7 @@ function production_start() {
         return 1
     fi
     if [ -r "$active_tag_file" ]; then
-        production_read_validate_accepted_state "$active_tag_file" || { echo "accepted release state is invalid; explicit adoption is required" >&2; return 1; }
+        production_read_validate_accepted_state "$active_tag_file" active preserve || { echo "accepted release state is invalid; explicit adoption is required" >&2; return 1; }
         previous_tag="$ACCEPTED_APP_TAG"
         previous_vlm="$ACCEPTED_VLM_IMAGE"
         previous_receipt="$ACCEPTED_INVENTORY_RECEIPT"
@@ -1005,9 +1035,10 @@ function production_start() {
     else
         docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" pull vlm-wrapper || return 1
     fi
+    docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" pull gpu-model || return 1
     python3 "$SCRIPT_DIR/scripts/generate_local_gpu_predeploy.py" >"$predeploy_receipt" || return 1
     python3 "$SCRIPT_DIR/scripts/validate_gpu_predeploy.py" <"$predeploy_receipt" || return 1
-    if ! docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 120; then
+    if ! docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 300; then
         echo "candidate containers did not become healthy" >&2
         docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" logs --no-color --tail 500 >"$LOG_DIR/seraph-prod-failed-candidate.log" 2>&1 || true
         production_restore_after_failure "$previous_tag" "$previous_vlm" "$previous_receipt"; return $?
@@ -1046,7 +1077,7 @@ function production_abort() {
     [ -r "$staged" ] || error_exit "production $stage stage does not exist"
     local previous_tag="" previous_vlm="" previous_receipt=""
     if [ -r "$active" ]; then
-        production_read_validate_accepted_state "$active" || return 1
+        production_read_validate_accepted_state "$active" active || return 1
         previous_tag="$ACCEPTED_APP_TAG"; previous_vlm="$ACCEPTED_VLM_IMAGE"; previous_receipt="$ACCEPTED_INVENTORY_RECEIPT"
     fi
     production_cleanup_candidate_state "$stage"
@@ -1067,7 +1098,7 @@ function production_accept_staged() {
     ensure_runtime_dirs
     local candidate_state="$PID_DIR/seraph-prod-$stage-release"
     local active_state="$PID_DIR/seraph-prod-active-release"
-    production_read_validate_accepted_state "$candidate_state" || return 1
+    production_read_validate_accepted_state "$candidate_state" staged || return 1
     production_validate_mac_receipt "$mac_receipt" "$PID_DIR/seraph-prod-$stage-challenge.json" || return 1
     local prior_binding fresh_binding fresh_receipt challenged_receipt
     challenged_receipt="$ACCEPTED_INVENTORY_RECEIPT"
@@ -1084,14 +1115,17 @@ function production_accept_staged() {
 }
 
 function production_restart() {
-    production_config_validate
     ensure_runtime_dirs
     production_any_staged_state && error_exit "restart refused while another stage awaits LAN acceptance"
     local active="$PID_DIR/seraph-prod-active-release"
-    production_read_validate_accepted_state "$active" || error_exit "restart requires an accepted release"
-    [ "$ACCEPTED_APP_TAG" = "$SERAPH_IMAGE_TAG" ] && [ "$ACCEPTED_VLM_IMAGE" = "$SERAPH_VLM_IMAGE" ] || error_exit "restart only supports the identical accepted tuple; use start for a new candidate"
+    production_read_validate_accepted_state "$active" active || error_exit "restart requires an accepted release"
+    SERAPH_IMAGE_TAG="$ACCEPTED_APP_TAG"; SERAPH_VLM_IMAGE="$ACCEPTED_VLM_IMAGE"
+    SERAPH_GPU_MODEL_IMAGE="$ACCEPTED_GPU_MODEL_IMAGE"; SERAPH_GPU_MODEL_ALIAS="$ACCEPTED_GPU_MODEL_ALIAS"; SERAPH_GPU_MODEL_DIR="$ACCEPTED_GPU_MODEL_DIR"; SERAPH_GPU_MODEL_FILE="$ACCEPTED_GPU_MODEL_FILE"; SERAPH_GPU_MMPROJ_FILE="$ACCEPTED_GPU_MMPROJ_FILE"; SERAPH_GPU_MODEL_CTX_SIZE="$ACCEPTED_GPU_MODEL_CTX_SIZE"; SERAPH_GPU_MODEL_LAYERS="$ACCEPTED_GPU_MODEL_LAYERS"
+    export SERAPH_GPU_MODEL_IMAGE SERAPH_GPU_MODEL_ALIAS SERAPH_GPU_MODEL_DIR SERAPH_GPU_MODEL_FILE SERAPH_GPU_MMPROJ_FILE SERAPH_GPU_MODEL_CTX_SIZE SERAPH_GPU_MODEL_LAYERS
+    export SERAPH_IMAGE_TAG SERAPH_VLM_IMAGE
+    SERAPH_VALIDATING_ROLLBACK=true production_config_validate || return 1
     production_cleanup_candidate_state restart
-    docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --force-recreate --wait --wait-timeout 120 || return 1
+    docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --force-recreate --wait --wait-timeout 300 || return 1
     docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" exec -T backend uv run python production_preflight.py || return 1
     local receipt="$PID_DIR/seraph-prod-restart-attestation.json"
     production_generate_local_attestation "$receipt" "$SERAPH_VLM_IMAGE" && production_host_inventory_validate "$receipt" "$SERAPH_VLM_IMAGE" && production_write_accepted_state "$PID_DIR/seraph-prod-restart-release" "$receipt" || return 1
@@ -1119,6 +1153,20 @@ function production_write_accepted_state() {
     mv "$state_tmp" "$state_file"
 }
 
+function production_prepare_active_state() {
+    local active_state="$1" state_tmp="$2" bundle_content="$3" persisted_bundle="$4" app="$5" vlm="$6" history_json
+    history_json=$(python3 -c 'import hashlib,json,os,sys; state,content,persisted,app,vlm=sys.argv[1:]; history=[]
+if os.path.isfile(state):
+ lines=open(state).read().splitlines()
+ if len(lines)==4: history=json.loads(lines[3])
+history=[e for e in history if e.get("bundle")!=persisted]
+history.append({"app_sha":app,"vlm_image":vlm,"bundle":persisted,"sha256":hashlib.sha256(open(content,"rb").read()).hexdigest()})
+print(json.dumps(history,sort_keys=True,separators=(",",":")))' "$active_state" "$bundle_content" "$persisted_bundle" "$app" "$vlm") || return 1
+    printf '%s\n%s\n%s\n%s\n' "$app" "$vlm" "$persisted_bundle" "$history_json" >"$state_tmp" || return 1
+    chmod 0600 "$state_tmp" || return 1
+    sync "$state_tmp" 2>/dev/null || true
+}
+
 function production_write_acceptance_bundle() {
     local state_file="$1" challenged_receipt="$2" final_receipt="$3" mac_receipt="$4" stage="$5"
     local release_dir="$PID_DIR/releases" challenged_hash final_hash mac_hash challenged_copy final_copy mac_copy bundle_tmp bundle_hash bundle_copy state_tmp
@@ -1137,12 +1185,13 @@ function production_write_acceptance_bundle() {
     vlm_id=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["compose_observation"]["containers"]["vlm-wrapper"]["container_id"])' "$final_receipt") || return 1
     network_id=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["compose_observation"]["containers"]["ingress"]["network_id"])' "$final_receipt") || return 1
     bundle_tmp="$release_dir/bundle.tmp.$$"
-    python3 -c 'import json,sys; print(json.dumps({"schema":"seraph.production-acceptance.v1","stage":sys.argv[15],"app_sha":sys.argv[1],"vlm_image":sys.argv[2],"compose_project":"seraph-prod","network_name":"seraph-core-prod","network_id":sys.argv[3],"container_ids":{"ingress":sys.argv[4],"backend":sys.argv[5],"vlm-wrapper":sys.argv[6]},"challenged_attestation":{"path":sys.argv[7],"sha256":sys.argv[8]},"final_attestation":{"path":sys.argv[9],"sha256":sys.argv[10]},"mac_receipt":{"path":sys.argv[11],"sha256":sys.argv[12]},"acceptance_challenge":json.load(open(sys.argv[11]))["challenge"],"expected_origin":sys.argv[13],"client_identity":sys.argv[14]},sort_keys=True,separators=(",",":")))' "$SERAPH_IMAGE_TAG" "$SERAPH_VLM_IMAGE" "$network_id" "$ingress_id" "$backend_id" "$vlm_id" "$challenged_copy" "$challenged_hash" "$final_copy" "$final_hash" "$mac_copy" "$mac_hash" "$SERAPH_EXPECTED_HTTPS_ORIGIN" "$SERAPH_MAC_PROBE_CLIENT_ID" "$stage" >"$bundle_tmp" || return 1
+    python3 -c 'import json,sys; final=json.load(open(sys.argv[9])); print(json.dumps({"schema":"seraph.production-acceptance.v2","stage":sys.argv[15],"app_sha":sys.argv[1],"vlm_image":sys.argv[2],"gpu_release":final["gpu_release"],"compose_project":"seraph-prod","network_name":"seraph-core-prod","network_id":sys.argv[3],"container_ids":{k:v["container_id"] for k,v in final["compose_observation"]["containers"].items()},"challenged_attestation":{"path":sys.argv[7],"sha256":sys.argv[8]},"final_attestation":{"path":sys.argv[9],"sha256":sys.argv[10]},"mac_receipt":{"path":sys.argv[11],"sha256":sys.argv[12]},"acceptance_challenge":json.load(open(sys.argv[11]))["challenge"],"expected_origin":sys.argv[13],"client_identity":sys.argv[14]},sort_keys=True,separators=(",",":")))' "$SERAPH_IMAGE_TAG" "$SERAPH_VLM_IMAGE" "$network_id" "$ingress_id" "$backend_id" "$vlm_id" "$challenged_copy" "$challenged_hash" "$final_copy" "$final_hash" "$mac_copy" "$mac_hash" "$SERAPH_EXPECTED_HTTPS_ORIGIN" "$SERAPH_MAC_PROBE_CLIENT_ID" "$stage" >"$bundle_tmp" || return 1
     SERAPH_BUNDLE_APP_SHA="$SERAPH_IMAGE_TAG" SERAPH_BUNDLE_VLM_IMAGE="$SERAPH_VLM_IMAGE" python3 "$SCRIPT_DIR/scripts/validate_acceptance_bundle.py" <"$bundle_tmp" || return 1
     bundle_hash=$(sha256sum "$bundle_tmp" | awk '{print $1}'); bundle_copy="$release_dir/$SERAPH_IMAGE_TAG-$bundle_hash.json"
-    state_tmp="$state_file.tmp.$$"; printf '%s\n%s\n%s\n' "$SERAPH_IMAGE_TAG" "$SERAPH_VLM_IMAGE" "$bundle_copy" >"$state_tmp" || return 1
+    state_tmp="$state_file.tmp.$$"
+    production_prepare_active_state "$state_file" "$state_tmp" "$bundle_tmp" "$bundle_copy" "$SERAPH_IMAGE_TAG" "$SERAPH_VLM_IMAGE" || return 1
     { [ -r "$consumed_file" ] && cat "$consumed_file"; printf 'nonce:%s\nchallenge:%s\n' "$MAC_RECEIPT_NONCE" "$MAC_CHALLENGE_NONCE"; } >"$consumed_tmp" || return 1
-    chmod 0444 "$bundle_tmp" && chmod 0600 "$state_tmp" "$consumed_tmp" || return 1
+    chmod 0444 "$bundle_tmp" && chmod 0600 "$consumed_tmp" || return 1
     sync "$challenged_copy" "$final_copy" "$mac_copy" "$bundle_tmp" "$state_tmp" "$consumed_tmp" 2>/dev/null || true
     mv "$bundle_tmp" "$bundle_copy" || return 1
     mv "$consumed_tmp" "$consumed_file" || return 1
@@ -1151,8 +1200,13 @@ function production_write_acceptance_bundle() {
 
 function production_read_validate_accepted_state() {
     local state_file="$1"
+    local authority_mode="${2:-active}"
+    local apply_mode="${3:-apply}"
+    [ "$apply_mode" = apply ] || [ "$apply_mode" = preserve ] || { echo "release tuple apply mode must be apply or preserve" >&2; return 1; }
     [ -r "$state_file" ] || { echo "accepted release state is missing" >&2; return 1; }
-    [ "$(awk 'END {print NR}' "$state_file")" -eq 3 ] || { echo "accepted release state must contain exactly three lines" >&2; return 1; }
+    local line_count
+    line_count=$(awk 'END {print NR}' "$state_file")
+    if [ "$authority_mode" = active ]; then [ "$line_count" -eq 4 ] || { echo "active release state must contain tuple, bundle, and accepted history index" >&2; return 1; }; else [ "$line_count" -eq 3 ] || { echo "staged release state must contain exactly three lines" >&2; return 1; }; fi
     local tag vlm receipt hash expected_name mode revision image
     tag=$(sed -n '1p' "$state_file")
     vlm=$(sed -n '2p' "$state_file")
@@ -1173,14 +1227,31 @@ function production_read_validate_accepted_state() {
     docker image inspect "$vlm" >/dev/null 2>&1 || { echo "accepted VLM image missing" >&2; return 1; }
     local receipt_schema challenged_attestation final_attestation
     receipt_schema=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("schema",""))' "$receipt") || return 1
-    if [ "$receipt_schema" = "seraph.production-acceptance.v1" ]; then
+    if [ "$authority_mode" = active ] && [ "$receipt_schema" != "seraph.production-acceptance.v2" ]; then echo "active release requires a v2 Mac-accepted bundle" >&2; return 1; fi
+    if [ "$authority_mode" = staged ] && [ "$receipt_schema" = "seraph.production-acceptance.v2" ]; then echo "staged release must contain raw local attestation, not accepted authority" >&2; return 1; fi
+    if [ "$authority_mode" = active ]; then
+        python3 -c 'import hashlib,json,sys; bundle=sys.argv[1]; entries=json.loads(open(sys.argv[2]).read().splitlines()[3]); matches=[e for e in entries if e.get("bundle")==bundle]; assert len(matches)==1 and matches[0].get("sha256")==hashlib.sha256(open(bundle,"rb").read()).hexdigest()' "$receipt" "$state_file" || { echo "accepted release history index is invalid" >&2; return 1; }
+    fi
+    python3 -c 'import json,os,sys; g=json.load(open(sys.argv[1])).get("gpu_release"); assert isinstance(g,dict); assert all(k in g for k in ("image_ref","alias","artifact_root","model","mmproj","ctx_size","layers","command_contract")); assert os.path.isabs(g["artifact_root"]); assert all(k in g["model"] and k in g["mmproj"] for k in ("filename","sha256","size"))' "$receipt" 2>/dev/null || { echo "release receipt lacks a complete absolute GPU release tuple" >&2; return 1; }
+    ACCEPTED_GPU_MODEL_IMAGE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["image_ref"])' "$receipt") || return 1
+    ACCEPTED_GPU_MODEL_ALIAS=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["alias"])' "$receipt") || return 1
+    ACCEPTED_GPU_MODEL_DIR=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["artifact_root"])' "$receipt") || return 1
+    ACCEPTED_GPU_MODEL_FILE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["model"]["filename"])' "$receipt") || return 1
+    ACCEPTED_GPU_MMPROJ_FILE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["mmproj"]["filename"])' "$receipt") || return 1
+    ACCEPTED_GPU_MODEL_CTX_SIZE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["ctx_size"])' "$receipt") || return 1
+    ACCEPTED_GPU_MODEL_LAYERS=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["layers"])' "$receipt") || return 1
+    if [ "$apply_mode" = apply ]; then
+        SERAPH_GPU_MODEL_IMAGE="$ACCEPTED_GPU_MODEL_IMAGE"; SERAPH_GPU_MODEL_ALIAS="$ACCEPTED_GPU_MODEL_ALIAS"; SERAPH_GPU_MODEL_DIR="$ACCEPTED_GPU_MODEL_DIR"; SERAPH_GPU_MODEL_FILE="$ACCEPTED_GPU_MODEL_FILE"; SERAPH_GPU_MMPROJ_FILE="$ACCEPTED_GPU_MMPROJ_FILE"; SERAPH_GPU_MODEL_CTX_SIZE="$ACCEPTED_GPU_MODEL_CTX_SIZE"; SERAPH_GPU_MODEL_LAYERS="$ACCEPTED_GPU_MODEL_LAYERS"
+        export SERAPH_GPU_MODEL_IMAGE SERAPH_GPU_MODEL_ALIAS SERAPH_GPU_MODEL_DIR SERAPH_GPU_MODEL_FILE SERAPH_GPU_MMPROJ_FILE SERAPH_GPU_MODEL_CTX_SIZE SERAPH_GPU_MODEL_LAYERS
+    fi
+    if [ "$receipt_schema" = "seraph.production-acceptance.v2" ]; then
         SERAPH_BUNDLE_APP_SHA="$tag" SERAPH_BUNDLE_VLM_IMAGE="$vlm" python3 "$SCRIPT_DIR/scripts/validate_acceptance_bundle.py" <"$receipt" || return 1
         challenged_attestation=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["challenged_attestation"]["path"])' "$receipt") || return 1
         final_attestation=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["final_attestation"]["path"])' "$receipt") || return 1
-        SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$challenged_attestation" "$vlm" || return 1
-        SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$final_attestation" "$vlm" || return 1
+        SERAPH_GPU_MODEL_IMAGE="$ACCEPTED_GPU_MODEL_IMAGE" SERAPH_GPU_MODEL_ALIAS="$ACCEPTED_GPU_MODEL_ALIAS" SERAPH_GPU_MODEL_DIR="$ACCEPTED_GPU_MODEL_DIR" SERAPH_GPU_MODEL_FILE="$ACCEPTED_GPU_MODEL_FILE" SERAPH_GPU_MMPROJ_FILE="$ACCEPTED_GPU_MMPROJ_FILE" SERAPH_GPU_MODEL_CTX_SIZE="$ACCEPTED_GPU_MODEL_CTX_SIZE" SERAPH_GPU_MODEL_LAYERS="$ACCEPTED_GPU_MODEL_LAYERS" SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$challenged_attestation" "$vlm" || return 1
+        SERAPH_GPU_MODEL_IMAGE="$ACCEPTED_GPU_MODEL_IMAGE" SERAPH_GPU_MODEL_ALIAS="$ACCEPTED_GPU_MODEL_ALIAS" SERAPH_GPU_MODEL_DIR="$ACCEPTED_GPU_MODEL_DIR" SERAPH_GPU_MODEL_FILE="$ACCEPTED_GPU_MODEL_FILE" SERAPH_GPU_MMPROJ_FILE="$ACCEPTED_GPU_MMPROJ_FILE" SERAPH_GPU_MODEL_CTX_SIZE="$ACCEPTED_GPU_MODEL_CTX_SIZE" SERAPH_GPU_MODEL_LAYERS="$ACCEPTED_GPU_MODEL_LAYERS" SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$final_attestation" "$vlm" || return 1
     else
-        SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$receipt" "$vlm" || return 1
+        SERAPH_GPU_MODEL_IMAGE="$ACCEPTED_GPU_MODEL_IMAGE" SERAPH_GPU_MODEL_ALIAS="$ACCEPTED_GPU_MODEL_ALIAS" SERAPH_GPU_MODEL_DIR="$ACCEPTED_GPU_MODEL_DIR" SERAPH_GPU_MODEL_FILE="$ACCEPTED_GPU_MODEL_FILE" SERAPH_GPU_MMPROJ_FILE="$ACCEPTED_GPU_MMPROJ_FILE" SERAPH_GPU_MODEL_CTX_SIZE="$ACCEPTED_GPU_MODEL_CTX_SIZE" SERAPH_GPU_MODEL_LAYERS="$ACCEPTED_GPU_MODEL_LAYERS" SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT=true production_host_inventory_validate "$receipt" "$vlm" || return 1
     fi
     ACCEPTED_APP_TAG="$tag"
     ACCEPTED_VLM_IMAGE="$vlm"
@@ -1195,12 +1266,24 @@ function production_rollback() {
     production_any_staged_state && error_exit "rollback refused while another stage awaits LAN acceptance"
     [[ "$tag" =~ ^[0-9a-f]{40}$ ]] || error_exit "rollback application tag must be a full git SHA"
     [[ "$vlm_image" =~ ^([^[:space:]@]+@sha256:[0-9a-fA-F]{64}|sha256:[0-9a-fA-F]{64})$ ]] || error_exit "rollback VLM image must use a registry RepoDigest or exact local sha256 image ID"
+    local target_bundle active_tag_file="$PID_DIR/seraph-prod-active-release"
+    [ -r "$active_tag_file" ] || error_exit "rollback requires accepted release history"
+    target_bundle=$(python3 -c 'import hashlib,json,sys; lines=open(sys.argv[1]).read().splitlines(); entries=json.loads(lines[3]) if len(lines)==4 else []; matches=[e for e in entries if e.get("app_sha")==sys.argv[2] and e.get("vlm_image")==sys.argv[3] and e.get("sha256") and e.get("bundle")]; valid=[e["bundle"] for e in matches if hashlib.sha256(open(e["bundle"],"rb").read()).hexdigest()==e["sha256"]]; print(valid[0] if len(valid)==1 else "")' "$active_tag_file" "$tag" "$vlm_image") || return 1
+    [ -r "$target_bundle" ] || error_exit "rollback requires exactly one previously accepted complete GPU release bundle"
+    SERAPH_BUNDLE_APP_SHA="$tag" SERAPH_BUNDLE_VLM_IMAGE="$vlm_image" python3 "$SCRIPT_DIR/scripts/validate_acceptance_bundle.py" <"$target_bundle" || error_exit "rollback accepted-history bundle validation failed"
+    SERAPH_GPU_MODEL_IMAGE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["image_ref"])' "$target_bundle") || return 1
+    SERAPH_GPU_MODEL_ALIAS=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["alias"])' "$target_bundle") || return 1
+    SERAPH_GPU_MODEL_DIR=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["artifact_root"])' "$target_bundle") || return 1
+    SERAPH_GPU_MODEL_FILE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["model"]["filename"])' "$target_bundle") || return 1
+    SERAPH_GPU_MMPROJ_FILE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["mmproj"]["filename"])' "$target_bundle") || return 1
+    SERAPH_GPU_MODEL_CTX_SIZE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["ctx_size"])' "$target_bundle") || return 1
+    SERAPH_GPU_MODEL_LAYERS=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gpu_release"]["layers"])' "$target_bundle") || return 1
+    export SERAPH_GPU_MODEL_IMAGE SERAPH_GPU_MODEL_ALIAS SERAPH_GPU_MODEL_DIR SERAPH_GPU_MODEL_FILE SERAPH_GPU_MMPROJ_FILE SERAPH_GPU_MODEL_CTX_SIZE SERAPH_GPU_MODEL_LAYERS
     docker image inspect "seraph/backend:$tag" >/dev/null 2>&1 || error_exit "missing seraph/backend:$tag"
     docker image inspect "seraph/frontend-ingress:$tag" >/dev/null 2>&1 || error_exit "missing seraph/frontend-ingress:$tag"
     docker image inspect "$vlm_image" >/dev/null 2>&1 || error_exit "missing $vlm_image"
     SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" SERAPH_VALIDATING_ROLLBACK=true production_config_validate
     ensure_runtime_dirs
-    local active_tag_file="$PID_DIR/seraph-prod-active-release"
     local original_tag=""
     local original_vlm=""
     local original_receipt=""
@@ -1209,10 +1292,10 @@ function production_rollback() {
     running_vlm_id=$(docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" ps -q vlm-wrapper 2>/dev/null || true)
     if { [ -n "$running_backend_id" ] || [ -n "$running_vlm_id" ]; } && [ ! -r "$active_tag_file" ]; then echo "running production containers require explicit adoption before rollback" >&2; return 1; fi
     if [ -r "$active_tag_file" ]; then
-        production_read_validate_accepted_state "$active_tag_file" || { echo "accepted release state is invalid; refusing rollback cutover" >&2; return 1; }
+        production_read_validate_accepted_state "$active_tag_file" active preserve || { echo "accepted release state is invalid; refusing rollback cutover" >&2; return 1; }
         original_tag="$ACCEPTED_APP_TAG"; original_vlm="$ACCEPTED_VLM_IMAGE"; original_receipt="$ACCEPTED_INVENTORY_RECEIPT"
     fi
-    if ! SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 120 || ! SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" exec -T backend uv run python production_preflight.py; then
+    if ! SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d --no-build --wait --wait-timeout 300 || ! SERAPH_IMAGE_TAG="$tag" SERAPH_VLM_IMAGE="$vlm_image" docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" exec -T backend uv run python production_preflight.py; then
         docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" logs --no-color --tail 500 >"$LOG_DIR/seraph-prod-failed-rollback.log" 2>&1 || true
         echo "requested rollback tuple failed; restoring original active tuple" >&2
         production_restore_after_failure "$original_tag" "$original_vlm" "$original_receipt"; return $?

--- a/scripts/generate_acceptance_challenge.py
+++ b/scripts/generate_acceptance_challenge.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
-import argparse,hashlib,json,secrets
-from datetime import datetime,timezone
-p=argparse.ArgumentParser(); p.add_argument('--stage',required=True); p.add_argument('--app-sha',required=True); p.add_argument('--vlm-image',required=True); p.add_argument('--local-attestation',required=True); p.add_argument('--origin',required=True); p.add_argument('--lan-host',required=True); p.add_argument('--lan-ip',required=True); p.add_argument('--client-identity',required=True); a=p.parse_args()
-raw=open(a.local_attestation,'rb').read(); local=json.loads(raw); containers=local['compose_observation']['containers']; network_ids={v['network_id'] for v in containers.values()}
+import argparse, hashlib, json, secrets
+from datetime import datetime, timezone
+
+p=argparse.ArgumentParser()
+for name in ('stage','app-sha','vlm-image','local-attestation','origin','lan-host','lan-ip','client-identity'): p.add_argument('--'+name,required=True)
+a=p.parse_args(); raw=open(a.local_attestation,'rb').read(); local=json.loads(raw)
+containers=local['compose_observation']['containers']; network_ids={v['network_id'] for v in containers.values()}
 if len(network_ids)!=1: raise SystemExit('local attestation network mismatch')
-challenge={'schema':'seraph.acceptance-challenge.v1','stage':a.stage,'app_sha':a.app_sha,'vlm_image':a.vlm_image,'local_attestation_sha256':hashlib.sha256(raw).hexdigest(),'compose_project':'seraph-prod','network_name':'seraph-core-prod','network_id':next(iter(network_ids)),'container_ids':{k:v['container_id'] for k,v in containers.items()},'image_identities':{k:{'image_id':v['image_id'],'image_revision':v.get('image_revision','')} for k,v in containers.items()},'expected_origin':a.origin,'lan_host':a.lan_host,'lan_ip':a.lan_ip,'client_identity':a.client_identity,'server_nonce':secrets.token_hex(32),'issued_at':datetime.now(timezone.utc).isoformat()}
+gpu=local['gpu_model_observation']
+challenge={'schema':'seraph.acceptance-challenge.v1','stage':a.stage,'app_sha':a.app_sha,'vlm_image':a.vlm_image,'gpu_model_image':gpu['image_ref'],'gpu_model_alias':gpu['alias'],'local_attestation_sha256':hashlib.sha256(raw).hexdigest(),'compose_project':'seraph-prod','network_name':'seraph-core-prod','network_id':next(iter(network_ids)),'container_ids':{k:v['container_id'] for k,v in containers.items()},'image_identities':{k:{'image_id':v['image_id'],'image_revision':v.get('image_revision','')} for k,v in containers.items()},'expected_origin':a.origin,'lan_host':a.lan_host,'lan_ip':a.lan_ip,'client_identity':a.client_identity,'server_nonce':secrets.token_hex(32),'issued_at':datetime.now(timezone.utc).isoformat()}
+challenge['gpu_release']=local['gpu_release']
 print(json.dumps(challenge,indent=2,sort_keys=True))

--- a/scripts/generate_acceptance_challenge.py
+++ b/scripts/generate_acceptance_challenge.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+import argparse,hashlib,json,secrets
+from datetime import datetime,timezone
+p=argparse.ArgumentParser(); p.add_argument('--stage',required=True); p.add_argument('--app-sha',required=True); p.add_argument('--vlm-image',required=True); p.add_argument('--local-attestation',required=True); p.add_argument('--origin',required=True); p.add_argument('--lan-host',required=True); p.add_argument('--lan-ip',required=True); p.add_argument('--client-identity',required=True); a=p.parse_args()
+raw=open(a.local_attestation,'rb').read(); local=json.loads(raw); containers=local['compose_observation']['containers']; network_ids={v['network_id'] for v in containers.values()}
+if len(network_ids)!=1: raise SystemExit('local attestation network mismatch')
+challenge={'schema':'seraph.acceptance-challenge.v1','stage':a.stage,'app_sha':a.app_sha,'vlm_image':a.vlm_image,'local_attestation_sha256':hashlib.sha256(raw).hexdigest(),'compose_project':'seraph-prod','network_name':'seraph-core-prod','network_id':next(iter(network_ids)),'container_ids':{k:v['container_id'] for k,v in containers.items()},'image_identities':{k:{'image_id':v['image_id'],'image_revision':v.get('image_revision','')} for k,v in containers.items()},'expected_origin':a.origin,'lan_host':a.lan_host,'lan_ip':a.lan_ip,'client_identity':a.client_identity,'server_nonce':secrets.token_hex(32),'issued_at':datetime.now(timezone.utc).isoformat()}
+print(json.dumps(challenge,indent=2,sort_keys=True))

--- a/scripts/generate_local_gpu_inventory.py
+++ b/scripts/generate_local_gpu_inventory.py
@@ -22,9 +22,26 @@ p.add_argument("--expected-vlm-image", required=True)
 p.add_argument("--vlm-container", required=True)
 p.add_argument("--ingress-container", required=True)
 p.add_argument("--backend-container", required=True)
+p.add_argument("--gpu-model-container", required=True)
+p.add_argument("--expected-gpu-model-image", required=True)
+p.add_argument("--expected-gpu-model-alias", required=True)
+p.add_argument("--gpu-model-dir", type=Path, required=True)
+p.add_argument("--gpu-model-file", required=True)
+p.add_argument("--gpu-mmproj-file", required=True)
+p.add_argument("--gpu-ctx-size", type=int, required=True)
+p.add_argument("--gpu-layers", type=int, required=True)
 p.add_argument("--vlm-api-key-file", type=Path)
 p.add_argument("--docker-network", default="bridge")
 args = p.parse_args()
+def artifact(path: Path):
+    h=hashlib.sha256()
+    with path.open('rb') as stream:
+        for chunk in iter(lambda:stream.read(8*1024*1024),b''): h.update(chunk)
+    return {'filename':path.name,'sha256':h.hexdigest(),'size':path.stat().st_size}
+if not args.gpu_model_dir.is_absolute(): raise SystemExit('GPU artifact root must be an absolute existing directory')
+gpu_root=args.gpu_model_dir.resolve(strict=True)
+if not gpu_root.is_dir(): raise SystemExit('GPU artifact root must be an absolute existing directory')
+gpu_release={'image_ref':args.expected_gpu_model_image,'alias':args.expected_gpu_model_alias,'artifact_root':str(gpu_root),'model':artifact(gpu_root/args.gpu_model_file),'mmproj':artifact(gpu_root/args.gpu_mmproj_file),'ctx_size':args.gpu_ctx_size,'layers':args.gpu_layers,'command_contract':'llama-server-gemma4-v1'}
 
 machine_path = next((x for x in (Path("/etc/machine-id"), Path("/var/lib/dbus/machine-id")) if x.is_file()), None)
 if machine_path is None:
@@ -69,12 +86,12 @@ except Exception:
     checks['auth_closed'] = checks['auth_interface'] = False
 
 compose_containers={}
-for service, container_id, expected_ip in (("ingress",args.ingress_container,"172.30.0.10"),("backend",args.backend_container,"172.30.0.20"),("vlm-wrapper",args.vlm_container,"172.30.0.30")):
+for service, container_id, expected_ip in (("ingress",args.ingress_container,"172.30.0.10"),("backend",args.backend_container,"172.30.0.20"),("vlm-wrapper",args.vlm_container,"172.30.0.30"),("gpu-model",args.gpu_model_container,"172.30.0.40")):
     observed=json.loads(run(["docker","inspect",container_id]).stdout)[0]
     observed_image=json.loads(run(["docker","image","inspect",str(observed.get("Image",""))]).stdout)[0]
     labels=observed.get("Config",{}).get("Labels",{}) or {}
     net=observed.get("NetworkSettings",{}).get("Networks",{}).get("seraph-core-prod",{})
-    compose_containers[service]={"container_id":observed.get("Id",""),"image_id":observed_image.get("Id",""),"image_revision":(observed_image.get("Config",{}).get("Labels",{}) or {}).get("org.opencontainers.image.revision","") ,"project":labels.get("com.docker.compose.project",""),"service":labels.get("com.docker.compose.service",""),"network_name":"seraph-core-prod" if net else "","network_id":net.get("NetworkID",""),"ip_address":net.get("IPAddress",""),"expected_ip":expected_ip}
+    compose_containers[service]={"container_id":observed.get("Id",""),"image_id":observed_image.get("Id",""),"image_revision":(observed_image.get("Config",{}).get("Labels",{}) or {}).get("org.opencontainers.image.revision","") ,"repo_digests":observed_image.get("RepoDigests",[]) or [],"project":labels.get("com.docker.compose.project",""),"service":labels.get("com.docker.compose.service",""),"network_name":"seraph-core-prod" if net else "","network_id":net.get("NetworkID",""),"ip_address":net.get("IPAddress",""),"expected_ip":expected_ip}
 
 payload = {
     "local_hostname": socket.gethostname(), "machine_identity_sha256": machine_digest,
@@ -83,6 +100,8 @@ payload = {
     "vlm_image": actual_image, "vlm_interface_contract": "vlm-health-backend-queue-chat-auth-v1",
     "vlm_wrapper_contract_verified": container_running and actual_image != "unverified" and all(checks.values()),
     "vlm_observation": {"container": args.vlm_container, "container_id": container.get("Id", ""), "image_id": observed_image_id, "running": container_running, "repo_digests": repo_digests, "networks": networks, "published_ports": published_ports, "checks": checks},
+    "gpu_release":gpu_release,
+    "gpu_model_observation":{"image_ref":args.expected_gpu_model_image,"image_id":compose_containers["gpu-model"]["image_id"],"alias":args.expected_gpu_model_alias,"health":get("http://172.30.0.40:8000/health")==200},
     "compose_observation":{"project":"seraph-prod","network_name":"seraph-core-prod","containers":compose_containers},
 }
 print(json.dumps(payload, indent=2, sort_keys=True))

--- a/scripts/generate_local_gpu_inventory.py
+++ b/scripts/generate_local_gpu_inventory.py
@@ -49,7 +49,9 @@ container = json.loads(inspect.stdout)[0]
 image_inspect = run(["docker", "image", "inspect", str(container.get("Image", ""))])
 image_details = json.loads(image_inspect.stdout)[0] if image_inspect.returncode == 0 else {}
 repo_digests = image_details.get("RepoDigests") or []
-actual_image = args.expected_vlm_image if args.expected_vlm_image in repo_digests else "unverified"
+observed_image_id = image_details.get("Id", "")
+is_local_id = args.expected_vlm_image.startswith("sha256:") and "@" not in args.expected_vlm_image
+actual_image = args.expected_vlm_image if ((is_local_id and observed_image_id == args.expected_vlm_image) or (not is_local_id and args.expected_vlm_image in repo_digests)) else "unverified"
 container_running = bool(container.get("State", {}).get("Running"))
 published_ports = container.get("NetworkSettings", {}).get("Ports", {})
 networks = container.get("NetworkSettings", {}).get("Networks", {})
@@ -80,7 +82,7 @@ payload = {
     "docker_bridge_addresses": bridges, "docker_network_bindings": bindings,
     "vlm_image": actual_image, "vlm_interface_contract": "vlm-health-backend-queue-chat-auth-v1",
     "vlm_wrapper_contract_verified": container_running and actual_image != "unverified" and all(checks.values()),
-    "vlm_observation": {"container": args.vlm_container, "container_id": container.get("Id", ""), "running": container_running, "repo_digests": repo_digests, "networks": networks, "published_ports": published_ports, "checks": checks},
+    "vlm_observation": {"container": args.vlm_container, "container_id": container.get("Id", ""), "image_id": observed_image_id, "running": container_running, "repo_digests": repo_digests, "networks": networks, "published_ports": published_ports, "checks": checks},
     "compose_observation":{"project":"seraph-prod","network_name":"seraph-core-prod","containers":compose_containers},
 }
 print(json.dumps(payload, indent=2, sort_keys=True))

--- a/scripts/generate_local_gpu_inventory.py
+++ b/scripts/generate_local_gpu_inventory.py
@@ -31,6 +31,12 @@ def gpu_healthy(container_id: str) -> bool:
     result=run(['docker','exec',container_id,'curl','--fail','--silent','--show-error','--max-time','5','http://127.0.0.1:8000/health'])
     return result.returncode == 0
 
+def canonical_repo_digest(reference: str) -> str:
+    if '@sha256:' not in reference: return reference
+    name,digest=reference.rsplit('@',1); slash=name.rfind('/'); colon=name.rfind(':')
+    if colon > slash: name=name[:colon]
+    return name+'@'+digest
+
 p = argparse.ArgumentParser()
 p.add_argument("--expected-vlm-image", required=True)
 p.add_argument("--vlm-container", required=True)
@@ -82,7 +88,7 @@ image_details = json.loads(image_inspect.stdout)[0] if image_inspect.returncode 
 repo_digests = image_details.get("RepoDigests") or []
 observed_image_id = image_details.get("Id", "")
 is_local_id = args.expected_vlm_image.startswith("sha256:") and "@" not in args.expected_vlm_image
-actual_image = args.expected_vlm_image if ((is_local_id and observed_image_id == args.expected_vlm_image) or (not is_local_id and args.expected_vlm_image in repo_digests)) else "unverified"
+actual_image = args.expected_vlm_image if ((is_local_id and observed_image_id == args.expected_vlm_image) or (not is_local_id and canonical_repo_digest(args.expected_vlm_image) in {canonical_repo_digest(x) for x in repo_digests})) else "unverified"
 container_running = bool(container.get("State", {}).get("Running"))
 published_ports = container.get("NetworkSettings", {}).get("Ports", {})
 networks = container.get("NetworkSettings", {}).get("Networks", {})

--- a/scripts/generate_local_gpu_inventory.py
+++ b/scripts/generate_local_gpu_inventory.py
@@ -9,19 +9,23 @@ from pathlib import Path
 def run(args: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(args, text=True, capture_output=True, check=False)
 
-VLM_PROBE = """import sys,urllib.error,urllib.request
+VLM_PROBE = """import json,sys,urllib.error,urllib.request
 path=sys.argv[1]; key=sys.stdin.read().strip(); headers={'Authorization':'Bearer '+key} if key else {}
 try:
     with urllib.request.urlopen(urllib.request.Request('http://127.0.0.1:8001'+path,headers=headers),timeout=5) as response:
-        response.read(4096); print(response.status)
-except urllib.error.HTTPError as exc: print(exc.code)
+        raw=response.read(4096); body=json.loads(raw) if raw else {}; print(json.dumps({'http_status':response.status,'body':body}))
+except urllib.error.HTTPError as exc:
+    raw=exc.read(4096); body=json.loads(raw) if raw else {}; print(json.dumps({'http_status':exc.code,'body':body}))
 except Exception: raise SystemExit(1)
 """
 
-def vlm_status(container_id: str, path: str, key: str = "") -> int:
+def vlm_response(container_id: str, path: str, key: str = "") -> tuple[int, dict]:
     result=subprocess.run(['docker','exec','-i',container_id,'python','-c',VLM_PROBE,path],input=key,text=True,capture_output=True,check=False)
-    try: return int(result.stdout.strip()) if result.returncode == 0 else 0
-    except ValueError: return 0
+    try:
+        payload=json.loads(result.stdout) if result.returncode == 0 else {}
+        body=payload.get('body',{})
+        return int(payload.get('http_status',0)), body if isinstance(body,dict) else {}
+    except (ValueError,TypeError,json.JSONDecodeError): return 0, {}
 
 def gpu_healthy(container_id: str) -> bool:
     result=run(['docker','exec',container_id,'curl','--fail','--silent','--show-error','--max-time','5','http://127.0.0.1:8000/health'])
@@ -85,9 +89,12 @@ networks = container.get("NetworkSettings", {}).get("Networks", {})
 api_key = args.vlm_api_key_file.read_text().strip() if args.vlm_api_key_file else ""
 checks = {}
 for name, path in (("health", "/health"), ("backend", "/health/backend"), ("queue", "/queue/status")):
-    checks[name] = vlm_status(args.vlm_container,path) == 200
-checks['auth_closed'] = vlm_status(args.vlm_container,'/health/chat') in (401,403)
-checks['auth_interface'] = vlm_status(args.vlm_container,'/health/chat',api_key) == 200
+    checks[name] = vlm_response(args.vlm_container,path)[0] == 200
+closed_status,closed=vlm_response(args.vlm_container,'/health/chat')
+open_status,opened=vlm_response(args.vlm_container,'/health/chat',api_key)
+checks['auth_closed'] = closed_status == 200 and closed.get('enabled') is True and closed.get('auth_configured') is True and closed.get('status') == 'auth_failed' and closed.get('auth_ok') is False
+model_identity=opened.get('model',opened.get('model_alias'))
+checks['auth_interface'] = open_status == 200 and opened.get('enabled') is True and opened.get('auth_configured') is True and opened.get('status') == 'ok' and opened.get('auth_ok') is True and model_identity == args.expected_gpu_model_alias
 
 compose_containers={}
 for service, container_id, expected_ip in (("ingress",args.ingress_container,"172.30.0.10"),("backend",args.backend_container,"172.30.0.20"),("vlm-wrapper",args.vlm_container,"172.30.0.30"),("gpu-model",args.gpu_model_container,"172.30.0.40")):

--- a/scripts/generate_local_gpu_inventory.py
+++ b/scripts/generate_local_gpu_inventory.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Observe local host/firewall/wrapper state and emit a sanitized receipt."""
+from __future__ import annotations
+
+import argparse, hashlib, json, socket, subprocess, urllib.request, urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, text=True, capture_output=True, check=False)
+
+def get(url: str, key: str = "") -> int:
+    headers = {"Authorization": f"Bearer {key}"} if key else {}
+    try:
+        with urllib.request.urlopen(urllib.request.Request(url, headers=headers), timeout=5) as response:  # noqa: S310
+            response.read(4096); return response.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
+
+p = argparse.ArgumentParser()
+p.add_argument("--expected-vlm-image", required=True)
+p.add_argument("--vlm-container", required=True)
+p.add_argument("--ingress-container", required=True)
+p.add_argument("--backend-container", required=True)
+p.add_argument("--vlm-api-key-file", type=Path)
+p.add_argument("--docker-network", default="bridge")
+args = p.parse_args()
+
+machine_path = next((x for x in (Path("/etc/machine-id"), Path("/var/lib/dbus/machine-id")) if x.is_file()), None)
+if machine_path is None:
+    raise SystemExit("local machine-id source unavailable")
+machine_digest = hashlib.sha256(machine_path.read_bytes().strip()).hexdigest()
+ss_result = run(["ss", "-lntp"])
+if ss_result.returncode:
+    raise SystemExit("ss -lntp failed")
+
+network_result = run(["docker", "network", "inspect", args.docker_network])
+bridges, bindings = [], {}
+if network_result.returncode == 0:
+    network = json.loads(network_result.stdout)[0]
+    gateway = str(network.get("IPAM", {}).get("Config", [{}])[0].get("Gateway", ""))
+    if gateway:
+        bridges.append(gateway); bindings["host-gateway"] = gateway
+
+inspect = run(["docker", "inspect", args.vlm_container])
+if inspect.returncode:
+    raise SystemExit("configured VLM container is not running/inspectable")
+container = json.loads(inspect.stdout)[0]
+image_inspect = run(["docker", "image", "inspect", str(container.get("Image", ""))])
+image_details = json.loads(image_inspect.stdout)[0] if image_inspect.returncode == 0 else {}
+repo_digests = image_details.get("RepoDigests") or []
+actual_image = args.expected_vlm_image if args.expected_vlm_image in repo_digests else "unverified"
+container_running = bool(container.get("State", {}).get("Running"))
+published_ports = container.get("NetworkSettings", {}).get("Ports", {})
+networks = container.get("NetworkSettings", {}).get("Networks", {})
+container_ip = next((str(value.get("IPAddress", "")) for value in networks.values() if value.get("IPAddress")), "")
+base_url = f"http://{container_ip}:8001" if container_ip else ""
+api_key = args.vlm_api_key_file.read_text().strip() if args.vlm_api_key_file else ""
+checks = {}
+for name, path in (("health", "/health"), ("backend", "/health/backend"), ("queue", "/queue/status")):
+    try: checks[name] = get(base_url + path) == 200
+    except Exception: checks[name] = False
+try:
+    checks['auth_closed'] = get(base_url + '/health/chat') in (401,403)
+    checks['auth_interface'] = get(base_url + '/health/chat', api_key) == 200
+except Exception:
+    checks['auth_closed'] = checks['auth_interface'] = False
+
+compose_containers={}
+for service, container_id, expected_ip in (("ingress",args.ingress_container,"172.30.0.10"),("backend",args.backend_container,"172.30.0.20"),("vlm-wrapper",args.vlm_container,"172.30.0.30")):
+    observed=json.loads(run(["docker","inspect",container_id]).stdout)[0]
+    observed_image=json.loads(run(["docker","image","inspect",str(observed.get("Image",""))]).stdout)[0]
+    labels=observed.get("Config",{}).get("Labels",{}) or {}
+    net=observed.get("NetworkSettings",{}).get("Networks",{}).get("seraph-core-prod",{})
+    compose_containers[service]={"container_id":observed.get("Id",""),"image_id":observed_image.get("Id",""),"image_revision":(observed_image.get("Config",{}).get("Labels",{}) or {}).get("org.opencontainers.image.revision","") ,"project":labels.get("com.docker.compose.project",""),"service":labels.get("com.docker.compose.service",""),"network_name":"seraph-core-prod" if net else "","network_id":net.get("NetworkID",""),"ip_address":net.get("IPAddress",""),"expected_ip":expected_ip}
+
+payload = {
+    "local_hostname": socket.gethostname(), "machine_identity_sha256": machine_digest,
+    "captured_at": datetime.now(timezone.utc).isoformat(), "ss_lntp": ss_result.stdout,
+    "docker_bridge_addresses": bridges, "docker_network_bindings": bindings,
+    "vlm_image": actual_image, "vlm_interface_contract": "vlm-health-backend-queue-chat-auth-v1",
+    "vlm_wrapper_contract_verified": container_running and actual_image != "unverified" and all(checks.values()),
+    "vlm_observation": {"container": args.vlm_container, "container_id": container.get("Id", ""), "running": container_running, "repo_digests": repo_digests, "networks": networks, "published_ports": published_ports, "checks": checks},
+    "compose_observation":{"project":"seraph-prod","network_name":"seraph-core-prod","containers":compose_containers},
+}
+print(json.dumps(payload, indent=2, sort_keys=True))

--- a/scripts/generate_local_gpu_inventory.py
+++ b/scripts/generate_local_gpu_inventory.py
@@ -2,20 +2,30 @@
 """Observe local host/firewall/wrapper state and emit a sanitized receipt."""
 from __future__ import annotations
 
-import argparse, hashlib, json, socket, subprocess, urllib.request, urllib.error
+import argparse, hashlib, json, socket, subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
 def run(args: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(args, text=True, capture_output=True, check=False)
 
-def get(url: str, key: str = "") -> int:
-    headers = {"Authorization": f"Bearer {key}"} if key else {}
-    try:
-        with urllib.request.urlopen(urllib.request.Request(url, headers=headers), timeout=5) as response:  # noqa: S310
-            response.read(4096); return response.status
-    except urllib.error.HTTPError as exc:
-        return exc.code
+VLM_PROBE = """import sys,urllib.error,urllib.request
+path=sys.argv[1]; key=sys.stdin.read().strip(); headers={'Authorization':'Bearer '+key} if key else {}
+try:
+    with urllib.request.urlopen(urllib.request.Request('http://127.0.0.1:8001'+path,headers=headers),timeout=5) as response:
+        response.read(4096); print(response.status)
+except urllib.error.HTTPError as exc: print(exc.code)
+except Exception: raise SystemExit(1)
+"""
+
+def vlm_status(container_id: str, path: str, key: str = "") -> int:
+    result=subprocess.run(['docker','exec','-i',container_id,'python','-c',VLM_PROBE,path],input=key,text=True,capture_output=True,check=False)
+    try: return int(result.stdout.strip()) if result.returncode == 0 else 0
+    except ValueError: return 0
+
+def gpu_healthy(container_id: str) -> bool:
+    result=run(['docker','exec',container_id,'curl','--fail','--silent','--show-error','--max-time','5','http://127.0.0.1:8000/health'])
+    return result.returncode == 0
 
 p = argparse.ArgumentParser()
 p.add_argument("--expected-vlm-image", required=True)
@@ -72,18 +82,12 @@ actual_image = args.expected_vlm_image if ((is_local_id and observed_image_id ==
 container_running = bool(container.get("State", {}).get("Running"))
 published_ports = container.get("NetworkSettings", {}).get("Ports", {})
 networks = container.get("NetworkSettings", {}).get("Networks", {})
-container_ip = next((str(value.get("IPAddress", "")) for value in networks.values() if value.get("IPAddress")), "")
-base_url = f"http://{container_ip}:8001" if container_ip else ""
 api_key = args.vlm_api_key_file.read_text().strip() if args.vlm_api_key_file else ""
 checks = {}
 for name, path in (("health", "/health"), ("backend", "/health/backend"), ("queue", "/queue/status")):
-    try: checks[name] = get(base_url + path) == 200
-    except Exception: checks[name] = False
-try:
-    checks['auth_closed'] = get(base_url + '/health/chat') in (401,403)
-    checks['auth_interface'] = get(base_url + '/health/chat', api_key) == 200
-except Exception:
-    checks['auth_closed'] = checks['auth_interface'] = False
+    checks[name] = vlm_status(args.vlm_container,path) == 200
+checks['auth_closed'] = vlm_status(args.vlm_container,'/health/chat') in (401,403)
+checks['auth_interface'] = vlm_status(args.vlm_container,'/health/chat',api_key) == 200
 
 compose_containers={}
 for service, container_id, expected_ip in (("ingress",args.ingress_container,"172.30.0.10"),("backend",args.backend_container,"172.30.0.20"),("vlm-wrapper",args.vlm_container,"172.30.0.30"),("gpu-model",args.gpu_model_container,"172.30.0.40")):
@@ -101,7 +105,7 @@ payload = {
     "vlm_wrapper_contract_verified": container_running and actual_image != "unverified" and all(checks.values()),
     "vlm_observation": {"container": args.vlm_container, "container_id": container.get("Id", ""), "image_id": observed_image_id, "running": container_running, "repo_digests": repo_digests, "networks": networks, "published_ports": published_ports, "checks": checks},
     "gpu_release":gpu_release,
-    "gpu_model_observation":{"image_ref":args.expected_gpu_model_image,"image_id":compose_containers["gpu-model"]["image_id"],"alias":args.expected_gpu_model_alias,"health":get("http://172.30.0.40:8000/health")==200},
+    "gpu_model_observation":{"image_ref":args.expected_gpu_model_image,"image_id":compose_containers["gpu-model"]["image_id"],"alias":args.expected_gpu_model_alias,"health":gpu_healthy(args.gpu_model_container)},
     "compose_observation":{"project":"seraph-prod","network_name":"seraph-core-prod","containers":compose_containers},
 }
 print(json.dumps(payload, indent=2, sort_keys=True))

--- a/scripts/generate_local_gpu_predeploy.py
+++ b/scripts/generate_local_gpu_predeploy.py
@@ -1,13 +1,23 @@
 #!/usr/bin/env python3
-"""Generate the local identity/listener gate used before candidate startup."""
-import hashlib, json, socket, subprocess
+"""Generate local identity, listener, and immutable GPU artifact gate."""
+import hashlib, json, os, socket, subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
-machine = next((p for p in (Path('/etc/machine-id'), Path('/var/lib/dbus/machine-id')) if p.is_file()), None)
-if not machine:
-    raise SystemExit('machine-id unavailable')
-ss = subprocess.run(['ss', '-lntp'], text=True, capture_output=True, check=True).stdout
-network = subprocess.run(['docker', 'network', 'inspect', 'bridge'], text=True, capture_output=True, check=True)
-gateway = str(json.loads(network.stdout)[0].get('IPAM', {}).get('Config', [{}])[0].get('Gateway', ''))
-print(json.dumps({'local_hostname': socket.gethostname(), 'machine_identity_sha256': hashlib.sha256(machine.read_bytes().strip()).hexdigest(), 'captured_at': datetime.now(timezone.utc).isoformat(), 'ss_lntp': ss, 'docker_bridge_addresses': [gateway] if gateway else [], 'docker_network_bindings': {'host-gateway': gateway} if gateway else {}}, indent=2, sort_keys=True))
+def artifact(path):
+    p=Path(path); h=hashlib.sha256()
+    with p.open('rb') as stream:
+        for chunk in iter(lambda:stream.read(8*1024*1024),b''): h.update(chunk)
+    return {'filename':p.name,'sha256':h.hexdigest(),'size':p.stat().st_size}
+
+machine=next((p for p in (Path('/etc/machine-id'),Path('/var/lib/dbus/machine-id')) if p.is_file()),None)
+if not machine: raise SystemExit('machine-id unavailable')
+ss=subprocess.run(['ss','-lntp'],text=True,capture_output=True,check=True).stdout
+network=subprocess.run(['docker','network','inspect','bridge'],text=True,capture_output=True,check=True)
+gateway=str(json.loads(network.stdout)[0].get('IPAM',{}).get('Config',[{}])[0].get('Gateway',''))
+configured_model_dir=Path(os.environ['SERAPH_GPU_MODEL_DIR'])
+if not configured_model_dir.is_absolute(): raise SystemExit('GPU artifact root must be an absolute existing directory')
+model_dir=configured_model_dir.resolve(strict=True)
+if not model_dir.is_dir(): raise SystemExit('GPU artifact root must be an absolute existing directory')
+gpu_release={'image_ref':os.environ['SERAPH_GPU_MODEL_IMAGE'],'alias':os.environ['SERAPH_GPU_MODEL_ALIAS'],'artifact_root':str(model_dir),'model':artifact(model_dir/os.environ['SERAPH_GPU_MODEL_FILE']),'mmproj':artifact(model_dir/os.environ['SERAPH_GPU_MMPROJ_FILE']),'ctx_size':int(os.environ.get('SERAPH_GPU_MODEL_CTX_SIZE','32768')),'layers':int(os.environ.get('SERAPH_GPU_MODEL_LAYERS','999')),'command_contract':'llama-server-gemma4-v1'}
+print(json.dumps({'local_hostname':socket.gethostname(),'machine_identity_sha256':hashlib.sha256(machine.read_bytes().strip()).hexdigest(),'captured_at':datetime.now(timezone.utc).isoformat(),'ss_lntp':ss,'docker_bridge_addresses':[gateway] if gateway else [],'docker_network_bindings':{'host-gateway':gateway} if gateway else {},'gpu_release':gpu_release},indent=2,sort_keys=True))

--- a/scripts/generate_local_gpu_predeploy.py
+++ b/scripts/generate_local_gpu_predeploy.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Generate the local identity/listener gate used before candidate startup."""
+import hashlib, json, socket, subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+machine = next((p for p in (Path('/etc/machine-id'), Path('/var/lib/dbus/machine-id')) if p.is_file()), None)
+if not machine:
+    raise SystemExit('machine-id unavailable')
+ss = subprocess.run(['ss', '-lntp'], text=True, capture_output=True, check=True).stdout
+network = subprocess.run(['docker', 'network', 'inspect', 'bridge'], text=True, capture_output=True, check=True)
+gateway = str(json.loads(network.stdout)[0].get('IPAM', {}).get('Config', [{}])[0].get('Gateway', ''))
+print(json.dumps({'local_hostname': socket.gethostname(), 'machine_identity_sha256': hashlib.sha256(machine.read_bytes().strip()).hexdigest(), 'captured_at': datetime.now(timezone.utc).isoformat(), 'ss_lntp': ss, 'docker_bridge_addresses': [gateway] if gateway else [], 'docker_network_bindings': {'host-gateway': gateway} if gateway else {}}, indent=2, sort_keys=True))

--- a/scripts/generate_mac_lan_acceptance.py
+++ b/scripts/generate_mac_lan_acceptance.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Run on the operator Mac; emits no credential or probe-key material."""
+import argparse, hashlib, hmac, http.client, json, secrets, socket, ssl, time
+from datetime import datetime, timezone
+from pathlib import Path
+
+p=argparse.ArgumentParser()
+p.add_argument('--challenge-file',type=Path,required=True)
+p.add_argument('--https-origin',required=True); p.add_argument('--lan-host',required=True); p.add_argument('--lan-ip',required=True)
+p.add_argument('--trusted-ca',type=Path,required=True); p.add_argument('--operator-secret-file',type=Path,required=True)
+p.add_argument('--probe-key-file',type=Path,required=True); p.add_argument('--client-identity',required=True)
+a=p.parse_args(); origin=a.https_origin.rstrip('/'); challenge=json.loads(a.challenge_file.read_text()); challenge_raw=json.dumps(challenge,sort_keys=True,separators=(',',':')).encode()
+from urllib.parse import urlsplit
+parsed=urlsplit(origin); expected_host=parsed.hostname
+if parsed.scheme!='https' or not expected_host: raise SystemExit('HTTPS origin required')
+resolved={item[4][0] for item in socket.getaddrinfo(expected_host,parsed.port or 443,type=socket.SOCK_STREAM)}
+if resolved!={a.lan_ip} or expected_host!=a.lan_host or challenge.get('expected_origin')!=origin or challenge.get('lan_host')!=a.lan_host or challenge.get('lan_ip')!=a.lan_ip or challenge.get('client_identity')!=a.client_identity: raise SystemExit('challenge/origin/host/IP/client mismatch')
+password=a.operator_secret_file.read_text().strip(); key=a.probe_key_file.read_bytes().strip()
+if not password or len(key)<32: raise SystemExit('required nonempty operator/probe key file missing')
+ctx=ssl.create_default_context(cafile=str(a.trusted_ca)); port=parsed.port or 443
+class PinnedHTTPSConnection(http.client.HTTPSConnection):
+    def connect(self):
+        raw=socket.create_connection((a.lan_ip,port),timeout=self.timeout)
+        self.sock=ctx.wrap_socket(raw,server_hostname=expected_host)
+        if self.sock.getpeername()[0]!=a.lan_ip:
+            self.sock.close(); raise OSError('TLS peer IP mismatch')
+def request(method,path,body=None,headers=None):
+    connection=PinnedHTTPSConnection(expected_host,port=port,timeout=10,context=ctx)
+    request_headers={'Host':parsed.netloc,**(headers or {})}
+    connection.request(method,path,body=body,headers=request_headers)
+    response=connection.getresponse(); payload=response.read(); response_headers=response.getheaders(); connection.close()
+    if response.status < 200 or response.status >= 300: raise SystemExit('authenticated HTTPS probe failed')
+    return json.loads(payload),response_headers
+login_payload,login_headers=request('POST','/api/auth/login',json.dumps({'password':password}).encode(),{'Content-Type':'application/json'})
+cookies=[value.split(';',1)[0] for name,value in login_headers if name.lower()=='set-cookie']
+session_payload,_=request('GET','/api/auth/session',headers={'Cookie':'; '.join(cookies)})
+authenticated=login_payload.get('authenticated') is True and session_payload.get('authenticated') is True
+probes={}
+for port in (8000,8001,8004):
+    started=time.monotonic(); connected=False; error=''
+    try:
+        with socket.create_connection((a.lan_ip,port),timeout=3): connected=True
+    except ConnectionRefusedError: error='connection_refused'
+    except TimeoutError: error='timeout'
+    except Exception: error='invalid_network_error'
+    probes[str(port)]={'connected':connected,'error_class':error,'latency_ms':round((time.monotonic()-started)*1000)}
+receipt={'schema':'seraph.mac-lan-acceptance.v1','challenge':challenge,'challenge_sha256':hashlib.sha256(challenge_raw).hexdigest(),'https_origin':origin,'lan_host':a.lan_host,'lan_ip':a.lan_ip,'client_identity':a.client_identity,'captured_at':datetime.now(timezone.utc).isoformat(),'nonce':secrets.token_hex(24),'authenticated_session':authenticated,'port_probes':probes}
+canonical=json.dumps(receipt,sort_keys=True,separators=(',',':')).encode(); receipt['hmac_sha256']=hmac.new(key,canonical,hashlib.sha256).hexdigest()
+print(json.dumps(receipt,indent=2,sort_keys=True))

--- a/scripts/validate_acceptance_bundle.py
+++ b/scripts/validate_acceptance_bundle.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+
+def fail(message):
+    raise SystemExit("acceptance bundle invalid: " + message)
+
+
+bundle = json.load(sys.stdin)
+if bundle.get("schema") != "seraph.production-acceptance.v1":
+    fail("schema")
+if bundle.get("app_sha") != os.environ.get("SERAPH_BUNDLE_APP_SHA") or bundle.get("vlm_image") != os.environ.get("SERAPH_BUNDLE_VLM_IMAGE"):
+    fail("release tuple mismatch")
+if bundle.get("compose_project") != "seraph-prod" or bundle.get("network_name") != "seraph-core-prod":
+    fail("compose identity mismatch")
+if bundle.get("expected_origin") != os.environ.get("SERAPH_EXPECTED_HTTPS_ORIGIN") or bundle.get("client_identity") != os.environ.get("SERAPH_MAC_PROBE_CLIENT_ID"):
+    fail("operator acceptance identity mismatch")
+
+for kind in ("challenged_attestation", "final_attestation", "mac_receipt"):
+    item = bundle.get(kind, {})
+    try:
+        data = open(item["path"], "rb").read()
+    except Exception:
+        fail(kind + " missing")
+    if hashlib.sha256(data).hexdigest() != item.get("sha256"):
+        fail(kind + " hash mismatch")
+
+ids = bundle.get("container_ids", {})
+if set(ids) != {"ingress", "backend", "vlm-wrapper"} or not all(ids.values()):
+    fail("container identity incomplete")
+expected_ips = {"ingress": "172.30.0.10", "backend": "172.30.0.20", "vlm-wrapper": "172.30.0.30"}
+def validate_attestation(kind):
+    local = json.load(open(bundle[kind]["path"]))
+    compose = local.get("compose_observation", {})
+    if compose.get("project") != "seraph-prod" or compose.get("network_name") != "seraph-core-prod": fail(kind + " compose identity mismatch")
+    observed = compose.get("containers", {}); network_ids = set()
+    for service, expected_ip in expected_ips.items():
+        item = observed.get(service, {})
+        if item.get("container_id") != ids[service] or item.get("project") != "seraph-prod" or item.get("service") != service or item.get("network_name") != "seraph-core-prod" or item.get("ip_address") != expected_ip: fail(kind + " container binding mismatch: " + service)
+        if not item.get("image_id"): fail(kind + " image identity missing: " + service)
+        network_ids.add(item.get("network_id"))
+    if network_ids != {bundle.get("network_id")}: fail(kind + " network ID mismatch")
+    for service in ("ingress", "backend"):
+        if observed[service].get("image_revision") != bundle["app_sha"]: fail(kind + " application image identity mismatch: " + service)
+    repo_digests = local.get("vlm_observation", {}).get("repo_digests", [])
+    if bundle["vlm_image"] not in repo_digests: fail(kind + " VLM RepoDigest mismatch")
+    immutable = {"project":compose.get("project"),"network_name":compose.get("network_name"),"containers":{s:{k:observed[s].get(k) for k in ("container_id","image_id","image_revision","project","service","network_name","network_id","ip_address")} for s in expected_ips},"vlm_repo_digest":bundle["vlm_image"]}
+    return local, observed, immutable
+
+challenged, challenged_observed, challenged_immutable = validate_attestation("challenged_attestation")
+local, observed, final_immutable = validate_attestation("final_attestation")
+if challenged_immutable != final_immutable: fail("challenged/final immutable binding mismatch")
+
+challenge = bundle.get("acceptance_challenge", {})
+expected_challenge_fields = {
+    "schema": "seraph.acceptance-challenge.v1",
+    "stage": bundle.get("stage"),
+    "app_sha": bundle["app_sha"],
+    "vlm_image": bundle["vlm_image"],
+    "local_attestation_sha256": bundle["challenged_attestation"]["sha256"],
+    "compose_project": bundle["compose_project"],
+    "network_name": bundle["network_name"],
+    "network_id": bundle["network_id"],
+    "container_ids": ids,
+    "image_identities": {service: {"image_id": observed[service]["image_id"], "image_revision": observed[service].get("image_revision", "")} for service in expected_ips},
+    "expected_origin": bundle["expected_origin"],
+    "lan_host": os.environ.get("SERAPH_LAN_HOST"),
+    "lan_ip": os.environ.get("SERAPH_LAN_IP"),
+    "client_identity": bundle["client_identity"],
+}
+if bundle.get("stage") not in {"candidate", "rollback", "restore", "restart"}:
+    fail("challenge stage mismatch")
+for field, expected in expected_challenge_fields.items():
+    if challenge.get(field) != expected:
+        fail("challenge immutable field mismatch: " + field)
+if not challenge.get("server_nonce") or not challenge.get("issued_at"):
+    fail("challenge authority incomplete")
+
+env = os.environ.copy()
+env["SERAPH_MAC_RECEIPT_HISTORICAL"] = "true"
+with tempfile.NamedTemporaryFile("w", encoding="utf-8") as expected_file:
+    json.dump(challenge, expected_file, sort_keys=True)
+    expected_file.flush()
+    env["SERAPH_ACCEPTANCE_CHALLENGE_FILE"] = expected_file.name
+    validator = os.path.join(os.path.dirname(__file__), "validate_mac_lan_negative.py")
+    mac_result = subprocess.run([sys.executable, validator], input=open(bundle["mac_receipt"]["path"]).read(), text=True, capture_output=True, env=env)
+if mac_result.returncode:
+    fail("historical Mac signature/challenge invalid: " + mac_result.stderr.strip())
+print("acceptance bundle valid")

--- a/scripts/validate_acceptance_bundle.py
+++ b/scripts/validate_acceptance_bundle.py
@@ -11,6 +11,17 @@ def fail(message):
     raise SystemExit("acceptance bundle invalid: " + message)
 
 
+def canonical_repo_digest(reference):
+    if "@sha256:" not in reference: return reference
+    name,digest=reference.rsplit("@",1); slash=name.rfind("/"); colon=name.rfind(":")
+    if colon > slash: name=name[:colon]
+    return name+"@"+digest
+
+
+def repo_digest_matches(configured, observed):
+    return canonical_repo_digest(configured) in {canonical_repo_digest(value) for value in observed}
+
+
 bundle = json.load(sys.stdin)
 if bundle.get("schema") != "seraph.production-acceptance.v2":
     fail("schema")
@@ -51,9 +62,9 @@ def validate_attestation(kind):
     if not vlm_observation.get("image_id"): fail(kind + " VLM observed image ID missing")
     if configured_vlm.startswith("sha256:") and "@" not in configured_vlm:
         if vlm_observation.get("image_id") != configured_vlm: fail(kind + " VLM local image ID mismatch")
-    elif configured_vlm not in vlm_observation.get("repo_digests", []): fail(kind + " VLM RepoDigest mismatch")
+    elif not repo_digest_matches(configured_vlm,vlm_observation.get("repo_digests", [])): fail(kind + " VLM RepoDigest mismatch")
     gpu=local.get("gpu_model_observation",{}); release=bundle.get("gpu_release",{}); expected_gpu=release.get("image_ref"); expected_alias=release.get("alias")
-    if gpu.get("image_ref")!=expected_gpu or gpu.get("alias")!=expected_alias or gpu.get("image_id")!=observed["gpu-model"].get("image_id") or expected_gpu not in observed["gpu-model"].get("repo_digests",[]) or gpu.get("health") is not True: fail(kind + " GPU model identity/health mismatch")
+    if gpu.get("image_ref")!=expected_gpu or gpu.get("alias")!=expected_alias or gpu.get("image_id")!=observed["gpu-model"].get("image_id") or not repo_digest_matches(expected_gpu,observed["gpu-model"].get("repo_digests",[])) or gpu.get("health") is not True: fail(kind + " GPU model identity/health mismatch")
     if local.get("gpu_release")!=release: fail(kind + " GPU release manifest mismatch")
     immutable = {"project":compose.get("project"),"network_name":compose.get("network_name"),"containers":{s:{k:observed[s].get(k) for k in ("container_id","image_id","image_revision","project","service","network_name","network_id","ip_address")} for s in expected_ips},"vlm_configured_ref":configured_vlm,"vlm_observed_image_id":vlm_observation.get("image_id"),"gpu_model_image":gpu.get("image_ref"),"gpu_model_alias":gpu.get("alias")}
     return local, observed, immutable

--- a/scripts/validate_acceptance_bundle.py
+++ b/scripts/validate_acceptance_bundle.py
@@ -12,7 +12,7 @@ def fail(message):
 
 
 bundle = json.load(sys.stdin)
-if bundle.get("schema") != "seraph.production-acceptance.v1":
+if bundle.get("schema") != "seraph.production-acceptance.v2":
     fail("schema")
 if bundle.get("app_sha") != os.environ.get("SERAPH_BUNDLE_APP_SHA") or bundle.get("vlm_image") != os.environ.get("SERAPH_BUNDLE_VLM_IMAGE"):
     fail("release tuple mismatch")
@@ -31,9 +31,9 @@ for kind in ("challenged_attestation", "final_attestation", "mac_receipt"):
         fail(kind + " hash mismatch")
 
 ids = bundle.get("container_ids", {})
-if set(ids) != {"ingress", "backend", "vlm-wrapper"} or not all(ids.values()):
+if set(ids) != {"ingress", "backend", "vlm-wrapper", "gpu-model"} or not all(ids.values()):
     fail("container identity incomplete")
-expected_ips = {"ingress": "172.30.0.10", "backend": "172.30.0.20", "vlm-wrapper": "172.30.0.30"}
+expected_ips = {"ingress": "172.30.0.10", "backend": "172.30.0.20", "vlm-wrapper": "172.30.0.30", "gpu-model": "172.30.0.40"}
 def validate_attestation(kind):
     local = json.load(open(bundle[kind]["path"]))
     compose = local.get("compose_observation", {})
@@ -52,7 +52,10 @@ def validate_attestation(kind):
     if configured_vlm.startswith("sha256:") and "@" not in configured_vlm:
         if vlm_observation.get("image_id") != configured_vlm: fail(kind + " VLM local image ID mismatch")
     elif configured_vlm not in vlm_observation.get("repo_digests", []): fail(kind + " VLM RepoDigest mismatch")
-    immutable = {"project":compose.get("project"),"network_name":compose.get("network_name"),"containers":{s:{k:observed[s].get(k) for k in ("container_id","image_id","image_revision","project","service","network_name","network_id","ip_address")} for s in expected_ips},"vlm_configured_ref":configured_vlm,"vlm_observed_image_id":vlm_observation.get("image_id")}
+    gpu=local.get("gpu_model_observation",{}); release=bundle.get("gpu_release",{}); expected_gpu=release.get("image_ref"); expected_alias=release.get("alias")
+    if gpu.get("image_ref")!=expected_gpu or gpu.get("alias")!=expected_alias or gpu.get("image_id")!=observed["gpu-model"].get("image_id") or expected_gpu not in observed["gpu-model"].get("repo_digests",[]) or gpu.get("health") is not True: fail(kind + " GPU model identity/health mismatch")
+    if local.get("gpu_release")!=release: fail(kind + " GPU release manifest mismatch")
+    immutable = {"project":compose.get("project"),"network_name":compose.get("network_name"),"containers":{s:{k:observed[s].get(k) for k in ("container_id","image_id","image_revision","project","service","network_name","network_id","ip_address")} for s in expected_ips},"vlm_configured_ref":configured_vlm,"vlm_observed_image_id":vlm_observation.get("image_id"),"gpu_model_image":gpu.get("image_ref"),"gpu_model_alias":gpu.get("alias")}
     return local, observed, immutable
 
 challenged, challenged_observed, challenged_immutable = validate_attestation("challenged_attestation")
@@ -65,6 +68,9 @@ expected_challenge_fields = {
     "stage": bundle.get("stage"),
     "app_sha": bundle["app_sha"],
     "vlm_image": bundle["vlm_image"],
+    "gpu_model_image": bundle.get("gpu_release",{}).get("image_ref"),
+    "gpu_model_alias": bundle.get("gpu_release",{}).get("alias"),
+    "gpu_release": bundle.get("gpu_release"),
     "local_attestation_sha256": bundle["challenged_attestation"]["sha256"],
     "compose_project": bundle["compose_project"],
     "network_name": bundle["network_name"],

--- a/scripts/validate_acceptance_bundle.py
+++ b/scripts/validate_acceptance_bundle.py
@@ -47,9 +47,12 @@ def validate_attestation(kind):
     if network_ids != {bundle.get("network_id")}: fail(kind + " network ID mismatch")
     for service in ("ingress", "backend"):
         if observed[service].get("image_revision") != bundle["app_sha"]: fail(kind + " application image identity mismatch: " + service)
-    repo_digests = local.get("vlm_observation", {}).get("repo_digests", [])
-    if bundle["vlm_image"] not in repo_digests: fail(kind + " VLM RepoDigest mismatch")
-    immutable = {"project":compose.get("project"),"network_name":compose.get("network_name"),"containers":{s:{k:observed[s].get(k) for k in ("container_id","image_id","image_revision","project","service","network_name","network_id","ip_address")} for s in expected_ips},"vlm_repo_digest":bundle["vlm_image"]}
+    vlm_observation = local.get("vlm_observation", {}); configured_vlm = bundle["vlm_image"]
+    if not vlm_observation.get("image_id"): fail(kind + " VLM observed image ID missing")
+    if configured_vlm.startswith("sha256:") and "@" not in configured_vlm:
+        if vlm_observation.get("image_id") != configured_vlm: fail(kind + " VLM local image ID mismatch")
+    elif configured_vlm not in vlm_observation.get("repo_digests", []): fail(kind + " VLM RepoDigest mismatch")
+    immutable = {"project":compose.get("project"),"network_name":compose.get("network_name"),"containers":{s:{k:observed[s].get(k) for k in ("container_id","image_id","image_revision","project","service","network_name","network_id","ip_address")} for s in expected_ips},"vlm_configured_ref":configured_vlm,"vlm_observed_image_id":vlm_observation.get("image_id")}
     return local, observed, immutable
 
 challenged, challenged_observed, challenged_immutable = validate_attestation("challenged_attestation")

--- a/scripts/validate_gpu_host_inventory.py
+++ b/scripts/validate_gpu_host_inventory.py
@@ -15,18 +15,18 @@ def fail(message: str) -> None:
 
 
 receipt = json.load(sys.stdin)
-expected_host = os.environ.get("SERAPH_GPU_SSH_HOST", "")
-expected_fingerprint = os.environ.get("SERAPH_GPU_SSH_HOST_FINGERPRINT", "")
+if any(key in receipt for key in ("machine_id", "raw_machine_id", "machine_identity_raw")):
+    fail("raw machine identity material is forbidden")
+expected_host = os.environ.get("SERAPH_GPU_EXPECTED_HOSTNAME", "")
+expected_identity = os.environ.get("SERAPH_GPU_MACHINE_IDENTITY_SHA256", "")
 expected_vlm_image = os.environ.get("SERAPH_VLM_IMAGE", "")
 expected_vlm_contract = os.environ.get("SERAPH_VLM_INTERFACE_CONTRACT", "")
-if not all((expected_host, expected_fingerprint, expected_vlm_image, expected_vlm_contract)):
-    fail("configured host identity, fingerprint, VLM digest, and interface contract are required")
-if receipt.get("ssh_host") != expected_host:
-    fail("SSH host identity does not match configured host")
-if receipt.get("host_key_verified") is not True:
-    fail("host key was not verified")
-if receipt.get("host_key_fingerprint") != expected_fingerprint:
-    fail("host key fingerprint does not match configured fingerprint")
+if not all((expected_host, expected_identity, expected_vlm_image, expected_vlm_contract)):
+    fail("configured local hostname, machine identity, VLM digest, and interface contract are required")
+if receipt.get("local_hostname") != expected_host:
+    fail("local hostname does not match configured host")
+if receipt.get("machine_identity_sha256") != expected_identity:
+    fail("local machine identity does not match configured digest")
 try:
     captured = datetime.fromisoformat(str(receipt["captured_at"]).replace("Z", "+00:00"))
     if captured.tzinfo is None or captured.utcoffset() != timezone.utc.utcoffset(captured):
@@ -59,14 +59,36 @@ for line in ss_lntp.splitlines():
 if unsafe:
     fail(f"private ports have wildcard/LAN listeners: {unsafe}")
 
-firewall = receipt.get("firewall", {})
-for port in (8000, 8001, 8004):
-    if firewall.get(f"lan_ingress_{port}") != "blocked":
-        fail(f"firewall receipt does not prove LAN ingress {port} blocked")
 if receipt.get("vlm_image") != expected_vlm_image:
     fail("managed VLM wrapper digest does not match configured release")
 if receipt.get("vlm_interface_contract") != expected_vlm_contract:
     fail("managed VLM wrapper interface contract does not match configured contract")
 if receipt.get("vlm_wrapper_contract_verified") is not True:
     fail("managed VLM wrapper image/interface contract is unverified")
-print("GPU host inventory valid: host key, ss listeners, firewall gates, and wrapper contract verified")
+vlm_observation = receipt.get("vlm_observation", {})
+if vlm_observation.get("running") is not True:
+    fail("managed VLM wrapper container is not running")
+if any(value for value in vlm_observation.get("published_ports", {}).values()):
+    fail("managed VLM wrapper still publishes a host port")
+checks = vlm_observation.get("checks", {})
+if not all(checks.get(name) is True for name in ("health", "backend", "queue", "auth_closed", "auth_interface")):
+    fail("managed VLM wrapper active interface checks are incomplete")
+compose = receipt.get("compose_observation", {})
+if compose.get("project") != "seraph-prod" or compose.get("network_name") != "seraph-core-prod":
+    fail("compose project/network identity mismatch")
+containers=compose.get("containers",{})
+expected={"ingress":"172.30.0.10","backend":"172.30.0.20","vlm-wrapper":"172.30.0.30"}
+network_ids=set()
+app_revisions=set()
+for service,ip in expected.items():
+    item=containers.get(service,{})
+    if not item.get("container_id") or item.get("project")!="seraph-prod" or item.get("service")!=service or item.get("network_name")!="seraph-core-prod" or item.get("ip_address")!=ip:
+        fail(f"compose container binding mismatch: {service}")
+    network_ids.add(item.get("network_id"))
+    if not item.get("image_id"): fail(f"container image ID missing: {service}")
+    if service in {"ingress","backend"}: app_revisions.add(item.get("image_revision"))
+if len(network_ids)!=1 or not next(iter(network_ids),""):
+    fail("compose network ID mismatch")
+if len(app_revisions)!=1 or not next(iter(app_revisions),""):
+    fail("application image revision mismatch")
+print("GPU host inventory valid: local identity, ss listeners, firewall receipt, and wrapper contract verified")

--- a/scripts/validate_gpu_host_inventory.py
+++ b/scripts/validate_gpu_host_inventory.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Validate an operator-produced GPU host listener/firewall receipt."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"GPU host inventory invalid: {message}")
+
+
+receipt = json.load(sys.stdin)
+expected_host = os.environ.get("SERAPH_GPU_SSH_HOST", "")
+expected_fingerprint = os.environ.get("SERAPH_GPU_SSH_HOST_FINGERPRINT", "")
+expected_vlm_image = os.environ.get("SERAPH_VLM_IMAGE", "")
+expected_vlm_contract = os.environ.get("SERAPH_VLM_INTERFACE_CONTRACT", "")
+if not all((expected_host, expected_fingerprint, expected_vlm_image, expected_vlm_contract)):
+    fail("configured host identity, fingerprint, VLM digest, and interface contract are required")
+if receipt.get("ssh_host") != expected_host:
+    fail("SSH host identity does not match configured host")
+if receipt.get("host_key_verified") is not True:
+    fail("host key was not verified")
+if receipt.get("host_key_fingerprint") != expected_fingerprint:
+    fail("host key fingerprint does not match configured fingerprint")
+try:
+    captured = datetime.fromisoformat(str(receipt["captured_at"]).replace("Z", "+00:00"))
+    if captured.tzinfo is None or captured.utcoffset() != timezone.utc.utcoffset(captured):
+        fail("captured_at must carry an explicit UTC offset")
+    age = (datetime.now(timezone.utc) - captured.astimezone(timezone.utc)).total_seconds()
+except (KeyError, TypeError, ValueError):
+    fail("captured_at must be an ISO-8601 UTC timestamp")
+max_age = int(os.environ.get("SERAPH_HOST_INVENTORY_MAX_AGE_SECONDS", "900"))
+if age < -30 or (age > max_age and os.environ.get("SERAPH_ALLOW_PREVIOUS_ACCEPTED_RECEIPT") != "true"):
+    fail("inventory receipt is stale or from the future")
+ss_lntp = str(receipt.get("ss_lntp", ""))
+if not ss_lntp.strip():
+    fail("raw ss -lntp receipt is missing")
+
+unsafe = []
+bridge_addresses = {str(item) for item in receipt.get("docker_bridge_addresses", [])}
+if not bridge_addresses:
+    fail("Docker bridge address inventory is missing")
+bindings = receipt.get("docker_network_bindings", {})
+if bindings.get("host-gateway") not in bridge_addresses:
+    fail("current host-gateway binding is absent from Docker bridge inventory")
+allowed_addresses = {"127.0.0.1", "::1", "[::1]"} | bridge_addresses
+for line in ss_lntp.splitlines():
+    match = re.search(r"LISTEN\s+\d+\s+\d+\s+(\S+):(8000|8001|8004)\b", line)
+    if not match:
+        continue
+    address, port = match.groups()
+    if address not in allowed_addresses:
+        unsafe.append({"address": address, "port": int(port), "line": line})
+if unsafe:
+    fail(f"private ports have wildcard/LAN listeners: {unsafe}")
+
+firewall = receipt.get("firewall", {})
+for port in (8000, 8001, 8004):
+    if firewall.get(f"lan_ingress_{port}") != "blocked":
+        fail(f"firewall receipt does not prove LAN ingress {port} blocked")
+if receipt.get("vlm_image") != expected_vlm_image:
+    fail("managed VLM wrapper digest does not match configured release")
+if receipt.get("vlm_interface_contract") != expected_vlm_contract:
+    fail("managed VLM wrapper interface contract does not match configured contract")
+if receipt.get("vlm_wrapper_contract_verified") is not True:
+    fail("managed VLM wrapper image/interface contract is unverified")
+print("GPU host inventory valid: host key, ss listeners, firewall gates, and wrapper contract verified")

--- a/scripts/validate_gpu_host_inventory.py
+++ b/scripts/validate_gpu_host_inventory.py
@@ -60,12 +60,17 @@ if unsafe:
     fail(f"private ports have wildcard/LAN listeners: {unsafe}")
 
 if receipt.get("vlm_image") != expected_vlm_image:
-    fail("managed VLM wrapper digest does not match configured release")
+    fail("managed VLM wrapper immutable reference does not match configured release")
 if receipt.get("vlm_interface_contract") != expected_vlm_contract:
     fail("managed VLM wrapper interface contract does not match configured contract")
 if receipt.get("vlm_wrapper_contract_verified") is not True:
     fail("managed VLM wrapper image/interface contract is unverified")
 vlm_observation = receipt.get("vlm_observation", {})
+if not vlm_observation.get("image_id"): fail("managed VLM observed image ID missing")
+if expected_vlm_image.startswith("sha256:") and "@" not in expected_vlm_image:
+    if vlm_observation.get("image_id") != expected_vlm_image: fail("managed VLM local image ID mismatch")
+elif expected_vlm_image not in vlm_observation.get("repo_digests", []):
+    fail("managed VLM RepoDigest mismatch")
 if vlm_observation.get("running") is not True:
     fail("managed VLM wrapper container is not running")
 if any(value for value in vlm_observation.get("published_ports", {}).values()):

--- a/scripts/validate_gpu_host_inventory.py
+++ b/scripts/validate_gpu_host_inventory.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import re
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
 
 def fail(message: str) -> None:
@@ -20,8 +22,10 @@ if any(key in receipt for key in ("machine_id", "raw_machine_id", "machine_ident
 expected_host = os.environ.get("SERAPH_GPU_EXPECTED_HOSTNAME", "")
 expected_identity = os.environ.get("SERAPH_GPU_MACHINE_IDENTITY_SHA256", "")
 expected_vlm_image = os.environ.get("SERAPH_VLM_IMAGE", "")
+expected_gpu_model_image = os.environ.get("SERAPH_GPU_MODEL_IMAGE", "")
+expected_gpu_model_alias = os.environ.get("SERAPH_GPU_MODEL_ALIAS", "")
 expected_vlm_contract = os.environ.get("SERAPH_VLM_INTERFACE_CONTRACT", "")
-if not all((expected_host, expected_identity, expected_vlm_image, expected_vlm_contract)):
+if not all((expected_host, expected_identity, expected_vlm_image, expected_vlm_contract, expected_gpu_model_image, expected_gpu_model_alias)):
     fail("configured local hostname, machine identity, VLM digest, and interface contract are required")
 if receipt.get("local_hostname") != expected_host:
     fail("local hostname does not match configured host")
@@ -42,20 +46,12 @@ if not ss_lntp.strip():
     fail("raw ss -lntp receipt is missing")
 
 unsafe = []
-bridge_addresses = {str(item) for item in receipt.get("docker_bridge_addresses", [])}
-if not bridge_addresses:
-    fail("Docker bridge address inventory is missing")
-bindings = receipt.get("docker_network_bindings", {})
-if bindings.get("host-gateway") not in bridge_addresses:
-    fail("current host-gateway binding is absent from Docker bridge inventory")
-allowed_addresses = {"127.0.0.1", "::1", "[::1]"} | bridge_addresses
 for line in ss_lntp.splitlines():
     match = re.search(r"LISTEN\s+\d+\s+\d+\s+(\S+):(8000|8001|8004)\b", line)
     if not match:
         continue
     address, port = match.groups()
-    if address not in allowed_addresses:
-        unsafe.append({"address": address, "port": int(port), "line": line})
+    unsafe.append({"address": address, "port": int(port), "line": line})
 if unsafe:
     fail(f"private ports have wildcard/LAN listeners: {unsafe}")
 
@@ -82,7 +78,7 @@ compose = receipt.get("compose_observation", {})
 if compose.get("project") != "seraph-prod" or compose.get("network_name") != "seraph-core-prod":
     fail("compose project/network identity mismatch")
 containers=compose.get("containers",{})
-expected={"ingress":"172.30.0.10","backend":"172.30.0.20","vlm-wrapper":"172.30.0.30"}
+expected={"ingress":"172.30.0.10","backend":"172.30.0.20","vlm-wrapper":"172.30.0.30","gpu-model":"172.30.0.40"}
 network_ids=set()
 app_revisions=set()
 for service,ip in expected.items():
@@ -96,4 +92,18 @@ if len(network_ids)!=1 or not next(iter(network_ids),""):
     fail("compose network ID mismatch")
 if len(app_revisions)!=1 or not next(iter(app_revisions),""):
     fail("application image revision mismatch")
+gpu=receipt.get("gpu_model_observation",{})
+if gpu.get("image_ref")!=expected_gpu_model_image or expected_gpu_model_image not in containers.get("gpu-model",{}).get("repo_digests",[]) or gpu.get("image_id")!=containers.get("gpu-model",{}).get("image_id") or gpu.get("alias")!=expected_gpu_model_alias or gpu.get("health") is not True:
+    fail("GPU model immutable identity/health mismatch")
+def artifact(path):
+    p=Path(path); h=hashlib.sha256()
+    with p.open('rb') as stream:
+        for chunk in iter(lambda:stream.read(8*1024*1024),b''): h.update(chunk)
+    return {'filename':p.name,'sha256':h.hexdigest(),'size':p.stat().st_size}
+configured_model_dir=Path(os.environ['SERAPH_GPU_MODEL_DIR'])
+if not configured_model_dir.is_absolute(): fail('GPU artifact root must be an absolute existing directory')
+model_dir=configured_model_dir.resolve(strict=True)
+if not model_dir.is_dir(): fail('GPU artifact root must be an absolute existing directory')
+expected_release={'image_ref':expected_gpu_model_image,'alias':expected_gpu_model_alias,'artifact_root':str(model_dir),'model':artifact(model_dir/os.environ['SERAPH_GPU_MODEL_FILE']),'mmproj':artifact(model_dir/os.environ['SERAPH_GPU_MMPROJ_FILE']),'ctx_size':int(os.environ.get('SERAPH_GPU_MODEL_CTX_SIZE','32768')),'layers':int(os.environ.get('SERAPH_GPU_MODEL_LAYERS','999')),'command_contract':'llama-server-gemma4-v1'}
+if receipt.get('gpu_release')!=expected_release: fail('GPU release artifact manifest mismatch')
 print("GPU host inventory valid: local identity, ss listeners, firewall receipt, and wrapper contract verified")

--- a/scripts/validate_gpu_host_inventory.py
+++ b/scripts/validate_gpu_host_inventory.py
@@ -16,6 +16,17 @@ def fail(message: str) -> None:
     raise SystemExit(f"GPU host inventory invalid: {message}")
 
 
+def canonical_repo_digest(reference: str) -> str:
+    if "@sha256:" not in reference: return reference
+    name,digest=reference.rsplit("@",1); slash=name.rfind("/"); colon=name.rfind(":")
+    if colon > slash: name=name[:colon]
+    return name+"@"+digest
+
+
+def repo_digest_matches(configured: str, observed: list[str]) -> bool:
+    return canonical_repo_digest(configured) in {canonical_repo_digest(value) for value in observed}
+
+
 receipt = json.load(sys.stdin)
 if any(key in receipt for key in ("machine_id", "raw_machine_id", "machine_identity_raw")):
     fail("raw machine identity material is forbidden")
@@ -65,7 +76,7 @@ vlm_observation = receipt.get("vlm_observation", {})
 if not vlm_observation.get("image_id"): fail("managed VLM observed image ID missing")
 if expected_vlm_image.startswith("sha256:") and "@" not in expected_vlm_image:
     if vlm_observation.get("image_id") != expected_vlm_image: fail("managed VLM local image ID mismatch")
-elif expected_vlm_image not in vlm_observation.get("repo_digests", []):
+elif not repo_digest_matches(expected_vlm_image, vlm_observation.get("repo_digests", [])):
     fail("managed VLM RepoDigest mismatch")
 if vlm_observation.get("running") is not True:
     fail("managed VLM wrapper container is not running")
@@ -93,7 +104,7 @@ if len(network_ids)!=1 or not next(iter(network_ids),""):
 if len(app_revisions)!=1 or not next(iter(app_revisions),""):
     fail("application image revision mismatch")
 gpu=receipt.get("gpu_model_observation",{})
-if gpu.get("image_ref")!=expected_gpu_model_image or expected_gpu_model_image not in containers.get("gpu-model",{}).get("repo_digests",[]) or gpu.get("image_id")!=containers.get("gpu-model",{}).get("image_id") or gpu.get("alias")!=expected_gpu_model_alias or gpu.get("health") is not True:
+if gpu.get("image_ref")!=expected_gpu_model_image or not repo_digest_matches(expected_gpu_model_image,containers.get("gpu-model",{}).get("repo_digests",[])) or gpu.get("image_id")!=containers.get("gpu-model",{}).get("image_id") or gpu.get("alias")!=expected_gpu_model_alias or gpu.get("health") is not True:
     fail("GPU model immutable identity/health mismatch")
 def artifact(path):
     p=Path(path); h=hashlib.sha256()

--- a/scripts/validate_gpu_predeploy.py
+++ b/scripts/validate_gpu_predeploy.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-import json, os, re, sys
+import hashlib, json, os, re, sys
+from pathlib import Path
 from datetime import datetime, timezone
 
 r=json.load(sys.stdin)
@@ -9,12 +10,21 @@ if r.get('machine_identity_sha256') != os.environ.get('SERAPH_GPU_MACHINE_IDENTI
 try: age=(datetime.now(timezone.utc)-datetime.fromisoformat(r['captured_at'].replace('Z','+00:00'))).total_seconds()
 except Exception: fail('invalid captured_at')
 if age < -30 or age > int(os.environ.get('SERAPH_HOST_INVENTORY_MAX_AGE_SECONDS','900')): fail('stale receipt')
+def artifact(path):
+    p=Path(path); h=hashlib.sha256()
+    with p.open('rb') as stream:
+        for chunk in iter(lambda:stream.read(8*1024*1024),b''): h.update(chunk)
+    return {'filename':p.name,'sha256':h.hexdigest(),'size':p.stat().st_size}
+configured_model_dir=Path(os.environ['SERAPH_GPU_MODEL_DIR'])
+if not configured_model_dir.is_absolute(): fail('GPU artifact root must be an absolute existing directory')
+model_dir=configured_model_dir.resolve(strict=True)
+if not model_dir.is_dir(): fail('GPU artifact root must be an absolute existing directory')
+expected={'image_ref':os.environ['SERAPH_GPU_MODEL_IMAGE'],'alias':os.environ['SERAPH_GPU_MODEL_ALIAS'],'artifact_root':str(model_dir),'model':artifact(model_dir/os.environ['SERAPH_GPU_MODEL_FILE']),'mmproj':artifact(model_dir/os.environ['SERAPH_GPU_MMPROJ_FILE']),'ctx_size':int(os.environ.get('SERAPH_GPU_MODEL_CTX_SIZE','32768')),'layers':int(os.environ.get('SERAPH_GPU_MODEL_LAYERS','999')),'command_contract':'llama-server-gemma4-v1'}
+if r.get('gpu_release')!=expected: fail('GPU release artifact manifest mismatch')
 allowed={'127.0.0.1','::1','[::1]'} | set(r.get('docker_bridge_addresses',[]))
 for line in str(r.get('ss_lntp','')).splitlines():
     m=re.search(r'LISTEN\s+\d+\s+\d+\s+(\S+):(8000|8001|8004)\b',line)
     if not m: continue
     address,port=m.groups()
-    if port in {'8001','8004'}: fail(f'old service listener {address}:{port} must be stopped before managed cutover')
-    if address not in allowed: fail(f'model listener is LAN/wildcard: {address}:{port}')
-if r.get('docker_network_bindings',{}).get('host-gateway') not in allowed: fail('host-gateway binding missing')
-print('GPU predeploy valid: local identity and private model listener verified; old wrapper/backend stopped')
+    fail(f'old unmanaged service listener {address}:{port} must be stopped before managed cutover')
+print('GPU predeploy valid: local identity verified; unmanaged model/wrapper/backend listeners stopped')

--- a/scripts/validate_gpu_predeploy.py
+++ b/scripts/validate_gpu_predeploy.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import json, os, re, sys
+from datetime import datetime, timezone
+
+r=json.load(sys.stdin)
+def fail(x): raise SystemExit('GPU predeploy invalid: '+x)
+if r.get('local_hostname') != os.environ.get('SERAPH_GPU_EXPECTED_HOSTNAME'): fail('hostname mismatch')
+if r.get('machine_identity_sha256') != os.environ.get('SERAPH_GPU_MACHINE_IDENTITY_SHA256'): fail('machine identity mismatch')
+try: age=(datetime.now(timezone.utc)-datetime.fromisoformat(r['captured_at'].replace('Z','+00:00'))).total_seconds()
+except Exception: fail('invalid captured_at')
+if age < -30 or age > int(os.environ.get('SERAPH_HOST_INVENTORY_MAX_AGE_SECONDS','900')): fail('stale receipt')
+allowed={'127.0.0.1','::1','[::1]'} | set(r.get('docker_bridge_addresses',[]))
+for line in str(r.get('ss_lntp','')).splitlines():
+    m=re.search(r'LISTEN\s+\d+\s+\d+\s+(\S+):(8000|8001|8004)\b',line)
+    if not m: continue
+    address,port=m.groups()
+    if port in {'8001','8004'}: fail(f'old service listener {address}:{port} must be stopped before managed cutover')
+    if address not in allowed: fail(f'model listener is LAN/wildcard: {address}:{port}')
+if r.get('docker_network_bindings',{}).get('host-gateway') not in allowed: fail('host-gateway binding missing')
+print('GPU predeploy valid: local identity and private model listener verified; old wrapper/backend stopped')

--- a/scripts/validate_mac_lan_negative.py
+++ b/scripts/validate_mac_lan_negative.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import hashlib, hmac, json, os, re, sys
+from datetime import datetime, timezone
+
+r=json.load(sys.stdin); historical=os.environ.get('SERAPH_MAC_RECEIPT_HISTORICAL')=='true'
+def fail(x): raise SystemExit('Mac operator acceptance invalid: '+x)
+expected_origin=os.environ.get('SERAPH_EXPECTED_HTTPS_ORIGIN','').rstrip('/')
+expected_host=os.environ.get('SERAPH_LAN_HOST','')
+expected_ip=os.environ.get('SERAPH_LAN_IP','')
+expected_client=os.environ.get('SERAPH_MAC_PROBE_CLIENT_ID','')
+key_file=os.environ.get('SERAPH_MAC_PROBE_KEY_FILE',''); challenge_file=os.environ.get('SERAPH_ACCEPTANCE_CHALLENGE_FILE','')
+if not all((expected_origin,expected_host,expected_ip,expected_client,key_file,challenge_file)): fail('server expectations are incomplete')
+if r.get('schema')!='seraph.mac-lan-acceptance.v1': fail('schema mismatch')
+if r.get('https_origin')!=expected_origin or r.get('lan_host')!=expected_host or r.get('lan_ip')!=expected_ip: fail('origin/host/IP mismatch')
+if r.get('client_identity')!=expected_client: fail('client identity mismatch')
+if not re.fullmatch(r'[0-9a-f]{32,128}',str(r.get('nonce',''))): fail('nonce invalid')
+try: age=(datetime.now(timezone.utc)-datetime.fromisoformat(r['captured_at'].replace('Z','+00:00'))).total_seconds()
+except Exception: fail('invalid captured_at')
+if not historical and (age < -30 or age > 300): fail('stale receipt')
+if r.get('authenticated_session') is not True: fail('authenticated session proof missing')
+for port in ('8000','8001','8004'):
+    probe=r.get('port_probes',{}).get(port,{})
+    if probe.get('connected') is not False or probe.get('error_class') not in {'connection_refused','timeout'}: fail(f'measured LAN denial missing for {port}')
+expected_challenge=json.load(open(challenge_file)); canonical_challenge=json.dumps(expected_challenge,sort_keys=True,separators=(',',':')).encode()
+if r.get('challenge')!=expected_challenge or r.get('challenge_sha256')!=hashlib.sha256(canonical_challenge).hexdigest(): fail('acceptance challenge mismatch')
+signature=str(r.pop('hmac_sha256',''))
+canonical=json.dumps(r,sort_keys=True,separators=(',',':')).encode()
+key=open(key_file,'rb').read().strip()
+if len(key)<32: fail('probe key is missing/too short')
+if not hmac.compare_digest(signature,hmac.new(key,canonical,hashlib.sha256).hexdigest()): fail('HMAC mismatch')
+print('Mac operator acceptance valid: authenticated origin and measured internal-port denials verified')

--- a/scripts/validate_production_compose_state.py
+++ b/scripts/validate_production_compose_state.py
@@ -11,14 +11,14 @@ try:
     rows = parsed if isinstance(parsed, list) else [parsed]
 except json.JSONDecodeError:
     rows = [json.loads(line) for line in raw.splitlines() if line.strip()]
-expected = {"backend", "ingress", "vlm-wrapper"}
+expected = {"backend", "ingress", "vlm-wrapper", "gpu-model"}
 counts = Counter(str(row.get("Service", "")) for row in rows)
 expected_counts = Counter({service: 1 for service in expected})
-if len(rows) != 3 or counts != expected_counts:
+if len(rows) != 4 or counts != expected_counts:
     raise SystemExit(f"expected exactly one row per service {sorted(expected)}, found {dict(counts)}")
 for row in rows:
     if str(row.get("State", "")).lower() != "running":
         raise SystemExit(f"service {row.get('Service')} is not running")
     if str(row.get("Health", "")).lower() != "healthy":
         raise SystemExit(f"service {row.get('Service')} is not healthy")
-print("compose runtime valid: ingress, backend, and VLM wrapper are running and healthy")
+print("compose runtime valid: ingress, backend, VLM wrapper, and GPU model are running and healthy")

--- a/scripts/validate_production_compose_state.py
+++ b/scripts/validate_production_compose_state.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import json
+import sys
+from collections import Counter
+
+raw = sys.stdin.read().strip()
+if not raw:
+    raise SystemExit("compose state is empty")
+try:
+    parsed = json.loads(raw)
+    rows = parsed if isinstance(parsed, list) else [parsed]
+except json.JSONDecodeError:
+    rows = [json.loads(line) for line in raw.splitlines() if line.strip()]
+expected = {"backend", "ingress", "vlm-wrapper"}
+counts = Counter(str(row.get("Service", "")) for row in rows)
+expected_counts = Counter({service: 1 for service in expected})
+if len(rows) != 3 or counts != expected_counts:
+    raise SystemExit(f"expected exactly one row per service {sorted(expected)}, found {dict(counts)}")
+for row in rows:
+    if str(row.get("State", "")).lower() != "running":
+        raise SystemExit(f"service {row.get('Service')} is not running")
+    if str(row.get("Health", "")).lower() != "healthy":
+        raise SystemExit(f"service {row.get('Service')} is not healthy")
+print("compose runtime valid: ingress, backend, and VLM wrapper are running and healthy")

--- a/scripts/validate_production_listeners.py
+++ b/scripts/validate_production_listeners.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Report Docker-published listeners and reject private Seraph ports."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+
+forbidden = re.compile(r"(?:0\.0\.0\.0|\[::\]|:::|127\.0\.0\.1):(8000|8001|8004)->")
+bad: list[dict[str, str]] = []
+rows: list[dict[str, str]] = []
+for line in sys.stdin:
+    if not line.strip():
+        continue
+    row = json.loads(line)
+    receipt = {"name": str(row.get("Names", "")), "ports": str(row.get("Ports", ""))}
+    rows.append(receipt)
+    if forbidden.search(receipt["ports"]):
+        bad.append(receipt)
+print(json.dumps({"container_listeners": rows, "unsafe_private_port_publications": bad}, sort_keys=True))
+if bad:
+    raise SystemExit("unsafe Docker publication of 8000, 8001, or 8004")

--- a/scripts/validate_production_topology.py
+++ b/scripts/validate_production_topology.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 
 
@@ -17,8 +18,8 @@ def fail(message: str) -> None:
 def main() -> None:
     config = json.load(sys.stdin)
     services = config.get("services", {})
-    if set(services) != {"ingress", "backend", "vlm-wrapper"}:
-        fail("compose must contain exactly ingress, backend, and private VLM wrapper services")
+    if set(services) != {"ingress", "backend", "vlm-wrapper", "gpu-model"}:
+        fail("compose must contain exactly ingress, backend, VLM wrapper, and GPU model services")
     published: list[tuple[str, int, int]] = []
     for name, service in services.items():
         for port in service.get("ports", []) or []:
@@ -44,7 +45,25 @@ def main() -> None:
         fail("backend must not publish a host port")
     if services["vlm-wrapper"].get("ports"):
         fail("VLM wrapper must not publish a host port")
-    print("compose topology valid: one TLS ingress; backend and VLM wrapper have no Docker publications")
+    if services["gpu-model"].get("ports"):
+        fail("GPU model must not publish a host port")
+    if environment.get("LOCAL_LLM_API_BASE") != "http://gpu-model:8000/v1" or environment.get("SERAPH_VLM_BACKEND_URL") != "http://gpu-model:8000/v1":
+        fail("backend model routes must use private gpu-model service")
+    if services["vlm-wrapper"].get("environment", {}).get("VLM_BASE_URL") != "http://gpu-model:8000/v1":
+        fail("VLM wrapper backend must use private gpu-model service")
+    devices = services["gpu-model"].get("deploy", {}).get("resources", {}).get("reservations", {}).get("devices", [])
+    if not any(device.get("driver") == "nvidia" and "gpu" in (device.get("capabilities") or []) for device in devices):
+        fail("GPU model must reserve an NVIDIA GPU")
+    model = services["gpu-model"]
+    if not re.fullmatch(r"[^\s@]+@sha256:[0-9a-fA-F]{64}", str(model.get("image", ""))):
+        fail("GPU model image must be pinned by registry RepoDigest")
+    model_mounts = model.get("volumes", []) or []
+    if len(model_mounts) != 1 or model_mounts[0].get("target") != "/models" or model_mounts[0].get("read_only") is not True:
+        fail("GPU model artifact directory must be one read-only /models bind mount")
+    command = model.get("command", []) or []
+    for flag in ("--model", "--mmproj", "--alias", "--ctx-size", "--n-gpu-layers"):
+        if flag not in command: fail(f"GPU model command missing {flag}")
+    print("compose topology valid: one TLS ingress; backend, VLM wrapper, and GPU model are private")
 
 
 if __name__ == "__main__":

--- a/scripts/validate_production_topology.py
+++ b/scripts/validate_production_topology.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Fail closed on unsafe Seraph production compose output."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+FORBIDDEN_PORTS = {8000, 8001, 8004}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"production topology invalid: {message}")
+
+
+def main() -> None:
+    config = json.load(sys.stdin)
+    services = config.get("services", {})
+    if set(services) != {"ingress", "backend", "vlm-wrapper"}:
+        fail("compose must contain exactly ingress, backend, and private VLM wrapper services")
+    published: list[tuple[str, int, int]] = []
+    for name, service in services.items():
+        for port in service.get("ports", []) or []:
+            target = int(port["target"])
+            published_port = int(port["published"])
+            published.append((name, target, published_port))
+            if target in FORBIDDEN_PORTS or published_port in FORBIDDEN_PORTS:
+                fail(f"{name} publishes forbidden inference/backend port {published_port}:{target}")
+    if len(published) != 1 or published[0][0] != "ingress" or published[0][1] != 443:
+        fail("exactly one ingress TLS port targeting 443 must be published")
+    backend = services["backend"]
+    environment = backend.get("environment", {})
+    required = {
+        "DEPLOYMENT_ENVIRONMENT": "production",
+        "OPERATOR_AUTH_COOKIE_SECURE": "true",
+        "OPERATOR_AUTH_BACKEND_WORKERS": "1",
+        "OPERATOR_AUTH_TRUSTED_PROXY_IPS": "172.30.0.10",
+    }
+    for key, value in required.items():
+        if str(environment.get(key, "")).lower() != value:
+            fail(f"{key} must equal {value}")
+    if backend.get("ports"):
+        fail("backend must not publish a host port")
+    if services["vlm-wrapper"].get("ports"):
+        fail("VLM wrapper must not publish a host port")
+    print("compose topology valid: one TLS ingress; backend and VLM wrapper have no Docker publications")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Done on develop
- [x] Existing FastAPI/React guardian baseline, scheduler, observer, reports, and model-routing foundations.

## Working in this PR
- [x] Run the Seraph core on `jupyter` behind one trusted-CA HTTPS LAN ingress with fail-closed operator authentication and revocable sessions.
- [x] Keep backend, VLM wrapper, and Gemma model private on one managed rootless-Docker network.
- [x] Run Gemma through a digest-pinned official llama.cpp CUDA service using the RTX 3090 and read-only GGUF/mmproj artifacts.
- [x] Bind app, VLM, GPU image, model alias, artifact root/hashes/sizes, command contract, and four-container identity into staged acceptance and rollback state.
- [x] Preserve complete GPU tuples across candidate, restart, rollback, restore, and cross-process acceptance flows.
- [x] Add rootless-safe container-namespace probes, structured wrapper authentication checks, canonical RepoDigest matching, and operator-visible lifecycle receipts.
- [x] Update AGENTS.md and shipped-truth operations documentation for the GPU-host core and future paired Mac edge.

## Still to do after this PR
- [ ] Run the challenge-bound receipt from an external trusted LAN client when available. The user explicitly deferred this Mac/external-client gate for now. The candidate remains staged, not accepted; external HTTPS reachability and negative 8000/8001/8004 probes are therefore residual deployment evidence, not claimed here.
- [ ] Implement the paired Mac screenshot upload edge under #749.
- [ ] Address the backend Dockerfile cache layout separately; exact-revision verifier commits currently invalidate expensive dependency layers without weakening release identity.

## Validation
- Backend focused authentication/security/topology: `37 passed`.
- Production topology suite after live fixes: `23 passed`.
- Frontend full `npm test`: passed; focused auth UI: `11 passed`.
- Documentation `npm run build`: passed.
- Backend full-suite attempt with writable `/tmp` uv cache stalled after the first test without a failure and was interrupted; focused changed-scope suites passed. Hosted CI is not treated as the ordinary feature authority per repository policy.
- Live pinned llama.cpp image: RTX 3090 model+mmproj loaded; `/health` 200; `/v1/models` reported the exact multimodal alias; OpenAI-compatible chat returned `ready`.
- Live staged Compose: ingress, backend, VLM wrapper, and GPU model all healthy; backend preflight reached all private inference routes; immutable host inventory passed.
- Listener receipt: only `0.0.0.0:8443` is published by Seraph; ports 8000/8001/8004 have no host listeners or Docker publications.
- Trusted-CA HTTPS `/health`: 200. Auth lifecycle: unauthenticated session 401, login 200, session 200, refresh 200, logout 204, revoked session 401.
- Independent team: Bohr implemented GPU/runtime changes; Descartes ran fresh Critic/Contrarian reviews after every behavior-affecting update. Final cumulative result: PASS.

Refs #741
